### PR TITLE
Mm fractran, simplified backward step proof

### DIFF
--- a/H10/DPRM.v
+++ b/H10/DPRM.v
@@ -37,12 +37,11 @@ Section DPRM_n.
 
   (* There is a FRACTRAN program simulating R *)
 
-  Let reg_FRACTRAN : { l | Forall (fun c => snd c <> 0) l
-                    /\ forall v, R v <-> l /F/ ps 1 * exp 1 v ↓ }.
+  Let FRACTRAN : { l | forall v, R v <-> l /F/ ps 1 * exp 1 v ↓ }.
   Proof.
     destruct HR as (m & Q & HQ).
-    destruct mm_fractran_n with (P := Q) as (l & H1 & Hl).
-    exists l; split; auto. 
+    destruct mm_fractran_n with (P := Q) as (l & _ & Hl).
+    exists l. 
     intros x; rewrite HQ, Hl.
     rewrite exp_app, exp_zero, Nat.mul_1_r; tauto.
   Qed.
@@ -51,8 +50,8 @@ Section DPRM_n.
 
   Theorem DPRM_n : diophantine_n R.
   Proof.
-    destruct reg_FRACTRAN as (l & H1 & Hl).
-    clear reg_FRACTRAN HR.
+    destruct FRACTRAN as (l & Hl).
+    clear FRACTRAN HR.
     destruct FRACTRAN_HALTING_on_exp_diophantine with n l as (f & Hf); auto.
     destruct (dio_formula_elem f) as (ll & _ & _ & G3).
     destruct (dio_elem_equation ll) as (c & _ & G4).

--- a/H10/Dio/dio_elem.v
+++ b/H10/Dio/dio_elem.v
@@ -699,7 +699,7 @@ Section diophantine_system.
   Fact df_weigth_2_size f : df_weight_2 f <= 3*df_size f.
   Proof. induction f; simpl in *; omega. Qed.
 
-  Theorem dio_repr_at_form n f : dio_repr_at (df_pred f) n (df_weight_1 f) (df_weight_2 f).
+  Lemma dio_repr_at_form n f : dio_repr_at (df_pred f) n (df_weight_1 f) (df_weight_2 f).
   Proof.
     revert n;
     induction f as [ a b | f IHf g IHg | f IHf g IHg | f IHf ]; intros n; simpl df_pred; simpl df_weight_1; simpl df_weight_2.
@@ -714,9 +714,9 @@ Section diophantine_system.
       most 4*s variables and such that df_pred f ν is equivalent to 
       the simultaneous satisfiability at ν of all the elementary constraints in l *)
 
-  Corollary dio_formula_elem f : { l | length l <= 1+3*df_size f
-                                    /\ (forall c x, In c l -> dc_vars c x -> x < 4*df_size f)  
-                                    /\  forall ν, df_pred f ν <-> exists φ, Forall (dc_eval φ ν) l }.
+  Theorem dio_formula_elem f : { l | length l <= 1+3*df_size f
+                                 /\ (forall c x, In c l -> dc_vars c x -> x < 4*df_size f)  
+                                 /\  forall ν, df_pred f ν <-> exists φ, Forall (dc_eval φ ν) l }.
   Proof.
     destruct (dio_repr_at_form 0 f) as [l r H0 H1 H2 H3 H4].
     exists ((r,dee_nat 0) :: l); split; [ | split ]; simpl length; try omega.

--- a/H10/Dio/dio_rt_closure.v
+++ b/H10/Dio/dio_rt_closure.v
@@ -64,24 +64,21 @@ Defined.
 
 Section df_rel_iter.
 
-  (** we show that for a linearly bounded diophantine binary relation R,
+  (** we show that for a diophantine binary relation R,
       the iterator fun n x y => rel_iter R n x y is also diophantine
       using the rel_iter_bounded characterization as:
 
-        rel_iter R n x y <-> exists q c, x*power k n < q /\ is_seq R c q n /\ is_digit c q 0 x /\ is_digit c q n y. *)
+        rel_iter R n x y <-> exists q c, is_seq R c q n /\ is_digit c q 0 x /\ is_digit c q n y. *)
 
-  Variable (R : nat -> nat -> Prop) (k : nat)
-           (Hk : forall x y, R x y -> y <= k*x)
-           (HR : dio_rel (fun ν => R (ν 1) (ν 0))).
+  Variable (R : nat -> nat -> Prop) (HR : dio_rel (fun ν => R (ν 1) (ν 0))).
 
   Lemma dio_rel_rel_iter n x y : 
                   𝔻P n -> 𝔻P x -> 𝔻P y
       -> 𝔻R (fun ν => rel_iter R (n ν) (x ν) (y ν)).
   Proof.
     intros Hn Hx Hy.
-    apply dio_rel_equiv with (1 := fun v => rel_iter_bound_equiv R k Hk (n v) (x v) (y v)).
+    apply dio_rel_equiv with (1 := fun v => rel_iter_seq_equiv R (n v) (x v) (y v)).
     dio_rel_auto.
-    apply dio_rel_power_subst with (R := fun p v => _ * p < _); auto.
   Defined.
 
   Hint Resolve dio_rel_rel_iter.
@@ -94,5 +91,5 @@ End df_rel_iter.
 
 Hint Resolve dio_rel_rel_iter.
 
-Check dio_rel_rel_iter.
-Print Assumptions dio_rel_rel_iter.
+Check dio_rel_rt.
+Print Assumptions dio_rel_rt.

--- a/H10/Dio/dio_single.v
+++ b/H10/Dio/dio_single.v
@@ -352,7 +352,9 @@ Section dio_poly_pos.
       destruct o; f_equal; auto.
   Qed.
 
-  Theorem dio_poly_eq_pos (e : dio_single nat P) : { m : nat & { p' : dio_polynomial (pos m) P & { q' | forall ν, dio_single_pred e ν <-> dio_single_pred (p',q') ν } } }.
+  Theorem dio_poly_eq_pos (e : dio_single nat P) : { m : nat 
+                                                 & { p' : dio_polynomial (pos m) P 
+                                                 & { q' | forall ν, dio_single_pred e ν <-> dio_single_pred (p',q') ν } } }.
   Proof.
     destruct e as (p,q).
     destruct (list_upper_bound (dp_var_list p++dp_var_list q)) as (m & Hm).

--- a/H10/FRACTRAN_DIO.v
+++ b/H10/FRACTRAN_DIO.v
@@ -29,26 +29,28 @@ Proof.
   exact (df_pred A v).
 Defined.
 
-Section FRACTRAN_REG_HALTING_DIO_LOGIC_SAT.
+Section FRACTRAN_HALTING_DIO_LOGIC_SAT.
 
-  Let f : FRACTRAN_REG_PROBLEM -> DIO_LOGIC_PROBLEM.
+  Let f : FRACTRAN_PROBLEM -> DIO_LOGIC_PROBLEM.
   Proof.
-    intros (l & x & H).
-    destruct FRACTRAN_HALTING_diophantine_1 with (1 := H) (x := fun _ : nat -> nat => x)
+    intros (l & x).
+    destruct FRACTRAN_HALTING_on_diophantine with (ll := l) (x := fun _ : nat -> nat => x)
       as (A & HA).
     + auto.
     + exact (A, fun _ => 0).
   Defined.
 
-  Theorem FRACTRAN_REG_HALTING_DIO_LOGIC_SAT : FRACTRAN_REG_HALTING ⪯ DIO_LOGIC_SAT.
+  Opaque FRACTRAN_HALTING_on_diophantine.
+
+  Theorem FRACTRAN_HALTING_DIO_LOGIC_SAT : FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT.
   Proof.
     exists f.
-    intros (l & x & H); simpl.
-    destruct FRACTRAN_HALTING_diophantine_1 with (1 := H) as (A & HA); simpl.
+    intros (l & x); simpl.
+    destruct FRACTRAN_HALTING_on_diophantine with (ll := l) as (A & HA); simpl.
     unfold DIO_LOGIC_SAT; rewrite HA; tauto.
   Qed.
 
-End FRACTRAN_REG_HALTING_DIO_LOGIC_SAT.
+End FRACTRAN_HALTING_DIO_LOGIC_SAT.
 
 (** An elementary diophantine problem is a list of elementary diophantine
     constraints and a valuation for the parameters. The question is whether

--- a/H10/H10.v
+++ b/H10/H10.v
@@ -51,16 +51,16 @@ Section DIO_SINGLE_SAT_H10.
 
 End DIO_SINGLE_SAT_H10.
 
-Theorem Fractran_UNDEC : Halt ⪯ FRACTRAN_REG_HALTING.
+Theorem Fractran_UNDEC : Halt ⪯ FRACTRAN_HALTING.
 Proof.
   eapply reduces_transitive. exact MM_HALTING_undec.
-  exact MM_FRACTRAN_REG_HALTING.
+  exact MM_FRACTRAN_HALTING.
 Qed.
 
 Theorem Hilberts_Tenth : Halt ⪯ PCP
                       /\ PCP ⪯ MM_HALTING
-                      /\ MM_HALTING ⪯ FRACTRAN_REG_HALTING
-                      /\ FRACTRAN_REG_HALTING ⪯ DIO_LOGIC_SAT
+                      /\ MM_HALTING ⪯ FRACTRAN_HALTING
+                      /\ FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT
                       /\ DIO_LOGIC_SAT ⪯ DIO_ELEM_SAT
                       /\ DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT
                       /\ DIO_SINGLE_SAT ⪯ H10.
@@ -68,8 +68,8 @@ Proof.
   msplit 6.
   + apply Halt_PCP.
   + apply PCP_MM_HALTING.
-  + apply MM_FRACTRAN_REG_HALTING.
-  + apply FRACTRAN_REG_HALTING_DIO_LOGIC_SAT.
+  + apply MM_FRACTRAN_HALTING.
+  + apply FRACTRAN_HALTING_DIO_LOGIC_SAT.
   + apply DIO_LOGIC_ELEM_SAT.
   + apply DIO_ELEM_SINGLE_SAT.
   + apply DIO_SINGLE_SAT_H10.

--- a/H10/H10.v
+++ b/H10/H10.v
@@ -12,7 +12,7 @@ Require Import ILL.Definitions singleTM.
 Require Import utils_tac pos vec.
 Require Import mm_defs fractran_defs dio_logic dio_elem dio_single.
 
-Require Import HALT_MM MM_FRACTRAN FRACTRAN_DIO.
+Require Import HALT_MM MM_FRACTRAN FRACTRAN_DIO UNDEC.
 
 Set Implicit Arguments.
 
@@ -51,17 +51,37 @@ Section DIO_SINGLE_SAT_H10.
 
 End DIO_SINGLE_SAT_H10.
 
-Theorem Hilberts_Tenth : Halt ⪯ H10.
+Theorem Fractran_UNDEC : Halt ⪯ FRACTRAN_REG_HALTING.
 Proof.
   eapply reduces_transitive. exact MM_HALTING_undec.
-  eapply reduces_transitive. exact MM_FRACTRAN_REG_HALTING.
-  eapply reduces_transitive. exact FRACTRAN_REG_HALTING_DIO_LOGIC_SAT.
-  eapply reduces_transitive. exact DIO_LOGIC_ELEM_SAT.
-  eapply reduces_transitive. exact DIO_ELEM_SINGLE_SAT.
-  exact DIO_SINGLE_SAT_H10.
+  exact MM_FRACTRAN_REG_HALTING.
 Qed.
 
-Check Hilberts_Tenth.
+Theorem Hilberts_Tenth : Halt ⪯ PCP
+                      /\ PCP ⪯ MM_HALTING
+                      /\ MM_HALTING ⪯ FRACTRAN_REG_HALTING
+                      /\ FRACTRAN_REG_HALTING ⪯ DIO_LOGIC_SAT
+                      /\ DIO_LOGIC_SAT ⪯ DIO_ELEM_SAT
+                      /\ DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT
+                      /\ DIO_SINGLE_SAT ⪯ H10.
+Proof.
+  msplit 6.
+  + apply Halt_PCP.
+  + apply PCP_MM_HALTING.
+  + apply MM_FRACTRAN_REG_HALTING.
+  + apply FRACTRAN_REG_HALTING_DIO_LOGIC_SAT.
+  + apply DIO_LOGIC_ELEM_SAT.
+  + apply DIO_ELEM_SINGLE_SAT.
+  + apply DIO_SINGLE_SAT_H10.
+Qed.
+
+Theorem H10_undec : Halt ⪯ H10.
+Proof.
+  repeat (eapply reduces_transitive; [ apply Hilberts_Tenth | ]).
+  apply reduces_reflexive.
+Qed.
+
+Check H10_undec.
 Print Assumptions Hilberts_Tenth.
   
     

--- a/H10/HALT_MM.v
+++ b/H10/HALT_MM.v
@@ -17,12 +17,17 @@ From Undecidability.PCP Require Import singleTM TM_SRH SRH_SR SR_MPCP MPCP_PCP.
 
 Set Implicit Arguments.
 
-Corollary MM_HALTING_undec : Halt ⪯ MM_HALTING.
+Corollary Halt_PCP : Halt ⪯ PCP.
 Proof.
   eapply reduces_transitive. exact TM_SRH.Halt_SRH.
   eapply reduces_transitive. exact SRH_SR.reduction.
   eapply reduces_transitive. exact SR_MPCP.reduction.
-  eapply reduces_transitive. exact MPCP_PCP.reduction.
+  exact MPCP_PCP.reduction.
+Qed.
+
+Corollary MM_HALTING_undec : Halt ⪯ MM_HALTING.
+Proof.
+  eapply reduces_transitive. exact Halt_PCP.
   exact PCP_MM_HALTING.
 Qed.
 

--- a/H10/MM_FRACTRAN.v
+++ b/H10/MM_FRACTRAN.v
@@ -19,26 +19,24 @@ Require Import fractran_defs prime_seq mm_fractran.
 
 Set Implicit Arguments.
 
-(** Given a regular FRACTRAN program and a starting state, does it terminate *)
+(** Given a FRACTRAN program and a starting state, does it terminate *)
 
-Definition FRACTRAN_REG_PROBLEM := { l : list (nat*nat) & { _ : nat | fractran_regular l } }%type.
+Definition FRACTRAN_PROBLEM := (list (nat*nat) * nat)%type.
 
-Definition FRACTRAN_REG_HALTING (P : FRACTRAN_REG_PROBLEM) : Prop.
+Definition FRACTRAN_HALTING (P : FRACTRAN_PROBLEM) : Prop.
 Proof.
-  destruct P as (l & x & _).
+  destruct P as (l & x).
   exact (l /F/ x ↓).
 Defined.
 
-(** Given a regular FRACTRAN program and a starting vector [v1,...,vn],
+(** Given a FRACTRAN program and a starting vector [v1,...,vn],
     does the program terminate starting from p1 * q1^v1 * ... qn^vn *)
 
-Definition FRACTRAN_ALT_PROBLEM := { n : nat & 
-                                   { l :list (nat*nat) & 
-                                   { _ : vec nat n | fractran_regular l } } }%type.
+Definition FRACTRAN_ALT_PROBLEM := (list (nat*nat) * { n : nat & vec nat n })%type.
 
-Definition FRACTRAN_ALT_HALTING (P : FRACTRAN_ALT_PROBLEM) : Prop.
+Definition FRACTRAN_ALT_HALTING : FRACTRAN_ALT_PROBLEM -> Prop.
 Proof.
-  destruct P as (n & l & v & _).
+  intros (l & n & v).
   exact (l /F/ ps 1 * exp 1 v ↓).
 Defined.
 
@@ -48,7 +46,9 @@ Section MM_HALTING_FRACTRAN_ALT_HALTING.
   Proof.
     intros (n & P & v); red.
     destruct (mm_fractran_n P) as (l & H1 & _).
-    exists n, l, v; apply H1.
+    split. 
+    + exact l. 
+    + exists n; exact v.
   Defined.
 
   Theorem MM_FRACTRAN_ALT_HALTING : MM_HALTING ⪯ FRACTRAN_ALT_HALTING.
@@ -59,27 +59,26 @@ Section MM_HALTING_FRACTRAN_ALT_HALTING.
 
 End MM_HALTING_FRACTRAN_ALT_HALTING.
 
-Section FRACTRAN_ALT_HALTING_REG_HALTING.
+Section FRACTRAN_ALT_HALTING_HALTING.
 
-  Let f : FRACTRAN_ALT_PROBLEM -> FRACTRAN_REG_PROBLEM.
+  Let f : FRACTRAN_ALT_PROBLEM -> FRACTRAN_PROBLEM.
   Proof.
-    intros (n & l & v & H).
-    exists l, (ps 1 * exp 1 v); apply H.
+    intros (l & n & v).
+    exact (l,(ps 1 * exp 1 v)).
   Defined.
 
-  Theorem FRACTRAN_ALT_HALTING_REG_HALTING : FRACTRAN_ALT_HALTING ⪯ FRACTRAN_REG_HALTING.
+  Theorem FRACTRAN_ALT_HALTING_HALTING : FRACTRAN_ALT_HALTING ⪯ FRACTRAN_HALTING.
   Proof. 
-    exists f; intros (n & P & v & H); simpl; tauto.
+    exists f; intros (n & P & v); simpl; tauto.
   Qed.
 
-End FRACTRAN_ALT_HALTING_REG_HALTING.
+End FRACTRAN_ALT_HALTING_HALTING.
 
-Corollary MM_FRACTRAN_REG_HALTING : MM_HALTING ⪯ FRACTRAN_REG_HALTING.
+Corollary MM_FRACTRAN_HALTING : MM_HALTING ⪯ FRACTRAN_HALTING.
 Proof.
   eapply reduces_transitive. apply MM_FRACTRAN_ALT_HALTING.
-  exact FRACTRAN_ALT_HALTING_REG_HALTING.
+  exact FRACTRAN_ALT_HALTING_HALTING.
 Qed.
 
-Check MM_FRACTRAN_REG_HALTING.
-Print Assumptions MM_FRACTRAN_REG_HALTING.
-   
+Check MM_FRACTRAN_HALTING.
+Print Assumptions MM_FRACTRAN_HALTING.

--- a/Problems/Reduction.v
+++ b/Problems/Reduction.v
@@ -3,6 +3,9 @@ Require Export Shared.Prelim.
 Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := exists f : X -> Y, forall x, p x <-> q (f x).
 Notation "p ⪯ q" := (reduces p q) (at level 50).
 
+Lemma reduces_reflexive X (p : X -> Prop) : p ⪯ p.
+Proof. exists (fun x => x); tauto. Qed.
+
 Lemma reduces_transitive X Y Z (p : X -> Prop) (q : Y -> Prop) (r : Z -> Prop) :
   p ⪯ q -> q ⪯ r -> p ⪯ r.
 Proof.

--- a/Shared/Libs/DLW/Utils/utils_list.v
+++ b/Shared/Libs/DLW/Utils/utils_list.v
@@ -245,6 +245,16 @@ Proof.
   inversion H2; subst.
   right; exists m; auto.
 Qed.
+
+Fact list_cons_app_cons_eq_inv X (l2 r1 r2 : list X) x y :
+       x::r1 = l2++y::r2 -> (l2 = nil /\ x = y /\ r1 = r2) 
+                          + { m | l2 = x::m /\ r1 = m++y::r2 }.
+Proof.
+  intros H.
+  destruct l2 as [ | z m ]; simpl in H.
+  + left; inversion H; auto.
+  + right; exists m; inversion H; auto.
+Qed.
  
 Fact list_app_inj X (l1 l2 r1 r2 : list X) : length l1 = length l2 -> l1++r1 = l2++r2 -> l1 = l2 /\ r1 = r2.
 Proof.


### PR DESCRIPTION
Hi Yannick ... I propose a shortened proof of the backward simulation one step FRACTRAN -> one step MM. The trick is the one with functionality of FRACTRAN and totality of MM combined with one step forward. 

Also some improvements of the code for better corresp. with the paper.

Do you agree merging in wip ?