### PR TITLE
Merged public changes for private complexity development

### DIFF
--- a/theories/L/AbstractMachines/AbstractHeapMachine.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachine.v
@@ -1,5 +1,6 @@
 From Undecidability.L Require Import L  Complexity.ResourceMeasures AbstractMachines.LargestVar.
 From Undecidability.L Require Export AbstractMachines.AbstractHeapMachineDef.
+Import AbstractHeapMachineDef.clos_notation.
 
 Require Import Lia.
 
@@ -465,6 +466,18 @@ Section Analysis.
                 | _ => simpl_list;cbn; eauto 5 ;
                       try now (rewrite <- Nat.le_add_r; eauto 5)
                 end).
+  Qed.
+
+  Lemma largestVarH_leq : largestVarH H <= largestVar s0.
+    edestruct subterm_property as (_&_&H').
+    apply largestVarH_bound. intros [] ? H''%(H' _ _).
+    eapply subterm_lam_inv in H''.
+    eapply subterm_largestVar. easy.
+  Qed.
+
+  Lemma largestVarC_V_leq : forall g, g el V -> largestVarC g <= largestVar s0.
+    edestruct subterm_property as (_&H'&_).
+    intros [] H''. apply H' in H''.  eapply subterm_lam_inv in H''. eapply subterm_largestVar. easy.
   Qed.
   
   (** *** Space *)

--- a/theories/L/AbstractMachines/AbstractHeapMachine.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachine.v
@@ -1,271 +1,335 @@
-From Undecidability.L Require Import L AbstractMachines.Programs Complexity.ResourceMeasures.
+From Undecidability.L Require Import L  Complexity.ResourceMeasures AbstractMachines.LargestVar.
+From Undecidability.L Require Export AbstractMachines.AbstractHeapMachineDef.
 
 Require Import Lia.
 
-  (** ** Abstract Heap Machine *)
-Section Lin.
+Lemma get_current H m H' alpha : put H m = (H', alpha) -> get H' alpha = Some m.
+Proof.
+  unfold put, get. intros [= <- <-].
+  rewrite nth_error_app2. now rewrite <- minus_n_n. reflexivity.
+Qed.
 
-  Let HA:=nat.
+Lemma put_extends H H' m b: put H m = (H',b) -> extended H H'.
+Proof.
+  unfold extended,get,put.
+  intros [= <- <-] ? ? ?. rewrite nth_error_app1;eauto using nth_error_Some_lt.
+Qed.
 
-  Notation clos := (Pro * HA)%type.
+Lemma step_functional : functional step.
+Proof.
+  intros ? ? ? R1 R2;inv R1;inv R2. all:congruence.
+Qed.
 
-  Inductive heapEntry := heapEntryC (g:clos) (alpha:HA).
+Lemma unfolds_functional H a k:
+  functional (unfolds H a k).
+Proof.
+  intros x y1 y2 R1 R2.
+  induction R1 in y2,R2|-*.
+  -inv R2. easy. nia.
+  -inv R2. nia. 
+   rewrite H1 in H4. inv H4.
+   f_equal.
+   eapply IHR1. eauto. 
+  -inv R2. f_equal.
+   eapply IHR1. easy.
+  -inv R2. f_equal. all: now auto.
+Qed.
 
-  (** *** Heaps *)
-  
-  Let Heap := list heapEntry.
-  Implicit Type H : Heap.
-  Definition put H e := (H++[e],|H|).
-  Definition get H alpha:= nth_error H alpha.
-  Definition extended H H' := forall alpha m, get H alpha = Some m -> get H' alpha = Some m.
+Lemma unfolds_bound H k s s' a:
+  unfolds H a k s s'
+  -> bound k s'.
+Proof.
+  induction 1.
+  -now constructor. 
+  -econstructor. eapply bound_ge;eauto. omega.
+  -now constructor.
+  -now constructor. 
+Qed.
 
-  Lemma get_current H m H' alpha : put H m = (H', alpha) -> get H' alpha = Some m.
-  Proof.
-    unfold put, get. intros [= <- <-].
-    rewrite nth_error_app2. now rewrite <- minus_n_n. reflexivity.
-  Qed.
 
-  Lemma put_extends H H' m b: put H m = (H',b) -> extended H H'.
-  Proof.
-    unfold extended,get,put.
-    intros [= <- <-] ? ? ?. rewrite nth_error_app1;eauto using nth_error_Some_lt.
-  Qed.
+Lemma reprC_functional H :
+  functional (reprC H ).
+Proof.
+  intros x y1 y2 R1 R2.
+  inv R1. inv R2.
+  f_equal.
+  eapply unfolds_functional. all:now eauto.
+Qed.
 
-  Fixpoint lookup H alpha x : option clos:=
-    match get H alpha with
-      Some (heapEntryC bound env') =>
-      match x with
-        0 => Some bound
-      | S x' => lookup H env' x'
-      end
-    |  _ => None
-    end.
+Lemma unfolds_subst' H s s' t' a a' k g:
+  get H a' = Some (heapEntryC g a) ->
+  reprC H g t' ->
+  unfolds H a (S k) s s' ->
+  unfolds H a' k s (subst s' k t').
+Proof.
+  intros H1 R I__s. remember (S k) as k' eqn:eq__k.
+  induction I__s in H1,k,eq__k|-*. all:subst k0. 
+  -cbn. destruct (Nat.eqb_spec n k).
+   +assert (H':lookup H a' (n-k) = Some g).
+    {subst n. cbn. rewrite Nat.sub_diag. cbn. rewrite H1. reflexivity. }
+    inv R.
+    econstructor.
+    all:try eauto using unfolds;try omega. 
+   +econstructor. omega.      
+  -rename s into u.
+   assert (H':lookup H a' (n-k) = Some (u,b)).
+   {destruct n. omega. rewrite Nat.sub_succ_l. cbn. rewrite H1. now rewrite Nat.sub_succ in H2. omega. }
+   rewrite bound_closed_k.
+   2:{ eapply bound_ge with (k:=0). 2:omega. now eauto using unfolds,unfolds_bound. }
+   econstructor. all:try eassumption;omega.
+  -econstructor. all:eauto.
+  -econstructor. all:eauto.
+Qed.
 
- (** *** Reduction Rules *)
 
-  Definition state := (list clos * list clos *Heap)%type.
+Lemma unfolds_subst H s s' t' a a' g:
+  get H a' = Some (heapEntryC g a) ->
+  reprC H g t' ->
+  unfolds H a 1 s s' ->
+  unfolds H a' 0 s (subst s' 0 t').
+Proof.
+  apply unfolds_subst'.
+Qed.
 
-  Hint Transparent state.
 
-  Inductive step : state -> state -> Prop :=
-    step_pushVal P P' Q a T V H:
-      jumpTarget 0 [] P = Some (Q,P')
-      ->step (((lamT::P),a)::T,V,H) ((P',a)::T,(Q,a)::V,H)
-  | step_beta a b g P Q H H' c T V:
-      put H (heapEntryC g b) = (H',c)
-      -> step ((appT::P,a)::T,g::(Q,b)::V,H) ((Q,c) ::(P,a)::T,V,H')
-  | step_load P a x g T V H:
-      lookup H a x = Some g
-      -> step ((varT x::P,a)::T,V,H) ((P,a)::T,g::V,H)
-  | step_nil a T V H: step (([],a)::T,V,H) (T,V,H).
+Lemma bound_unfolds_id H k s a:
+  bound k s ->
+  unfolds H a k s s.
+Proof.
+  induction 1.
+  -now constructor. 
+  -now constructor. 
+  -now constructor. 
+Qed.
 
-  Hint Constructors step.
 
-  (** *** Unfolding *)
-  
-  Inductive unfolds H a: nat -> term -> term -> Prop :=
-  | unfoldsUnbound k n :
-      n < k ->
-      unfolds H a k (var n) (var n)
-  | unfoldsBound k b P s s' n:
-      n >= k ->
-      lookup H a (n-k) = Some (P,b) ->
-      reprP P s ->
-      unfolds H b 0 s s' ->
-      unfolds H a k (var n) s'
-  | unfoldsLam k s s':
-      unfolds H a (S k) s s' ->
-      unfolds H a k (lam s) (lam s')
-  | unfoldsApp k (s t s' t' : term):
-      unfolds H a k s s' ->
-      unfolds H a k t t' ->
-      unfolds H a k (s t) (s' t').
+Instance extended_PO :
+  PreOrder extended.
+Proof.
+  unfold extended;split;repeat intro. all:eauto.
+Qed.
 
-  Lemma unfolds_bound H k s s' a:
-    unfolds H a k s s'
-    -> bound k s'.
-  Proof.
-    induction 1.
-    -now constructor. 
-    -inv H2. inv H3. constructor. inv IHunfolds. eapply bound_ge. eauto. omega.
-    -now constructor.
-    -now constructor. 
-  Qed.
+Typeclasses Opaque extended.
 
-  Inductive reprC : Heap -> clos -> term -> Prop :=
-    reprCC H P s a s' :
-      reprP P s ->
-      unfolds H a 0 s s' ->
-      reprC H (P,a) s'.
-  
-  Lemma unfolds_subst' H s s' t' a a' k g:
-    get H a' = Some (heapEntryC g a) ->
-    reprC H g t' ->
-    unfolds H a (S k) s s' ->
-    unfolds H a' k s (subst s' k t').
-  Proof.
-    intros H1 R I__s. remember (S k) as k' eqn:eq__k.
-    induction I__s in H1,k,eq__k|-*. all:subst k0. 
-    -cbn. destruct (Nat.eqb_spec n k).
-     +assert (H':lookup H a' (n-k) = Some g).
-      {subst n. cbn. rewrite Nat.sub_diag. cbn. rewrite H1. reflexivity. }
-      inv R.
-      econstructor.
-      all:try eassumption;try omega.
-     +econstructor. omega.      
-    -rename s into u.
-     assert (H':lookup H a' (n-k) = Some (P,b)).
-     {destruct n. omega. rewrite Nat.sub_succ_l. cbn. rewrite H1. now rewrite Nat.sub_succ in H2. omega. }
-     rewrite bound_closed_k.
-     2:{ eapply bound_ge with (k:=0). 2:omega. now eauto using unfolds_bound. }
-     econstructor. all:try eassumption;omega.
-    -econstructor. all:eauto.
-    -econstructor. all:eauto.
-  Qed.
+Lemma lookup_extend H H' a x g:
+  extended H H' -> lookup H a x = Some g -> lookup H' a x = Some g.
+Proof.
+  induction x in H,H',a,g|-*;intros H1 H2.
+  all:cbn in H2|-*.
+  all:destruct get as [[]|]eqn:H3.
+  all:try congruence.
+  all:try rewrite (H1 _ _ H3).
+  all:try congruence.
+  eapply IHx;eauto.
+Qed.
 
-  
-  Lemma unfolds_subst H s s' t' a a' g:
-    get H a' = Some (heapEntryC g a) ->
-    reprC H g t' ->
-    unfolds H a 1 s s' ->
-    unfolds H a' 0 s (subst s' 0 t').
-  Proof.
-    apply unfolds_subst'.
-  Qed.
+Lemma unfolds_extend H H' a s t k :
+  extended H H' ->
+  unfolds H a k s t ->
+  unfolds H' a k s t.
+Proof.
+  induction 2.
+  all:econstructor. 1-2,4-8:now eauto. erewrite lookup_extend;eauto.
+Qed.
 
-  
-  Lemma bound_unfolds_id H k s a:
-    bound k s ->
-    unfolds H a k s s.
-  Proof.
-    induction 1.
-    -now constructor. 
-    -now constructor. 
-    -now constructor. 
-  Qed.
-  
+Instance unfold_extend_Proper : Proper (extended ==> eq ==> eq ==> eq ==> eq ==>Basics.impl) unfolds.
+Proof.
+  repeat intro. subst. eapply unfolds_extend.  all:eassumption.
+Qed.
 
-  Instance extended_PO :
-    PreOrder extended.
-  Proof.
-    unfold extended;split;repeat intro. all:eauto.
-  Qed.
+Lemma reprC_extend H H' g s:
+  extended H H' ->
+  reprC H g s ->
+  reprC H' g s.
+Proof.
+  inversion 2. subst. eauto using reprC, unfolds_extend.
+Qed.
 
-  Typeclasses Opaque extended.
-  
-  Lemma lookup_extend H H' a x g:
-    extended H H' -> lookup H a x = Some g -> lookup H' a x = Some g.
-  Proof.
-    induction x in H,H',a,g|-*;intros H1 H2.
-    all:cbn in H2|-*.
-    all:destruct get as [[]|]eqn:H3.
-    all:try congruence.
-    all:try rewrite (H1 _ _ H3).
-    all:try congruence.
-    eapply IHx;eauto.
-  Qed.
+Lemma In_extend H H' g:
+  extended H H' ->
+  g el H ->
+  g el H'.
+Proof.
+  unfold extended,get.
+  intros H1 H2.
+  eapply In_nth_error in H2 as (?&H2).
+  apply H1 in H2. eauto using nth_error_In.
+Qed.
 
-  Lemma unfolds_extend H H' a s t k :
-    extended H H' ->
-    unfolds H a k s t ->
-    unfolds H' a k s t.
-  Proof.
-    induction 2.
-    all:econstructor. 1-2,4-8:now eauto. erewrite lookup_extend;eauto.
-  Qed.
+Instance reprC_extend_Proper : Proper (extended ==> eq ==> eq ==>Basics.impl) reprC.
+Proof.
+  repeat intro. subst. eapply reprC_extend.  all:eassumption.
+Qed.
 
-  Lemma reprC_extend H H' g s:
-    extended H H' ->
-    reprC H g s ->
-    reprC H' g s.
-  Proof.
-    inversion 2. subst. eauto using reprC, unfolds_extend.
-  Qed.
+(** *** Time *)
 
-  (** *** Time *)
-  
-  Lemma correctTime' s t k s0 P a T V H:
+Lemma correctTime' s t k s0 a T V H:
   timeBS k s t -> unfolds H a 0 s0 s ->
   exists g l H', reprC H' g t
-            /\ pow step l ((compile s0++P,a)::T,V,H)
-                  ((P,a)::T,g::V,H') /\ l = 4*k+1 /\ extended H H'.
-  Proof.
-    intros Ev R.
-    induction Ev in s0,P,a,T,V,H,R |-*.
-    -inversion R.
-     +subst k s' s0. clear H0 R. rename P0 into Q,H3 into R.
-      rewrite Nat.sub_0_r in H1.
-      eexists (Q , b),1,H.
-      repeat split.
-      *eauto using reprC.
-      *cbn [compile]. apply (rcomp_1 step).  now constructor. 
-      *hnf. tauto.
-     +subst k s' s0. clear R. rename H3 into R.
-      eexists (compile s1 , a),1,H.
-      repeat split.
-      *eauto using reprC,reprP,unfolds.
-      *cbn [compile Datatypes.app]; autorewrite with list;cbn [Datatypes.app].
-       apply (rcomp_1 step). constructor. apply jumpTarget_correct.
-      *hnf. tauto.
-    -inv R. 
-     {exfalso. inv H3. inv H4. } 
-     rename t0 into t1. rename H5 into I__s, H6 into I__t.
-     cbn [compile List.app]; autorewrite with list; cbn [List.app]. 
-     specialize (IHEv1 _ (compile t1 ++ appT ::P) _ T V _ I__s)
-       as ([P__temp a2]&k1&Heap1&rep1&R1&eq_k1&Ext1).
-     inv rep1. inv H4. inv H6. rename H3 into I__s'.
-     apply (unfolds_extend Ext1) in I__t.
-     specialize (IHEv2 _ (appT ::P) _ T ((compile s2,a2)::V) _ I__t)
-                 as (g__t&k2&Heap2&rep2&R2&eq2&Ext2).
-     edestruct (put Heap2 (heapEntryC g__t a2)) as [Heap2' a2'] eqn:eq.
-     assert (Ext2' := (put_extends eq)).
-     apply ( reprC_extend Ext2') in rep2.
-     apply ( unfolds_extend Ext2) in I__s'. apply ( unfolds_extend Ext2') in I__s'.
+            /\ pow step l (closT(s0,a)::T,V,H)
+                  (T,g::V,H') /\ l = 4*k+1 /\ extended H H'.
+Proof.
+  intros Ev R.
+  induction Ev in s0,a,T,V,H,R |-*.
+  -inversion R.
+   +subst k s' s0. clear H1 R. rename H5 into R.
+    rewrite Nat.sub_0_r in H2.
+    eexists (s1 , b),1,H.
+    repeat split.
+    *eauto using reprC.
+    *apply (rcomp_1 step).  now constructor. 
+    *hnf. tauto.
+   +subst k s' s0. clear R. rename H3 into R.
+    eexists (s1 , a),1,H.
+    repeat split.
+    *eauto.
+    *apply (rcomp_1 step). constructor.
+    *reflexivity.
+  -inv R. 
+   rename t0 into t1. rename H5 into I__s, H6 into I__t.
+   specialize (IHEv1 _ _ (closT (t1,a)::appT::T) V _ I__s)
+     as ((s0'&a')&k1&Heap1&rep1&R1&eq_k1&Ext1).
+   inv rep1. rename H3 into I__s'.
+   apply (unfolds_extend Ext1) in I__t.
+   specialize (IHEv2 _ _ (appT::T) ((s0',a')::V) _ I__t)
+     as (g__t&k2&Heap2&rep2&R2&eq2&Ext2).
+   edestruct (put Heap2 (heapEntryC g__t a')) as [Heap2' a2'] eqn:eq.
+   assert (Ext2' := (put_extends eq)).
+   apply ( reprC_extend Ext2') in rep2.
+   apply ( unfolds_extend Ext2) in I__s'. apply ( unfolds_extend Ext2') in I__s'.
 
-     specialize (unfolds_subst (get_current eq) rep2 I__s') as I__subst.
-     edestruct (IHEv3 _ [] _ ((P,a)::T) V _ I__subst) as (g__u&k3&Heap3&rep3&R3&eq3&Ext3).
-     eexists g__u,_,Heap3. 
-     split;[ | split;[| split]].
-     +eassumption.
-     +apply pow_add. eexists. split.
-      { exact R1. }
-      apply pow_add. eexists. split.
-      { exact R2. }
-      apply pow_add. eexists. split.
-      { apply (rcomp_1 step). constructor;eassumption. }
-      autorewrite with list in R3.
-      apply pow_add. eexists. split.
-      {exact R3. }
-      now apply (rcomp_1 step); constructor.
-     +lia.
-     +rewrite Ext1,Ext2,Ext2',Ext3. reflexivity.
-  Qed.
-  
-  Definition init s :state := ([(compile s,0)],[],[]).
+   specialize (unfolds_subst (get_current eq) rep2 I__s') as I__subst.
+   edestruct (IHEv3 _ _ T V _ I__subst) as (g__u&k3&Heap3&rep3&R3&eq3&Ext3).
+   eexists g__u,(1+ (_+(k2+(1+k3)))),Heap3. 
+   split;[ | split;[| split]].
+   +eassumption.
+   +apply pow_add. eexists. split.
+    { apply (rcomp_1 step). constructor;eassumption. }
+    apply pow_add. eexists. split.
+    { exact R1. }
+    apply pow_add. eexists. split.
+    { exact R2. }
+    apply pow_add. eexists. split.
+    { apply (rcomp_1 step). constructor;eassumption. }
+    {exact R3. }
+   +lia.
+   +rewrite Ext1,Ext2,Ext2',Ext3. reflexivity.
+Qed.
 
-  
-  Lemma correctTime s t k:
-    timeBS k s t -> closed s ->
-    exists g H, reprC H g t
-           /\ pow step (4*k+2) (init s)
-                  ([],[g],H).
-  
-  Proof.
-    intros H1 H2.
-    edestruct (correctTime' (s0:=s) (a:=0) (H:=[]) [] [] [] H1)
-      as (g&l&H'&rep&R&eq&_).
-    -apply bound_unfolds_id. eauto using closed_k_bound.
-    -autorewrite with list in R.
-      exists g,H'. split. assumption.
-     replace (4 * k + 2) with ((4 * k + 1)+1) by omega.
-     apply pow_add. eexists;split. subst l;eassumption.
-     apply (rcomp_1 step). constructor. 
-  Qed.
 
-End Lin.
 
-Notation clos := (Pro * nat)%type.
+Lemma correctTime s t k:
+  timeBS k s t -> closed s ->
+  exists g H, reprC H g t
+         /\ pow step (4*k+1) (init s)
+               ([],[g],H).
 
+Proof.
+  intros H1 H2.
+  edestruct (correctTime' (s0:=s) (a:=0) (H:=[]) [] [] H1)
+    as (g&l&H'&rep&R&eq&_).
+  -apply bound_unfolds_id. eauto using closed_k_bound.
+  -autorewrite with list in R.
+   exists g,H'. split. assumption. subst l.
+   eassumption.
+Qed.
+
+(** *** Soundness  *)
+Definition evaluatesIn (X : Type) (R : X -> X -> Prop) n (x y : X) := pow R n x y /\ terminal R y.
+
+Lemma soundness' s0 s a T V H k sigma:
+  evaluatesIn step k (closT(s0,a)::T,V,H) sigma ->
+  unfolds H a 0 s0 s ->
+  exists k1 k2 g H' t n, k = k1 + k2
+                    /\ pow step k1 (closT(s0,a)::T,V,H) (T,g::V,H')
+                    /\ evaluatesIn step k2 (T,g::V,H') sigma
+                    /\ ResourceMeasures.timeBS n s t
+                    /\ extended H H'
+                    /\ reprC H' g t
+                    /\ k1 = 4*n+1.
+Proof.
+  intros [R Ter].
+  revert s s0 a T V H R.
+  induction k as [k IH] using lt_wf_ind .
+  intros s s0 a T V H R Unf.
+  assert (exists k', k = 1 + k') as (k'&->).
+  {destruct k. 2:easy.
+   exfalso. inv R. inv Unf.
+   1:easy.
+   all:eapply Ter.
+   1:rewrite Nat.sub_0_r in H1.
+   all:eauto using step.
+  }
+  apply pow_add in R as (?&R0&R).
+  apply rcomp_1 in R0.
+  inv R0.
+  -inv Unf. eexists 1,k',_,_,_,0.
+   repeat eapply conj.
+   2:apply rcomp_1 with (R:=step).
+   3:{ exact R. }
+   6:{ now econstructor. }
+   all:try easy;eauto using timeBS,step.
+   
+  -inv Unf. easy.
+   rewrite Nat.sub_0_r in H2.
+   rewrite H2 in H7. inv H7.
+   
+   eexists 1,k',_,_,_,0.
+   repeat eapply conj.
+   2:apply rcomp_1 with (R:=step).
+   3:{ exact R. }
+   6:{ now econstructor. }
+   all:try easy;eauto using timeBS,step.
+  -inversion Unf as [| | | tmp1 tmp2 tmp3 tmp4 tmp5 Unf1 Unf2]. subst tmp1 tmp2 tmp3 s.
+   edestruct IH with (2:=R) (3:=Unf1) as (k11&k12&[s1' a']&H'1&t1&n1&eq1&R11&[R12 _]&Ev1&Ext1&Rg1&eqn1). now omega.
+   rewrite Ext1 in Unf2.
+   edestruct IH with (2:=R12) (3:=Unf2) as (k21&k22&g2&H'2&t2&n2&eq2&R21&[R22 _]&Ev2&Ext2&Rg2&eqn2). now omega.
+   setoid_rewrite Ext2 in Rg1.
+   
+   assert (exists k22', k22 = 1 + k22') as (k22'&->).
+   {destruct k22. 2:eauto. exfalso.
+    inv R22. eapply Ter. econstructor. reflexivity.
+   }
+   apply pow_add with (R:= step) in R22 as (x&R22&R3).
+   apply rcomp_1 in R22. inversion R22 as [|  AA BB CC DD H3 b GG HH | |]. subst AA BB CC GG HH DD. subst x.
+   assert (Ext2':=put_extends H0).
+   inversion Rg1 as [AA BB CC t1' Unft']. subst AA BB CC t1.
+   edestruct IH with (2:=R3) as (k31&k32&g3&H'3&t3&n3&eq3&R31&[R32 _]&Ev3&Ext3&Rg3&eqn3).
+   1:now omega.
+   1:{ eapply unfolds_subst. now eauto using get_current.
+       all:setoid_rewrite <- Ext2'. all:eauto.
+   }
+   eexists (1+(k11+(k21+(1+k31)))),k32,_,_,_,_.
+   repeat eapply ex_intro. repeat eapply conj.
+   +omega.
+   +repeat (eapply pow_add with (R:=step);eexists;split).
+    all:try eapply rcomp_1 with (R:=step).
+    all:now eauto using step.
+   +eassumption.
+   +eauto.
+   +inv Rg1. inv Rg2. inv Rg3. econstructor.
+    all:try eassumption. reflexivity.
+   +setoid_rewrite Ext1. setoid_rewrite Ext2. setoid_rewrite Ext2'. easy.
+   +eassumption.
+   +omega.
+Qed.
+
+Lemma soundness k s sigma:
+  closed s -> 
+  evaluatesIn step k (init s) sigma ->
+  exists g H t n , sigma = ([],[g],H) /\ ResourceMeasures.timeBS n s t /\ reprC H g t /\ k = 4*n+1.
+Proof.
+  intros cs [R Ter].
+  edestruct soundness' as (k1&k2&g&H&t&n&eq&R1&[R2 _]&Ev&_&Rgt&->).
+  -split. all:eassumption.
+  -apply bound_unfolds_id. eapply closed_dcl. eassumption.
+  -assert (k2 = 0) as ->.
+   {destruct k2 as [|]. easy.
+    destruct R2 as (?&R'&R2). inv R'.
+   }
+   inv R2.
+   eauto 10.
+Qed.
 
 Lemma lookup_el H alpha x e: lookup H alpha x = Some e -> exists beta, heapEntryC e beta el H.
 Proof.
@@ -276,32 +340,137 @@ Proof.
   all:eauto using nth_error_In.
 Qed.
 
+
+Lemma lookup_size H a n q: lookup H a n = Some q -> largestVarC q <= largestVarH H.
+Proof.
+  intros (b&?)%lookup_el.
+  eapply maxl_leq. eapply in_map_iff. eexists (heapEntryC _ _). eauto.
+Qed.
+
+
+Lemma largestVarH_bound H c:
+  (forall q beta, heapEntryC q beta el H -> largestVarC q <= c) -> largestVarH H <= c.
+Proof.
+  intros H'. eapply maxl_leq_l. setoid_rewrite in_map_iff.
+  intros ? ([]&<-&?). eauto.
+Qed.
+
+
+Inductive subterm (s:term) : term -> Prop :=
+  subtermR : subterm s s
+| subtermAppL (s' t:term) : subterm s s' -> subterm s (s' t)
+| subtermAppR (t s':term) : subterm s s' -> subterm s (t s')
+| subtermLam s': subterm s s' -> subterm s (lam s').
+
+Instance subtermPO : PreOrder subterm.
+Proof.
+  split. now constructor.
+  intros x y z H1 H2.
+  induction H2 in H1,x|-*. all:eauto using subterm.
+Qed.
+
+Lemma subterm_lam_inv s s0 :
+  subterm (lam s) s0 -> subterm s s0.
+Proof.
+  intros.  rewrite <- H. eauto using subterm.
+Qed.
+
+Lemma subterm_app_l s t s0 :
+  subterm (app s t) s0 -> subterm s s0.
+Proof.
+  intros. rewrite <- H. eauto using subterm.
+Qed.
+
+Lemma subterm_app_r s t s0 :
+  subterm (app s t) s0 -> subterm t s0.
+Proof.
+  intros. rewrite <- H. eauto using subterm.
+Qed.
+
+Lemma subterm_largestVar s s' :
+  subterm s s' -> largestVar s <= largestVar s'.
+Proof.
+  induction 1;cbn;Lia.nia.
+Qed.
+
 Section Analysis.
 
-  Variable s : term.
- (* Hypothesis cs : closed s.*)
-  Variable T V : list clos.
+  Variable s0 : term.
+  (* Hypothesis cs : closed s.*)
+  Variable T : list task.
+  Variable V : list clos.
   Variable H: list heapEntry.
   Variable i : nat.
 
-  Hypothesis R: pow step i (init s) (T,V,H).
+  Hypothesis R: pow step i (init s0) (T,V,H).
 
-
-  Lemma jumpTarget_eq c c0 c1 c2: jumpTarget 0 c0 c = Some (c1,c2) -> c1++[retT]++c2=c0++c.
+  Lemma subterm_property:
+    (forall s a, closT (s,a) el T -> subterm s s0)
+    /\ (forall s a, (s,a) el V -> subterm (lam s) s0)
+    /\ (forall s a b, heapEntryC (s,a) b el H -> subterm (lam s) s0).
   Proof.
-    generalize 0 as k. 
-    induction c as [|[]] in c1,c2,c0|-*;cbn. congruence.
-    all:intros ? H'.
-    4:destruct k;[inv H';congruence|].
-    all:apply IHc in H'. 
-    all:autorewrite with list in *.
-    all:now cbn in *. 
+    induction i in R,T,V,H|-*.
+    {inv R. cbn. intuition. inv H0. eauto using subterm. }
+    replace (S n) with (n + 1) in R by omega.
+    apply pow_add with (R:=step) in R. destruct R as [[[T' V'] H'] [R1 R2]].
+    specialize IHn with (1:=R1) as (IH__T&IH__V&IH__H).
+    eapply rcomp_1 in R2.
+    inv R2.
+    all:cbn in *.
+    all:(repeat split;repeat intro;
+         repeat lazymatch goal with
+                | H : (_,_)=(_,_) |- _ => inv H
+                | H : heapEntryC _ _=heapEntryC _ _ |- _ => inv H
+                | H : closT _ = closT _ |- _ => inv H
+                | H : _ \/ _ |- _=> inv H
+                | H : lookup H _ _ = Some _ |- _=> eapply lookup_el in H as (?&?)
+                | H : appT = closT _ |- _ => inv H
+                | H : put _ _ = (_, _) |- _ =>
+                  inv H
+                | H : _ el (_ ++ _) |- _ =>
+                  apply in_app_or in H;cbn in H
+                | _ => eauto 5 using subterm ; eauto 5 using subterm,subterm_lam_inv,In_extend,lookup_el,subterm_app_l,subterm_app_r
+                end).
   Qed.
 
+  Lemma adress_size:
+    (forall s a, closT (s,a) el T -> a <= length H)
+    /\ (forall s a, (s,a) el V -> a <= length H)
+    /\ (forall s a b, heapEntryC (s,a) b el H -> a <= length H /\ b <= length H).
+  Proof.
+    induction i in R,T,V,H|-*.
+    {inv R. cbn. intuition. inv H0. eauto using subterm. }
+    replace (S n) with (n + 1) in R by omega.
+    apply pow_add with (R:=step) in R. destruct R as [[[T' V'] H'] [R1 R2]].
+    specialize IHn with (1:=R1) as (IH__T&IH__V&IH__H).
+    eapply rcomp_1 in R2.
+    inv R2.
+    all:cbn in *.
+    all:(repeat split;repeat intro;
+         repeat lazymatch goal with
+                  
+                | H : (_,_)=(_,_) |- _ => inv H 
+                | H : heapEntryC _ _=heapEntryC _ _ |- _ => inv H 
+                | H : closT _ = closT _ |- _ => inv H
+                | H : _ \/ _ |- _=> inv H
+                | H : lookup H _ _ = Some _ |- _=> eapply lookup_el in H as (?&?)
+                | H : appT = closT _ |- _ => inv H 
+                | H : put _ _ = (_, _) |- _ =>
+                  inv H
+                | H : _ el (_ ++ _) |- _ =>
+                  apply in_app_or in H;cbn in H
+                | H : heapEntryC (_, _) _ el _ |- _ =>
+                  eapply IH__H in H as []
+                (*| _ => once ((rewrite IH__H + rewrite IH__V + rewrite IH__T);[easy|])*)
+                | _ => simpl_list;cbn; eauto 5 ;
+                      try now (rewrite <- Nat.le_add_r; eauto 5)
+                end).
+  Qed.
+  
   (** *** Space *)
-
-  Lemma size_clos P a : ((P,a) el (T++V) -> sizeP P <= 2*size s /\ a <= length H)
-                        /\ (forall beta, heapEntryC (P,a) beta el H -> sizeP P <= 2*size s /\ a <= length H /\ beta <= length H).
+(*
+  Lemma size_clos P a : ((P,a) el (T++V) -> sizeP P <= 2*size s0 /\ a <= length H)
+                        /\ (forall beta, heapEntryC (P,a) beta el H -> sizeP P <= 2*size s0 /\ a <= length H /\ beta <= length H).
   Proof.
     unfold sizeP. 
     induction i in T,V,H,R,P,a|-*.
@@ -385,6 +554,219 @@ Section Analysis.
       omega.
   Qed.
 
+  Lemma largestVar_bound : (forall q, q el T -> largestVarC q <= largestVar s0)
+                           /\ (forall q, q el V -> largestVarC q <= largestVar s0)
+                           /\ (forall q beta, heapEntryC q beta el H -> largestVarC q <= largestVar s0).
+  Proof.
+    induction i in T,V,H,R|-*.
+    -inv R. repeat split.
+     +intros ? [<-|[]]. cbn. 
+      now rewrite largestVar_compile.
+     +intros ? [].
+     +intros ? ? [].
+    -replace (S n) with (n + 1) in R by omega.
+     apply pow_add in R. destruct R as [[[T' V'] H'] [R1 R2]].
+     specialize (IHn _ _ _ R1).
+     destruct IHn as [IHn1 [IHn2 IHn3]].
+     eapply rcomp_1 in R2.
+     repeat split;intros q.
+     +intros Hel.
+      inv R2. 
+      *apply jumpTarget_eq in H2.  cbn in H2;inv H2.
+       cbn in IHn1.
+       assert (max (largestVarP Q) (largestVarP P') <= largestVar s0).
+       { unfold largestVarP. erewrite <- IHn1. 2:left;reflexivity. cbn. autorewrite with list. cbn.
+         rewrite !maxl_app. cbn. Lia.lia. }
+       destruct Hel as [<- | ].
+       all:cbn in *.  all:try Lia.lia. all:intuition.
+      *inv H2.
+       cbn in *.
+       destruct Hel as [<- | [<-|]].
+       all:cbn.
+       --erewrite <- IHn2 with (q:=(_,_)). cbn. reflexivity. eauto.
+       --erewrite <- IHn1 . unfold largestVarP. 2:now left;eauto. cbn. Lia.lia.
+       --eauto.
+      *destruct Hel as [<-|]. cbn.
+       --erewrite <- IHn1 . unfold largestVarP. 2:now left;eauto. cbn. Lia.lia.
+       --eauto.
+      *eauto.
+     +intros Hel.
+      inv R2. 
+      *apply jumpTarget_eq in H2.  cbn in H2;inv H2.
+       cbn in IHn1.
+       assert (max (largestVarP Q) (largestVarP P') <= largestVar s0).
+       { unfold largestVarP. erewrite <- IHn1. 2:left;reflexivity. cbn. autorewrite with list. cbn.
+         rewrite !maxl_app. cbn. Lia.lia. }
+       destruct Hel as [<- | ].
+       all:cbn in *.  all:try Lia.lia. all:intuition.
+      *inv H2.
+       cbn in *. eauto. 
+      *destruct Hel as [<-|].
+       --apply lookup_el in H2 as (?&?). eauto.
+       --eauto.
+      *eauto.
+     +intros ? Hel. inv R2.
+      1,3,4:now eauto.
+      inv H2.
+      apply in_app_or in Hel.
+      edestruct Hel as [|[[= -> ->]|[]]].
+      --eauto.
+      --eauto.
+  Qed. *)
+(*
+  
+  Inductive subterm (u:term) :term -> Prop :=
+    subterm_here: subterm u u
+  | subterm_lam s: subterm u s -> subterm u (lam s)
+  | subterm_appL (s t:term): subterm u s -> subterm u (s t)
+  | subterm_appR (s t:term): subterm u t -> subterm u (s t).
+
+  Definition isSuffix {X} (P Q:list X) := exists pre, pre++P=Q.
+  
+  Definition isCA P : Prop := exists s', (s0=s' \/ subterm (lam s') s0) /\  isSuffix P (compile s').
+
+  Instance isSuffix_PO X: PreOrder (@isSuffix X).
+  Proof.
+    split.
+    -exists []. reflexivity.
+    -intros ? ? ? (a&<-) (b&<-).
+     exists (b++a). now autorewrite with list.
+  Qed.
+
+  Lemma compile_isCA s':
+    (s0 = s' \/ subterm (lam s') s0) -> isCA (compile s').
+  Proof.
+    intros. exists s'. split. eauto. reflexivity.
+  Qed.
+  
+  Lemma all_subterm :
+    (forall q, q el T -> isCA (fst q))
+    /\ (forall g, g el V -> exists s, fst g = compile s0 /\ subterm (lam s) s0)
+    /\ (forall g b, heapEntryC g b el H ->  exists s, fst g = compile s0 /\ subterm (lam s) s0).
+  Proof.
+    induction i in T,V,H,R|-*.
+    {inv R. repeat split. 2,3:easy.
+     -intros ? [<-|[]]. cbn. eauto using compile_isCA. }
+    replace (S n) with (n + 1) in R by omega.
+    apply pow_add in R. destruct R as [[[T' V'] H'] [R1 R2]].
+    specialize (IHn _ _ _ R1).
+    destruct IHn as [IHT [IHV IHH]].
+    eapply rcomp_1 in R2.
+    inv R2.
+    -repeat eapply conj. 3:easy.
+     all:intros ? [<-|];[|now eauto].
+     +specialize IHT with (1:=or_introl eq_refl). cbn in IHT |-*.
+
+      Lemma compile_start_lamT_subterm P0 P1 s :
+        lamT :: P1 = compile s ++ P0
+        -> exists s' rem, subterm (lam s') s
+                   /\ compile s = compile (lam s')++rem
+                   /\ P1 = compile s' ++ retT :: rem ++ P0.
+      Proof.
+        induction s as [n|s IHs t _ | s IHs] in P0,P1|-*.
+        all:cbn. all:intros eq.
+        -inv eq.
+        -rewrite <- !app_assoc in eq.
+         specialize IHs with (1:=eq) as (s'&eqm&eq1&eq2&->).
+         rewrite eq2. cbn.
+         eexists s',(eqm ++ compile t ++[appT]). cbn. repeat (try rewrite !app_assoc_reverse;cbn).
+         repeat split. eauto using subterm.
+        -exists s,[]. inv eq. autorewrite with list.
+         repeat split. eauto using subterm.
+      Qed.
+
+        
+      Lemma isCA_lamT P :
+        isCA (lamT :: P)
+        -> exists s' P', subterm (lam s') s0
+                   /\ P = compile s' ++ retT :: P'.
+      Proof.
+        intros (s&sub&suf).
+        specialize (compile_start_lamT_subterm) with (P0:=[]) as H'.
+        setoid_rewrite app_nil_r in H'.
+        specialize H' with (2:=)
+        pose (rem:=@nil Tok).
+        replace (pre ++ lamT :: P = compile s0) with (pre ++ [lamT] ++ P ++rem= compile s0++rem) in suf by now (subst rem;autorewrite with list).
+        clearbody rem.
+        induction s0 as [n | s0 IHs t0 IHt | s0 IHs] in rem,sub,suf,pre,P|-*.
+        -rewrite !app_assoc in suf. eapply app_inv_tail in suf. exfalso. destruct pre as [|?[]];inv suf.
+        -cbn in suf.
+         specialize IHs with (P:=)
+         autorewrite with list in suf. cbn in suf,IHs,IHt|-*.
+         eapply IHs in suf.
+        admit. -exfalso. cbn in *.
+        
+        -> jumpTarget 0 [] P = Some (Q, P')
+        ->isCA P'
+     all:firstorder.
+    repeat split;intros q.
+    +intros Hel.
+     inv R2. 
+     *apply jumpTarget_eq in H2.  cbn in H2;inv H2.
+      cbn in IHn1.
+      assert (max (largestVarP Q) (largestVarP P') <= largestVar s).
+       { unfold largestVarP. erewrite <- IHn1. 2:left;reflexivity. cbn. autorewrite with list. cbn.
+         rewrite !maxl_app. cbn. Lia.lia. }
+       destruct Hel as [<- | ].
+       all:cbn in *.  all:try Lia.lia. all:intuition.
+      *inv H2.
+       cbn in *.
+       destruct Hel as [<- | [<-|]].
+       all:cbn.
+       --erewrite <- IHn2 with (q:=(_,_)). cbn. reflexivity. eauto.
+       --erewrite <- IHn1 . unfold largestVarP. 2:now left;eauto. cbn. Lia.lia.
+       --eauto.
+      *destruct Hel as [<-|]. cbn.
+       --erewrite <- IHn1 . unfold largestVarP. 2:now left;eauto. cbn. Lia.lia.
+       --eauto.
+      *eauto.
+     +intros Hel.
+      inv R2. 
+      *apply jumpTarget_eq in H2.  cbn in H2;inv H2.
+       cbn in IHn1.
+       assert (max (largestVarP Q) (largestVarP P') <= largestVar s).
+       { unfold largestVarP. erewrite <- IHn1. 2:left;reflexivity. cbn. autorewrite with list. cbn.
+         rewrite !maxl_app. cbn. Lia.lia. }
+       destruct Hel as [<- | ].
+       all:cbn in *.  all:try Lia.lia. all:intuition.
+      *inv H2.
+       cbn in *. eauto. 
+      *destruct Hel as [<-|].
+       --apply lookup_el in H2 as (?&?). eauto.
+       --eauto.
+      *eauto.
+     +intros ? Hel. inv R2.
+      1,3,4:now eauto.
+      inv H2.
+      apply in_app_or in Hel.
+      edestruct Hel as [|[[= -> ->]|[]]].
+      --eauto.
+      --eauto.
+  Qed.
+
+  Lemma Hcompile:
+    (forall g b, heapEntryC g b el H -> exists s0, fst g = compile s0)
+    /\ (forall g, g el V -> exists s0, fst g = compile s0)
+    /\ (forall g, g el T -> exists P0 s0, fst g = compile s0).
+  Proof.
+    induction i in T,V,H,R|-*.
+    {inv R. easy. }
+    replace (S n) with (n + 1) in R by omega.
+    apply pow_add in R. destruct R as [[[T' V'] H'] [R1 R2]].
+    specialize (IHn _ _ _ R1).
+    eapply rcomp_1 in R2.
+    inv R2.
+    -split. repeat eapply conj.
+    all:try now apply IHn.
+    -
+    -
+    -
+    -
+    all:try cbn;firstorder.
+    1,3,4:now omega.
+    inv H2. autorewrite with list. cbn. omega.
+*)    
+
   Lemma length_H : length H <= i.
   Proof.
     induction i in T,V,H,R|-*.
@@ -398,30 +780,18 @@ Section Analysis.
      inv H2. autorewrite with list. cbn. omega.
   Qed.
 
-  Lemma length_TV : length T + length V <= 1+i.
+  Lemma length_TV : length T + length V <= 2*i + 1.
   Proof.
     induction i in T,V,H,R|-*.
-    -inv R. cbn;omega.
+    -inv R. cbn. omega.
     -replace (S n) with (n + 1) in R by omega.
      apply pow_add in R. destruct R as [[[T' V'] H'] [R1 R2]].
      specialize (IHn _ _ _ R1).
      eapply rcomp_1 in R2.
      inv R2.
-     all:cbn in *. all:omega.
+     all:cbn in *. all:try omega.
   Qed.
 
-  Definition sizeC g :=
-    match g with
-      (P,a) => sizeP P + a 
-    end.
-  Definition sizeHE e :=
-    match e with
-      heapEntryC g b => sizeC g + b
-    end.
-  Definition sizeH H :=
-    sumn (map sizeHE H).
-
-  Definition sizeSt '(T,V,H) := sumn (map sizeC T) + sumn (map sizeC V) + sizeH H.
 
   Lemma list_bound X size m (A:list X):
     (forall x, x el A -> size x <= m) -> sumn (map size A) <= length A * m.
@@ -429,13 +799,13 @@ Section Analysis.
     induction A;cbn;intros H'. omega.
     rewrite IHA. rewrite H'. omega. tauto. intuition.
   Qed.
-
+(*
   Lemma correctSpace:
-    sizeSt (T,V,H) <= (i + 1) * (3*i+4*size s).
+    sizeSt (T,V,H) <= 2*(i + 1) * (3*i+4*size s0).
   Proof.
     cbn. rewrite <- sumn_app,<-map_app. unfold sizeH.
-    rewrite list_bound with (size:=sizeC) (m:=2*size s + i).
-    rewrite list_bound with (size:=sizeHE) (m:=2*size s + 2*i).
+    rewrite list_bound with (size:=sizeC) (m:=2*size s0 + i).
+    rewrite list_bound with (size:=sizeHE) (m:=2*size s0 + 2*i).
     rewrite length_H. rewrite app_length,length_TV.
     lia.
     -intros [[]] H'. cbn - [mult sizeP]. edestruct size_clos as [H1 H2].
@@ -444,6 +814,6 @@ Section Analysis.
     -intros [] H'. cbn - [mult sizeP]. edestruct size_clos as [H1 H2].
      apply H1 in H' as (->&->).
      rewrite length_H. omega.
-  Qed.  
+  Qed.  *)
 
 End Analysis.

--- a/theories/L/AbstractMachines/AbstractHeapMachineDef.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachineDef.v
@@ -78,10 +78,12 @@ Section Lin.
   Definition init s :state := ([closT (s,0)],[],[]).
 
 End Lin.
-Notation clos := (term * nat)%type.
+
+Module clos_notation.
+  Notation clos := (term * nat)%type.
+End clos_notation.
+Import clos_notation.
 Hint Transparent state.
-
-
 
 Definition largestVarC : clos -> nat := (fun '(s,_) => largestVar s).
 

--- a/theories/L/AbstractMachines/AbstractHeapMachineDef.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachineDef.v
@@ -1,0 +1,113 @@
+From Undecidability.L Require Import L.
+From Undecidability.L Require Import AbstractMachines.LargestVar.
+
+(** ** Abstract Heap Machine *)
+Section Lin.
+
+  Let HA:=nat.
+
+  Notation clos := (term * HA)%type.
+  Inductive task := appT | closT (g:clos).
+
+  Inductive heapEntry := heapEntryC (g:clos) (alpha:HA).
+
+  (** *** Heaps *)
+  
+  Let Heap := list heapEntry.
+  Implicit Type H : Heap.
+  Definition put H e := (H++[e],|H|).
+  Definition get H alpha:= nth_error H alpha.
+  Definition extended H H' := forall alpha m, get H alpha = Some m -> get H' alpha = Some m.
+
+  
+  Fixpoint lookup H alpha x : option clos:=
+    match get H alpha with
+      Some (heapEntryC bound env') =>
+      match x with
+        0 => Some bound
+      | S x' => lookup H env' x'
+      end
+    |  _ => None
+    end.
+
+  (** *** Reduction Rules *)
+
+  Definition state := (list task * list clos *Heap)%type.
+
+  Hint Transparent state.
+
+  Inductive step : state -> state -> Prop :=
+    step_pushVal a s T V H:
+      step (closT (lam s,a)::T,V,H) (T,(s,a)::V,H)
+  | step_beta b s g H H' c T V:
+      put H (heapEntryC g b) = (H',c)
+      -> step (appT::T,g::(s,b)::V,H) (closT (s,c) ::T,V,H')
+  | step_load a x g T V H:
+      lookup H a x = Some g
+      -> step (closT (var x,a)::T,V,H) (T,g::V,H)
+  | step_app s t a T V H: step (closT (app s t,a)::T,V,H) (closT (s,a)::closT(t,a)::appT::T,V,H).
+
+  Hint Constructors step.
+
+  
+  (** *** Unfolding *)
+
+  Inductive unfolds H a: nat -> term -> term -> Prop :=
+  | unfoldsUnbound k n :
+      n < k ->
+      unfolds H a k (var n) (var n)
+  | unfoldsBound k b s s' n:
+      n >= k ->
+      lookup H a (n-k) = Some (s,b) ->
+      unfolds H b 1 s s' ->
+      unfolds H a k (var n) (lam s')
+  | unfoldsLam k s s':
+      unfolds H a (S k) s s' ->
+      unfolds H a k (lam s) (lam s')
+  | unfoldsApp k (s t s' t' : term):
+      unfolds H a k s s' ->
+      unfolds H a k t t' ->
+      unfolds H a k (s t) (s' t').
+
+  
+  Inductive reprC : Heap -> clos -> term -> Prop :=
+    reprCC H s a s' :
+      unfolds H a 1 s s' ->
+      reprC H (s,a) (lam s').
+
+  Definition init s :state := ([closT (s,0)],[],[]).
+
+End Lin.
+Notation clos := (term * nat)%type.
+Hint Transparent state.
+
+
+
+Definition largestVarC : clos -> nat := (fun '(s,_) => largestVar s).
+
+Definition largestVarCs (T:list clos) :=
+  maxl (map largestVarC T).
+
+Definition largestVarH (H:list heapEntry) :=
+  maxl (map (fun e:heapEntry => let (q,_) := e in largestVarC q) H).
+
+
+Definition sizeC g :=
+  match g with
+    (s,a) => size s + a 
+  end.
+
+Definition sizeT t :=
+  match t with
+    appT => 1
+  | closT g => sizeC g
+  end.
+
+Definition sizeHE e :=
+  match e with
+    heapEntryC g b => sizeC g + b
+  end.
+Definition sizeH H :=
+  sumn (map sizeHE H).
+
+Definition sizeSt '(T,V,H) := sumn (map sizeC T) + sumn (map sizeC V) + sizeH H.

--- a/theories/L/AbstractMachines/Computable/EvalForTime.v
+++ b/theories/L/AbstractMachines/Computable/EvalForTime.v
@@ -1,0 +1,320 @@
+From Undecidability.L Require Import L Tactics.LTactics.
+
+From Undecidability.L.AbstractMachines Require Import AbstractHeapMachineDef UnfoldTailRec FunctionalDefinitions.
+From Undecidability.L.AbstractMachines.Computable Require Import Unfolding HeapMachine Shared.
+
+From Undecidability.L.Datatypes Require Import Lists LBinNums.
+From Undecidability.L.Functions Require Import BinNums BinNumsCompare UnboundIteration Proc.
+
+Import AbstractHeapMachineDef.clos_notation .
+
+Definition extractRes (sigma : state) :=
+  match sigma with
+    ([],[g],_) => Some (g)
+  | _ => None
+  end.
+
+Definition evalForTime__step : N * state -> N * state + option (clos * list heapEntry) :=
+  fun '(i,sigma) =>
+    let '(_,_,H):= sigma in
+    match extractRes sigma with
+      Some g => inr (Some (g,H))
+    | _ => if (0 <? i)%N then 
+            match heapStep sigma with
+              Some sigma' => inl (N.pred i,sigma')
+            | _ => inr None 
+            end
+          else inr None
+    end.
+
+
+Definition init__evalForTime (fuel:N) (s:term) :=
+  ((4 * fuel +1)%N,init s).
+
+Definition evalForTime (fuel : N) ( s:term) : option (clos * list heapEntry) :=
+  if closedb s then
+    let '(fuel,x) := init__evalForTime fuel s in
+    
+    match loopSum (N.to_nat fuel + 1) evalForTime__step (fuel,x) with
+      Some g => g
+    |  _ => None
+    end
+  else None.
+
+Lemma spec_extractRes sigma:
+  match extractRes sigma with
+    Some g => exists H, sigma = ([],[g],H)
+  | None => forall g H, sigma <> ([],[g],H)
+  end.
+Proof.
+  unfold extractRes.
+  all:repeat (let eq := fresh "eq" in destruct _ eqn:eq).
+  all:try congruence. eexists _;repeat f_equal. congruence.
+Qed.
+
+Arguments extractRes : simpl never.
+
+Lemma spec_evalForTime__step i sigma:
+  match evalForTime__step (i,sigma) with
+    inl (i',sigma') => i = N.succ i' /\ step sigma sigma' /\ extractRes sigma = None
+  | inr None => (i = 0%N \/ terminal step sigma) /\ extractRes sigma = None
+  | inr (Some (g,H)) => sigma = ([],[g],H) 
+  end.
+Proof.
+  specialize (heapStep_sound sigma) as R.
+  specialize (spec_extractRes sigma) as H''.
+  all:cbn.
+  all:destruct sigma as [[T V] H];cbn [snd].
+  all:destruct (N.ltb_spec0 0 i);[|replace i with (0%N) by Lia.nia].
+  all:repeat (let eq := fresh "eq" in destruct _ eqn:eq).
+  all:try discriminate.
+  all:subst.
+  all:repeat match goal with
+               H :  inl _ = inl _ |- _ => inv H
+             | H :  inr _ = inr _ |- _ => inv H
+             end.
+  1:now split;(tauto + Lia.nia).
+  all:try (destruct H'' as (?&H'');inv H'').
+  all:easy.
+Qed.
+
+Instance termT_extractRes : computableTime' extractRes (fun _ _ => (23,tt)).
+Proof.
+  unfold state.
+  extract. solverec. 
+Qed.
+
+Definition time_evalForTime__step x :=
+  let '(i,x) := x in
+  let '(T,V,H):=x in
+  match extractRes x with
+    Some g  => 0
+  | _ => N.size_nat i * 12
+        + if (0 <? i)%N
+          then heapStep_time T H
+          else 0
+  end + 81.
+
+Instance termT_evalForTime__step : computableTime' evalForTime__step (fun x _ => (time_evalForTime__step x,tt)).
+Proof.
+  unfold state.
+  extract. intros (i&((T&V)&H)). unfold time_evalForTime__step. (*recRel_prettify2.*)
+  all:solverec.
+Qed.
+
+Arguments evalForTime__step : simpl never.
+(*
+  Lemma time_evalForTime__step_eq i T V H:
+    ~(T=[] /\ exists g, V=[g]) ->
+    time_evalForTime__step (i, (T, V, H))
+    = N.size_nat i * 12
+      + (if (0 <? i)%N then heapStep_time T H else 0)
+      + 60.
+  Proof.
+    intros ?.
+    unfold time_evalForTime__step. destruct T. destruct V as [|? []]. 2:exfalso.
+    all:destruct (N.ltb_spec0 0 i);[|try easy]. all:easy.
+  Qed.*)
+
+
+
+Instance termT_init__evalForTime : computableTime' init__evalForTime (fun fuel (_:unit) => (1,fun s (_:unit) => (size s * 108 + N.size_nat fuel * 84 + 244,tt))).
+Proof.
+  eapply computableTimeExt with (x:=fun fuel s => ((fuel + fuel + fuel + fuel +1)%N,init s)).
+  -unfold init__evalForTime. repeat intro. hnf. f_equal. Lia.nia.
+  -extract.
+   recRel_prettify2. reflexivity.
+   change (N.size_nat 1) with 1. ring_simplify.
+   
+   repeat rewrite N_size_nat_add_leq.
+   rewrite !Nat.max_l. all:try Lia.lia.
+Qed.
+
+Tactic Notation "destruct" "*" "eqn" :=
+  let E := fresh "eq" in destruct * eqn:E.
+
+Definition R__step := fun '(i,s) '(i',s') => i = N.succ i' /\ step s s'.
+
+Lemma pow_Rstep k i i' x x':
+  ARS.pow R__step k (i,x) (i',x')
+  <-> (i = i' + N.of_nat k)%N /\ ARS.pow step k x x'.
+Proof.
+  induction k in i',x'|-*.
+  {unfold pow. cbn. split. now intros [=]. intros. f_equal; intuition try solve [lia|easy]. }
+  replace (S k) with (k + 1) in * by omega.
+  rewrite !pow_add. unfold rcomp.
+  repeat setoid_rewrite <- rcomp_1.
+  split.
+  -intros ([]&(->&?)%IHk&?&?). intuition. lia. eauto.
+  -intros (->&(?&?&?)).
+   eexists (_,_). rewrite IHk. cbn. repeat split. 2,3:eassumption. lia.
+Qed.
+
+Import Undecidability.L.AbstractMachines.LargestVar Undecidability.L.AbstractMachines.AbstractHeapMachine.
+
+
+Lemma time_uiter_evalForTime__step s fuel:
+  uiterTime evalForTime__step (fun x (_:unit) => (time_evalForTime__step x,tt)) (N.to_nat fuel + 1) (fuel,init s) <=
+  (N.to_nat fuel + 1) * (N.size_nat fuel * 12 + heapStep_timeBound (largestVar s) (N.to_nat fuel) + 90).
+Proof.
+  rewrite uiterTime_computesRel
+    with (R:= R__step)
+         (t__step := N.size_nat fuel * 12 + heapStep_timeBound (largestVar s) (N.to_nat fuel) + 81)
+         (t__end := 0).
+  2:{
+    intros fuel' (i'&x') ? R.
+    eapply pow_Rstep in R as (->&R). cbn [fst].
+    specialize spec_evalForTime__step with (i:=i') (sigma:=x') as H'.
+    specialize (spec_extractRes x') as Hx'.
+    -destruct x' as [[T V] Hp].
+     cbn [fst snd] in *.
+     unfold time_evalForTime__step.
+     destruct extractRes.
+     +destruct evalForTime__step as [[]|]. now destruct H'. split. 2:tauto. lia.
+     +split.
+      *rewrite N_size_nat_monotone with (n':=(i' + N.of_nat fuel')%N). 2:Lia.nia.
+       destruct N.ltb_spec0 with (x:=0%N) (y:=i'%N). 2:Lia.nia.
+       rewrite heapStep_timeBound_le. 2:eassumption.
+       rewrite heapStep_timeBound_mono with (k':=(N.to_nat (i' + N.of_nat fuel'))). 2:Lia.nia. Lia.nia.
+      *destruct evalForTime__step as [[]|]. 2:easy.
+       split. 2:easy. easy.
+  }
+  Lia.nia.
+Qed.  
+
+Lemma sound_evalForTime__step fuel x: {res & loopSum (N.to_nat fuel +1 ) evalForTime__step (fuel,x) = Some res}.
+Proof.
+  remember (N.to_nat fuel) as n eqn:eqn.
+  induction n in eqn,fuel,x|-*.
+  all:cbn.
+  all:specialize (spec_evalForTime__step fuel x) as H'.
+  all:destruct evalForTime__step as [[]|].
+  1:exfalso;Lia.nia.
+  1,3:eauto.
+  {destruct H' as (->&?&?).
+   edestruct IHn with (fuel:=n0). Lia.nia.
+   eauto.
+  }
+Qed.    
+
+Definition term_evalForTime : term := Eval cbn [convert TH]in (λ fuel s, (!!(extT (closedb)) s) (λ _, (!!(uiter evalForTime__step) (!!(extT (init__evalForTime)) fuel s))) (λ _, (enc (None (A:=clos * list heapEntry)))) I).
+
+Definition t__evalForTime maxVar (size:nat) fuel :=
+  let fuel' := (4*fuel + 1) in
+  size *139 + N.size_nat (N.of_nat fuel) * 84+
+  (fuel' + 1) * (N.size_nat (N.of_nat fuel') * 12
+                 + heapStep_timeBound maxVar fuel' +90) +264.
+
+Instance evalForTime_comp : computableTime' evalForTime (fun fuel _ => (1,fun s _ => (t__evalForTime (largestVar s)(size s) (N.to_nat fuel),tt))).
+Proof.
+  exists term_evalForTime. unfold term_evalForTime,evalForTime.
+  Intern.cstep. Intern.cstep. Intern.cstep.
+  destruct closedb. 1,2:reflexivity. Unshelve.
+  4:{ eapply uiter_sound. unfold evalForTime,init__evalForTime. edestruct sound_evalForTime__step as (?&eq').
+      rewrite eq'. reflexivity. }
+  2:exact True.
+  {intros fuel _. recRel_prettify2. easy.
+   all:unfold t__evalForTime. 2:lia. unfold init__evalForTime. rewrite time_uiter_evalForTime__step.
+   pose (fuel':=(4*fuel + 1)%N).
+   fold fuel'.
+   replace (4 * N.to_nat fuel + 1) with (N.to_nat fuel') by (unfold fuel';lia).
+   rewrite !Nnat.N2Nat.id. lia.
+  }
+Qed.
+
+Lemma rel_evalForTime__step (x : N * state) : match evalForTime__step x with
+                                            | inl y => R__step x y
+                                            | inr _ => terminal R__step x
+                                            end.
+Proof.
+  destruct x as [i x]. assert (H':=spec_evalForTime__step i x).
+  destruct evalForTime__step as [[]|[[]|]].
+  -destruct H' as (->&?&?).
+   hnf. easy.
+  -intros [i' x'] R'. destruct R' as (->&R').
+   assert  (Hx:=spec_extractRes x). destruct extractRes.
+   +destruct Hx as (?&->).
+    inv R'.
+   +easy.
+  -intros [] []. destruct H' as [[->|Ter] ?]. easy.
+   edestruct Ter. easy.
+Qed.
+
+Lemma sound_evalForTime__step2' i sigma g H:
+  loopSum (N.to_nat i + 1) evalForTime__step (i,sigma) = Some (Some (g,H))
+  <-> (exists k, k <= N.to_nat i /\ ARS.pow step k sigma ([],[g],H)).
+Proof.
+  split.
+  -intros H'.
+   eapply loopSum_rel_correct2 with (R:=R__step) in H' as (k&(x'&i')&?&eq1&R&Ter&eq2). 2:exact rel_evalForTime__step.
+   eapply pow_Rstep in R as (->&R).
+   eassert (H'':=spec_evalForTime__step _ _ ).
+   unfold state in *.
+   rewrite eq2 in H''.
+   eassert (H':=spec_extractRes i').
+   destruct extractRes;cbn;try congruence.
+   destruct H' as (?&->). inv H''. eexists;split. 2:eauto. lia.
+  -intros (k'&?&?).
+   induction k' in i,sigma,k',H1,H0 |-*.
+   +inv H1. replace (N.to_nat i + 1) with (1 + N.to_nat i). cbn.
+    specialize (spec_evalForTime__step i ([],[g],H)). destruct evalForTime__step as [[]|[[]|]]. all:easy.
+   +replace (S k') with (1+k') in H1 by easy.
+    assert (H1':=H1).
+    eapply pow_add in H1 as (sigma'&R&H1).
+    eapply rcomp_1 in R.
+    assert (exists i', N.to_nat i = S (N.to_nat i')) as (i'&eq) by (exists (i-1)%N;lia).
+    rewrite eq in *. cbn.
+    specialize (spec_evalForTime__step i sigma). destruct evalForTime__step as [[? sigma'']|[[]|]].
+    *intros (->&?&?). replace n with i' in * by lia.
+     apply IHk'. lia.
+     specialize parametrized_semi_confluence with (X:=state) (t1:=([],[g],H) ) (3:=H2) (2:=H1') as (?&?&?&?&?&?&?&?);[now eauto using functional_uc,step_functional|].
+     destruct x. 2:{ destruct H6 as (?&?&?);easy. }
+     inv H6.
+     replace k' with x0 by lia. easy.
+    *intros ->. easy.
+    *intros [[|Ter ]]. easy. edestruct Ter;easy.
+Qed. 
+
+Lemma evalForTime_spec (s:term) (fuel : N):
+  match evalForTime fuel s with
+  |Some (g,H) =>
+   closed s
+   /\ (exists k, k <= N.to_nat (4* fuel+1) /\ ARS.pow step k (init s) ([],[g],H))
+   /\ exists t, reprC H g t /\ s ⇓(<= N.to_nat fuel) t
+  | None => ~ closed s \/ ~ exists t,  s ⇓(<= N.to_nat fuel) t
+  end.
+Proof.
+  unfold evalForTime. destruct (closedb_spec s). 2:easy.
+  cbn [init__evalForTime].
+  destruct loopSum as [[[]|]|] eqn:eq.
+  -split. easy.
+   eapply sound_evalForTime__step2' in eq. split. easy.
+   destruct eq as (?&?&?).
+   edestruct soundness as (?&?&?&?&eq&?&?&?). 2:split. 1,2:eassumption. now intros ? ?.
+   inv eq.
+   rewrite ResourceMeasures.timeBS_evalIn in H1.
+   do 2 esplit. eassumption. eapply evalIn_evalLe. 2:eassumption. lia.
+  -right. intros (?&(?&?&R')%evalLe_evalIn).
+   rewrite <- ResourceMeasures.timeBS_evalIn in R'.
+   eapply correctTime in R' as (?&?&?&?). 2:easy.
+   eassert (H':=sound_evalForTime__step2' _ _ _ _). rewrite eq in H'. destruct H' as [_ H']. discriminate H'.
+   repeat eexists. 2:eassumption. lia.
+  -edestruct sound_evalForTime__step as (?&eq'). rewrite eq' in eq. easy.
+Qed.
+
+Lemma mono_t__evalForTime maxVar maxVar' x x' size size' :
+  maxVar <= maxVar' -> x <= x' -> size <= size' -> t__evalForTime maxVar size x <= t__evalForTime maxVar' size' x'.
+Proof.
+  intros H1 H2 H3.
+  unfold t__evalForTime.
+  repeat (lazymatch goal with
+            |- _ + _ <= _ + _ => eapply plus_le_compat
+          | |- _ * _ <= _ * _ => eapply mult_le_compat
+          | |- _ => first [eassumption | reflexivity | eapply N_size_nat_monotone | eapply unfoldBool_time_mono | Lia.nia |eapply heapStep_timeBound_mono'] 
+          end).
+Qed.
+
+Lemma suplin_t__evalForTime maxVar size x : x <= t__evalForTime maxVar size x. 
+Proof.
+  unfold t__evalForTime. Lia.nia.
+Qed.

--- a/theories/L/AbstractMachines/Computable/EvalForTimeBool.v
+++ b/theories/L/AbstractMachines/Computable/EvalForTimeBool.v
@@ -1,0 +1,53 @@
+From Undecidability.L Require Import L Tactics.LTactics AbstractMachines.LargestVar.
+
+From Undecidability.L Require Import AbstractHeapMachineDef UnfoldTailRec AbstractHeapMachine.
+From Undecidability.L.AbstractMachines.Computable Require Import Unfolding HeapMachine Shared EvalForTime.
+
+From Undecidability.L.Datatypes Require Import Lists LBinNums.
+From Undecidability.L.Functions Require Import BinNums BinNumsCompare UnboundIteration.
+
+Definition evalForTimeBool (checkFor:bool) (fuel : N) (s:term) := match evalForTime fuel s with
+                                                   Some (g,H) => match unfoldBoolean H g with
+                                                                  None => false
+                                                                | Some b => if checkFor then b else negb b
+                                                                end
+                                                 | None => false
+                                                 end.
+
+Definition t__evalForTimeBool (largestVar size:nat) fuel := t__evalForTime largestVar size fuel+ unfoldBool_time (4*fuel+1) largestVar + 22.
+
+Lemma evalForTimeBool_spec (checkFor :bool) (s:term) (fuel : N):
+  reflect (closed s /\ s ⇓(<= N.to_nat fuel) (enc checkFor)) (evalForTimeBool checkFor fuel s).
+Proof.
+  unfold evalForTimeBool.
+  eassert (H':=evalForTime_spec _ _).
+  destruct evalForTime as [[]|] eqn:eq;rewrite eq.
+  2:{ econstructor. easy. }
+  destruct H' as (?&_&H').
+  destruct unfoldBoolean eqn:eq'.
+  -eapply iff_reflect.  destruct H' as (?&eq''&?).
+   eapply unfoldBoolean_sound in eq'.
+   replace x with (enc b) in *.
+   2:{ eapply reprC_functional. all:easy. }
+   (destruct b,checkFor;cbn).
+   all:intuition. all:eapply inj_enc,eval_unique. all:eapply evalLe_eval_subrelation;easy.
+  -econstructor. intros (_&H'').
+   destruct H' as (?&H'&?).
+   replace x with (enc checkFor) in *.
+   2:{  all:eapply eval_unique. all:eapply evalLe_eval_subrelation;easy. }
+   eapply unfoldBoolean_complete in H'. easy.
+Qed.
+
+Instance evalForTimeBool__comp : computableTime' evalForTimeBool (fun _ _ => (1,fun fuel _ => (1,fun s _ => (t__evalForTimeBool (largestVar s) (size s) (N.to_nat fuel),tt)))).
+Proof.
+  unfold evalForTimeBool. extract. solverec.
+  all:unfold t__evalForTimeBool. 4:lia.
+  all:eassert (H':=evalForTime_spec _ _).
+  all:rewrite H in H'.
+  all:destruct H' as (?&(?&?&R)&?).
+  all:rewrite unfoldBool_time_mono with (l':=(4 * N.to_nat x0 + 1)) (n':=(largestVar x1));[try lia | |].
+  all:try (etransitivity;[eapply AbstractHeapMachine.length_H;eassumption|lia]).
+  all:rewrite largestVarH_leq with (1:=R).
+  all:rewrite largestVarC_V_leq with (1:=R);[|easy].
+  all:now rewrite Nat.max_id.
+Qed.

--- a/theories/L/AbstractMachines/Computable/HeapMachine.v
+++ b/theories/L/AbstractMachines/Computable/HeapMachine.v
@@ -1,54 +1,82 @@
-From Undecidability.L Require Import L.
+From Undecidability.L Require Import L Tactics.LTactics.
 From Undecidability.L.AbstractMachines Require Import Programs FunctionalDefinitions.
-From Undecidability.L.Datatypes Require Import LNat LProd Lists LOptions.
-From Undecidability.L Require AbstractHeapMachine.
-From Undecidability.L Require Import AbstractMachines.Computable.Shared.
-From Undecidability.L.Tactics Require Import LTactics.
+From Undecidability.L.Datatypes Require Import LTerm LOptions.
+
+From Undecidability.L Require Import AbstractMachines.LargestVar.
+
+
+From Undecidability.L.AbstractMachines Require Import AbstractHeapMachineDef AbstractHeapMachine.
+From Undecidability.L.AbstractMachines.Computable Require Import Shared Lookup.
 
 (** *** Heap Machine *)
 
-Import AbstractHeapMachine.
+Run TemplateProgram (tmGenEncode "task_enc" task).
+Hint Resolve task_enc_correct : Lrewrite.
+Instance termT_S : computableTime' closT (fun _ _ => (1,tt)).
+Proof.
+  extract constructor.
+  solverec.
+Defined.
 
-Run TemplateProgram (tmGenEncode "heapEntry_enc" heapEntry).
-Hint Resolve heapEntry_enc_correct : Lrewrite.
-
-Instance term_heapEntryC : computableTime heapEntryC (fun _ _ => (1,fun _ _ => (1,tt))).
-extract constructor. solverec.
-Qed.
-
-
-Instance term_get : computableTime get (fun A _ => (1,fun n _ => (min n (length A)*15+16,tt))).
-extract. solverec.
-Qed.
+Instance TermT_init : computableTime' init (fun s _ => (108 * size s + 44,tt)).
+Proof. extract. solverec. Qed.
 
 
-Instance put_get : computableTime put (fun A _ => (1,fun _ _ => (length A * 27 + 22,tt))).
-extract. solverec.
-Qed.
+(** *** Heap Machine Step *)
 
-Instance term_lookup : computableTime lookup (fun H _ => (5,fun alpha _ => (1,fun x _ => ((1+x)*(length H*15 + 38),tt)))).
-extract. solverec.
-Qed.
 
-Definition heapStep_time (T:list clos) (H: list heapEntry) :=
+Definition heapStep_time (T:list task) (H: list heapEntry) :=
   match T with
-    (varT n :: _,_)::_ => (n+1)*(length H*15+38)
-  | (appT::_,_)::_ => length H*27 
-  | (lamT::_ as P,_)::_ => length P *36 (* only because of the linear encoding of programs! *)
+    closT (var n,_)::_ => lookupTime (length H) n
+  | appT::_ => length H*27 
   | _ => 0
   end + 84.
 
-Instance term_heapStep : computableTime heapStep (fun '(T,V,H) _ => (heapStep_time T H,tt)).
+
+Definition heapStep_timeBound maxVar k :=
+  lookupTime k maxVar + k * 27 + 84.
+
+Lemma heapStep_timeBound_le s k T V H:
+  pow step k (init s) (T,V,H) ->
+  heapStep_time T H <= heapStep_timeBound (largestVar s) k.
+Proof.
+  intros H'.
+  unfold heapStep_timeBound, heapStep_time. destruct T as [|[|[[] a]]].
+  1,4,5:now Lia.lia.
+  -rewrite length_H. 2:eassumption. Lia.lia.
+  -rewrite lookupTime_mono with (k':=k) (n':=largestVar s).
+   +Lia.lia.
+   +eapply length_H;eassumption.
+   +eapply subterm_property in H' as (H'&_).
+    rewrite <- subterm_largestVar. 2:eapply H'. 2:eauto. easy.
+Qed.
+
+Lemma heapStep_timeBound_mono' maxVar maxVar'  k k' :
+  k <= k' -> maxVar <= maxVar' ->
+  heapStep_timeBound maxVar k <= heapStep_timeBound maxVar' k'.
+Proof.
+  intros H1 H3. 
+  unfold heapStep_timeBound. rewrite Lookup.lookupTime_mono. 2,3:eassumption. Lia.nia.
+Qed.
+
+Lemma heapStep_timeBound_mono maxVar k k' :
+  k <= k' -> heapStep_timeBound maxVar k <= heapStep_timeBound maxVar k'.
+Proof.
+  intros. 
+  unfold heapStep_timeBound. rewrite lookupTime_mono. 2:eassumption. 2:reflexivity. Lia.lia.
+Qed.
+
+Instance term_heapStep : computableTime' heapStep (fun '(T,V,H) _ => (heapStep_time T H,tt)).
 Proof.
   Arguments put : simpl never.
   extract.
 
   Unshelve.
-  5:{inv eq8. now Intern.extractCorrectCrush_new. }
-  {inv eq8. Intern.cstep. }
+  5:{inv eq6. now Intern.extractCorrectCrush_new. }
+  {inv eq6. Intern.cstep. }
   {unfold heapStep_time. recRel_prettify2.
    all:cbn [length].
-   all:Lia.nia.
+   all:try Lia.nia.
   }
 Qed.
 (* with Lrewrite_new: *)

--- a/theories/L/AbstractMachines/Computable/LargestVar.v
+++ b/theories/L/AbstractMachines/Computable/LargestVar.v
@@ -1,0 +1,88 @@
+From Undecidability.L Require Import L Tactics.LTactics.
+From Undecidability.L.Datatypes Require Import LNat LProd Lists LOptions. 
+
+From Undecidability.L.AbstractMachines Require Import FunctionalDefinitions AbstractHeapMachineDef Programs.
+
+Require Import Undecidability.L.AbstractMachines.LargestVar.
+
+From Undecidability.L Require Import Prelim.LoopSum Functions.LoopSum Functions.UnboundIteration.
+
+Instance termT_max : computableTime' max (fun x _ => (5,fun y _ => (min x y * 15 + 8,tt))).
+Proof.
+  extract. fold max. solverec.
+Qed.
+
+Definition largestVarTR' '(stack,res) : (list term * nat) + nat :=
+  match stack with
+    [] => inr res
+  | s::stack =>
+    match s with
+      var n => inl (stack,max n res)
+    | app s t => inl (s::t::stack,res)
+    | lam s => inl (s::stack,res)
+    end
+  end.
+
+Fixpoint largestVarTR'_fuel (s:term) : nat :=
+  match s with
+    var _ => 1
+  | app s t => 1 + (largestVarTR'_fuel s + largestVarTR'_fuel t)
+  | lam s => 1 + largestVarTR'_fuel s
+  end.
+
+
+Lemma largestVarTR'_correct stack res s k:
+  loopSum (largestVarTR'_fuel s + k) largestVarTR' (s::stack,res)
+  = loopSum k largestVarTR' (stack,max (largestVar s) res).
+Proof.
+  induction s in res,stack,k |- *.
+  all:cbn.
+  -reflexivity.
+  -rewrite <- !Nat.add_assoc. cbn.
+   rewrite IHs1, IHs2. easy.
+  -rewrite IHs. easy.
+Qed.
+                       
+Lemma largestVarTR_correct s:
+  loopSum (largestVarTR'_fuel s + 1) largestVarTR' ([s],0) = Some (largestVar s). 
+Proof.
+  rewrite largestVarTR'_correct. cbn. easy.
+Qed.
+
+Instance termT_largestVarTR' : computableTime' largestVarTR'
+                                           (fun x _ => (let '(stack,res) := x in
+                                                    match stack with
+                                                      var n ::_ =>  n*15
+                                                    | _ => 0
+                                                    end + 31,tt)).
+Proof.
+ extract. solverec.
+Qed.
+
+Lemma largestVarTR'_fuel_leq_largestVar s : largestVarTR'_fuel s <= size s.
+Proof.
+  induction s;cbn [size largestVarTR'_fuel];try Lia.lia.
+Qed.
+
+Instance termT_largestVar : computableTime' largestVar (fun s _ => ((40 * size s) +46,tt)).
+Proof.
+  eexists.
+  eapply computesTime_timeLeq.
+  
+  2:{ unshelve (eapply uiter_total_instanceTime with (1 := largestVarTR_correct) (preprocessT:=(fun _ _ => (5,tt)))).
+      4:{ extract. solverec. }
+      2:{ apply termT_largestVarTR'. }
+  }
+  split. 2:exact Logic.I.
+  cbn [fst].
+  erewrite uiterTime_bound_recRel with (iterT := fun _ '(stack,res) => ((sumn (map size stack)) * 40
+                                                                   + 40))
+                                       (P:= fun n x => True).
+  { cbn [length map sumn]. Lia.lia. }
+  {intros n [stack res] H. cbn.
+   destruct stack as [|[[]| |]].
+   2-5:split;[easy|].
+   all:cbn [length map sumn largestVarTR'_fuel size];try Lia.lia.
+  }
+  all:easy.
+Qed.

--- a/theories/L/AbstractMachines/Computable/Lookup.v
+++ b/theories/L/AbstractMachines/Computable/Lookup.v
@@ -1,0 +1,17 @@
+From Undecidability.L Require Import Tactics.LTactics.
+From Undecidability.L.Datatypes Require Import Lists.
+
+From Undecidability.L.AbstractMachines Require Import AbstractHeapMachineDef Computable.Shared.
+
+Definition lookupTime l x := (x+1) * (l*15 + 38).
+
+Instance term_lookup : computableTime' lookup (fun H _ => (5,fun alpha _ => (1,fun x _ => (lookupTime (length H) x ,tt)))).
+extract. unfold lookupTime. solverec.
+Qed.
+
+
+Lemma lookupTime_mono k k' n n' :
+  k <= k' -> n <= n' -> lookupTime k n <= lookupTime k' n'.
+Proof.
+  unfold lookupTime. now intros -> ->. 
+Qed.

--- a/theories/L/AbstractMachines/Computable/Shared.v
+++ b/theories/L/AbstractMachines/Computable/Shared.v
@@ -1,7 +1,9 @@
-From Undecidability.L Require Import L.
-From Undecidability.L.AbstractMachines Require Import Programs FunctionalDefinitions.
-From Undecidability.L.Datatypes Require Import LNat LProd Lists LOptions.
-From Undecidability.L.Tactics Require Import LTactics.
+From Undecidability.L Require Import L Tactics.LTactics.
+
+From Undecidability.L.AbstractMachines Require Import Programs FunctionalDefinitions AbstractHeapMachineDef.
+From Undecidability.L.Datatypes Require Import Lists LOptions.
+
+From Undecidability.L Require Import Tactics.GenEncode.
 
 (** * Computability in L *)
 (** *** Encoding for Tokens *)
@@ -9,31 +11,31 @@ From Undecidability.L.Tactics Require Import LTactics.
 Run TemplateProgram (tmGenEncode "token_enc" Tok).
 Hint Resolve token_enc_correct : Lrewrite.
 
-Fixpoint jumpTarget_tr' l res P {struct P} : option (list Tok * list Tok) :=
-  match P with
-  | [] => None
-  | lamT :: P0 => jumpTarget_tr' (S l) (lamT::res) P0
-  | retT :: P0 => match l with
-                | 0 => Some (rev res, P0)
-                | S l0 => jumpTarget_tr' l0 (retT::res) P0
-                end
-  | t::P => jumpTarget_tr' l (t::res) P
-  end.
-
-Definition jumpTarget_tr l res P := jumpTarget_tr' l (rev res) P.
-
-Lemma jumpTarget_tr_extEq : extEq  jumpTarget_tr jumpTarget.
-Proof.
-  intros l res P. unfold jumpTarget_tr. hnf.
-  induction P as [|[]]in res,l |-*. 5:destruct l.
-  all:cbn. all:try rewrite <- IHP. all:simpl_list;cbn. all:try congruence.
+Instance term_varT : computableTime' varT (fun _ _ => (1,tt)).
+extract constructor. solverec.
 Qed.
 
-Instance term_jump_target_tr' : computableTime jumpTarget_tr' (fun l _ => (5,fun res _ => (1,fun P _ => (length P * 36 +length res * 13 + 4,tt)))).
+(* Instance term_tok_eqb : computableTime' Tok_eqb (fun t _ => (1,fun t' _ => (min (sizeT t) (sizeT t') * 17 + 10,tt))). *)
+(* extract. solverec. *)
+(* Qed. *)
+
+(** *** Encoding Heaps *)
+Import AbstractHeapMachineDef.
+
+Run TemplateProgram (tmGenEncode "heapEntry_enc" heapEntry).
+Hint Resolve heapEntry_enc_correct : Lrewrite.
+
+Instance term_heapEntryC : computableTime' heapEntryC (fun _ _ => (1,fun _ _ => (1,tt))).
+extract constructor. solverec.
+Qed.
+
+(** *** Primitive functions with Heaps*)
+
+Instance term_get : computableTime' get (fun A _ => (1,fun n _ => (min n (length A)*15+16,tt))).
 extract. solverec.
 Qed.
 
-Instance term_jump_target : computableTime jumpTarget (fun l _ => (1,fun res _ => (1,fun P _ => (length P * 36 + length res * 26+ 21,tt)))).
-eapply computableTimeExt. now exact jumpTarget_tr_extEq. unfold jumpTarget_tr.
-extract. solverec. rewrite rev_length. Lia.lia.
+
+Instance put_get : computableTime' put (fun A _ => (1,fun _ _ => (length A * 27 + 22,tt))).
+extract. solverec.
 Qed.

--- a/theories/L/AbstractMachines/Computable/SubstMachine.v
+++ b/theories/L/AbstractMachines/Computable/SubstMachine.v
@@ -1,5 +1,261 @@
 (* Require Import L Programs AbstractMachines.FunctionalDefinitions LNat LProd Datatypes.Lists LOptions. *)
 (* Require Import LTactics. *)
 (* Require Import AbstractMachines.Computable.PslBase. *)
+(*
+Lemma N_size_nat_add_leq x y : N.size_nat (x+y) <= 1 + max (N.size_nat x) (N.size_nat y).
+Proof.
+  destruct x,y;cbn. 1-3:Lia.nia.
+  rewrite !pos_size_eq_log2.
+  destruct (@Pos.leb_spec0 p p0).
+  2:rename n into l;apply Pos.lt_nle,Pos.lt_le_incl in l. 
+  all:setoid_rewrite l at 1.
+  replace (p0 + p0)%positive with (2*p0)%positive;[|Lia.lia].
+  2:  replace (p + p)%positive with (2*p)%positive;[|Lia.lia].
+  all:rewrite Pos2Nat.inj_mul.
+  all:change (Pos.to_nat 2) with 2.
+  all:rewrite Nat.log2_double;[|now eauto using Pos2Nat.is_pos]. all:Lia.lia.
+Qed.
 
-(** *** TODO: Subst Machine *)
+Fixpoint substP_keepTrack'_time (m sizeQ : N) (P : list Tok) (k:nat) (revQ akk : Pro) (curSize : N) {struct P} := 
+          match P with
+            [] => length akk*13
+          | (t::P') =>
+            let
+              '(d, Q', k0) :=
+               match t with
+               | varT k' => if k' =? k then (sizeQ, None, Some k) else (N.of_nat (1 + k'), Some t, Some k)
+               | appT => (1%N, Some t, Some k)
+               | lamT => (1%N, Some t, Some (1 + k))
+               | retT => (1%N, Some t, if k =? 0 then None else Some (k - 1))
+               end in
+            match t with
+              varT k' => time_N_of_nat (1 + k') + 17 * Init.Nat.min k' k + 12 * N.size_nat sizeQ
+            | _ => 0
+            end
+            +
+            let curSize' := (d + curSize)%N in
+            24 * N.size_nat d + 24* N.size_nat curSize + 17 * N.size_nat curSize' +
+            if (curSize' <=? m)%N
+            then
+              let akk0 := match Q' with
+                    | Some t0 => t0 :: akk
+                    | None => revQ ++ akk
+                          end
+              in
+              match Q' with
+                Some t0 => 0
+              | _ => length revQ*16
+              end
+              +
+              match k0 with
+                None => length akk0 * 13
+              | Some k1 => substP_keepTrack'_time m sizeQ P' k1 revQ akk0 curSize'
+              end
+            else
+              0
+          end + 180.
+
+Fixpoint largestVar P :=
+  match P with
+    varT k::P' => max k (largestVar P')
+  | _::P' => largestVar P'
+  | [] => 0
+  end.
+
+Instance time_N_of_nat_mono: Proper (le ==> le) time_N_of_nat.
+Admitted.
+(*
+Lemma substP_keepTrack'_time_solved m sizeQ P k revQ akk curSize:
+  substP_keepTrack'_time m sizeQ P k revQ akk curSize <= sizeP P * 17 + 
+  length P * (time_N_of_nat (1 + largestVar P) + 180) + length akk * 13 + 180.
+Proof.
+  induction P in m,k,akk,curSize |-*;cbn- [plus mult largestVar]. 1:now Lia.lia.
+  destruct match a with
+    | varT k' => if k' =? k then (sizeQ, None, Some k) else (N.of_nat (1 + k'), Some a, Some k)
+    | appT => (1%N, Some a, Some k)
+    | lamT => (1%N, Some a, Some (1 + k))
+    | retT => (1%N, Some a, if k =? 0 then None else Some (k - 1))
+           end as [[d Q'] k0 ] eqn:eq.
+  remember (match Q' with
+            | Some t0 => t0 :: akk
+            | None => revQ ++ akk
+            end) as akk0.
+
+  setoid_rewrite ( _ : (match a with
+  | varT k' => time_N_of_nat (1 + k') + 17 * Init.Nat.min k' k + 12 * N.size_nat sizeQ
+  | _ => 0
+                        end <= time_N_of_nat (1 + largestVar (a :: P)) + 17 * sizeT a + 12*N.size_nat sizeQ)) at 1.
+  2:{ destruct a. 2-4:omega. cbn [largestVar].
+      rewrite <- (Nat.le_max_l n (largestVar P)) at 1. cbn [sizeT]. Lia.nia. (*assert (12 * N.size_nat sizeQ <= cnst "12*N.size_nat sizeQ"
+                                                             ) by admit. Lia.nia. *) }
+  rewrite N_size_nat_add_leq. 
+  2:admit.
+
+  
+  repeat (let eq := fresh "eq" in destruct _ eqn:eq);try (exfalso;congruence).
+  all:try rewrite !IHP.
+  all:inv eq. all:cbn [length]. ring_sim(plify.
+  all:try setoid_rewrite <- (Nat.le_max_l n0 (largestVar P)) at 2.
+  all:try setoid_rewrite <- (Nat.le_max_r n0 (largestVar P)) at 1.
+
+  y. ring_simplify. 
+  intros.  (d&Q'&k0). 
+*)
+Require Import Functions.BinNums BinNumsCompare.
+Require Import AbstractMachines.Computable.Shared.
+
+Instance cubstP_keepTrack' :
+  computableTime' substP_keepTrack'
+                 (fun m _ =>
+                    (5,fun sizeQ _ =>
+                         (1,fun P _ =>
+                              (1,fun k _ =>
+                                   (1,fun revQ _ =>
+                                        (1,fun akk _ =>
+                                             (1,fun curSize _ =>
+                                                (substP_keepTrack'_time m sizeQ P k revQ akk curSize,tt)))))))).
+unfold substP_keepTrack'.
+unfold sizeT.
+(*Set Ltac Profiling.*)
+extract.
+(*Show Ltac Profile.*)
+(* Without time:
+─extract -------------------------------   0.0% 100.0%       1   99.141s
+└computable using (open_constr) --------   0.0%  98.1%       1   97.241s
+└Intern.cstep --------------------------   0.0%  97.9%       0   71.965s
+└Intern.cstep' -------------------------   0.0%  97.9%       0   71.965s
+ ├─extractSimp -------------------------   0.0%  87.0%      10   71.207s
+ │└Intern.extractCorrectCrush_new ------   0.0%  87.0%      20   71.188s
+ │└Lrewrite_new ------------------------   0.0%  85.6%       0   16.354s
+ │└Lrewrite_wrapper --------------------  85.4%  85.6%       0   16.354s
+ │└Lrewrite_new' -----------------------  73.2%  85.4%     808    7.740s
+ │ ├─find_Lrewrite_lemma ---------------  33.5%  33.5%     774    0.694s
+ │ │ ├─eauto (int_or_var_opt) (int_or_va  20.4%  30.9%     774    0.694s
+ │ │ │└Lproc ---------------------------   6.8%   6.8%      60    0.549s
+ │ │ │└now (tactic) --------------------   0.0%   5.0%      60    0.491s
+ │ │ │└t -------------------------------   0.0%   5.0%      60    0.491s
+ │ │ │└Lproc' --------------------------   2.8%   4.9%    2973    0.018s
+ │ │ │└constructor ---------------------   2.1%   2.1%    1612    0.016s
+ │ │ └─eassumption ---------------------   2.5%   2.5%     709    0.018s
+ │ ├─Lbeta -----------------------------   0.0%  33.3%      99    0.951s
+ │ │└Lbeta' ----------------------------   0.1%  33.2%      99    0.951s
+ │ │└simplify_L' -----------------------   0.1%  32.3%       0    0.931s
+ │ │ ├─assert (pp : Reflection.Proc phi)   0.0%  21.8%      99    0.556s
+ │ │ │└ProcPhi -------------------------   0.0%  21.8%      99    0.556s
+ │ │ │└ProcPhi' ------------------------  20.0%  21.6%    1599    0.553s
+ │ │ │ ├─destruct H as [eq| H] ---------  10.0%  10.0%    1500    0.051s
+ │ │ │ ├─Lproc -------------------------   6.6%   6.6%    1500    0.028s
+ │ │ │ │└now (tactic) ------------------   0.0%   4.2%    1500    0.023s
+ │ │ │ │└t -----------------------------   0.0%   4.2%    1500    0.023s
+ │ │ │ │└Lproc' ------------------------   1.6%   4.2%    1792    0.023s
+ │ │ │ │└apply closed_dcl --------------   2.5%   2.5%    1500    0.023s
+ │ │ │ └─rewrite <- eq -----------------   2.6%   2.6%    1500    0.028s
+ │ │ ├─allVars -------------------------   0.0%   4.1%       0    0.162s
+ │ │ │└allVars' ------------------------   4.1%   4.1%       0    0.161s
+ │ │ │└addToList -----------------------   0.1%   3.7%       0    0.019s
+ │ │ │└AddFvTail -----------------------   3.6%   3.6%       0    0.019s
+ │ │ └─reifyTerm -----------------------   2.9%   2.9%       0    0.125s
+ │ ├─useFixHypo ------------------------  11.2%  11.2%     709    0.050s
+ │ │└eauto (int_or_var_opt) (int_or_var_   9.9%  10.0%     709    0.044s
+ │ ├─Lreflexivity ----------------------   2.8%   2.8%       0    0.014s
+ │ └─Ltransitivity ---------------------   0.1%   2.7%    3330    0.011s
+ │  └eapply star_trans -----------------   2.6%   2.6%    1665    0.011s
+ ├─Lproc -------------------------------   4.4%   4.4%       9    0.633s
+ │└now (tactic) ------------------------   0.0%   4.1%       9    0.598s
+ │└t -----------------------------------   0.0%   4.1%       9    0.598s
+ │└Lproc' ------------------------------   2.0%   4.1%    2271    0.023s
+ │└constructor -------------------------   2.1%   2.1%    1276    0.019s
+ └─step --------------------------------   3.9%   3.9%       4    3.910s
+  └extractSimp -------------------------   0.0%   3.8%       3    2.218s
+  └Intern.extractCorrectCrush_new ------   0.0%   3.8%       6    2.161s
+  └Lrewrite_new ------------------------   0.0%   3.7%       0    2.160s
+  └Lrewrite_wrapper --------------------   3.6%   3.7%       0    2.160s
+  └Lrewrite_new' -----------------------   2.5%   3.6%      18    2.143s
+  └Lbeta -------------------------------   0.0%   2.9%       5    0.615s
+  └Lbeta' ------------------------------   0.0%   2.9%       5    0.615s
+  └simplify_L' -------------------------   0.0%   2.8%       0    0.598s
+*)
+
+(*
+With time: 
+ tactic                                   local  total   calls       max 
+────────────────────────────────────────┴──────┴──────┴───────┴─────────┘
+─extract -------------------------------   0.0% 100.0%       1  156.385s
+ ├─computable using (open_constr) ------   0.0%  97.6%       1  152.579s
+ │└Intern.cstep ------------------------   0.0%  97.4%       0   92.135s
+ │└Intern.cstep' -----------------------   0.0%  97.4%       0   92.135s
+ │ ├─extractSimp -----------------------   0.0%  70.5%       8   90.958s
+ │ │└Intern.extractCorrectCrush_new ----   0.0%  70.5%      16   90.898s
+ │ │ ├─Lrewrite_new --------------------   0.0%  66.0%       0   21.996s
+ │ │ │└Lrewrite_wrapper ----------------  65.9%  66.0%       0   21.996s
+ │ │ │└Lrewrite_new' -------------------  55.9%  65.9%     782    9.255s
+ │ │ │ ├─Lbeta -------------------------   0.0%  23.3%      91    1.639s
+ │ │ │ │└Lbeta' ------------------------   0.1%  23.3%      91    1.638s
+ │ │ │ │└simplify_L' -------------------   0.1%  22.9%       0    1.608s
+ │ │ │ │ ├─assert (pp : Reflection.Proc    0.0%  15.6%      91    0.926s
+ │ │ │ │ │└ProcPhi ---------------------   0.0%  15.6%      91    0.926s
+ │ │ │ │ │└ProcPhi' --------------------  14.4%  15.5%    1395    0.923s
+ │ │ │ │ │ ├─destruct H as [eq| H] -----   6.2%   6.2%    1304    0.049s
+ │ │ │ │ │ └─Lproc ---------------------   6.0%   6.0%    1304    0.067s
+ │ │ │ │ │  └now (tactic) --------------   0.0%   3.9%    1304    0.047s
+ │ │ │ │ │  └t -------------------------   0.0%   3.9%    1304    0.047s
+ │ │ │ │ │  └Lproc' --------------------   2.0%   3.9%    1564    0.043s
+ │ │ │ │ └─allVars ---------------------   0.0%   3.1%       0    0.326s
+ │ │ │ │  └allVars' --------------------   3.1%   3.1%       0    0.326s
+ │ │ │ │  └addToList -------------------   0.1%   2.8%       0    0.025s
+ │ │ │ │  └AddFvTail -------------------   2.8%   2.8%       0    0.025s
+ │ │ │ ├─find_Lrewrite_lemma -----------  21.8%  21.8%     756    0.981s
+ │ │ │ │ ├─eauto (int_or_var_opt) (int_o  11.4%  18.7%     756    0.981s
+ │ │ │ │ │└Lproc -----------------------   6.1%   6.1%      60    0.851s
+ │ │ │ │ │└now (tactic) ----------------   0.0%   4.3%      60    0.737s
+ │ │ │ │ │└t ---------------------------   0.0%   4.3%      60    0.737s
+ │ │ │ │ │└Lproc' ----------------------   2.8%   4.2%    2973    0.042s
+ │ │ │ │ └─eassumption -----------------   3.0%   3.0%     691    0.113s
+ │ │ │ ├─useFixHypo --------------------  13.6%  13.6%     691    0.494s
+ │ │ │ │└eauto (int_or_var_opt) (int_or_  11.8%  11.9%     691    0.442s
+ │ │ │ └─Ltransitivity -----------------   0.1%   2.8%    3024    0.044s
+ │ │ │  └eapply redLe_trans ------------   2.7%   2.7%    1512    0.044s
+ │ │ └─Lreflexivity --------------------   3.8%   3.8%      19    1.186s
+ │ │  └Lproc ---------------------------   3.8%   3.8%      19    1.177s
+ │ │  └now (tactic) --------------------   0.0%   3.4%      19    1.067s
+ │ │  └t -------------------------------   0.0%   3.4%      19    1.066s
+ │ │  └Lproc' --------------------------   1.9%   3.4%    1695    0.049s
+ │ ├─loop ------------------------------  11.6%  11.6%       7   18.172s
+ │ │└extractSimp -----------------------   0.0%  11.4%       2    9.039s
+ │ │└Intern.extractCorrectCrush_new ----   0.0%  11.4%       4    7.596s
+ │ │└Lrewrite_new ----------------------   0.0%   9.7%       0    7.594s
+ │ │└Lrewrite_wrapper ------------------   9.6%   9.7%       0    7.594s
+ │ │└Lrewrite_new' ---------------------   7.8%   9.6%      26    7.504s
+ │ │└Lbeta -----------------------------   0.0%   6.9%       8    1.396s
+ │ │└Lbeta' ----------------------------   0.0%   6.9%       8    1.395s
+ │ │└simplify_L' -----------------------   0.0%   6.5%       0    1.326s
+ │ │└assert (pp : Reflection.Proc phi) b   0.0%   3.5%       8    0.731s
+ │ │└ProcPhi ---------------------------   0.0%   3.5%       8    0.731s
+ │ │└ProcPhi' --------------------------   3.2%   3.4%     204    0.723s
+ │ ├─Lproc -----------------------------   5.3%   5.3%       9    1.289s
+ │ │└now (tactic) ----------------------   0.0%   5.0%       9    1.227s
+ │ │└t ---------------------------------   0.0%   5.0%       9    1.227s
+ │ │└Lproc' ----------------------------   2.9%   5.0%    2271    0.055s
+ │ │└constructor -----------------------   2.1%   2.1%    1276    0.034s
+ │ ├─step ------------------------------   3.9%   4.0%       4    6.233s
+ │ │└extractSimp -----------------------   0.0%   3.7%       3    3.072s
+ │ │└Lsimpl ----------------------------   0.0%   3.7%       3    3.072s
+ │ │└Lbeta -----------------------------   0.0%   3.5%       7    1.332s
+ │ │└Lbeta' ----------------------------   1.8%   3.5%       6    1.332s
+ │ │└simplify_L' -----------------------   0.0%   3.4%       0    1.307s
+ │ └─destruct tt -----------------------   3.5%   3.5%      13    0.526s
+ └─Intern.extractAs --------------------   0.0%   2.4%       1    3.806s
+  └run_template_program (constr) (tactic   2.4%   2.4%       1    3.805s
+ *)
+solverec.
+(*recRel_prettify_arith.
+unfold substP_keepTrack'_time.
+all:fold substP_keepTrack'_time.
+all:change (N.size_nat 1) with 1%nat.
+all:try rewrite !Nat.min_0_r.
+all:try pose (Nat.le_min_r x0 1).
+all:cbn [length].
+all:try abstract Lia.nia.*)
+all:fail.
+Check "success modulo QED., TODO: use recursion instead fix".
+Admitted.*)

--- a/theories/L/AbstractMachines/Computable/Unfolding.v
+++ b/theories/L/AbstractMachines/Computable/Unfolding.v
@@ -1,0 +1,105 @@
+From Undecidability.L Require Import L Tactics.LTactics.
+From Undecidability.L.Datatypes Require Import LSum LBool LNat Lists.
+
+From Undecidability.L.AbstractMachines Require Import FunctionalDefinitions AbstractHeapMachineDef Programs UnfoldTailRec UnfoldHeap.
+
+Require Import Undecidability.L.AbstractMachines.LargestVar.
+
+From Undecidability.L Require Import Prelim.LoopSum Functions.LoopSum Functions.UnboundIteration Functions.LoopSum Functions.Equality.
+
+From Undecidability.L.AbstractMachines.Computable Require Import Shared Lookup.
+
+
+Run TemplateProgram (tmGenEncode "task_enc" task).
+Hint Resolve task_enc_correct : Lrewrite.
+
+Instance termT_S : computableTime' closT (fun _ _ => (1,fun _ _ => (1,tt))).
+Proof.
+  extract constructor.
+  solverec.
+Defined.
+
+Definition time_unfoldTailRecStep : (list task * list heapEntry * list term ) -> _ :=
+  fun '(stack,H,res) => match stack with
+                     | closT (var n,a) k::_ => lookupTime (length H) (n-k) + min n k * 28
+                     | _ => 0
+                     end + 96.
+
+Instance term_unfoldTailRecStep : computableTime' unfoldTailRecStep (fun x _ => (time_unfoldTailRecStep x,tt)).
+extract. unfold time_unfoldTailRecStep. solverec.
+Qed.
+
+
+
+Definition unfoldBool_time lengthH largestVar :=
+  lookupTime lengthH largestVar * 7 + largestVar *196+ 1245.
+
+Instance term_unfoldBool : computableTime' unfoldBoolean
+                                          (fun H _ => (1,fun q _ => (unfoldBool_time (length H) (max (largestVarH H) (largestVarC q)),tt))).
+Proof.
+  unfold unfoldBoolean.
+  unfold enc. cbn [registered_bool_enc bool_enc].
+  extract.
+  clear used_term.
+  recRel_prettify.
+  intros H _. split. reflexivity.
+  intros [s a] _. split. 2:now solverec.
+  unshelve eassert (H':= time_loopSum_bound_onlyByN _ _
+      (f:=unfoldTailRecStep)
+      (fT:=(fun (x0 : list task * list heapEntry * list term) (_ : unit) => (time_unfoldTailRecStep x0, tt)))
+      (P:= fun n '(stack,H',res) =>
+             H' = H
+             /\ largestVarState (stack,H',res) <= max (largestVarH H) (largestVar s)
+             /\ (length res <= n))
+      (boundL := 96 + lookupTime (length H) (max (largestVarH H) (largestVar s)) + max (largestVarH H) (largestVar s) * 28)
+      (boundR := fun n => 28*n) _).
+
+  -intros n x. assert (H':=unfoldTailRecStep_largestVar_inv x).
+   unfold unfoldTailRecStep in *.
+   repeat (let eq := fresh "eq" in destruct _ eqn:eq);inv eq1;try congruence.
+   all:unfold time_unfoldTailRecStep.
+   
+   all:intros (->&H'1&?).
+   all:try rewrite H',H'1.
+   all:cbn [fst].
+   all:intuition (try eassumption;cbn [length];try Lia.lia;try eauto).
+   
+
+   all:repeat match goal with
+                H : _ <=? _ = true |- _ => apply Nat.leb_le in H
+              | H : _ <=? _ = false |- _ => apply Nat.leb_gt in H
+              | H : lookup _ _ _ = Some _ |- _ => apply lookup_size in H;cbn in H
+              end.
+   3:now cbn in *;Lia.nia.
+   1-3:assert (H'3 : n1 <= (Init.Nat.max (largestVarH H) (largestVar s))) by (cbn in *; Lia.nia).
+   1-3:rewrite lookupTime_mono with (n' := Init.Nat.max (largestVarH H) (largestVar s));[|reflexivity|try omega].
+   1-3:cbn - [plus mult]in *.
+   1-3:Lia.lia.
+  -rewrite H'. clear H'.
+   2:{ cbn. intuition idtac. all:Lia.lia. } 
+   ring_simplify.
+   (*
+   specialize @list_eqbTime_bound_r with (f:=fun x => 17 * sizeT x + 11) as H'1.
+*)
+   destruct loopSum as [[]|].
+   cbn [size].
+   repeat destruct _.
+   all:unfold unfoldBool_time, largestVarC.
+   all:Lia.lia.
+Qed.
+
+
+Lemma unfoldBool_time_mono l l' n n':
+  l <= l' -> n <= n' -> unfoldBool_time l n <= unfoldBool_time l' n'.
+Proof.
+  unfold unfoldBool_time. intros H1 H2.
+  rewrite lookupTime_mono. 2,3:eassumption. rewrite H2. reflexivity.
+Qed.
+
+Lemma unfoldBool_time_leq lengthH largestVar :
+  unfoldBool_time lengthH largestVar <= (largestVar + 1) * (lengthH * 15 + 38 + 28) * 7 + 1245.
+Proof.
+  unfold unfoldBool_time. unfold lookupTime.
+  Lia.nia.
+Qed.
+

--- a/theories/L/AbstractMachines/Computable/UnivDecTime.v
+++ b/theories/L/AbstractMachines/Computable/UnivDecTime.v
@@ -1,0 +1,129 @@
+From Undecidability.L.Datatypes Require Import LNat LBool.
+From Undecidability.L Require Import Tactics.LTactics AbstractMachines.Computable.Unfolding Prelim.LoopSum Functions.UnboundIteration AbstractMachines.LargestVar.
+From Undecidability.L.AbstractMachines Require Import AbstractHeapMachine FunctionalDefinitions Programs UnfoldHeap UnfoldTailRec. 
+From Undecidability.L.AbstractMachines.Computable Require Import Shared HeapMachine Unfolding.
+
+Definition univStep '(T,V,H) : _ + bool :=
+  match heapStep (T,V,H) with
+    Some s' => inl s'
+  | None =>
+    match T,V with
+      [],[g] => match unfoldBoolean H g with
+                 Some b => inr b
+               | None => inr false (* don't care *)
+               end
+    | _,_ => inr false (* don't care *) 
+    end
+  end.
+
+Instance termT_univStep : computableTime' univStep (fun x _ => 
+                                                     (let '(T,V,H):=x in
+                                                      heapStep_time T H +
+                                                      match heapStep x with
+                                                        Some _ => 0
+                                                      | _ => match T,V with
+                                                              [],[q] => unfoldBool_time (length H) (Init.Nat.max (largestVarH H) (largestVarC q))
+                                                            | _,_ => 0 end
+                                                      end + 33,tt)).
+Proof.
+  extract. solverec.
+Qed.
+
+Definition univDecTime :term := Eval cbn in λ s , uiter univStep (!!(extT init) s).
+
+Definition univDecTime_time maxVar size n0 :=
+  108 * size + (n0+2) * (heapStep_timeBound maxVar (n0+1) + 42) + unfoldBool_time (n0+1) maxVar +87.
+
+Lemma step_UC : uniform_confluent step.
+Proof.
+  intros ? ? ? R1 R2;inv R1;inv R2. all:left;congruence.
+Qed.
+
+Lemma evalIn_mono s t n n' :
+  s ⇓(<=n) t -> n <= n' -> s ⇓(<=n') t.
+Proof.
+  intros ? <-. easy.
+Qed.
+
+Lemma univDecTime_complete (s:term) (b:bool) k:
+  closed s ->
+  s ⇓(k) (enc b) ->
+  univDecTime (enc s) ⇓(<= univDecTime_time (largestVar s) (size s) (k*4+1)) enc b.
+Proof.
+  intros cs R. apply ResourceMeasures.timeBS_evalIn in R.
+  apply correctTime in R as (g&H&rep&R). 2:easy.
+  unfold univDecTime, univDecTime_time.
+  Lsimpl.
+  eapply loopSum_sound_rel with (n:=1) (f:=univStep)in R as R'.
+  2:{ intros ? ? R'. unfold univStep. cbn. repeat (let eq := fresh in destruct _ eqn:eq);inv R';try congruence. }
+  cbn [loopSum univStep heapStep] in R'.
+  erewrite unfoldBoolean_complete in R'. 2:eassumption.
+  unshelve eapply uiter_sound in R'. 4:now exact _.
+  cbn -[plus mult] in R'.
+  remember (4*k+2) as n0.
+  erewrite uiterTime_bound_recRel with
+      (iterT := fun n _ => n* (heapStep_timeBound (largestVar s) n0 + 9 + 33) + unfoldBool_time n0 (largestVar s))
+      (P:= fun i x => i <= n0 /\  pow AbstractHeapMachineDef.step i (init s) x)
+      (2:=le_n _)
+    in R'.
+  2:{
+    intros n ((T&V)&Hp) [H1 H2].
+    specialize uniform_confluence_parameterized_terminal with (3:=R) (4:=H2) as (n'&R2&?).
+    1:exact step_UC.
+    1:now (intros ? H';inv H').
+    unfold univStep. cbn [fst snd].
+    specialize (subterm_property H2) as (st1&st2&st3).
+    assert (largestVarH Hp <= largestVar s).
+    { eapply largestVarH_bound. intros [] ? H'. cbn. eauto using subterm_lam_inv, subterm_largestVar. }
+    destruct n'.
+    -inversion R2. subst T V H. cbn [heapStep].
+     erewrite unfoldBoolean_complete. 2:eassumption.
+     rewrite heapStep_timeBound_le. 2:now eauto.
+     rewrite heapStep_timeBound_mono with (k':=n0). 2:eassumption.
+     rewrite unfoldBool_time_mono with (l':= n0) (n':=largestVar s).
+     *now Lia.nia.
+     *rewrite <- H1. eapply length_H. eauto.
+     *eapply Nat.max_case. easy.
+      destruct g. cbn. eauto using subterm_lam_inv, subterm_largestVar.
+    -change (S n') with (1+n') in R2. replace (S n) with (n+1) by omega.
+     eapply pow_add with (R:=step) in R2 as (?&R2&R2').
+     eapply rcomp_1 with (R:=step) in R2. revert Heqn0. inv R2. all:intro.
+     all: cbn [heapStep].
+     +rewrite H0. intuition idtac.
+      *Lia.lia.
+      *eapply pow_add with (R:=step).
+       eexists;split. eassumption. apply (rcomp_1 step). now constructor.
+      *rewrite heapStep_timeBound_le. 2:now eauto.
+       rewrite heapStep_timeBound_mono with (k:=n). 2:eassumption.
+       Lia.nia.
+     +rewrite H9. intuition idtac.
+      *Lia.lia.
+      *eapply pow_add with (R:=step).
+       eexists;split. eassumption. apply (rcomp_1 step). now constructor.
+      *rewrite heapStep_timeBound_le. 2:now eauto.
+       rewrite heapStep_timeBound_mono with (k:=n). 2:eassumption.
+       Lia.nia.
+     +rewrite H9. intuition idtac.
+      *Lia.lia.
+      *eapply pow_add with (R:=step).
+       eexists;split. eassumption. apply (rcomp_1 step). now constructor.
+      *rewrite heapStep_timeBound_le. 2:now eauto.
+       rewrite heapStep_timeBound_mono with (k:=n). 2:eassumption.
+       Lia.nia.
+     +intuition idtac.
+      *Lia.lia.
+      *eapply pow_add with (R:=step).
+       eexists;split. eassumption. apply (rcomp_1 step). now constructor.
+      *rewrite heapStep_timeBound_le. 2:now eauto.
+       rewrite heapStep_timeBound_mono with (k:=n). 2:eassumption.
+       Lia.nia.
+  }
+  {
+    subst n0.
+    eapply evalIn_mono. 1:Lsimpl. exact R'. cbn [fst snd].
+    replace (k*4) with (4*k) by Lia.lia. replace (4*k +1+1) with (4*k+2) by Lia.lia. ring_simplify.
+    Lia.nia.
+  }
+  rewrite !Nat.sub_diag. easy.
+Qed.
+

--- a/theories/L/AbstractMachines/FunctionalDefinitions.v
+++ b/theories/L/AbstractMachines/FunctionalDefinitions.v
@@ -1,5 +1,6 @@
 From Undecidability.L Require Import L Programs.
 From Undecidability.L.AbstractMachines Require AbstractHeapMachineDef AbstractSubstMachine.
+Import AbstractHeapMachineDef.clos_notation.
 
 (** ** Functional definitions of the abstract machines *)
 

--- a/theories/L/AbstractMachines/LargestVar.v
+++ b/theories/L/AbstractMachines/LargestVar.v
@@ -1,0 +1,36 @@
+From Undecidability.L.Datatypes Require Import LProd LNat LTerm.
+
+Fixpoint largestVar (s:term) : nat :=
+  match s with
+    var n => n
+  | app s t => max (largestVar s) (largestVar t)
+  | lam s => largestVar s
+  end.
+
+
+Lemma largestVar_prod X Y `{Rx : registered X} {Ry : registered Y} (w:X*Y):
+  largestVar (enc w) = max (largestVar (enc (fst w))) (largestVar (enc (snd w))).
+Proof.
+  destruct w.
+  unfold enc. destruct Rx,Ry. cbn.  reflexivity.
+Qed.
+Lemma largestVar_nat (n:nat):
+  largestVar (enc n) <= 1.
+Proof.
+  unfold enc,registered_nat_enc.
+  induction n;cbn in *. all:Lia.lia.
+Qed.
+Lemma largestVar_term (s:term):
+  largestVar (enc s) <= 2.
+Proof.
+  unfold enc,registered_term_enc.
+  induction s;cbn -[max] in *.
+  1:rewrite largestVar_nat.
+  all:try Lia.lia.
+Qed.
+
+Lemma largestVar_size s :
+  largestVar s <= size s.
+Proof.
+  induction s;cbn;Lia.lia.
+Qed.

--- a/theories/L/AbstractMachines/Programs.v
+++ b/theories/L/AbstractMachines/Programs.v
@@ -1,4 +1,5 @@
-From Undecidability.L Require Import Prelim.MoreBase L.
+From Undecidability.L Require Import Prelim.MoreBase L AbstractMachines.LargestVar.
+Require Import Lia.
 
 (** * Abstract L machines *)
 (** ** Encoding Terms as Programs *)
@@ -49,6 +50,12 @@ Proof.
   all:autorewrite with list. all:cbn. all:try omega.
 Qed.
 
+
+Lemma le_length_sizeP P :
+  length P <= sizeP P.
+Proof.
+  unfold sizeP. induction P as [|[]];cbn in *;try Lia.lia.
+Qed.
 
 (** *** Programm Decomposition *)
 
@@ -113,22 +120,23 @@ Qed.
 
 (** *** Injectivity of Programm Encoding *)
 
-Fixpoint decompile l P A : option (list term) :=
+(** returning the internal state as inr allows for stronger results w.r.t. decompiling initial segments*)
+Fixpoint decompile l P A {struct P}: (list term) + (nat * Pro * list term) :=
   match P with
     retT::P => match l with
-                0 => None
+                0 => inr (l,retT::P,A)
               | S l => match A with
                         s::A => decompile l P (lam s::A)
-                      | [] => None
+                      | [] => inr (S l, retT::P, A)
                       end
               end
   | varT n::P => decompile l P (var n::A)
   | lamT::P =>  decompile (S l) P A
   | appT::P => match A with
                t::s::A => decompile l P (app s t::A)
-             | _ => None
+             | _ => inr (l, appT::P, A)
               end
-  | [] => Some A
+  | [] => inl A
   end.
 
 Lemma decompile_correct' l s P A:
@@ -147,4 +155,60 @@ Proof.
   specialize (@decompile_correct' 0 s [] []) as H1.
   specialize (@decompile_correct' 0 s' [] []) as H2.
   rewrite eq in H1. rewrite H1 in H2. now inv H2.
+Qed.
+
+Lemma compile_neq_nil s:
+  compile s <> [].
+Proof.
+  edestruct (compile s) eqn:eq. 2:easy.
+  specialize decompile_correct' with (l:=0) (s:=s) (P:=[]) (A:=[]).
+  rewrite eq.
+  cbn. easy.
+Qed.
+
+Lemma compile_inj_retT s s' P P':
+  compile s ++ retT::P = compile s' ++ retT::P' -> s = s' /\ P = P'.
+Proof.
+  intros eq.
+  specialize (@decompile_correct' 0 s (retT::P) []) as H1.
+  specialize (@decompile_correct' 0 s' (retT::P') []) as H2.
+  rewrite eq in H1. rewrite H1 in H2.
+  now inv H2.
+Qed.
+
+Definition Tok_eqb (t t' : Tok) :=
+  match t,t' with
+    varT n, varT n' => Nat.eqb n n'
+  | retT,retT => true
+  | lamT, lamT => true
+  | appT, appT => true
+  | _,_ => false
+  end.
+
+Lemma Tok_eqb_spec t t' : reflect (t = t') (Tok_eqb t t').
+Proof.
+  destruct t,t'. all:cbn. destruct (Nat.eqb_spec n n0);[subst|].
+  all:try left;eauto.
+  all:right;congruence.
+Qed.
+
+Definition largestVarT t :=
+  match t with
+    varT n => n
+  | _ => 0
+  end.
+
+
+Definition largestVarP P := maxl (map largestVarT P).
+
+Lemma largestVar_compile s :
+  largestVarP (compile s) = largestVar s.
+Proof.
+  unfold largestVarP in *. 
+  induction s;cbn.
+  -Lia.lia.
+  -autorewrite with list. rewrite ! maxl_app.
+   rewrite IHs1,IHs2. cbn. Lia.lia.
+  -autorewrite with list. rewrite ! maxl_app.
+   rewrite IHs. cbn. Lia.lia.
 Qed.

--- a/theories/L/AbstractMachines/UnfoldTailRec.v
+++ b/theories/L/AbstractMachines/UnfoldTailRec.v
@@ -1,5 +1,6 @@
 From Undecidability.L Require Import L Prelim.LoopSum Functions.UnboundIteration AbstractMachines.LargestVar.
 From Undecidability.L.AbstractMachines Require Import AbstractHeapMachine UnfoldHeap.
+Import AbstractHeapMachineDef.clos_notation.
 
 Local Inductive task := closT (q:clos) (k:nat) | appT | lamT.
 

--- a/theories/L/AbstractMachines/UnfoldTailRec.v
+++ b/theories/L/AbstractMachines/UnfoldTailRec.v
@@ -1,0 +1,203 @@
+From Undecidability.L Require Import L Prelim.LoopSum Functions.UnboundIteration AbstractMachines.LargestVar.
+From Undecidability.L.AbstractMachines Require Import AbstractHeapMachine UnfoldHeap.
+
+Local Inductive task := closT (q:clos) (k:nat) | appT | lamT.
+
+(* function that unfolds if unfoldable *)
+Definition unfoldTailRecStep '(stack,H,res) : (list task * list heapEntry * list term) + option term :=
+  match stack with
+  | [] => match res with
+           [s] => inr (Some s)
+         | _ => inr None
+         end
+  | t::stack =>
+    match t with
+    | closT (s,a) k =>
+      match s with
+        var n => if ( k <=? n) then
+                  match lookup H a (n-k) with
+                  | Some q' =>
+                    inl (closT q' 1::lamT::stack,H,res)
+                  | None => inr None
+                  end
+                else
+                  inl (stack,H,var n::res)
+                      
+      | lam s => inl (closT (s,a) (S k)::lamT::stack,H,res)
+      | app s1 s2 => inl (closT (s1,a) k::closT (s2,a) k::appT::stack,H,res)
+      end
+    | appT => match res with
+               s2::s1::res => inl (stack,H,app s1 s2::res)
+             | _ => inr None
+             end
+    | lamT => match res with
+               s::res => inl (stack,H,lam s::res)
+             | _ => inr None
+             end
+    end
+  end.
+
+Lemma unfoldTailRecStep_complete' H a k s s' stack res fuel:
+  unfolds H a k s s' ->
+  exists n, 
+  loopSum (n + fuel) unfoldTailRecStep (closT (s,a) k::stack,H,res)
+  = loopSum fuel unfoldTailRecStep (stack,H,s'::res) /\ n <= size s' *2.
+Proof.
+  induction 1 in fuel,stack,res|-*.
+  -eexists 1. cbn [loopSum unfoldTailRecStep plus depth]. 
+   destruct (Nat.leb_spec0 k n). now omega.
+   intuition.
+  -edestruct IHunfolds as (n'&eq1&?).
+   exists (S (n' + 1)). cbn.
+   destruct (Nat.leb_spec0 k n). 2:now omega.
+   rewrite H1,<- Nat.add_assoc,eq1.
+   cbn. intuition.
+  -edestruct IHunfolds as (n'&eq1&?).
+   exists (S (n' + 1)). cbn.
+   rewrite <- Nat.add_assoc,eq1. 
+   cbn. intuition.
+  -edestruct IHunfolds2 as (n2&eq2&?).
+   edestruct IHunfolds1 as (n1&eq1&?).
+   exists (S (n1 + (n2 + 1))). cbn.
+   rewrite <- !Nat.add_assoc.
+   rewrite eq1, eq2. 
+   cbn. intuition.
+Qed.
+
+Lemma unfoldTailRecStep_complete H a k s s' n:
+  unfolds H a k s s' ->
+  2 * size s' + 1 <= n ->
+  loopSum n unfoldTailRecStep ([closT (s,a) k],H,[])
+  = Some (Some s').
+Proof.
+  intros ? ?.
+  edestruct unfoldTailRecStep_complete' as (n'&eq1&?). eassumption.
+  eapply loopSum_mono with (n:=n'+1). now Lia.nia.
+  rewrite eq1. reflexivity.
+Qed.
+
+Lemma unfoldTailRecStep_sound' s a k stack H res s0 fuel :
+  loopSum fuel unfoldTailRecStep (closT (s,a) k::stack,H,res) = Some (Some s0)
+  -> exists s' fuel', unfolds H a k s s'
+                /\ loopSum fuel unfoldTailRecStep (closT (s,a) k::stack,H,res)
+                  = loopSum fuel' unfoldTailRecStep (stack,H,s'::res)
+                /\ fuel' <= fuel.
+Proof.
+  revert s0 s a k stack res.
+  induction fuel as [fuel IH] using lt_wf_ind.
+  intros ? ? ? ? ? ?.
+  destruct fuel. easy.
+  destruct s as [n|s1 s2|s].
+  all:cbn in *.
+  -destruct (Nat.leb_spec0 k n) as [ |n0].
+   destruct lookup as [[R0 b]| ] eqn:eq__lookup . 2:now congruence.
+   +intros H'.
+    specialize IH with (2:=H') as (s'&fuel'&R&eq'&leq'). easy.
+    rewrite eq' in *.
+    destruct fuel' as [ |fuel']. easy.
+    cbn in *.
+    exists (lam s'), fuel'.
+    repeat apply conj.
+    1-2:now eauto using unfolds.
+    Lia.nia.
+   +intros H'.
+    do 2 eexists. repeat apply conj.
+    2,1:now eauto 10 using unfolds,not_ge.
+    Lia.nia.
+  -intros H'.
+   assert (IH':=IH).
+   specialize IH' with (2:=H') as (s1'&fuel1&R1&eq1&leq1). easy.
+   rewrite eq1 in *.
+   specialize IH with (2:=H') as (s2'&fuel2&R2&eq2&leq2). easy.
+   rewrite eq2 in *.
+   destruct fuel2 as [ |fuel2]. easy.
+   cbn in *.
+   eexists _,_. repeat apply conj.
+   1,2:now eauto using unfolds.
+   Lia.nia.
+  -intros H'.
+   specialize IH with (2:=H') as (s'&fuel'&R&eq1&leq'). easy.
+   rewrite eq1 in *.
+   destruct fuel' as [ |fuel']. easy.
+   eexists _,_. repeat apply conj.
+   1,2:now eauto using unfolds.
+   Lia.nia.
+Qed.
+   
+Lemma unfoldTailRecStep_sound s a k H s' fuel:
+  loopSum fuel unfoldTailRecStep ([closT (s,a) k],H,[]) = Some (Some s')
+  -> unfolds H a k s s'.
+Proof.
+  intros H'.
+  specialize (unfoldTailRecStep_sound' H') as (k0&fuel'&R&eq'&leq').
+  rewrite eq' in *. destruct fuel'. easy.
+  inv H'. easy.
+Qed.
+
+Definition largestVarState : (list task * list heapEntry * list term) -> nat :=
+  fun '(stack,H,res) => max (maxl (map (fun (t:task) =>
+                                       match t with
+                                         closT q _ => largestVarC q
+                                       | _ => 0
+                                       end) stack))
+                         (max (largestVarH H) (maxl (map largestVar res))).
+
+Lemma unfoldTailRecStep_largestVar_inv x:
+  match unfoldTailRecStep x with
+    inl x' => largestVarState x'
+  | inr (Some A)  => largestVar A
+  | _ => 0
+  end
+  <= largestVarState x.
+
+Proof.
+  unfold unfoldTailRecStep.
+  repeat (let eq := fresh "eq" in destruct _ eqn:eq);inv eq;try congruence.
+  
+
+  
+  all:repeat match goal with
+               H : _ <=? _ = true |- _ => apply Nat.leb_le in H
+             | H : _ <=? _ = false |- _ => apply Nat.leb_gt in H
+             | H : lookup _ _ _ = Some _ |- _ => apply lookup_size in H;cbn in H
+
+             end.
+  all:unfold largestVarState,largestVarCs,largestVarC in *; cbn;fold maxl.
+  all:try Lia.lia.
+Qed. 
+
+Require Import Undecidability.L.Functions.Equality.
+
+
+
+Definition unfoldBoolean H (p:clos) : option bool :=
+  let '(s,a) := p in
+  match loopSum 7 unfoldTailRecStep ([closT p 1],H,[]) with
+  | Some (Some t) =>
+    if term_eqb (lam t) (enc true)
+    then Some true
+    else if term_eqb (lam t) (enc false )
+         then Some false
+         else None       
+  | _ => None
+  end.
+
+Lemma unfoldBoolean_complete H p (b:bool) :
+  reprC H p (enc b) -> unfoldBoolean H p = Some b.
+Proof.
+  intros H1. inv H1. unfold unfoldBoolean.
+  erewrite unfoldTailRecStep_complete. 2:easy. 2:{ destruct b;inv H2;cbn;Lia.lia. }
+  destruct b;inv H2;cbv. all:reflexivity.
+Qed.
+
+Lemma unfoldBoolean_sound (H : list heapEntry) (p : clos) (b : bool) :
+  unfoldBoolean H p = Some b -> reprC H p (enc b).
+Proof.
+  unfold unfoldBoolean.
+  destruct p as [P a]. 
+  destruct loopSum as [[]| ] eqn:H'. 2-3:easy.
+  eapply unfoldTailRecStep_sound in H'.
+  destruct (term_eqb_spec (lam t) (enc true)).
+  2: destruct (term_eqb_spec (lam t) (enc false)).
+  all:inversion 1. all:inv e. all:cbv in *. all:easy.
+Qed.

--- a/theories/L/Computability/Acceptability.v
+++ b/theories/L/Computability/Acceptability.v
@@ -1,4 +1,4 @@
-From Undecidability.L Require Export Por Decidability Lbeta_nonrefl.
+From Undecidability.L Require Export LTerm Por Decidability Lbeta_nonrefl.
 
 (** * Definition of L-acceptability *)
 

--- a/theories/L/Computability/Decidability.v
+++ b/theories/L/Computability/Decidability.v
@@ -1,4 +1,4 @@
-From Undecidability.L Require Export Functions.Encoding Datatypes.LBool L.
+From Undecidability.L Require Export Tactics.LTactics Functions.Encoding Datatypes.LBool L.
 
 (** * Definition of L-decidability *)
 

--- a/theories/L/Computability/Enum.v
+++ b/theories/L/Computability/Enum.v
@@ -5,7 +5,7 @@ Notation "A '.[' i  ']'" := (elAt A i) (no associativity, at level 50).
 Fixpoint appCross A B :=
 match A with
 | nil => nil
-| a :: A => appCross A B ++ map (app a) B
+| a :: A => map (app a) B ++ appCross A B 
 end.
 
 Fixpoint T n := 
@@ -33,7 +33,7 @@ Lemma appCross_correct A B s t : (s el A /\ t el B) <-> (app s t) el appCross A 
 Proof.
   split.
   - induction A; simpl; intuition; subst; eauto using in_map. 
-  - induction A; simpl; try rewrite in_app_iff in *; intros H; try tauto; destruct H as [H1 | H2]; intuition; rewrite in_map_iff in *; destruct H2; destruct H; [left|]; congruence. 
+  - induction A; simpl; try rewrite in_app_iff in *; intros H; try tauto; destruct H as [H1 | H2]; intuition; rewrite in_map_iff in *; destruct H1; destruct H; [left|]; congruence. 
 Qed.
 
 Lemma T_var n : #n el T n.
@@ -136,10 +136,11 @@ Qed.
 Lemma appCross_dupfree A B : dupfree A -> dupfree B -> dupfree (appCross A B).
 Proof with eauto using dupfree; intuition.
   induction 1; intros dpf_B; simpl...
-  eapply dupfree_app... eapply disjoint_forall. intros y Hy. 
-  destruct (appCross_app Hy) as [y1 [y2 Hyy]]; subst. eapply appCross_correct in Hy.
-  intros D. eapply in_map_iff in D. destruct D as [d [D1 D2]]. inv D1...
-  eapply dupfree_map... congruence. 
+  eapply dupfree_app...
+  -eapply disjoint_forall. intros y D Hy. 
+  edestruct (appCross_app Hy) as [y1 [y2 Hyy]]; subst. eapply appCross_correct in Hy as []. 
+  eapply in_map_iff in D. destruct D as [d [D1 D2]]. inv D1...
+  -eapply dupfree_map... congruence. 
 Qed.
 
 Lemma dupfree_T : forall n, dupfree (T n).
@@ -352,4 +353,4 @@ Proof.
   destruct (nth_error (C n) n); Lsimpl.
   intros; Lproc. intros; Lproc.
 Qed.  
-*)
+ *) 

--- a/theories/L/Computability/Fixpoints.v
+++ b/theories/L/Computability/Fixpoints.v
@@ -1,4 +1,4 @@
-From Undecidability.L Require Export Functions.Encoding Tactics.Lbeta_nonrefl.
+From Undecidability.L Require Export LTactics LTerm Functions.Encoding Tactics.Lbeta_nonrefl.
 
 (** * First Fixed Point Theorem *)
 

--- a/theories/L/Computability/Por.v
+++ b/theories/L/Computability/Por.v
@@ -36,7 +36,7 @@ Proof.
   intros [convs | convt]; eauto using Por_correct_1a, Por_correct_1b.
 Qed.
 
-Lemma Por_correct_2 s t : converges (Por (ext s) (ext t)) -> 
+Lemma Por_correct_2 (s t:term) : converges (Por (ext s) (ext t)) -> 
   exists (b:bool), Por (ext s) (ext t) == ext b.
 Proof.
   intros [v [R lv]]. unfold Por in R. LsimplHypo.

--- a/theories/L/Computability/Seval.v
+++ b/theories/L/Computability/Seval.v
@@ -15,7 +15,7 @@ Inductive seval : nat -> term -> term -> Prop :=
 | sevalS n s t u v w : 
     seval n s (lam u) -> seval n t (lam v) -> seval n (subst u 0 (lam v)) w -> seval (S n) (s t) w.                                   
 
-Notation "s '⇓' n t" := (seval n s t) (at level 51).
+Local Notation "s '⇓' n t" := (seval n s t) (at level 51).
 
 Lemma seval_eval n s t : seval n s t -> eval s t.
 Proof with eauto using star_trans, star_trans_l, star_trans_r.
@@ -173,25 +173,28 @@ Fixpoint stepf (s : term) : list term :=
   | app s t => map (fun x => app x t) (stepf s) ++ map (fun x => app s x) (stepf t)
   end.
 
-Ltac inv_step :=
+Ltac stepf_tac := 
   match goal with
-  | [ H : ?s ≻ ?t |- ?P ] => inv H
-  end.
+  | [ H : app _ _ ≻ ?t |- ?P ] => inv H
+  | [ H : var _ ≻ ?t |- ?P ] => inv H
+  | [ H : lam _ ≻ ?t |- ?P ] => inv H
+
+  | [ H : exists x, _ |- _ ] => destruct H
+  | [ H : _ /\ _ |- _ ] => destruct H
+  end + subst.
 
 Lemma stepf_spec s t : t el stepf s <-> s ≻ t.
-(*Proof with try ( cbn; rewrite ?in_app_iff, !in_map_iff; firstorder; [ subst; econstructor; (eapply IHs1 || eapply IHs2); eauto | .. ]; try now (inv_step; firstorder)). 
-  revert t; induction s; intros; try now (firstorder; inv H).
+Proof.
+  revert t; induction s; intros; try now (firstorder; inv H). cbn.
   destruct s1, s2.
-  -now (firstorder; do 5 inv_step).
-  -idtac...
-  -now (firstorder; do 5 inv_step).
-  -idtac...
-  -idtac... rewrite <- H. econstructor. firstorder.
-  -idtac...
-  -now (firstorder; do 5 inv_step).
-  -idtac...
-  -cbn. firstorder subst. econstructor. inv_step; firstorder.*)
-Admitted.
+  all:cbn - [stepf].
+  all:try rewrite !in_app_iff;try rewrite !in_map_iff.
+  1-8:setoid_rewrite IHs1.
+  1-8:try setoid_rewrite IHs2.
+  all:intuition idtac.
+  all:repeat stepf_tac.
+  all:eauto using step.
+Qed.
 
 Fixpoint stepn (n : nat) s : list term :=
   match n with
@@ -211,4 +214,16 @@ Proof.
   intros H. destruct H. eapply star_pow in H. apply cChoice; eauto.
   intros. eapply dec_transfer.
   eapply stepn_spec. exact _.
+Qed.
+
+Lemma informative_eval2 s : (exists t, eval s t) -> {t | eval s t}.
+Proof.
+  intros H.
+  edestruct cChoice with (P:=fun n => exists t, t el stepn n s /\ lambda t).
+  -intros.
+   decide (exists t, t el stepn n s /\ lambda t). all:eauto.
+  -destruct H as (?&H&?). eapply star_pow in H as [? H].
+   eapply stepn_spec in H. eauto.
+  -apply list_cc in e. 2:eauto.
+   destruct e as (?&H'&?). unfold eval. apply stepn_spec,pow_star in H'. eauto.
 Qed.

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -1,6 +1,6 @@
 From Undecidability.L Require Import Computability.MuRec.
 From Undecidability.L.Datatypes Require Import LNat LOptions LProd Lists.
-From Undecidability Require Import FOL.DecidableEnumerable FOL.Reductions.
+From Undecidability Require Import FOL.DecidableEnumerable FOL.Reductions. 
 
 Inductive is_computable {A} {t : TT A} (a : A) : Prop :=
   C : computable a -> is_computable a.

--- a/theories/L/Datatypes/LBool.v
+++ b/theories/L/Datatypes/LBool.v
@@ -12,34 +12,33 @@ Hint Resolve bool_enc_correct : Lrewrite.
 
 (* register thefunctional constructors (not neccessary here) *)
 (*
-Instance true_term : computableTime true tt.
+Instance true_term : computableTime' true tt.
 Proof.
   extract constructor.
   solverec.
 Qed.
 
-Instance false_term : computableTime false tt.
+Instance false_term : computableTime' false tt.
 Proof.
   extract constructor.
   solverec.
 Qed.*)
 
-Instance term_negb : computableTime negb (fun _ _ => (4,tt)).
+Instance term_negb : computableTime' negb (fun _ _ => (4,tt)).
 Proof.
   extract.
   solverec.
 Qed.
 
-Instance term_andb : computableTime andb (fun _ _ => (1,fun _ _ => (4,tt))).
+Instance term_andb : computableTime' andb (fun _ _ => (1,fun _ _ => (4,tt))).
 Proof.
   extract.
   solverec.
 Qed.
 
-Instance term_orb : computableTime orb (fun _ _ => (1,fun _ _ => (4,tt))).
+Instance term_orb : computableTime' orb (fun _ _ => (1,fun _ _ => (4,tt))).
 Proof.
   extract.
   solverec.
 Qed.
 
-Definition b := 5.

--- a/theories/L/Datatypes/LComparison.v
+++ b/theories/L/Datatypes/LComparison.v
@@ -1,0 +1,9 @@
+From Undecidability.L Require Import Tactics.LTactics.
+From Undecidability.L Require Import Tactics.GenEncode.
+
+(** *** Encoding for Comparisons *)
+
+Run TemplateProgram (tmGenEncode "comparison_enc" comparison).
+Hint Resolve comparison_enc_correct : Lrewrite.
+
+

--- a/theories/L/Datatypes/LDepPair.v
+++ b/theories/L/Datatypes/LDepPair.v
@@ -1,0 +1,21 @@
+From Undecidability.L.Tactics Require Import LTactics GenEncode.
+
+
+(** TODO: I'm not sure how usable this definition is, I puit it here as i Didn;t want to rewrite it if needed. *)
+Section sigT.
+  Variable A : Type.
+  Context `{reg_A : registered A}.
+  Variable P : A -> Type.
+  Context `{reg_P : forall x, registered (P x)}.
+
+  Definition sigT_enc : encodable (sigT P) :=
+    fun '@existT _ _ x y => lam (0 (enc x) (enc y)).
+  
+  Global Instance registered_sigT : registered (sigT P).
+  Proof.
+    exists sigT_enc.
+    -intros []. cbn. Lproc.
+    -intros [] [] H. inv H. eapply inj_enc in H1. subst x. apply inj_enc in H2. subst p. easy.
+  Defined.
+
+End sigT.

--- a/theories/L/Datatypes/LFinType.v
+++ b/theories/L/Datatypes/LFinType.v
@@ -1,0 +1,37 @@
+From Undecidability.L.Tactics Require Import LTactics GenEncode.
+From Undecidability.L Require Import Datatypes.LNat.
+
+Require Export PslBase.FiniteTypes.FinTypes.
+
+(** *** Encoding finite types *)
+(* This is not an instance because we only want it for very specific types. *)
+Definition registered_finType `{X : finType} : registered X.
+Proof.
+  eapply (registerAs index).
+  intros x y H. now apply injective_index.
+Defined.
+
+Definition finType_eqb {X:finType} (x y : X) :=
+  Nat.eqb (index x) (index y).
+
+Lemma finType_eqb_reflect (X:finType) (x y:X) : reflect (x = y) (finType_eqb x y).
+Proof.
+  unfold finType_eqb. destruct (Nat.eqb_spec (index x) (index y));constructor.
+  -now apply injective_index.
+  -congruence.
+Qed.
+
+Section finType_eqb.
+  Local Existing Instance registered_finType.
+
+  Global Instance term_index (F:finType): computableTime' (@index F) (fun _ _=> (1, tt)).
+  Proof.
+    apply cast_computableTime.
+  Qed.
+
+  Global Instance term_finType_eqb (X:finType) : computableTime' (finType_eqb (X:=X)) (fun x _ => (1,fun y _ => (17 * Init.Nat.min (index x) (index y) + 17,tt))).
+  Proof.
+    extract.
+    solverec.
+  Qed.
+End finType_eqb.

--- a/theories/L/Datatypes/LNat.v
+++ b/theories/L/Datatypes/LNat.v
@@ -48,6 +48,17 @@ Proof.
   solverec.
 Defined.
 
+
+Instance termT_pow:
+  computableTime' Init.Nat.pow   (fun (x : nat) _ => (5,fun (n : nat) _ => (n* (x*19+x^n*11+19) + 5, tt))).
+Proof.
+  extract. fold Nat.pow. solverec.
+  decide (1<=x2).
+  1:Lia.nia. replace x2 with 0 by lia. ring_simplify.
+  decide (1<=n). now rewrite Nat.pow_0_l;Lia.nia.
+  Lia.nia.
+Qed.
+
 (* now some more encoding-related properties:*)
 
 Fixpoint nat_unenc (s : term) :=
@@ -81,16 +92,16 @@ Proof.
   - right. intros [n A]. rewrite A in H. rewrite unenc_correct in H. inv H.
 Qed.
 
-Lemma size_nat_enc n :
-  size (nat_enc n) = n * 4 + 4.
+Lemma size_nat_enc (n:nat) :
+  size (enc n) = n * 4 + 4.
 Proof.
-  induction n;cbn [size nat_enc] in *. all:solverec.
+  induction n;cbv [enc registered_nat_enc] in *. all:cbn [size nat_enc] in *. all:solverec.
 Qed.
 
-Lemma size_nat_enc_r n :
-  n <= size (nat_enc n).
+Lemma size_nat_enc_r (n:nat) :
+  n <= size (enc n).
 Proof.
-  induction n;cbn [size nat_enc] in *. all:solverec.
+    induction n;cbv [enc registered_nat_enc] in *. all:cbn [size nat_enc] in *. all:solverec.
 Qed.
 
 

--- a/theories/L/Datatypes/LNat.v
+++ b/theories/L/Datatypes/LNat.v
@@ -7,37 +7,42 @@ Require Import Nat Undecidability.L.Datatypes.LBool.
 Run TemplateProgram (tmGenEncode "nat_enc" nat).
 Hint Resolve nat_enc_correct : Lrewrite.
 
-Instance termT_S : computableTime S (fun _ _ => (1,tt)).
+Instance termT_S : computableTime' S (fun _ _ => (1,tt)).
 Proof.
   extract constructor.
   solverec.
 Defined.
 
-Instance termT_pred : computableTime pred (fun _ _ => (5,tt)).
+Instance termT_pred : computableTime' pred (fun _ _ => (5,tt)).
 Proof.
   extract.
   solverec.
 Defined.
 
-Instance termT_plus' : computableTime add (fun x xT => (5,(fun y yT => (11*x+4,tt)))).
+Instance termT_plus' : computableTime' add (fun x xT => (5,(fun y yT => (11*x+4,tt)))).
 Proof.
   extract.
   fold add. solverec.
 Defined.
 
-Instance termT_mult : computableTime mult (fun x xT => (5,(fun y yT => (x * (11 * y) + 19*x+ 4,tt)))).
+Instance termT_mult : computableTime' mult (fun x xT => (5,(fun y yT => (x * (11 * y) + 19*x+ 4,tt)))).
 Proof.
   extract.
   fold mul. solverec.
 Defined.
 
-Instance termT_leb : computableTime leb (fun x xT => (5,(fun y yT => (x*14 + 4,tt)))).
+Instance term_sub : computableTime' Nat.sub (fun n _ => (5,fun m _ => (min n m*14 + 8,tt)) ).
+Proof.
+  extract. recRel_prettify_arith. solverec.
+Qed.
+
+Instance termT_leb : computableTime' leb (fun x xT => (5,(fun y yT => (min x y*14 + 8,tt)))).
 Proof.
   extract.
   solverec.
 Defined.
 
-Instance termT_nat_eqb: computableTime Nat.eqb (fun x xT => (5,(fun y yT => ((min x y)*17 + 9,tt)))).
+Instance termT_nat_eqb: computableTime' Nat.eqb (fun x xT => (5,(fun y yT => ((min x y)*17 + 9,tt)))).
 Proof.
   extract.
   solverec.
@@ -76,10 +81,21 @@ Proof.
   - right. intros [n A]. rewrite A in H. rewrite unenc_correct in H. inv H.
 Qed.
 
+Lemma size_nat_enc n :
+  size (nat_enc n) = n * 4 + 4.
+Proof.
+  induction n;cbn [size nat_enc] in *. all:solverec.
+Qed.
+
+Lemma size_nat_enc_r n :
+  n <= size (nat_enc n).
+Proof.
+  induction n;cbn [size nat_enc] in *. all:solverec.
+Qed.
 
 
 (* This is an example for an function in which the run-time of the fix itself is not constant (in add, the fix on the first argument always returns an function in ~5 steps)*)
-(* Instance termT_testId : computableTime (fix f x := *)
+(* Instance termT_testId : computableTime' (fix f x := *)
 (*                                             match x with *)
 (*                                               0 => 0 *)
 (*                                             | S x => S (f x) *)

--- a/theories/L/Datatypes/LOptions.v
+++ b/theories/L/Datatypes/LOptions.v
@@ -3,7 +3,7 @@ From Undecidability.L Require Import Tactics.LTactics Datatypes.LBool Tactics.Ge
 (** ** Encoding of option type *)
 Section Fix_X.
   Variable X:Type.
-  Variable intX : registered X.
+  Context `{intX : registered X}.
 
 
   Run TemplateProgram (tmGenEncode "option_enc" (option X)).
@@ -80,4 +80,16 @@ Definition isSome {T} (u : option T) := match u with Some _ => true | _ => false
 Instance term_isSome {T} `{registered T} : computable (@isSome T).
 Proof.
   extract.
+Qed.
+
+
+Lemma size_option X `{registered X} (l:option X):
+  size (enc l) = match l with Some x => size (enc x) + 5 | _ => 3 end.
+Proof.
+  change (enc l) with (option_enc l).
+  destruct l. all:cbn [option_enc map sumn size].
+  change ((match H with
+           | @mk_registered _ enc _ _ => enc
+           end x)) with (enc x).
+  all:lia. 
 Qed.

--- a/theories/L/Datatypes/LOptions.v
+++ b/theories/L/Datatypes/LOptions.v
@@ -4,25 +4,25 @@ From Undecidability.L Require Import Tactics.LTactics Datatypes.LBool Tactics.Ge
 Section Fix_X.
   Variable X:Type.
   Variable intX : registered X.
-  
-  
+
+
   Run TemplateProgram (tmGenEncode "option_enc" (option X)).
   Hint Resolve option_enc_correct : Lrewrite.
-  
+
   (* now we must register the non-constant constructors*)
-  
-  Global Instance term_Some : computableTime (@Some X) (fun _ _ => (1,tt)).
+
+  Global Instance term_Some : computableTime' (@Some X) (fun _ _ => (1,tt)).
   Proof.
     extract constructor.
     solverec.
   Defined.
 
-  Lemma oenc_correct_some s (v : term) : lambda v -> enc s == ext (@Some X) v -> exists s', s = Some s' /\ v = enc s'.
-  Proof. 
+  Lemma oenc_correct_some (s: option X) (v : term) : lambda v -> enc s == ext (@Some X) v -> exists s', s = Some s' /\ v = enc s'.
+  Proof.
     intros lam_v H. unfold ext in H;cbn in H. unfold extT in H; cbn in H. redStep in H.
     apply unique_normal_forms in H;[|Lproc..]. destruct s;simpl in H.
     -injection H;eauto.
-    -discriminate H. 
+    -discriminate H.
   Qed.
        
 
@@ -46,7 +46,7 @@ Section option_eqb.
   Variable eqb : X -> X -> bool.
   Variable spec : forall x y, reflect (x = y) (eqb x y).
 
-  Definition option_eqb (A B : option X) := 
+  Definition option_eqb (A B : option X) :=
     match A,B with
     | None,None => true
     | Some x, Some y => eqb x y
@@ -65,8 +65,10 @@ Section int.
   Variable X:Type.
   Context {HX : registered X}.
 
-  Global Instance term_option_eqb : computableTime (@option_eqb X)
-                                                   (fun eqb eqbT => (1, fun a _ => (1,fun b _ => (match a,b with Some a, Some b => callTime2 eqbT a b + 10 | _,_ => 8 end,tt)))).
+  Global Instance term_option_eqb : computableTime' (@option_eqb X)
+                                                    (fun eqb eqbT => (1, fun a _ => (1,fun b _ => (match a,b with
+                                                                                            Some a, Some b => callTime2 eqbT a b + 10
+                                                                                          | _,_ => 8 end,tt)))). cbn.
   Proof.
     extract. solverec.
   Defined.

--- a/theories/L/Datatypes/LProd.v
+++ b/theories/L/Datatypes/LProd.v
@@ -8,24 +8,24 @@ Section Fix_XY.
 
   Variable X Y:Type.
   
-  Variable intX : registered X.
-  Variable intY : registered Y.
+  Context {intX : registered X}.
+  Context {intY : registered Y}.
 
   Run TemplateProgram (tmGenEncode "prod_enc" (X * Y)).
   Hint Resolve prod_enc_correct : Lrewrite.
   
   (* now we must register the constructors*)
-  Global Instance term_pair : computableTime (@pair X Y) (fun _ _ => (1,fun _ _ => (1,tt))).
+  Global Instance term_pair : computableTime' (@pair X Y) (fun _ _ => (1,fun _ _ => (1,tt))).
   Proof.
     extract constructor. solverec. 
   Defined.
 
-  Global Instance term_fst : computableTime (@fst X Y) (fun _ _ => (5,tt)).
+  Global Instance term_fst : computableTime' (@fst X Y) (fun _ _ => (5,tt)).
   Proof.
     extract. solverec.
   Defined.
 
-  Global Instance term_snd : computableTime (@snd X Y) (fun _ _ => (5,tt)).
+  Global Instance term_snd : computableTime' (@snd X Y) (fun _ _ => (5,tt)).
   Proof.
     extract. solverec.
   Defined.
@@ -47,7 +47,7 @@ Section Fix_XY.
 
   
   Global Instance term_prod_eqb :
-    computableTime prod_eqb
+    computableTime' prod_eqb
                      (fun _ eqT1 =>
                         (1,fun _ eqT2 =>
                              (1,fun x _ =>
@@ -65,6 +65,14 @@ Section Fix_XY.
   Proof.
     extract. 
   Defined.
+
+  
+  Lemma size_prod (w:X*Y):
+    size (enc w) = size (enc (fst w)) + size (enc (snd w)) + 4.
+  Proof.
+    destruct w. unfold enc. now cbn.
+  Qed.
+
   
 End Fix_XY.
 

--- a/theories/L/Datatypes/LSum.v
+++ b/theories/L/Datatypes/LSum.v
@@ -1,8 +1,6 @@
 From Undecidability.L Require Import Tactics.LTactics Datatypes.LBool.
 From Undecidability.L Require Import Tactics.GenEncode.
 
-Show Obligation Tactic.
-
 (** ** Encoding of sum type *)
 Section Fix_XY.
   Variable X Y:Type.

--- a/theories/L/Datatypes/LSum.v
+++ b/theories/L/Datatypes/LSum.v
@@ -1,0 +1,31 @@
+From Undecidability.L Require Import Tactics.LTactics Datatypes.LBool.
+From Undecidability.L Require Import Tactics.GenEncode.
+
+Show Obligation Tactic.
+
+(** ** Encoding of sum type *)
+Section Fix_XY.
+  Variable X Y:Type.
+  Context {intX : registered X}.
+  Context {intY : registered Y}.
+
+  
+  
+  Run TemplateProgram (tmGenEncode "sum_enc" (sum X Y)).
+  Hint Resolve sum_enc_correct : Lrewrite.
+  
+  (* now we must register the non-constant constructors*)
+  
+  Global Instance term_inl : computableTime' (@inl X Y) (fun _ _ => (1,tt)).
+  Proof.
+    extract constructor.
+    solverec.
+  Defined.
+
+   Global Instance term_inr : computableTime' (@inr X Y) (fun _ _ => (1,tt)).
+  Proof.
+    extract constructor.
+    solverec.
+  Defined.
+End Fix_XY.
+Hint Resolve sum_enc_correct : Lrewrite.

--- a/theories/L/Datatypes/LTerm.v
+++ b/theories/L/Datatypes/LTerm.v
@@ -22,15 +22,17 @@ Proof.
 Defined.
 
 
-Lemma size_term_enc s :
-  size (term_enc s) <= size s *11.
+Lemma size_term_enc (s:term) :
+  size (enc s) <= size s *11.
 Proof.
-  induction s;cbn [size term_enc]. rewrite size_nat_enc. all:solverec.
+  induction s;cbv [enc registered_term_enc] in *. all:cbn [size term_enc] in *.
+  rewrite size_nat_enc. all:solverec.
 Qed.
 
 
-Lemma size_term_enc_r s :
-  size s <= size (term_enc s).
+Lemma size_term_enc_r (s:term) :
+  size s <= size (enc s).
 Proof.
-  induction s;cbn [size term_enc]. rewrite <- size_nat_enc_r. all:solverec.
+  induction s;cbv [enc registered_term_enc] in *. all:cbn [size term_enc] in *.
+  rewrite <- size_nat_enc_r. all:solverec.
 Qed.

--- a/theories/L/Datatypes/LTerm.v
+++ b/theories/L/Datatypes/LTerm.v
@@ -6,17 +6,31 @@ Run TemplateProgram (tmGenEncode "term_enc" term).
 Hint Resolve term_enc_correct : Lrewrite.
   
 (* register the non-constant constructors *)
-Instance term_var : computableTime var (fun n _ => (1, tt)).
+Instance term_var : computableTime' var (fun n _ => (1, tt)).
 Proof.
   extract constructor. solverec.
 Defined.
 
-Instance term_app : computableTime app (fun s1 _ => (1, (fun s2 _ => (1, tt)))).
+Instance term_app : computableTime' app (fun s1 _ => (1, (fun s2 _ => (1, tt)))).
 Proof.
   extract constructor. solverec.
 Defined.
 
-Instance term_lam : computableTime lam (fun s _ => (1, tt)).
+Instance term_lam : computableTime' lam (fun s _ => (1, tt)).
 Proof.
   extract constructor. solverec.
 Defined.
+
+
+Lemma size_term_enc s :
+  size (term_enc s) <= size s *11.
+Proof.
+  induction s;cbn [size term_enc]. rewrite size_nat_enc. all:solverec.
+Qed.
+
+
+Lemma size_term_enc_r s :
+  size s <= size (term_enc s).
+Proof.
+  induction s;cbn [size term_enc]. rewrite <- size_nat_enc_r. all:solverec.
+Qed.

--- a/theories/L/Datatypes/LVector.v
+++ b/theories/L/Datatypes/LVector.v
@@ -1,0 +1,119 @@
+From Undecidability.L.Tactics Require Import LTactics GenEncode.
+From Undecidability.L.Datatypes Require Import LNat Lists LFinType.
+
+Require Import PslBase.Vectors.Vectors.
+
+(** *** Encoding vectors *)
+
+Instance register_vector X `{registered X} n : registered (Vector.t X n).
+Proof.
+  apply (registerAs VectorDef.to_list).
+  intros x. induction x.
+  - intros y. pattern y. revert y. eapply VectorDef.case0. cbn. reflexivity.
+  - intros y. clear H. revert h x IHx. pattern n, y. revert n y.
+    eapply Vector.caseS. intros h n y h0 x IHx [=].
+    subst. f_equal. eapply IHx. eassumption.
+Defined.
+
+Instance term_to_list X `{registered X} n : computableTime' (Vector.to_list (A:=X) (n:=n)) (fun _ _ => (1,tt)).
+Proof.
+  apply cast_computableTime.
+Qed.
+
+Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y) fT:
+  computableTime' f fT ->
+  computableTime' (VectorDef.map f (n:=n))
+                 (fun l _ => (map_time (fun x=> fst (fT x tt)) l + 3,tt)).
+Proof.
+  intros ?.
+  computable_casted_result.
+  apply computableTimeExt with (x:= fun x => map f (Vector.to_list x)).
+  2:{
+    extract.
+    solverec.
+  }
+
+  cbn. intros x.
+  clear - x.
+  induction n. revert x. apply VectorDef.case0. easy. revert IHn. apply Vector.caseS' with (v:=x).
+  intros. cbn. f_equal. fold (Vector.fold_right (A:=X) (B:=Y)).
+  setoid_rewrite IHn. reflexivity.
+Qed.
+
+(* Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y): computable f -> computable (VectorDef.map f (n:=n)). *)
+(* Proof. *)
+(*   intros ?. *)
+
+(*   internalize_casted_result. *)
+(*   apply computableExt with (x:= fun x => map f (Vector.to_list x)). *)
+(*   2:{ *)
+(*     extract. *)
+(*   } *)
+
+(*   cbn. intros x.  *)
+(*   clear - x. *)
+(*   induction n. revert x. apply VectorDef.case0. easy. revert IHn. apply Vector.caseS' with (v:=x). *)
+(*   intros. cbn. f_equal. fold (Vector.fold_right (A:=X) (B:=Y)). *)
+(*   setoid_rewrite IHn. reflexivity. *)
+(* Qed. *)
+
+Fixpoint time_map2 {X Y Z} `{registered X} `{registered Y} `{registered Z} (gT : timeComplexity (X->Y->Z)) (l1 :list X) (l2 : list Y) :=
+  match l1,l2 with
+  | x::l1,y::l2 => callTime2 gT x y + 18 + time_map2 gT l1 l2
+  | _,_ => 9
+  end.
+Instance term_map2 n A B C `{registered A} `{registered B} `{registered C} (g:A -> B -> C) gT:
+  computableTime' g gT-> computableTime' (Vector.map2 g (n:=n)) (fun l1 _ => (1,fun l2 _ => (time_map2 gT (Vector.to_list l1) (Vector.to_list l2) +8,tt))).
+Proof.
+  intros ?.
+  computable_casted_result.
+  pose (f:=(fix f t a : list C:=
+              match t,a with
+                t1::t,a1::a => g t1 a1 :: f t a
+              | _,_ => []
+              end)).
+  assert (computableTime' f (fun l1 _ => (5,fun l2 _ => (time_map2 gT l1 l2,tt)))).
+  {subst f; extract.
+
+
+
+   solverec. }
+  apply computableTimeExt with (x:= fun t a => f (Vector.to_list t) (Vector.to_list a)).
+  2:{extract. solverec. }
+  induction n;cbn.
+  -do 2 destruct x using Vector.case0. reflexivity.
+  -destruct x using Vector.caseS'. destruct x0 using Vector.caseS'.
+   cbn. f_equal. apply IHn.
+Qed.
+
+
+Lemma time_map2_leq X Y Z `{registered X}  `{registered Y}  `{registered Z}  (fT:timeComplexity (X -> Y -> Z))(l1 : list X) (l2:list Y) k:
+  (forall x y, callTime2 fT x y <= k) ->
+  time_map2 fT l1 l2<= length l1 * (k+18) + 9.
+Proof.
+  intros H';
+    induction l1 in l2|-*;cbn [time_map2].
+  -intuition.
+  -destruct l2;ring_simplify. intuition.
+   rewrite H',IHl1. cbn [length]. ring_simplify. intuition.
+Qed.
+
+Instance term_vector_eqb X `{registered X} (n' m:nat) (eqb:X->X->bool) eqbT:
+  computableTime' eqb eqbT
+  -> computableTime'
+      (VectorEq.eqb eqb (A:=X) (n:=n') (m:=m))
+      (fun A _ => (1,fun B _ => (list_eqbTime eqbT (Vector.to_list A) (Vector.to_list B) + 9,tt))).
+Proof.
+  intros ?.
+  apply computableTimeExt with (x:=(fun x y => list_eqb eqb (Vector.to_list x) (Vector.to_list y))).
+  2:{extract.
+     solverec. }
+  intros v v'. hnf.
+  induction v in n',v'|-*;cbn;destruct v';cbn;try tauto. rewrite <- IHv. f_equal.
+Qed.
+
+
+Lemma to_list_length X n0 (l:Vector.t X n0) :length l = n0.
+Proof.
+  induction l. reflexivity. rewrite <- IHl at 3. reflexivity.
+Qed.

--- a/theories/L/Datatypes/LVector.v
+++ b/theories/L/Datatypes/LVector.v
@@ -23,7 +23,7 @@ Qed.
 Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y) fT:
   computableTime' f fT ->
   computableTime' (VectorDef.map f (n:=n))
-                 (fun l _ => (map_time (fun x=> fst (fT x tt)) l + 3,tt)).
+                 (fun l _ => (map_time (fun x=> fst (fT x tt)) (Vector.to_list l) + 3,tt)).
 Proof.
   intros ?.
   computable_casted_result.
@@ -113,7 +113,7 @@ Proof.
 Qed.
 
 
-Lemma to_list_length X n0 (l:Vector.t X n0) :length l = n0.
+Lemma to_list_length X n0 (l:Vector.t X n0) :length (Vector.to_list l) = n0.
 Proof.
   induction l. reflexivity. rewrite <- IHl at 3. reflexivity.
 Qed.

--- a/theories/L/Datatypes/Lists.v
+++ b/theories/L/Datatypes/Lists.v
@@ -26,7 +26,7 @@ Section Fix_X.
   
 
   Global Instance termT_append : computableTime' (@List.app X) (fun A _ => (5,fun B _ => (length A * 16 +4,tt))).
-  Proof  using intX.
+  Proof using intX.
     extract.
     solverec.
   Qed.

--- a/theories/L/Functions/Ackermann.v
+++ b/theories/L/Functions/Ackermann.v
@@ -28,7 +28,7 @@ Local Lemma Ack_pos n m : 0 < ackermann n m.
 Qed.
 
 Lemma termT_ackermann :
-  computableTime ackermann
+  computableTime' ackermann
                  (fun x _ =>
                     (14,
                      fun y _ =>

--- a/theories/L/Functions/BinNums.v
+++ b/theories/L/Functions/BinNums.v
@@ -1,0 +1,2 @@
+From Undecidability.L.Functions Require Export BinNumsAdd BinNumsSub.
+

--- a/theories/L/Functions/BinNumsAdd.v
+++ b/theories/L/Functions/BinNumsAdd.v
@@ -1,0 +1,68 @@
+From Undecidability.L Require Import Tactics.LTactics.
+Require Import Numbers.BinNums.
+
+From Undecidability.L.Datatypes Require Import LNat LBool LBinNums.
+
+(** *** Addition of binary numbers *)
+Section pos_add.
+  Import Pos.
+
+  Fixpoint addC (c:bool) (x : positive) {struct x}: positive -> positive:=
+    (if c then  
+       match x with
+       | p~1 => fun y => match y with
+                     | q~1 => (addC true p q)~1
+                     | q~0 => (addC true p q)~0
+                     | 1 => (succ p)~1
+                     end
+       | p~0 => fun y => match y with
+                     | q~1 => (addC true p q)~0
+                     | q~0 => (addC false p q)~1
+                     | 1 => (succ p)~0
+                     end
+       | 1 => fun y => match y with
+                   | q~1 => (succ q)~1
+                   | q~0 => (succ q)~0
+                   | 1 => 3
+                   end
+       end
+     else
+       match x with
+       | p~1 => fun y => match y with
+                     | q~1 => (addC true p q)~0
+                     | q~0 => (addC false p q)~1
+                     | 1 => (succ p)~0
+                     end
+       | p~0 => fun y => match y with
+                     | q~1 => (addC false p q)~1
+                     | q~0 => (addC false p q)~0
+                     | 1 => p~1
+                     end
+       | 1 => fun y => match y with
+                   | q~1 => (succ q)~0
+                   | q~0 => q~1
+                   | 1 => 2
+                   end
+       end)%positive.
+
+  Lemma addC_ext_eq : extEq addC (fun b => if b then add_carry else add).
+  Proof.
+    intros b x y. induction x in b,y|-*;destruct b,y;cbn;try rewrite !IHx. all:reflexivity.
+  Qed.
+
+  Global Instance termT_Pos_addC: computableTime' addC (fun b _ => (5%nat,fun x _ => (11%nat,fun y _ => (12*(size_nat x + size_nat y),tt)))).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_add: computableTime' Pos.add (fun x _ => (17%nat,fun y _ => (12*(size_nat x + size_nat y),tt))).
+  Proof.
+    eapply computableTimeExt with (x:= (fun x => addC false x)).
+    -hnf;repeat intro;eapply addC_ext_eq.
+    -extract. solverec.
+  Qed.
+
+End pos_add.
+
+Instance termT_N_add: computableTime' N.add (fun x _ => (1,fun y _ => (12*(N.size_nat x + N.size_nat y) + 27 ,tt))).
+extract. solverec.
+Qed.

--- a/theories/L/Functions/BinNumsCompare.v
+++ b/theories/L/Functions/BinNumsCompare.v
@@ -1,0 +1,38 @@
+From Undecidability.L Require Import Tactics.LTactics.
+Require Import Numbers.BinNums.
+From Undecidability.L.Datatypes Require Import LBinNums LComparison LNat LBool.
+Instance termT_Pos_compare_cont : computableTime' Pos.compare_cont (fun _ _ => (5,fun x _ => (1,fun y _ => (min (Pos.size_nat x) (Pos.size_nat y)*17,tt)))).
+Proof.
+  extract. solverec.
+Qed.
+
+Instance term_Pos_compare : computableTime' Pos.compare (fun x _ => (7,fun y _ => (min (Pos.size_nat x) (Pos.size_nat y)*17,tt))).
+Proof.
+  change Pos.compare with (fun x => Pos.compare x). unfold Pos.compare.
+  extract. solverec.
+Qed.
+
+Instance termT_N_compare : computableTime' N.compare (fun x _ => (1,fun y _ => (min (N.size_nat x) (N.size_nat y)*17+ 16,tt))).
+Proof.
+  extract. solverec.
+Qed.
+
+Instance termT_N_leb : computableTime' N.leb (fun x _ => (1,fun y _ => (min (N.size_nat x) (N.size_nat y)*17+ 22,tt))).
+Proof.
+  extract. solverec.
+Qed.
+
+Instance termT_N_ltb : computableTime' N.ltb  (fun x _ => (1,fun y _ => (min (N.size_nat x) (N.size_nat y)*17+ 22,tt))).
+Proof.
+  extract. solverec.
+Qed.
+
+Instance termT_N_eqb : computableTime' N.eqb  (fun x _ => (1,fun y _ => (min (N.size_nat x) (N.size_nat y)*17+ 22,tt))).
+Proof.
+  eapply computableTimeExt with (x:=fun x y : N => match (x ?= y)%N with
+                       | Eq => true
+                       | _ => false
+                                                end).
+  -repeat intro. hnf. now rewrite N.eqb_compare.
+  -extract. solverec.
+Qed.

--- a/theories/L/Functions/BinNumsSub.v
+++ b/theories/L/Functions/BinNumsSub.v
@@ -1,0 +1,105 @@
+From Undecidability.L Require Import Tactics.LTactics.
+Require Import Numbers.BinNums.
+
+From Undecidability.L.Datatypes Require Import LNat LBool LBinNums.
+(** *** Subtraction of binary Numbers *)
+
+Run TemplateProgram (tmGenEncode "mask_enc" Pos.mask).
+Hint Resolve mask_enc_correct : Lrewrite.
+  
+Section pos_sub.
+
+  Import Pos.
+
+  Fixpoint sub_maskC (c:bool) (x y : positive) {struct y} : mask :=
+    (if negb c then 
+      match x with
+      | p~1 => match y with
+              | q~1 => double_mask (sub_maskC false p q)
+              | q~0 => succ_double_mask (sub_maskC false p q)
+              | 1 => IsPos p~0
+              end
+      | p~0 => match y with
+              | q~1 => succ_double_mask (sub_maskC true p q)
+              | q~0 => double_mask (sub_maskC false p q)
+              | 1 => IsPos (pred_double p)
+              end
+      | 1 => match y with
+            | 1 => IsNul
+            | _ => IsNeg
+            end
+      end
+    else
+      match x with
+      | p~1 => match y with
+              | q~1 => succ_double_mask (sub_maskC true p q)
+              | q~0 => double_mask (sub_maskC false p q)
+              | 1 => IsPos (pred_double p)
+              end
+      | p~0 => match y with
+              | q~1 => double_mask (sub_maskC true p q)
+              | q~0 => succ_double_mask (sub_maskC true p q)
+              | 1 => double_pred_mask p
+              end
+      | 1 => IsNeg
+      end)%positive.
+
+  Lemma sub_maskC_ext_eq : extEq sub_maskC (fun b => if b then sub_mask_carry else sub_mask).
+  Proof.
+    intros b x y. induction x in b,y|-*;destruct b,y;cbn;try rewrite !IHx. all:reflexivity.
+  Qed.
+
+  Global Instance termT_isPos : computableTime' IsPos (fun x _ => (1,tt)).
+  extract constructor. solverec.
+  Qed.
+
+  
+  Global Instance termT_Pos_double_mask: computableTime' double_mask (fun x _ => (8,tt)).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_succ_double_mask: computableTime' succ_double_mask (fun x _ => (8,tt)).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_pred_double: computableTime' pred_double (fun x _ => (size_nat x * 12 + 9,tt)).
+  extract. solverec.
+  Qed.
+  
+  Global Instance termT_Pos_double_pred_mask: computableTime' double_pred_mask (fun x _ => (size_nat x * 12 + 5,tt)).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_pred : computableTime' pred (fun x _ => (size_nat x * 12 + 3,tt)).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_predN : computableTime' pred_N (fun x _ => (size_nat x * 12 + 4,tt)).
+  extract. solverec.
+  Qed.
+  
+  Global Instance termT_Pos_sub_maskC: computableTime' sub_maskC (fun b _ => (5%nat,fun x _ => (1%nat,fun y _ => (size_nat x*32,tt)))).
+  extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_sub_mask: computableTime' sub_mask (fun x _ => (7%nat,fun y _ => (size_nat x*32,tt))).
+  eapply computableTimeExt with (x:= fun x => sub_maskC false x).
+  -repeat intro. hnf. eapply sub_maskC_ext_eq.
+  -extract. solverec.
+  Qed.
+
+  Global Instance termT_Pos_sub: computableTime' Pos.sub (fun x _ => (1%nat,fun y _ => (size_nat x*32 + 13,tt))).
+  Proof.
+    extract. solverec.
+  Qed.
+
+End pos_sub.
+
+
+Instance termT_N_sub: computableTime' N.sub (fun x _ => (1,fun y _ => (N.size_nat x*32 + 22 ,tt))).
+extract. solverec.
+Qed.
+
+Instance termT_N_pred: computableTime' N.pred (fun x _ => (N.size_nat x*12 + 9 ,tt)).
+extract. solverec.
+Qed.

--- a/theories/L/Functions/Decoding.v
+++ b/theories/L/Functions/Decoding.v
@@ -1,0 +1,180 @@
+From Undecidability.L Require Import Tactics.LTactics Datatypes.LNat Datatypes.LTerm.
+
+Class decodable X `{registered X}: Type :=
+  {
+    decode : term -> option X;
+    decode_correct : forall (x:X), decode (enc x) = Some x;
+    decode_correct2 : forall (t : term) (x : X), decode t = Some x -> enc x = t
+  }.
+
+Arguments decodable : clear implicits.
+Arguments decode    : clear implicits.
+
+Arguments decodable _ {_}.
+Arguments decode _ {_} {_} _ : simpl never.
+
+
+
+Instance decode_nat : decodable nat.
+Proof.
+  exists nat_unenc. all:eauto using LNat.unenc_correct, LNat.unenc_correct2.
+Defined.
+
+
+Fixpoint term_decode (s : term) :=
+  match s with
+  | lam (lam (lam (app 2 n))) =>
+    match decode nat n with
+      Some n => Some (var n)
+    | _ => None
+    end
+  |  lam (lam (lam (app (app 1 s1) s2))) =>
+     match term_decode s1,term_decode s2 with
+       Some s1, Some s2 => Some (s1 s2)
+     | _,_ => None
+     end
+  | lam (lam (lam (app O s))) =>
+    match term_decode s with
+      Some s => Some (lam s)
+    | _ => None  end
+  | _ => None
+  end.
+
+Instance decode_term : decodable term.
+Proof.
+  exists term_decode.
+  all:unfold enc at 1. all:cbn.
+  -induction x;cbn. change nat_enc with (enc (X:=nat)).
+   +rewrite (decode_correct n). congruence.
+   +now rewrite IHx1,IHx2.
+   +now rewrite IHx.  all:eauto using LNat.unenc_correct, LNat.unenc_correct2.
+  -apply (size_induction (f := size) (p := (fun t => forall x, term_decode t = Some x -> term_enc x = t))). intros t IHt s.
+   destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros [= <-].
+   +cbn. erewrite IHt.
+    *reflexivity.
+    *cbn;lia.
+    *easy.
+   +cbn. change nat_enc with (enc (X:=nat)).
+    erewrite decode_correct2. 2:eassumption.  reflexivity.
+   +cbn. erewrite !IHt. reflexivity.
+    1,3:cbn;lia.
+    all:eassumption.
+Defined.
+
+From Undecidability.L Require Import Datatypes.Lists.
+
+Definition list_decode X `{decodable X} :=
+  fix list_decode (s : term) : option (list X) :=
+    match s with
+    | lam (lam 1) => Some []
+    | lam (lam (app (app O x) xs)) =>
+      match decode X x,list_decode xs with
+        Some x, Some xs => Some (x::xs)
+      | _,_ => None
+      end
+    | _ => None
+    end.
+
+Arguments list_decode : clear implicits.
+Arguments list_decode _ {_ _} _.
+
+Instance decode_list X `{registered X} {H:decodable X}: decodable (list X).
+Proof.
+  exists (list_decode X).
+  all:unfold enc at 1. all:cbn.
+  -induction x;cbn.
+   +easy.
+   +setoid_rewrite decode_correct. now rewrite IHx.
+  -apply (size_induction (f := size) (p := (fun t => forall x, list_decode X t = Some x -> list_enc x = t))). intros t IHt s.
+   destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros [= <-].
+   +easy.
+   +cbn. change (match H with
+                | @mk_registered _ enc _ _ => enc
+                 end x) with (enc x). erewrite decode_correct2. 2:easy.
+    erewrite IHt.
+    *reflexivity.
+    *cbn;lia.
+    *easy.
+Defined.
+
+
+From Undecidability.L Require Import Datatypes.LProd.
+
+Definition prod_decode X Y `{decodable X} `{decodable Y} (s : term) : option (X*Y) :=
+    match s with
+    | lam (app (app 0 x) y) =>
+      match decode X x,decode Y y with
+        Some x, Some y => Some (x,y)
+      | _,_ => None                
+      end
+    | _ => None
+    end.
+
+Arguments prod_decode : clear implicits.
+Arguments prod_decode _ _ {_ _ _ _}.
+
+Instance decode_prod X Y `{decodable X} `{decodable Y}: decodable (X*Y).
+Proof.
+  exists (prod_decode X Y).
+  all:unfold enc at 1. all:cbn.
+  -intros [];cbn.
+   +repeat setoid_rewrite decode_correct. easy.
+  -destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros ? [= <-]. cbn.
+   setoid_rewrite decode_correct2;[|eassumption..]. easy.
+Defined.
+
+From Undecidability.L Require Import Datatypes.LOptions.
+
+Definition option_decode X `{decodable X} (s : term) : option (option X) :=
+  match s with
+  | lam (lam (app 1 x)) => 
+    match decode X x with
+      Some x => Some (Some x)
+    | _ => None
+    end
+  | lam (lam 0) => Some None
+  | _ => None
+  end.
+
+Arguments option_decode : clear implicits.
+Arguments option_decode _ {_ _} _.
+
+Instance decode_option X `{registered X} {H:decodable X}: decodable (option X).
+Proof.
+  exists (option_decode X).
+  all:unfold enc at 1. all:cbn.
+  -intros[];cbn. 2:easy. setoid_rewrite decode_correct. easy. 
+  -destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros ? [= <-]. 
+   +easy.
+   +cbn. change (match H with
+                | @mk_registered _ enc _ _ => enc
+                 end x) with (enc x). erewrite decode_correct2. all:easy.
+Defined.
+
+From Undecidability.L Require Import Datatypes.LBool.
+
+
+Definition bool_decode (s : term) : option bool:=
+  match s with
+  | lam (lam 1) => Some true
+  | lam (lam 0) => Some false
+  | _ => None
+  end.
+
+Instance decode_bool: decodable (bool).
+Proof.
+  exists (bool_decode).
+  all:unfold enc at 1. all:cbn.
+  -intros[];cbn. all:easy. 
+  -destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros ? [= <-]. all:easy.
+Defined.

--- a/theories/L/Functions/Encoding.v
+++ b/theories/L/Functions/Encoding.v
@@ -1,19 +1,17 @@
 From Undecidability.L.Tactics Require Import LTactics.
-From Undecidability.L.Datatypes Require Export LNat LTerm LProd.
+From Undecidability.L.Datatypes Require Import LNat LTerm LProd Lists.
 
 (** ** Extracted encoding of natural numbers *)
 
-Instance term_nat_enc : computableTime' (enc (X:=nat)) (fun n _ => (n * 14 + 12,tt)).
+Instance term_nat_enc : computableTime' (nat_enc) (fun n _ => (n * 14 + 12,tt)).
 Proof.
-  unfold enc. cbn.
   extract. solverec.
 Qed.
 
 (** ** Extracted term encoding *)
 
-Instance term_term_enc : computableTime' (enc (X:=term)) (fun s _ => (size s * 30,tt)).
+Instance term_term_enc : computableTime' (term_enc) (fun s _ => (size s * 30,tt)).
 Proof.
-  unfold enc;cbn.
   extract. solverec.
 Qed.
 
@@ -23,9 +21,42 @@ Instance term_prod_enc X Y (R1:registered X) (R2:registered Y) t__X t__Y
          `{computableTime' (@enc X _) t__X} `{computableTime' (@enc Y _) t__Y}
   :computableTime' (@prod_enc X Y R1 R2) (fun w _ => (let '(x,y):= w in  fst (t__X x tt) + fst (t__Y y tt) + 15,tt)).
 Proof.
-  unfold prod_enc. fold (@enc X _). fold (@enc Y _).
+  unfold prod_enc.
+  change (match R1 with
+          | @mk_registered _ enc _ _ => enc
+          end) with (enc (registered:=R1)).
+  change (match R2 with
+          | @mk_registered _ enc _ _ => enc
+          end) with (enc (registered:=R2)).
   extract. solverec.
 Qed.
+
+
+Instance term_list_enc X (R:registered X) t__X 
+         `{computableTime' (@enc X _) t__X} 
+  :computableTime' (@list_enc X R) (fun l _ => (sumn (map (fun x => fst (t__X x tt) + 17) l) + 12,tt)).
+Proof.
+  unfold list_enc.
+  change (match R with
+          | @mk_registered _ enc _ _ => enc
+          end) with (enc (registered:=R)).
+  extract. solverec.
+Qed.
+
+Import LOptions.
+
+Instance term_option_enc X (R:registered X) t__X 
+         `{computableTime' (@enc X _) t__X} 
+  :computableTime' (@option_enc X R) (fun x _ => (match x with Some x => fst (t__X x tt) | _ => 0 end + 15,tt)).
+Proof.
+  unfold option_enc.
+  change (match R with
+          | @mk_registered _ enc _ _ => enc
+          end) with (enc (registered:=R)).
+  extract. solverec.
+Qed.
+
+
 
 (*
 Set Printing Implicit.

--- a/theories/L/Functions/Encoding.v
+++ b/theories/L/Functions/Encoding.v
@@ -1,16 +1,39 @@
-From Undecidability.L.Tactics Require Import LTactics GenEncode.
-From Undecidability.L.Datatypes Require Export LNat LTerm.
+From Undecidability.L.Tactics Require Import LTactics.
+From Undecidability.L.Datatypes Require Export LNat LTerm LProd.
 
 (** ** Extracted encoding of natural numbers *)
 
-Instance term_nat_enc : computable nat_enc.
+Instance term_nat_enc : computableTime' nat_enc (fun n _ => (n * 14 + 12,tt)).
 Proof.
-  extract.   
-Defined.
+  extract. solverec.
+Qed.
 
 (** ** Extracted term encoding *)
 
-Instance term_term_enc : computable term_enc.
+Instance term_term_enc : computableTime' term_enc (fun s _ => (size s * 30,tt)).
 Proof.
-  extract.
+  extract. solverec.
+Qed.
+
+(* (** ** Extracted tuple encoding *) *)
+
+(* Instance term_prod_enc X Y (R1:registered X) (R2:registered Y): computable (@prod_enc X Y R1 R2). *)
+(* Proof. *)
+(*   unfold prod_enc. cbn. extract. *)
+(* Qed. *)
+
+Definition prod_enc' {X Y} (enc_x : X -> term) (enc_y : Y -> term) : X * Y -> term :=
+  fix f w := let '(x,y) := w in
+             lam (var 0 (enc_x x) (enc_y y)).
+
+Lemma enc_prod_eq {X Y} {H__x:registered X} {H__y : registered Y}:
+  @enc (X*Y) _ = prod_enc' (@enc _ H__x) (@enc _ H__y).
+Proof.
+  unfold enc. destruct H__x, H__y. reflexivity.
+Qed.
+
+Instance term_prod_enc' {X Y} {H__x : registered X} {H__Y : registered Y}:
+  computableTime' (@prod_enc' X Y) (fun _ t__X => (1,fun _ t__Y => (1,fun w _ => (let '(x,y):= w in  fst (t__X x tt) + fst (t__Y y tt) + 15,tt)))).
+Proof.
+  extract. solverec.
 Qed.

--- a/theories/L/Functions/Encoding.v
+++ b/theories/L/Functions/Encoding.v
@@ -3,25 +3,35 @@ From Undecidability.L.Datatypes Require Export LNat LTerm LProd.
 
 (** ** Extracted encoding of natural numbers *)
 
-Instance term_nat_enc : computableTime' nat_enc (fun n _ => (n * 14 + 12,tt)).
+Instance term_nat_enc : computableTime' (enc (X:=nat)) (fun n _ => (n * 14 + 12,tt)).
 Proof.
+  unfold enc. cbn.
   extract. solverec.
 Qed.
 
 (** ** Extracted term encoding *)
 
-Instance term_term_enc : computableTime' term_enc (fun s _ => (size s * 30,tt)).
+Instance term_term_enc : computableTime' (enc (X:=term)) (fun s _ => (size s * 30,tt)).
 Proof.
+  unfold enc;cbn.
   extract. solverec.
 Qed.
 
-(* (** ** Extracted tuple encoding *) *)
+(** ** Extracted tuple encoding *)
 
-(* Instance term_prod_enc X Y (R1:registered X) (R2:registered Y): computable (@prod_enc X Y R1 R2). *)
-(* Proof. *)
-(*   unfold prod_enc. cbn. extract. *)
-(* Qed. *)
+Instance term_prod_enc X Y (R1:registered X) (R2:registered Y) t__X t__Y
+         `{computableTime' (@enc X _) t__X} `{computableTime' (@enc Y _) t__Y}
+  :computableTime' (@prod_enc X Y R1 R2) (fun w _ => (let '(x,y):= w in  fst (t__X x tt) + fst (t__Y y tt) + 15,tt)).
+Proof.
+  unfold prod_enc. fold (@enc X _). fold (@enc Y _).
+  extract. solverec.
+Qed.
 
+(*
+Set Printing Implicit.
+Check (extT (@enc (nat*(nat*nat)) _)).
+*)
+(*
 Definition prod_enc' {X Y} (enc_x : X -> term) (enc_y : Y -> term) : X * Y -> term :=
   fix f w := let '(x,y) := w in
              lam (var 0 (enc_x x) (enc_y y)).
@@ -37,3 +47,4 @@ Instance term_prod_enc' {X Y} {H__x : registered X} {H__Y : registered Y}:
 Proof.
   extract. solverec.
 Qed.
+*)

--- a/theories/L/Functions/EnumInt.v
+++ b/theories/L/Functions/EnumInt.v
@@ -5,9 +5,9 @@ From Undecidability.L.Functions Require Import Encoding Equality.
 From Undecidability.L.Datatypes Require Import LNat Lists LProd.
 
 (** ** Enumeratibility of L-terms *)
-Instance term_appCross : computable appCross.
+Instance term_appCross : computableTime' appCross (fun A _ => (5,fun B _ => (length A * length B * 29 + length A * 30 +  4,tt))).
 Proof.
-  extract.
+  extract. solverec. fold appCross;rewrite map_time_const,map_length. Lia.nia.
 Defined.
 
 Instance term_exh_size : computable exh_size.

--- a/theories/L/Functions/Equality.v
+++ b/theories/L/Functions/Equality.v
@@ -29,9 +29,9 @@ Fixpoint term_eqb s t :=
   | _,_ => false
   end.
 
-Instance term_term_eqb : computable term_eqb.
+Instance term_termT_eqb : computableTime' term_eqb (fun s _ => (5,fun t _ => (min (size s) (size t) * 28,tt))).
 Proof.
-  extract.
+  extract. solverec.
 Defined.
 
 

--- a/theories/L/Functions/FinTypeLookup.v
+++ b/theories/L/Functions/FinTypeLookup.v
@@ -1,0 +1,63 @@
+From Undecidability.L.Tactics Require Import LTactics.
+From Undecidability.L.Datatypes Require Import LFinType LBool LProd Lists.
+
+Section Lookup.
+  Variable X Y : Type.
+  Variable eqb : X -> X -> bool.
+
+  Fixpoint lookup (x:X) (A:list (X*Y)) d: Y :=
+    match A with
+      [] => d
+    | (key,Lproc)::A =>
+      if eqb x key then Lproc else lookup x A d
+    end.
+
+End Lookup.
+
+Section funTable.
+
+  Variable X : finType.
+  Variable Y : Type.
+  Variable f : X -> Y.
+
+  Definition funTable :=
+    map (fun x => (x,f x)) (elem X).
+
+  Variable (eqb : X -> X -> bool).
+  Variable (Heqb:forall x y, reflect (x = y) (eqb x y)).
+
+  Lemma lookup_funTable x d:
+    lookup eqb x funTable d = f x.
+  Proof.
+    unfold funTable.
+    specialize (elem_spec x).
+    generalize (elem X) as l.
+    induction l;cbn;intros Hel.
+    -tauto.
+    -destruct (Heqb x a).
+     +congruence.
+     +destruct Hel. 1:congruence.
+      eauto.
+  Qed.
+End funTable.
+
+Definition lookupTime {X Y} `{registered X} (eqbT : timeComplexity (X ->X ->bool)) x (l:list (X*Y)):=
+  fold_right (fun '(a,b) res => callTime2 eqbT x a + res +19) 4 l.
+
+
+Global Instance term_lookup X Y `{registered X} `{registered Y}:
+  computableTime' (@lookup X Y) (fun eqb T__eqb => (1, fun x _ => (5, fun l _ => (1, fun d _ => (lookupTime T__eqb x l,tt))))).
+extract. unfold lookupTime. solverec.
+Qed.
+
+Lemma lookupTime_leq {X Y} `{registered X} (eqbT:timeComplexity (X -> X -> bool)) x (l:list (X*Y)) k:
+  (forall y, callTime2 eqbT x y <= k)
+  -> lookupTime eqbT x l <= length l * (k + 19) + 4.
+Proof.
+  intros H'.
+  induction l as [ | [a b] l].
+  -cbn. omega.
+  -unfold lookupTime. cbn [fold_right]. fold (lookupTime eqbT x l).
+   setoid_rewrite IHl. cbn [length]. rewrite H'.
+   ring_simplify. omega.
+Qed.

--- a/theories/L/Functions/IterupN.v
+++ b/theories/L/Functions/IterupN.v
@@ -1,5 +1,5 @@
 From Undecidability.L.Datatypes Require Import LProd LOptions.
-From Undecidability.L Require Import Tactics.LTactics Datatypes.LBinNums.
+From Undecidability.L Require Import Tactics.LTactics Datatypes.LBinNums Functions.BinNums Functions.BinNumsCompare.
 
 
 Definition iterupN {X} i max x f :=
@@ -16,9 +16,7 @@ Proof.
    edestruct (N.ltb_spec0 n max). exfalso;Lia.lia.
    rewrite (proj2 (N.sub_0_le _ _)). 2:Lia.lia. reflexivity.
   -(* Todo:generalize over internal state*)
-Admitted.
-   
-  
+Admitted.  
 
 Lemma iterupN_geq {X} i max {x:X} f :
   (i >= max)%N -> iterupN i max x f = x.
@@ -32,7 +30,80 @@ Proof.
   intros H. rewrite iterupN_eq. destruct (N.ltb_spec0 i max). all:easy.
 Qed.
 
-Instance term_iterupN X `{H:registered X} : computable (iterupN (X:=X)).
+(* Instance term_iterupN X `{H:registered X} : *)
+(*   computableTime' (iterupN (X:=X)) (fun i (_:unit) => *)
+(*                                      (5,fun max (_:unit) => *)
+(*                                           (1,fun x (_:unit) => *)
+(*                                                (1,fun f (fT: _ -> unit -> (nat * (_ -> unit -> (nat *unit)))) => (cnst (i,x),tt))))). *)
+(* Proof. *)
+(*   pose (s := rho (λ F i max x f, (!!(extT N.ltb) i max) (λ _ , F (!!(extT N.succ) i) max (f i x) f) (λ _ , x) I)). *)
+(*   cbv [convert TH minus] in s. *)
+  
+(*   exists s. unfold s. Intern.recRem P. *)
+(*   eapply computesTimeExpStart. now Lproc. *)
+(*   eexists. *)
+(*   eapply computesTimeExpStep. 2:now Lsimpl. reflexivity. now Lproc. *)
+(*   intros i iExt iT iExts. cbn in iExts. subst iExt. *)
+
+(*   eexists. *)
+(*   eapply computesTimeExpStep. *)
+(*   2:{Intern.recStepUnnamed. now Lsimpl. } *)
+(*   reflexivity. now Lproc. *)
+(*   intros max yExt yT yExts. cbn in yExts. subst yExt. *)
+(*   cbn [fst snd]. *)
+
+(*   remember ((max - i)%N) as d eqn:eqd. *)
+(*   revert i max eqd. *)
+(*   induction d using N.peano_rect. *)
+(*   all:intros i max eqd. *)
+(*   all:eexists. *)
+(*   all:eapply computesTimeExpStep. *)
+(*   2,6:now Intern.recStepUnnamed; Lsimpl. *)
+(*   1,4:reflexivity. *)
+(*   1,3:Lproc. *)
+
+(*   all:intros x xExt xT xExts. *)
+(*   all:hnf in xExts; subst xExt. *)
+(*   all:cbn [fst snd]. *)
+
+(*   all:eexists. *)
+(*   all:eapply computesTimeExpStep. *)
+(*   2,6:now Intern.recStepUnnamed; Lsimpl. *)
+(*   1,4:reflexivity. *)
+(*   1,3:Lproc. *)
+  
+
+(*   all:intros f fExt fT fExts. *)
+(*   all:change fExt with (@extT _ _ f _  (Build_computableTime' fExts)). *)
+(*   2: apply f_equal with (f:=N.pred) in eqd;rewrite N.pred_succ,<- N.sub_succ_r in eqd. *)
+(*   all:eexists;split. *)
+(*   all:cbn [fst snd]. *)
+(*   1,2:assert (N.ltb i max = false) by (apply N.ltb_ge;Lia.lia). *)
+(*   1,3:eapply le_evalLe_proper;[ | reflexivity..| ]. *)
+(*   2:{ Intern.recStepUnnamed. Lsimpl. Intern.extractCorrectCrush_new. congruence. } *)
+(*   {rewrite H2. cbn[fst snd]. ring_simplify. admit. } *)
+(*   2:{ Intern.recStepUnnamed. Lsimpl. Intern.extractCorrectCrush_new. } *)
+(*   2:{ rewrite H2. rewrite iterupN_geq. easy.  Lia.lia. } *)
+(*   2:{ destruct (N.ltb_spec0 i max). *)
+(*       -rewrite iterupN_lt. all:easy. *)
+(*       -rewrite iterupN_geq. all:easy. *)
+(*   } *)
+(*   recRel_prettify2. *)
+(*   all:cbn [fst snd]. *)
+(*     :unfold iterupN. repeat Intern.cstep. *)
+(*   2,3:hnf. *)
+(*   {rewrite } *)
+(*   intros. *)
+(*   destruct (NIntern.rexStepInit P. .ltb_spec0 i max). *)
+(*   rewrite iterupN_lt. 2:easy. *)
+(*   reflexivity. *)
+(*   rewrite iterupN_geq. all:easy. *)
+(*   Unshelve. all:now try constructor;try exact _;try eauto;try exact 0. *)
+(* Qed. *)
+
+
+Instance term_iterupN X `{H:registered X} :
+  computable (iterupN (X:=X)).
 Proof.
   pose (s := rho (λ F i max x f, (!!(ext N.ltb) i max) (λ _ , F (!!(ext N.succ) i) max (f i x) f) (λ _ , x) I)).
   cbv [convert TH minus] in s.
@@ -69,7 +140,7 @@ Proof.
   1,2:assert (N.ltb i max = false) by (apply N.ltb_ge;Lia.lia).
   1:{Intern.extractCorrectCrush_new. congruence. }
   {rewrite H3. rewrite iterupN_geq. 2:Lia.lia. reflexivity. }
-  {Intern.extractCorrectCrush_new. } 
+  {Intern.extractCorrectCrush_new. }
   intros.
   destruct (N.ltb_spec0 i max).
   rewrite iterupN_lt. 2:easy.

--- a/theories/L/Functions/LoopSum.v
+++ b/theories/L/Functions/LoopSum.v
@@ -1,0 +1,50 @@
+From Undecidability.L Require Import Tactics.LTactics.
+From Undecidability.L.Datatypes Require Import LNat LSum LOptions.
+Require Export Undecidability.L.Prelim.LoopSum.
+
+Section loopSum.
+  Variable X Y : Type.
+  Context `{registered X}.
+  Context `{registered Y}.
+
+  Fixpoint time_loopSum (f: X -> X + Y) (fT : timeComplexity (X -> X + Y))
+           (n:nat) (x : X) {struct n}:=
+    4 + match n with
+        | 0 => 0
+        | S n' => fst (fT x tt)
+                +  match f x with
+                     inl x' => time_loopSum f fT n' x'
+                   | inr x => 0
+                   end
+        end + 11.
+
+  Global Instance termT_loopSum : computableTime' (@loopSum X Y) (fun n _ => (5,fun f fT => (1,fun x _ => (time_loopSum f fT n x,tt)))).
+  extract.
+  solverec.
+  Qed.
+End loopSum.
+
+
+Lemma time_loopSum_bound_onlyByN {X Y} (H : registered X) (H0 : registered Y) (f:X -> X + Y) fT (P: nat -> _ -> Prop) boundL boundR:
+  (forall n x, P n x -> match f x with
+              | inl x' => P (S n) x' /\ fst (fT x tt) <= boundL
+              | inr y => forall n', n <= n' -> fst (fT x tt) <= boundL + boundR n'
+              end) ->
+  forall n x,
+    P 0 x -> 
+    time_loopSum f fT n x <= n * (boundL + 15) + boundR n + 15.
+Proof.
+  intros H' n x.
+  pose (n':=n). assert (Hleq : n<=n') by (cbn;omega).
+  replace 0 with (n'-n) at 1 by (cbn;omega).
+  replace (boundR n) with (boundR n') by reflexivity.
+  clearbody n'.
+  induction n in x,Hleq |-*. 1:now cbn;Lia.nia.
+  intros HPx.
+  cbn -[plus].
+  specialize H' with (x:=x).
+  destruct (f x).
+  -edestruct H' as [? ->]. eassumption. rewrite IHn. 2:easy. Lia.lia. replace (n'-n) with (S (n'-S n)) by Lia.nia. eassumption. 
+  -rewrite H' with (n':=n'). 2:easy. all:Lia.lia.
+Qed.
+

--- a/theories/L/Functions/Proc.v
+++ b/theories/L/Functions/Proc.v
@@ -1,4 +1,4 @@
-From Undecidability.L Require Export Computability.Decidability Datatypes.LNat L.
+From Undecidability.L Require Import Computability.Decidability Datatypes.LNat L.
 
 (** ** Decidabiity of closedness, boundedness and procness *)
 

--- a/theories/L/Functions/Proc.v
+++ b/theories/L/Functions/Proc.v
@@ -9,9 +9,9 @@ match t with
 | lam s => boundb (S k) s
 end.
 
-Instance term_boundb : computable boundb.
+Instance term_boundb : computableTime' boundb (fun _ _ => (5,fun s _ => (size s * 31+9,tt))).
 Proof.
-  extract.
+  extract. solverec.
 Defined.
 
 Lemma boundb_spec k t : Bool.reflect (bound k t) (boundb k t).
@@ -35,9 +35,10 @@ Lemma closedb_spec s : Bool.reflect (closed s) (closedb s).
   destruct (boundb_spec 0 s);constructor; rewrite closed_dcl;auto.
 Qed.
 
-Instance term_closedb : computable closedb.
+Instance termT_closedb : computableTime' closedb (fun s _ => (size s * 31+15,tt)).
 Proof.
-  exact _.
+  change closedb with (fun x => boundb 0 x).
+  extract. solverec.
 Defined.
 
 
@@ -47,9 +48,9 @@ match t with
 | _ => false
 end.
 
-Instance term_lambdab : computable lambdab.
+Instance term_lambdab : computableTime' lambdab (fun _ _ => (11,tt)).
 Proof.
-  extract.
+  extract. solverec.
 Defined.
 
 Lemma lambdab_spec t : Bool.reflect (lambda t) (lambdab t).

--- a/theories/L/Functions/Size.v
+++ b/theories/L/Functions/Size.v
@@ -1,12 +1,13 @@
-From Undecidability.L Require Import Tactics.LTactics Functions.Encoding.
+From Undecidability.L Require Import Tactics.LTactics Functions.Encoding Prelim.LoopSum Functions.LoopSum Functions.UnboundIteration.
 Require Import Nat.
+From Undecidability.L.Datatypes Require Import Lists.
 
 (** ** Extracted size of terms *)
 
-Instance term_size : computable size'.
+Instance term_size' : computable size'.
 Proof.
   extract.
-Defined.
+Abort.
 
 Lemma size'_surj : surjective size'.
 Proof.
@@ -14,4 +15,80 @@ Proof.
   -exists (var 0). cbn. omega.
   -destruct IHn as [x <-].
    exists (lam x). cbn. easy. 
+Qed.
+
+
+Definition sizeTR' '(stack,res) : (list term * nat) + nat :=
+  match stack with
+    [] => inr res
+  | s::stack =>
+    match s with
+      var n => inl (stack,S (n + res))
+    | app s t => inl (s::t::stack,S res)
+    | lam s => inl (s::stack,S res)
+    end
+  end.
+
+Fixpoint sizeTR'_fuel (s:term) : nat :=
+  match s with
+    var _ => 1
+  | app s t => 1 + (sizeTR'_fuel s + sizeTR'_fuel t)
+  | lam s => 1 + sizeTR'_fuel s
+  end.
+
+
+Lemma sizeTR'_correct stack res s k:
+  loopSum (sizeTR'_fuel s + k) sizeTR' (s::stack,res)
+  = loopSum k sizeTR' (stack,size s + res).
+Proof.
+  induction s in res,stack,k |- *.
+  all:cbn.
+  -reflexivity.
+  -rewrite <- !Nat.add_assoc. cbn.
+   rewrite IHs1, IHs2. easy.
+  -rewrite IHs. easy.
+Qed.
+                       
+Lemma sizeTR_correct s:
+  loopSum (sizeTR'_fuel s + 1) sizeTR' ([s],0) = Some (size s). 
+Proof.
+  rewrite sizeTR'_correct. cbn. easy.
+Qed.
+
+Instance termT_sizeTR' : computableTime' sizeTR'
+                                           (fun x _ => (let '(stack,res) := x in
+                                                    match stack with
+                                                      var n ::_ =>  n*11
+                                                    | _ => 0
+                                                    end + 28,tt)).
+Proof.
+ extract. solverec.
+Qed.
+
+Lemma sizeTR'_fuel_leq_size s : sizeTR'_fuel s <= size s.
+Proof.
+  induction s;cbn [size sizeTR'_fuel];try Lia.lia.
+Qed.
+
+Instance termT_size : computableTime' size (fun s _ => (108 * size s + 43,tt)).
+Proof.
+  eexists.
+  eapply computesTime_timeLeq.
+  
+  2:{ unshelve (eapply uiter_total_instanceTime with (1 := sizeTR_correct) (preprocessT:=(fun _ _ => (5,tt)))).
+      4:{ extract. solverec. }
+      2:{ apply termT_sizeTR'. }
+  }
+  split. 2:exact Logic.I.
+  cbn [fst].
+  erewrite uiterTime_bound_recRel with (iterT := fun _ '(stack,res) => ((sumn (map size stack)) * 108
+                                                                   + 28 + 9))
+                                       (P:= fun n x => True).
+  { cbn [length map sumn]. Lia.lia. }
+  {intros n [stack res] H. cbn.
+   destruct stack as [|[[]| |]].
+   2-5:split;[easy|].
+   all:cbn [length map sumn sizeTR'_fuel size];try Lia.lia.
+  }
+  all:easy.
 Qed.

--- a/theories/L/Functions/Subst.v
+++ b/theories/L/Functions/Subst.v
@@ -2,7 +2,7 @@ From Undecidability.L Require Import Tactics.LTactics Functions.Equality Datatyp
 (** ** Extracted substitution on terms *)
 
 Instance term_substT :
-  computableTime subst (fun s _ => (5, (fun n _ => (1, (fun t _ => ( 15 * n * size s + 43 * (size s) ^ 2 + 13, tt)))))).
+  computableTime' subst (fun s _ => (5, (fun n _ => (1, (fun t _ => ( 15 * n * size s + 43 * (size s) ^ 2 + 13, tt)))))).
 Proof.
   extract. solverec.
 Qed.

--- a/theories/L/Functions/UnboundIteration.v
+++ b/theories/L/Functions/UnboundIteration.v
@@ -1,0 +1,177 @@
+From Undecidability.L Require Import Tactics.LTactics Datatypes.LSum Datatypes.LOptions.
+From Undecidability.L Require Export Prelim.LoopSum.
+
+Section uiter.
+  Variable X Y : Type.
+  Context `{registered X}.
+  Context `{registered Y}.
+
+  Variable f : X -> X + Y.
+
+  Variable fT : timeComplexity (X -> X + Y).
+  Context `{computableTime' f fT}.
+
+  Definition uiter := Eval cbn -[enc] in rho (λ uiter x, !!(extT f) x (λ x' _ , uiter x') (λ y _ , y) I).
+
+  Lemma uiter_proc : proc uiter.
+  Proof. unfold uiter. Lproc. Qed.
+  Hint Resolve uiter_proc : LProc.
+
+  Fixpoint uiterTime n x :=
+    match n with
+      0 => 0
+    | S n' => fst (fT x tt) + 9 + match f x with
+                                       inl x' => uiterTime n' x'
+                                     | _ => 0
+                                     end
+    end. 
+
+  Lemma uiter_sound n x y:
+    loopSum n f x = Some y -> evalLe (uiterTime n x) (uiter (enc x)) (enc y).
+  Proof.
+    unfold uiter. Intern.recRem P.
+    induction n in x|-*;intros Heq. now easy.
+    cbn in Heq|-*.
+    eapply (@le_evalLe_proper (match f x with inl x' => _ | _ => _ end)).
+    2,3:reflexivity.
+    2:{
+      destruct (f x) eqn:eqfx.
+      -Intern.recStepUnnamed. Lrewrite_new. rewrite eqfx. Lrewrite_new. eapply IHn. eauto.
+      -inv Heq. Intern.recStepUnnamed. Lrewrite_new. rewrite eqfx. Lrewrite_new. Lreflexivity.
+    }
+    destruct (f x).
+    all:solverec.
+  Qed.
+
+  
+  Lemma uiter_total_instanceTime {Z} `{registered Z} (f':  Z -> Y) (preprocess : Z -> X) preprocessT (fuel : Z -> nat)
+    `{computableTime' preprocess preprocessT} :
+    (forall x, loopSum (fuel x) f (preprocess x) = Some (f' x)) ->
+    computesTime (TyArr _ _) f' (λ x, uiter (extT preprocess x)) (fun z _ => (1 + fst (preprocessT z tt) + uiterTime (fuel z) (preprocess z),tt)).
+  Proof.
+    cbn [convert TH].
+    intros total.
+    eapply computesTimeTyArr_helper with (time:=(fun x _ => _)).
+    { unfold uiter. now Lproc. }
+    intros z []. cbn. split. now reflexivity.
+    intros ? ->.
+    eexists. split. 2:reflexivity.
+    eapply le_evalLe_proper. 2-3:reflexivity.
+    2:{ eapply evalLe_trans with (t := (uiter (enc (preprocess z)))).
+        -now Lsimpl.
+        -eapply uiter_sound. apply total. }
+    omega.
+  Qed.
+    
+
+  Lemma uiterTime_bound_onlyByN (P: nat -> _ -> Prop) boundL boundR n0 x0:
+    (forall n x, n < n0
+            -> P n x
+            -> match f x with
+              | inl x' => P (S n) x' /\ fst (fT x tt) <= boundL
+              | inr y => forall n', n <= n' -> fst (fT x tt) <= boundL + boundR n'
+              end) ->
+    P 0 x0 -> 
+    uiterTime n0 x0 <= n0 * (boundL + 9) + boundR n0.
+  Proof.
+    intros H'.
+    pose (n0':=n0). assert (Hleq : n0<=n0') by (cbn;omega).
+    replace 0 with (n0'-n0) at 1 by (cbn;omega).
+    change (boundR n0) with (boundR n0').
+    change n0 with n0' in H'.
+    clearbody n0'.
+    induction n0 in x0,Hleq |-*. 1:cbn;Lia.nia.
+    intros HPx.
+    cbn -[plus].
+    specialize H' with (x:=x0).
+    destruct (f x0).
+    -edestruct H' as [? ->]. 2:eassumption. omega. rewrite IHn0. 2:easy.
+     now Lia.lia.
+     replace (n0'-n0) with (S (n0'-S n0)) by Lia.nia. eapply H2. 
+    -rewrite H' with (n:=n0'-S n0) (n':=n0'). all:try now Lia.lia. eassumption.
+  Qed.
+
+  Lemma uiterTime_bound_recRel2 (P: nat -> _ -> Prop) (iterT : X -> nat):
+    (forall i x, P i x -> match f x with
+                    | inl x' => P (S i) x' /\ iterT x' + 9 + fst (fT x tt) <= iterT x
+                    | inr y => fst (fT x tt) + 9 <= iterT x
+                    end) ->
+    forall n x,
+      P 0 x -> 
+      uiterTime n x <= iterT x.
+  Proof.
+    intros H' n x.
+    pose (n':=n). assert (Hleq : n<=n') by (cbn;omega).
+    replace 0 with (n'-n) at 1 by (cbn;omega).
+    clearbody n'.
+    induction n in x,Hleq |-*. 1:cbn;Lia.nia.
+    intros HPx.
+    cbn -[plus].
+    specialize H' with (x:=x).
+    destruct (f x) as [x'|y] eqn:eq. 
+    -edestruct H' as [? H'']. eassumption. rewrite IHn.
+2:easy. 2:{ replace (n'-n) with (S (n'-S n)) by Lia.nia. eassumption. }  Lia.lia.
+    -cbn. rewrite <- H'. 2:easy. all:Lia.lia.
+  Qed.
+
+  Lemma uiterTime_bound_recRel (P: nat -> _ -> Prop) (iterT : nat -> X -> nat) n:
+    (forall i x, P i x -> match f x with
+                    | inl x' => P (S i) x' /\ iterT (n-i-1) x' + 9 + fst (fT x tt) <= iterT (n-i) x
+                    | inr y => fst (fT x tt) + 9 <= iterT (n-i) x
+                    end) ->
+    forall x k,
+      k <= n ->
+      P (n-k) x -> 
+      uiterTime k x <= iterT k x.
+  Proof.
+    intros H' x k.
+    induction k in x |-*.
+    1:now cbn;Lia.nia.
+    intros ? HPx.
+    cbn -[plus].
+    specialize H' with (x:=x).
+    destruct (f x) as [x'|y] eqn:eq. 
+    -edestruct H' as [? H'']. eassumption. rewrite IHk.
+     +replace (n - (n - (S k))) with (1+k)  in H'' by Lia.lia.
+      cbn in H''. rewrite Nat.sub_0_r in H''.
+      Lia.nia.
+     +easy.
+     +replace (n-k) with (S (n-S k)) by Lia.nia. eassumption.
+    -replace (S k) with (n - (n - S k)) by Lia.lia.
+     rewrite <- H'. all:easy. 
+  Qed.
+  
+  Lemma uiterTime_computesRel (R : X -> X -> Prop) x0 k0 (t__step t__end : nat):
+    (forall k' x, k' < k0 -> pow R k' x0 x ->
+             fst (fT x tt) <= t__step +  match f x with
+                                       | inr _ => t__end | _ => 0
+                                       end
+             /\  match f x with
+                | inl x' =>  R x x'
+                | _ => True
+                end) ->
+    uiterTime k0 x0 <= k0 * (t__step + 9) + t__end.
+  Proof.
+    intros H'.
+    rewrite uiterTime_bound_onlyByN
+      with (P:= fun n x =>pow R n x0 x)
+           (boundL := t__step)
+           (boundR := fun _ => t__end).
+    -Lia.lia.
+    -intros n x lt'' R'.
+     specialize H' with (1:=lt'') (2:=R') as [H' H''].
+     destruct (f x).
+     +split. 2:easy. 
+      replace (S n) with (n+1) by omega.
+      eapply pow_add. eexists x. split. eauto. apply rcomp_1 with (R:=R). tauto.
+     +intro. omega.
+    -reflexivity. 
+  Qed.  
+    
+
+End uiter.
+
+Hint Resolve uiter_proc : LProc.
+Arguments uiter _ _ _ _ _ _ _ : clear implicits.
+Arguments uiter {X Y H H0} f {fT H1}.
+

--- a/theories/L/L.v
+++ b/theories/L/L.v
@@ -55,7 +55,7 @@ Coercion app : term >-> Funclass.
 
 (* Use Eval simpl in (term) when defining an term using convert.
 This converts while defining and therefore makes all later steps faster.
-See "important terms" belowI
+See "important terms" below
 
 Also: remember to give the type of combinators explicitly becuase we want to use the coercion!
 (e.g. "Definition R:term := ..." )*) 
@@ -524,6 +524,15 @@ Definition eval s t := s >* t /\ lambda t.
 Notation "s '⇓' t" := (eval s t) (at level 51).
 Hint Unfold eval.
 
+Lemma eval_unique s v1 v2 :
+  s ⇓ v1 -> s ⇓ v2 -> v1 = v2.
+Proof.
+  intros (R1&L1) (R2&L2).
+  eapply unique_normal_forms.
+  1-2:eassumption.
+  now rewrite <-R1,R2.
+Qed.
+
 Instance eval_star_subrelation : subrelation eval (star step).
 Proof.
   now intros ? ? [].
@@ -552,6 +561,18 @@ Notation "s '⇓(<=' l ')' t" := (evalLe l s t) (at level 50, format "s  '⇓(<=
 Instance evalLe_eval_subrelation i: subrelation (evalLe i) eval.
 Proof.
   intros ? ? [[? []] ?]. split. eapply pow_star_subrelation. all:eauto. 
+Qed.
+
+Lemma evalLe_evalIn s t k:
+  s ⇓(<=k) t -> exists k', k' <= k /\ s ⇓(k') t.
+Proof.
+  unfold evalLe,redLe,evalIn. firstorder.
+Qed.
+
+Lemma evalIn_evalLe s t k k':
+  k' <= k -> s ⇓(k') t -> s ⇓(<=k) t.
+Proof.
+  unfold evalLe,redLe,evalIn. firstorder.
 Qed.
 
 Instance evalIn_evalLe_subrelation i: subrelation (evalIn i) (evalLe i).

--- a/theories/L/Prelim/ARS.v
+++ b/theories/L/Prelim/ARS.v
@@ -5,9 +5,9 @@ Require Export PslBase.Base.
 
 Module ARSNotations.
   Notation "p '<=1' q" := (forall x, p x -> q x) (at level 70).
-  Notation "p '=1' q" := (p <=1 q /\ q <=1 p) (at level 70).
+  Notation "p '=1' q" := (forall x, p x <-> q x) (at level 70).
   Notation "R '<=2' S" := (forall x y, R x y -> S x y) (at level 70).
-  Notation "R '=2' S"  := (R <=2 S /\ S <=2 R) (at level 70).
+  Notation "R '=2' S"  := (forall x y, R x y <-> S x y) (at level 70).
 End ARSNotations.
 
 Import ARSNotations.
@@ -23,6 +23,9 @@ Definition rcomp X Y Z (R : X -> Y -> Prop) (S : Y -> Z -> Prop)
 Require Import Arith.
 Definition pow X R n : X -> X -> Prop := it (rcomp R) n eq.
 
+Definition functional {X Y} (R: X -> Y -> Prop) := forall x y1 y2, R x y1 -> R x y2 -> y1 = y2.
+Definition terminal {X Y} (R: X -> Y -> Prop) x:= forall y, ~ R x y.
+
 Section FixX.
   Variable X : Type.
   Implicit Types R S : X -> X -> Prop.
@@ -31,7 +34,8 @@ Section FixX.
   Definition reflexive R := forall x, R x x.
   Definition symmetric R := forall x y, R x y -> R y x.
   Definition transitive R := forall x y z, R x y -> R y z -> R x z.
-  Definition functional R := forall x y z, R x y -> R x z -> y = z.
+
+
 
   (** Reflexive transitive closure *)
 
@@ -39,7 +43,6 @@ Section FixX.
   | starR x : star R x x
   | starC x y z : R x y -> star R y z -> star R x z.
 
-  Definition terminal R x:= forall y, ~ R x y.
   Definition evaluates R x y := star R x y /\ terminal R y.
 
   (* Making first argument a non-uniform parameter doesn't simplify the induction principle. *)
@@ -196,6 +199,12 @@ Section FixX.
 
   Definition uniform_confluent (R : X -> X -> Prop ) := forall s t1 t2, R s t1 -> R s t2 -> t1 = t2 \/ exists u, R t1 u /\ R t2 u.
 
+  Lemma functional_uc R :
+    functional R -> uniform_confluent R.
+  Proof.
+    intros F ? ? ? H1 H2. left. eapply F. all:eauto.
+  Qed.
+
   Lemma pow_add R n m (s t : X) : pow R (n + m) s t <-> rcomp (pow R n) (pow R m) s t.
   Proof.
     revert m s t; induction n; intros m s t.
@@ -224,12 +233,12 @@ Section FixX.
   
   Lemma eq_ref : forall (R : X -> X -> Prop), R =2 R.
   Proof.
-    split; intros s t; tauto.
+    split; tauto.
   Qed.
   
   Lemma rcomp_1 (R : X -> X -> Prop): R =2 pow R 1.
   Proof.
-    split; intros s t; unfold pow in *; simpl in *; intros H.
+    intros s t; split;unfold pow in *; simpl in *; intros H.
     - econstructor. split; eauto.
     - destruct H as [u [H1 H2]]; subst u; eassumption.
   Qed.
@@ -377,4 +386,63 @@ Proof.
   induction 1;eauto using star.
 Qed.
 
+Lemma terminal_noRed {X} (R:X->X->Prop) x y :
+  terminal R x -> star R x y -> x = y.
+Proof.
+  intros ? R'. inv R'. easy. edestruct H. eassumption.
+Qed.
 
+Lemma unique_normal_forms {X} (R:X->X->Prop) x y:
+  confluent R -> ecl R x y -> terminal R x -> terminal R y -> x = y.
+Proof.
+  intros CR%confluent_CR E T1 T2.
+  specialize (CR _ _ E) as (z&R1&R2).
+  apply terminal_noRed in R1. apply terminal_noRed in R2. 2-3:eassumption. congruence.
+Qed.
+
+Instance ecl_Equivalence {X} (R:X->X->Prop) : Equivalence (ecl R).
+Proof.
+  split.
+  -constructor.
+  -apply ecl_sym.
+  -apply ecl_trans.
+Qed.
+
+Instance star_ecl_subrel {X} (R:X->X->Prop) : subrelation (star R) (ecl R).
+Proof.
+  intro. eapply star_ecl.
+Qed.
+
+Instance pow_ecl_subrel {X} (R:X->X->Prop) n : subrelation (pow R n) (ecl R).
+Proof.
+  intros ? ? H%pow_star. now rewrite H.
+Qed.
+
+Lemma uniform_confluence_parameterized_terminal (X : Type) (R : X -> X -> Prop) (m n : nat) (s t1 t2 : X):
+  uniform_confluent R -> terminal R t1 ->
+  pow R m s t1 -> pow R n s t2 -> exists n', pow R n' t2 t1 /\ m = n + n'.
+Proof.
+  intros H1 H2 H3 H4.
+  specialize (parametrized_confluence H1 H3 H4) as (n0&n'&?&?&?&R'&?&?).
+  destruct n0.
+  -inv R'. exists n'. intuition.
+  -exfalso. destruct R' as (?&?&?). eapply H2. eauto.
+Qed.
+
+Lemma uniform_confluence_parameterized_both_terminal (X : Type) (R : X -> X -> Prop) (n1 n2 : nat) (s t1 t2 : X):
+  uniform_confluent R -> terminal R t1 -> terminal R t2 ->
+  pow R n1 s t1 -> pow R n2 s t2 -> n1=n2 /\ t1 = t2.
+Proof.
+  intros H1 H2 H2' H3 H4.
+  specialize (parametrized_confluence H1 H3 H4) as (n0&n'&?&?&?&R'&R''&?).
+  destruct n0. destruct n'.
+  -inv R'. inv H5. split;first [omega | easy].
+  -exfalso. destruct R'' as (?&?&?). eapply H2'. eauto.
+  -exfalso. destruct R' as (?&?&?). eapply H2. eauto.
+Qed.
+
+Definition computesRel {X Y} (f : X -> option Y) (R:X -> Y -> Prop) :=
+  forall x, match f x with
+         Some y => R x y
+       | None => terminal R x
+       end.

--- a/theories/L/Prelim/LoopSum.v
+++ b/theories/L/Prelim/LoopSum.v
@@ -1,0 +1,62 @@
+From Undecidability.L.Prelim Require Import ARS MoreBase.
+  
+Definition loopSum {X} {Y} :=
+  fix loopSum n (f:X -> X + Y) (x:X) {struct n}:=
+  match n with
+    0 => None
+  | S n => match f x with
+          | inl x' => loopSum n f x'
+          | inr y => Some y
+          end
+  end.
+
+Definition loopSum_mono X Y f x y n n':
+  n <= n' -> @loopSum X Y n f x = Some y -> loopSum n' f x = Some y.
+Proof.
+  induction n in n',x|-*;intros H. now inversion 1.
+  -inv H. easy. cbn. destruct _. 2:easy. apply IHn. omega. 
+Qed.
+
+Lemma loopSum_sound_rel X Y {R:X->X->Prop} k n x y (f: X -> X + Y):
+  (forall x y, R x y -> f x = inl y) ->
+  pow R k x y ->
+  loopSum (k+n) f x = loopSum n f y.
+Proof.
+  intros H1 R1.
+  induction k in R1,x|-*.
+  -inv R1. reflexivity.
+  -change (S k) with (1+k) in R1. eapply pow_add in R1 as (x'&R2&R1).
+   eapply rcomp_1 in R2. apply H1 in R2. cbn.
+   rewrite R2. now apply IHk.
+Qed.
+
+Lemma loopSum_rel_correct2 X Y {R:X->X->Prop} k x y (f: X -> X + Y):
+  (forall x, match f x with
+        | inl y => R x y
+        | inr _ => terminal R x
+        end)->
+  loopSum k f x = Some y ->
+  exists i x', i < k /\ loopSum k f x = loopSum (k-i) f x'
+          /\ pow R i x x'
+          /\ terminal R x'
+          /\ f x' = inr y.
+Proof.
+  intros H1 Heq.
+  induction k in Heq,x|-*. now inv Heq.
+  cbn in Heq.
+  specialize (H1 x).
+  destruct (f x) eqn:eqf.
+  -eapply IHk in Heq as (i&x'&?&?&?&?&?).
+   eexists (1 + i),x'.
+   repeat eapply conj.
+   +omega.
+   +cbn. rewrite eqf. easy.
+   +eapply pow_add;do 2 esplit.
+    eapply rcomp_1 with (R:=R). all:eassumption.
+   +easy.
+   +easy.
+  -inv Heq.
+   exists 0,x.
+   repeat eapply conj.
+   all:solve [easy|omega].
+Qed.

--- a/theories/L/Prelim/MoreBase.v
+++ b/theories/L/Prelim/MoreBase.v
@@ -53,3 +53,11 @@ Proof.
 Qed.
 
 Definition maxP (P:nat -> Prop) m := P m /\ (forall m', P m' -> m' <= m). 
+
+Lemma sumn_le_bound l c :
+  (forall n, n el l -> n <= c) -> sumn l <= length l * c.
+Proof.
+  induction l;cbn. easy.
+  intros H.
+  rewrite <- IHl,<- H. all:now eauto.
+Qed.

--- a/theories/L/Prelim/MoreBase.v
+++ b/theories/L/Prelim/MoreBase.v
@@ -33,6 +33,20 @@ Instance min_le_proper : Proper (le ==> le ==> le) min.
 repeat intro. repeat eapply Nat.min_case_strong;omega.
 Qed.
 
+Instance Nat_log2_le_Proper : Proper (le ==> le) Nat.log2.
+Proof.
+  repeat intro. apply Nat.log2_le_mono. assumption.
+Qed.
+Instance Pos_to_nat_le_Proper : Proper (Pos.le ==> le) Pos.to_nat.
+Proof.
+  repeat intro. apply Pos2Nat.inj_le. assumption.
+Qed.
+
+Instance Pos_add_le_Proper : Proper (Pos.le ==> Pos.le ==>Pos.le) Pos.add.
+Proof.
+  repeat intro. eapply Pos.add_le_mono. 3:eauto. all:eauto. 
+Qed.
+
 Lemma nth_error_Some_lt A (H:list A) a x : nth_error H a = Some x -> a < |H|.
 Proof.
   intros eq. revert H eq. induction a;intros;destruct H;cbn in *;inv eq. omega. apply IHa in H1. omega.

--- a/theories/L/Prelim/MoreList.v
+++ b/theories/L/Prelim/MoreList.v
@@ -66,7 +66,6 @@ Proof.
   rewrite IHn. rewrite <- minus_n_O. reflexivity.
 Qed.
 
-
 Definition maxl := fold_right max 0.
 Lemma maxl_leq n l: n el l -> n <= maxl l.
 Proof.

--- a/theories/L/Prelim/MoreList.v
+++ b/theories/L/Prelim/MoreList.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Base.
+Require Import PslBase.Base Lia.
 (** Nats smaller than n *)
 
 Fixpoint natsLess n : list nat :=
@@ -64,4 +64,31 @@ Proof.
   rewrite natsLess_S at 2. cbn. rewrite map_app. cbn.
   rewrite map_map. cbn in IHn.
   rewrite IHn. rewrite <- minus_n_O. reflexivity.
+Qed.
+
+
+Definition maxl := fold_right max 0.
+Lemma maxl_leq n l: n el l -> n <= maxl l.
+Proof.
+  induction l;cbn.
+  -easy.
+  -intros [->|]. all:apply Nat.max_case_strong;try intuition Lia.lia.
+Qed.
+
+Lemma maxl_leq_l c l :
+  (forall n, n el l -> n <= c) -> maxl l <= c.
+Proof.
+  induction l;cbn. Lia.lia. 
+  intros H. eapply Nat.max_lub_iff;split. all:eauto.  
+Qed.
+
+Lemma maxl_app l l': maxl (l++l') = max (maxl l) (maxl l').
+Proof.
+  induction l;cbn;Lia.lia.
+Qed.
+
+Lemma maxl_rev l: maxl (rev l) = maxl l.
+Proof.
+  unfold maxl. rewrite fold_left_rev_right. rewrite fold_symmetric. 2,3:now intros;Lia.lia.
+  induction l;cbn;try Lia.lia.
 Qed.

--- a/theories/L/Reductions/TM_to_L.v
+++ b/theories/L/Reductions/TM_to_L.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.TMEncoding TM.TM.
+From Undecidability Require Import TM.TMEncoding TM.TMinL TM.TM.
 From Undecidability.L Require Import Computability.MuRec.
 Require Import Undecidability.FOL.Reductions.
 

--- a/theories/L/TM/TMEncoding.v
+++ b/theories/L/TM/TMEncoding.v
@@ -1,277 +1,121 @@
 From Undecidability.L.Tactics Require Import LTactics GenEncode.
-From Undecidability.L.Datatypes Require Import LNat Lists LProd.
-From Undecidability.L.Computability Require Import MuRec.
+From Undecidability.L.Datatypes Require Import LNat Lists LProd LFinType LVector.
+From Undecidability.L Require Import Computability.MuRec Functions.FinTypeLookup.
+From Undecidability.L Require Import MuRec.
 
-From Undecidability Require Import TM.TM.
+
+From Undecidability Require Import TM.TM L.Functions.Decoding.
 Require Import PslBase.FiniteTypes.FinTypes.
 
 (** ** Extraction of Turing Machine interpreter  *)
-
-(** *** Encoding finite types *)
-(* This is not an instance because we only want it for very specific types. *)
-Definition registered_finType `{X : finType} : registered X.
-Proof.
-  eapply (registerAs index).
-  intros x y H. now apply injective_index.
-Defined.
-
-Definition finType_eqb {X:finType} (x y : X) :=
-  Nat.eqb (index x) (index y).
-
-Lemma finType_eqb_reflect (X:finType) (x y:X) : reflect (x = y) (finType_eqb x y).
-Proof.
-  unfold finType_eqb. destruct (Nat.eqb_spec (index x) (index y));constructor.
-  -now apply injective_index.
-  -congruence.
-Qed.
-
-Section finType_eqb.
-  Local Existing Instance registered_finType.
-
-  Global Instance term_index (F:finType): computableTime' (@index F) (fun _ _=> (1, tt)).
-  Proof.
-    apply cast_computableTime.
-  Qed.
-
-  Global Instance term_eqb (X:finType) : computableTime' (finType_eqb (X:=X)) (fun x _ => (1,fun y _ => (17 * Init.Nat.min (index x) (index y) + 17,tt))).
-  Proof.
-    extract.
-    solverec.
-  Qed.
-End finType_eqb.
-
-
-
-Section Lookup.
-  Variable X Y : Type.
-  Variable eqb : X -> X -> bool.
-
-  Fixpoint lookup (x:X) (A:list (X*Y)) d: Y :=
-    match A with
-      [] => d
-    | (key,Lproc)::A =>
-      if eqb x key then Lproc else lookup x A d
-    end.
-
-End Lookup.
-
-Section funTable.
-
-  Variable X : finType.
-  Variable Y : Type.
-  Variable f : X -> Y.
-
-  Definition funTable :=
-    map (fun x => (x,f x)) (elem X).
-
-  Variable (eqb : X -> X -> bool).
-  Variable (Heqb:forall x y, reflect (x = y) (eqb x y)).
-
-  Lemma lookup_funTable x d:
-    lookup eqb x funTable d = f x.
-  Proof.
-    unfold funTable.
-    specialize (elem_spec x).
-    generalize (elem X) as l.
-    induction l;cbn;intros Hel.
-    -tauto.
-    -destruct (Heqb x a).
-     +congruence.
-     +destruct Hel. 1:congruence.
-      eauto.
-  Qed.
-End funTable.
-
-Definition lookupTime {X Y} `{registered X} (eqbT : timeComplexity (X ->X ->bool)) x (l:list (X*Y)):=
-  fold_right (fun '(a,b) res => callTime2 eqbT x a + res +19) 4 l.
-
-
-Global Instance term_lookup X Y `{registered X} `{registered Y}:
-  computableTime' (@lookup X Y) (fun eqb T__eqb => (1, fun x _ => (5, fun l _ => (1, fun d _ => (lookupTime T__eqb x l,tt))))).
-extract. unfold lookupTime. solverec.
-Qed.
-
-Lemma lookupTime_leq {X Y} `{registered X} (eqbT:timeComplexity (X -> X -> bool)) x (l:list (X*Y)) k:
-  (forall y, callTime2 eqbT x y <= k)
-  -> lookupTime eqbT x l <= length l * (k + 19) + 4.
-Proof.
-  intros H'.
-  induction l as [ | [a b] l].
-  -cbn. omega.
-  -unfold lookupTime. cbn [fold_right]. fold (lookupTime eqbT x l).
-   setoid_rewrite IHl. cbn [length]. rewrite H'.
-   ring_simplify. omega.
-Qed.
-
-(** *** Encoding vectors *)
-
-Instance register_vector X `{registered X} n : registered (Vector.t X n).
-Proof.
-  apply (registerAs VectorDef.to_list).
-  intros x. induction x.
-  - intros y. pattern y. revert y. eapply VectorDef.case0. cbn. reflexivity.
-  - intros y. clear H. revert h x IHx. pattern n, y. revert n y.
-    eapply Vector.caseS. intros h n y h0 x IHx [=].
-    subst. f_equal. eapply IHx. eassumption.
-Defined.
-
-Instance term_to_list X `{registered X} n : computableTime' (Vector.to_list (A:=X) (n:=n)) (fun _ _ => (1,tt)).
-Proof.
-  apply cast_computableTime.
-Qed.
-
-Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y) fT:
-  computableTime' f fT ->
-  computableTime' (VectorDef.map f (n:=n))
-                 (fun l _ => (fold_right (fun (x0 : X) (res : nat) => fst (fT x0 tt) + res + 12) 8 l + 3,tt)).
-Proof.
-  intros ?.
-  computable_casted_result.
-  apply computableTimeExt with (x:= fun x => map f (Vector.to_list x)).
-  2:{
-    extract.
-    solverec.
-  }
-
-  cbn. intros x.
-  clear - x.
-  induction n. revert x. apply VectorDef.case0. easy. revert IHn. apply Vector.caseS' with (v:=x).
-  intros. cbn. f_equal. fold (Vector.fold_right (A:=X) (B:=Y)).
-  setoid_rewrite IHn. reflexivity.
-Qed.
-
-(* Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y): computable f -> computable (VectorDef.map f (n:=n)). *)
-(* Proof. *)
-(*   intros ?. *)
-
-(*   internalize_casted_result. *)
-(*   apply computableExt with (x:= fun x => map f (Vector.to_list x)). *)
-(*   2:{ *)
-(*     extract. *)
-(*   } *)
-
-(*   cbn. intros x.  *)
-(*   clear - x. *)
-(*   induction n. revert x. apply VectorDef.case0. easy. revert IHn. apply Vector.caseS' with (v:=x). *)
-(*   intros. cbn. f_equal. fold (Vector.fold_right (A:=X) (B:=Y)). *)
-(*   setoid_rewrite IHn. reflexivity. *)
-(* Qed. *)
-
-Fixpoint time_map2 {X Y Z} `{registered X} `{registered Y} `{registered Z} (gT : timeComplexity (X->Y->Z)) (l1 :list X) (l2 : list Y) :=
-  match l1,l2 with
-  | x::l1,y::l2 => callTime2 gT x y + 18 + time_map2 gT l1 l2
-  | _,_ => 9
-  end.
-Instance term_map2 n A B C `{registered A} `{registered B} `{registered C} (g:A -> B -> C) gT:
-  computableTime' g gT-> computableTime' (Vector.map2 g (n:=n)) (fun l1 _ => (1,fun l2 _ => (time_map2 gT (Vector.to_list l1) (Vector.to_list l2) +8,tt))).
-Proof.
-  intros ?.
-  computable_casted_result.
-  pose (f:=(fix f t a : list C:=
-              match t,a with
-                t1::t,a1::a => g t1 a1 :: f t a
-              | _,_ => []
-              end)).
-  assert (computableTime' f (fun l1 _ => (5,fun l2 _ => (time_map2 gT l1 l2,tt)))).
-  {subst f; extract.
-
-
-
-   solverec. }
-  apply computableTimeExt with (x:= fun t a => f (Vector.to_list t) (Vector.to_list a)).
-  2:{extract. solverec. }
-  induction n;cbn.
-  -do 2 destruct x using Vector.case0. reflexivity.
-  -destruct x using Vector.caseS'. destruct x0 using Vector.caseS'.
-   cbn. f_equal. apply IHn.
-Qed.
-
-
-Lemma time_map2_leq X Y Z `{registered X}  `{registered Y}  `{registered Z}  (fT:timeComplexity (X -> Y -> Z))(l1 : list X) (l2:list Y) k:
-  (forall x y, callTime2 fT x y <= k) ->
-  time_map2 fT l1 l2<= length l1 * (k+18) + 9.
-Proof.
-  intros H';
-    induction l1 in l2|-*;cbn [time_map2].
-  -intuition.
-  -destruct l2;ring_simplify. intuition.
-   rewrite H',IHl1. cbn [length]. ring_simplify. intuition.
-Qed.
 
 
 Run TemplateProgram (tmGenEncode "move_enc" move).
 Hint Resolve move_enc_correct : Lrewrite.
 
+(*
+Definition move_decode (s : term) : option (move) :=
+  match s with
+  | lam (lam (lam n)) =>
+    match n with
+      2 => Some TM.L 
+    | 1 => Some TM.R
+    | 0 => Some TM.N
+    | _ => None
+    end
+  | _ => None
+  end.
+
+Instance decode_move: decodable move.
+Proof.
+  exists move_decode.
+  all:unfold enc at 1. all:cbn.
+  -destruct x;reflexivity.
+  -destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros ? [= <-]. all:reflexivity.
+Defined.*)
+
+(** *** Encoding Tapes *)
+Section reg_tapes.
+  Variable sig : Type.
+  Context `{reg_sig : registered sig}.
+
+  
+  Implicit Type (t : TM.tape sig).
+
+  Run TemplateProgram (tmGenEncode "tape_enc" (TM.tape sig)).
+  Hint Resolve tape_enc_correct : Lrewrite.
+
+  (**Internalize constructors **)
+
+  Global Instance term_leftof : computableTime' (@leftof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
+  Proof.
+    extract constructor.
+    solverec.
+  Qed.
+
+  Global Instance term_rightof : computableTime' (@rightof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
+  Proof.
+    extract constructor. solverec.
+  Qed.
+
+  Global Instance term_midtape : computableTime' (@midtape sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (1,tt)))).
+  Proof.
+    extract constructor. solverec.
+  Qed.
+  
+End reg_tapes.
+
+
+Definition tape_decode X `{decodable X} (s : term) : option (tape X) :=
+  match s with
+  | lam (lam (lam (lam 3))) => Some (niltape _)
+  | lam (lam (lam (lam (app ( app 2 c) r)))) =>
+     match decode X c,decode (list X) r with
+       Some x, Some xs => Some (leftof x xs)
+     | _,_ => None
+     end
+  | lam (lam (lam (lam (app ( app 1 c) l)))) =>
+    match decode X c,decode (list X) l with
+      Some x, Some xs => Some (rightof x xs)
+    | _,_ => None
+    end
+  | lam (lam (lam (lam (app ( app (app 0 l) c) r)))) =>
+    match decode X c,decode (list X) l,decode (list X) r with
+      Some x, Some xs, Some r => Some (midtape xs x r)
+    | _,_,_ => None
+    end
+  | _ => None
+  end.
+
+Arguments tape_decode : clear implicits.
+Arguments tape_decode _ {_ _} _.
+
+Instance decode_tape X `{registered X} {H:decodable X}: decodable (tape X).
+Proof.
+  exists (tape_decode X).
+  all:unfold enc at 1. all:cbn.
+  -destruct x;cbn.
+   all:repeat setoid_rewrite decode_correct. all:easy.
+  -destruct t eqn:eq. all:cbn.
+   all:repeat let eq := fresh in destruct _ eqn:eq. all:try congruence.
+   all:intros ? [= <-].
+   easy.
+   all:cbn.
+   all:change (match H with
+               | @mk_registered _ enc _ _ => enc
+               end x) with (enc x).
+   all: change (list_enc (intX:=H)) with (@enc _ _ : list X -> term) in *.
+   all: (setoid_rewrite @decode_correct2;[ |try eassumption..]).
+   all:easy.
+Defined.
+
 Section fix_sig.
   Variable sig : finType.
   Context `{reg_sig : registered sig}.
 
-  (** *** Encoding Tapes *)
-  Section reg_tapes.
-    Implicit Type (t : TM.tape sig).
 
-    Run TemplateProgram (tmGenEncode "tape_enc" (TM.tape sig)).
-    Hint Resolve tape_enc_correct : Lrewrite.
-
-    (**Internalize constructors **)
-
-    Global Instance term_leftof : computableTime' (@leftof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
-    Proof.
-      extract constructor.
-      solverec.
-    Qed.
-
-    Global Instance term_rightof : computableTime' (@rightof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
-    Proof.
-      extract constructor. solverec.
-    Qed.
-
-    Global Instance term_midtape : computableTime' (@midtape sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (1,tt)))).
-    Proof.
-      extract constructor. solverec.
-    Qed.
-
-    Global Instance term_tape_move_left' : computableTime' (@tape_move_left' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_tape_move_left : computableTime' (@tape_move_left sig) (fun _ _ => (23,tt)).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_tape_move_right' : computableTime' (@tape_move_right' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_tape_move_right : computableTime' (@tape_move_right sig) (fun _ _ => (23,tt)).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_tape_move : computableTime' (@tape_move sig) (fun _ _ => (1,fun _ _ => (48,tt))).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_left : computableTime' (@left sig) (fun _ _ => (10,tt)).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_right : computableTime' (@right sig) (fun _ _ => (10,tt)).
-    Proof.
-      extract. solverec.
-    Qed.
-
-    Global Instance term_tape_write : computableTime' (@tape_write sig) ((fun _ _ => (1,fun _ _ => (28,tt)))).
-    Proof.
-      extract. solverec.
-    Qed.
-
-  End reg_tapes.
 
   Definition mconfigAsPair {B : finType} {n} (c:mconfig sig B n):= let (x,y) := c in (x,y).
 
@@ -309,204 +153,4 @@ End fix_sig.
 
 
 (* Fixpoint time_loop f fT p pT := cnst 1. *)
-
-Definition Halt' Sigma n (M: mTM Sigma n) (start: mconfig Sigma (states M) n) :=
-  exists (f: mconfig _ (states M) _), halt (cstate f)=true /\ exists k, loopM start k = Some f.
-
-Definition Halt :{ '(Sigma, n) : _ & mTM Sigma n & tapes Sigma n} -> _ :=
-  fun '(existT2 _ _ (Sigma, n) M tp) =>
-    exists (f: mconfig _ (states M) _), halt (cstate f) = true
-                                   /\ exists k, loopM (mk_mconfig (start M) tp) k = Some f.
-
 Hint Resolve tape_enc_correct : Lrewrite.
-
-Fixpoint loopTime {X} `{registered X} f (fT: timeComplexity (X -> X)) (p: X -> bool) (pT : timeComplexity (X -> bool)) (a:X) k :=
-  fst (pT a tt) +
-  match k with
-    0 => 7
-  |  S k =>
-     fst (fT a tt) + 13 + loopTime f fT p pT (f a) k
-  end.
-
-Instance term_loop A `{registered A} :
-  computableTime' (@loop A)
-                 (fun f fT => (1,fun p pT => (1,fun a _ => (5,fun k _ =>(loopTime f fT p pT a k,tt))))).
-Proof.
-  extract.
-  solverec.
-Qed.
-
-Section loopM.
-  Context (sig : finType).
-  Let reg_sig := @registered_finType sig.
-  Existing Instance reg_sig.
-  Variable n : nat.
-  Variable M : mTM sig n.
-
-  Let reg_states := @registered_finType (states M).
-  Existing Instance reg_states.
-
-
-  Instance term_vector_eqb X `{registered X} (n' m:nat) (eqb:X->X->bool) eqbT:
-    computableTime' eqb eqbT
-    -> computableTime'
-        (VectorEq.eqb eqb (A:=X) (n:=n') (m:=m))
-        (fun A _ => (1,fun B _ => (list_eqbTime eqbT (Vector.to_list A) (Vector.to_list B) + 9,tt))).
-  Proof.
-    intros ?.
-    apply computableTimeExt with (x:=(fun x y => list_eqb eqb (Vector.to_list x) (Vector.to_list y))).
-    2:{extract.
-       solverec. }
-    intros v v'. hnf.
-    induction v in n',v'|-*;cbn;destruct v';cbn;try tauto. rewrite <- IHv. f_equal.
-  Qed.
-
-
-  Lemma to_list_length X n0 (l:Vector.t X n0) :length l = n0.
-  Proof.
-    induction l. reflexivity. rewrite <- IHl at 3. reflexivity.
-  Qed.
-
-  Definition transTime := (length (elem (states M) )*17 + n * 17 * (length ( elem sig )+ 4) + 71) * length (funTable (trans (m:=M))) + 16.
-
-  (** *** Computability of transition relation *)
-  Instance term_trans : computableTime' (trans (m:=M)) (fun _ _ => (transTime,tt)).
-  Proof.
-    pose (t:= (funTable (trans (m:=M)))).
-    apply computableTimeExt with (x:= fun c => lookup (prod_eqb finType_eqb (Vector.eqb (LOptions.option_eqb finType_eqb))) c t (start M,Vector.const (None,N) _)).
-    2:{extract.
-       cbn [fst snd]. intuition ring_simplify.
-
-
-       rewrite lookupTime_leq with (k:=(17* length (elem (states M)) + 17 * n * (length (elem sig) + 4) + 52)).
-       -unfold transTime.
-
-        repeat match goal with
-                 |- context C[length _] =>let G:= context C [length t] in progress change G
-               end.
-        ring_simplify.  omega.
-       -intros y. unfold callTime2.
-        cbn [fst snd]. ring_simplify.
-        setoid_rewrite index_leq at 1 2. rewrite Nat.min_id.
-        rewrite list_eqbTime_leq with (k:= | elem sig| * 17 + 29).
-        +rewrite to_list_length. ring_simplify. omega.
-        +intros [] [];unfold callTime2;cbn [fst snd].
-         setoid_rewrite index_leq at 1 2. rewrite Nat.min_id.
-         all:ring_simplify. all:omega.
-    }
-    cbn -[t] ;intro. subst t.  setoid_rewrite lookup_funTable. reflexivity.
-    apply prod_eqb_spec. apply finType_eqb_reflect. apply vector_eqb_spec,LOptions.option_eqb_spec,finType_eqb_reflect.
-  Qed.
-
-  Instance term_current: computableTime' ((current (sig:=sig))) (fun _ _ => (10,tt)).
-  Proof.
-    extract.
-    solverec.
-  Qed.
-
-  Instance term_current_chars: computableTime' (current_chars (sig:=sig) (n:=n))  (fun _ _ => (n * 22 +12,tt)).
-  Proof.
-    extract.
-    solverec.
-    assert (H1:forall X (l:list X), fold_right (fun _ (res : nat) => 10 + res + 12) 8 l = length l * 22 +8).
-    {induction l;ring_simplify;cbn [fold_right length]. now intuition. rewrite IHl.  omega. }
-    rewrite H1,to_list_length.  omega.
-  Qed.
-
-  Definition step' (c :  mconfig sig (states M) n) : mconfig sig (states M) n :=
-    let (news, actions) := trans (cstate c, current_chars (ctapes c)) in
-    mk_mconfig news (doAct_multi (ctapes c) actions).
-
-
-  Instance term_doAct: computableTime' (doAct (sig:=sig)) (fun _ _ => (1,fun _ _ => (89,tt))).
-  Proof.
-    extract.
-    solverec.
-  Qed.
-
-  Instance term_doAct_multi: computableTime' (doAct_multi (n:=n) (sig:=sig)) (fun _ _ => (1,fun _ _ =>(n * 108 + 19,tt))).
-  Proof.
-    extract.
-    solverec.
-    rewrite time_map2_leq with (k:=90).
-    2:now solverec.
-    solverec. now rewrite to_list_length.
-  Qed.
-
-
-  Instance term_step' : computableTime' (step (M:=M)) (fun _ _ => (n* 130+ transTime + 64,tt)).
-  Proof.
-    extract.
-    solverec.
-  Qed.
-
-  Definition haltTime := length (funTable (halt (m:=M))) * (length (elem (states M)) * 17 + 37) + 12.
-
-  Instance term_halt : computableTime' (halt (m:=M)) (fun _ _ => (haltTime,tt)).
-  Proof.
-    pose (t:= (funTable (halt (m:=M)))).
-    apply computableTimeExt with (x:= fun c => lookup finType_eqb c t false).
-    2:{extract.
-       solverec.
-       rewrite lookupTime_leq with (k:=17 * (| elem (states M) |) + 18).
-       2:{
-         intros. cbn [callTime2 fst].
-         repeat rewrite index_leq. rewrite Nat.min_id. omega.
-       }
-       unfold haltTime. subst t.
-       ring_simplify. reflexivity.
-    }
-    cbn;intro. subst t. setoid_rewrite lookup_funTable. reflexivity.
-    apply finType_eqb_reflect.
-  Qed.
-
-  Instance term_haltConf : computableTime' (haltConf (M:=M)) (fun _ _ => (haltTime+8,tt)).
-  Proof.
-    extract.
-    solverec.
-  Qed.
-
-  (** *** Computability of step-ndexed interpreter *)
-  Global Instance term_loopM :
-    let c1 := (haltTime + n*130 + transTime + 85) in
-    let c2 := 15 + haltTime in
-    computableTime' (loopM (M:=M)) (fun _ _ => (5,fun k _ => (c1 * k + c2,tt))).
-  Proof.
-    unfold loopM. (* as loop is already an registered instance, this here is a bit out of the scope. Therefore, we unfold manually here. *)
-    extract.
-    solverec. 
-  Qed.
-
-  Instance term_test cfg :
-    computable (fun k => LOptions.isSome (loopM (M := M) cfg k)).
-  Proof.
-    extract.
-  Qed.
-
-  Lemma Halt_red cfg :
-    Halt' cfg <-> converges (mu (ext ((fun k => LOptions.isSome (loopM (M := M) cfg k))))).
-  Proof.
-    split; intros.
-    - destruct H as (f & ? & k & ?).
-      edestruct (mu_complete).
-      + eapply term_test.
-      + intros. eexists. rewrite !ext_is_enc. now Lsimpl.
-      + Lsimpl. now rewrite H0.
-      + exists (ext x). split. eauto. Lproc.
-    - destruct H as (v & ? & ?). edestruct mu_sound as (k & ? & ? & _).
-      + eapply term_test.
-      + intros. eexists. now Lsimpl.
-      + eassumption.
-      + eauto.
-      + subst.
-        assert ((ext (fun k : nat => LOptions.isSome (loopM cfg k))) (ext k) ==
-                ext (LOptions.isSome (loopM cfg k))) by Lsimpl.
-        rewrite H1 in H2. clear H1.
-        eapply unique_normal_forms in H2; try Lproc. eapply inj_enc in H2.
-        destruct (loopM cfg k) eqn:E.
-        * exists m. split. 2: eauto.
-          unfold loopM in E. now eapply loop_fulfills in E.
-        * inv H2.
-  Qed.
-
-End loopM.

--- a/theories/L/TM/TMEncoding.v
+++ b/theories/L/TM/TMEncoding.v
@@ -28,12 +28,12 @@ Qed.
 Section finType_eqb.
   Local Existing Instance registered_finType.
 
-  Global Instance term_index (F:finType): computableTime (@index F) (fun _ _=> (1, tt)).
+  Global Instance term_index (F:finType): computableTime' (@index F) (fun _ _=> (1, tt)).
   Proof.
     apply cast_computableTime.
   Qed.
 
-  Global Instance term_eqb (X:finType) : computableTime (finType_eqb (X:=X)) (fun x _ => (1,fun y _ => (17 * Init.Nat.min (index x) (index y) + 17,tt))).
+  Global Instance term_eqb (X:finType) : computableTime' (finType_eqb (X:=X)) (fun x _ => (1,fun y _ => (17 * Init.Nat.min (index x) (index y) + 17,tt))).
   Proof.
     extract.
     solverec.
@@ -87,7 +87,7 @@ Definition lookupTime {X Y} `{registered X} (eqbT : timeComplexity (X ->X ->bool
 
 
 Global Instance term_lookup X Y `{registered X} `{registered Y}:
-  computableTime (@lookup X Y) (fun eqb T__eqb => (1, fun x _ => (5, fun l _ => (1, fun d _ => (lookupTime T__eqb x l,tt))))).
+  computableTime' (@lookup X Y) (fun eqb T__eqb => (1, fun x _ => (5, fun l _ => (1, fun d _ => (lookupTime T__eqb x l,tt))))).
 extract. unfold lookupTime. solverec.
 Qed.
 
@@ -115,14 +115,14 @@ Proof.
     subst. f_equal. eapply IHx. eassumption.
 Defined.
 
-Instance term_to_list X `{registered X} n : computableTime (Vector.to_list (A:=X) (n:=n)) (fun _ _ => (1,tt)).
+Instance term_to_list X `{registered X} n : computableTime' (Vector.to_list (A:=X) (n:=n)) (fun _ _ => (1,tt)).
 Proof.
   apply cast_computableTime.
 Qed.
 
 Instance term_vector_map X Y `{registered X} `{registered Y} n (f:X->Y) fT:
-  computableTime f fT ->
-  computableTime (VectorDef.map f (n:=n))
+  computableTime' f fT ->
+  computableTime' (VectorDef.map f (n:=n))
                  (fun l _ => (fold_right (fun (x0 : X) (res : nat) => fst (fT x0 tt) + res + 12) 8 l + 3,tt)).
 Proof.
   intros ?.
@@ -163,7 +163,7 @@ Fixpoint time_map2 {X Y Z} `{registered X} `{registered Y} `{registered Z} (gT :
   | _,_ => 9
   end.
 Instance term_map2 n A B C `{registered A} `{registered B} `{registered C} (g:A -> B -> C) gT:
-  computableTime g gT-> computableTime (Vector.map2 g (n:=n)) (fun l1 _ => (1,fun l2 _ => (time_map2 gT (Vector.to_list l1) (Vector.to_list l2) +8,tt))).
+  computableTime' g gT-> computableTime' (Vector.map2 g (n:=n)) (fun l1 _ => (1,fun l2 _ => (time_map2 gT (Vector.to_list l1) (Vector.to_list l2) +8,tt))).
 Proof.
   intros ?.
   computable_casted_result.
@@ -172,7 +172,7 @@ Proof.
                 t1::t,a1::a => g t1 a1 :: f t a
               | _,_ => []
               end)).
-  assert (computableTime f (fun l1 _ => (5,fun l2 _ => (time_map2 gT l1 l2,tt)))).
+  assert (computableTime' f (fun l1 _ => (5,fun l2 _ => (time_map2 gT l1 l2,tt)))).
   {subst f; extract.
 
 
@@ -215,58 +215,58 @@ Section fix_sig.
 
     (**Internalize constructors **)
 
-    Global Instance term_leftof : computableTime (@leftof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
+    Global Instance term_leftof : computableTime' (@leftof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
     Proof.
       extract constructor.
       solverec.
     Qed.
 
-    Global Instance term_rightof : computableTime (@rightof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
+    Global Instance term_rightof : computableTime' (@rightof sig) (fun _ _ => (1, fun _ _ => (1,tt))).
     Proof.
       extract constructor. solverec.
     Qed.
 
-    Global Instance term_midtape : computableTime (@midtape sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (1,tt)))).
+    Global Instance term_midtape : computableTime' (@midtape sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (1,tt)))).
     Proof.
       extract constructor. solverec.
     Qed.
 
-    Global Instance term_tape_move_left' : computableTime (@tape_move_left' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
+    Global Instance term_tape_move_left' : computableTime' (@tape_move_left' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_tape_move_left : computableTime (@tape_move_left sig) (fun _ _ => (23,tt)).
+    Global Instance term_tape_move_left : computableTime' (@tape_move_left sig) (fun _ _ => (23,tt)).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_tape_move_right' : computableTime (@tape_move_right' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
+    Global Instance term_tape_move_right' : computableTime' (@tape_move_right' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_tape_move_right : computableTime (@tape_move_right sig) (fun _ _ => (23,tt)).
+    Global Instance term_tape_move_right : computableTime' (@tape_move_right sig) (fun _ _ => (23,tt)).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_tape_move : computableTime (@tape_move sig) (fun _ _ => (1,fun _ _ => (48,tt))).
+    Global Instance term_tape_move : computableTime' (@tape_move sig) (fun _ _ => (1,fun _ _ => (48,tt))).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_left : computableTime (@left sig) (fun _ _ => (10,tt)).
+    Global Instance term_left : computableTime' (@left sig) (fun _ _ => (10,tt)).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_right : computableTime (@right sig) (fun _ _ => (10,tt)).
+    Global Instance term_right : computableTime' (@right sig) (fun _ _ => (10,tt)).
     Proof.
       extract. solverec.
     Qed.
 
-    Global Instance term_tape_write : computableTime (@tape_write sig) ((fun _ _ => (1,fun _ _ => (28,tt)))).
+    Global Instance term_tape_write : computableTime' (@tape_write sig) ((fun _ _ => (1,fun _ _ => (28,tt)))).
     Proof.
       extract. solverec.
     Qed.
@@ -281,26 +281,26 @@ Section fix_sig.
     register_inj.
   Defined.
 
-  Global Instance term_mconfigAsPair (B : finType) `{registered B} n: computableTime (@mconfigAsPair B n) (fun _ _ => (1,tt)).
+  Global Instance term_mconfigAsPair (B : finType) `{registered B} n: computableTime' (@mconfigAsPair B n) (fun _ _ => (1,tt)).
   Proof.
     apply cast_computableTime.
   Qed.
 
-  Global Instance term_cstate (B : finType) `{registered B} n: computableTime (@cstate sig B n) (fun _ _ => (7,tt)).
+  Global Instance term_cstate (B : finType) `{registered B} n: computableTime' (@cstate sig B n) (fun _ _ => (7,tt)).
   Proof.
     apply computableTimeExt with (x:=fun x => fst (mconfigAsPair x)).
     2:{extract. solverec. }
     intros [];reflexivity.
   Qed.
 
-  Global Instance term_ctapes (B : finType) `{registered B} n: computableTime (@ctapes sig B n) (fun _ _ => (7,tt)).
+  Global Instance term_ctapes (B : finType) `{registered B} n: computableTime' (@ctapes sig B n) (fun _ _ => (7,tt)).
   Proof.
     apply computableTimeExt with (x:=fun x => snd (mconfigAsPair x)).
     2:{extract. solverec. }
     intros [];reflexivity.
   Qed.
 
-  Global Instance registered_mk_mconfig (B : finType) `{registered B} n: computableTime (@mk_mconfig sig B n) (fun _ _ => (1,fun _ _ => (3,tt))).
+  Global Instance registered_mk_mconfig (B : finType) `{registered B} n: computableTime' (@mk_mconfig sig B n) (fun _ _ => (1,fun _ _ => (3,tt))).
   Proof.
     computable_casted_result.
     extract. solverec.
@@ -329,7 +329,7 @@ Fixpoint loopTime {X} `{registered X} f (fT: timeComplexity (X -> X)) (p: X -> b
   end.
 
 Instance term_loop A `{registered A} :
-  computableTime (@loop A)
+  computableTime' (@loop A)
                  (fun f fT => (1,fun p pT => (1,fun a _ => (5,fun k _ =>(loopTime f fT p pT a k,tt))))).
 Proof.
   extract.
@@ -348,8 +348,8 @@ Section loopM.
 
 
   Instance term_vector_eqb X `{registered X} (n' m:nat) (eqb:X->X->bool) eqbT:
-    computableTime eqb eqbT
-    -> computableTime
+    computableTime' eqb eqbT
+    -> computableTime'
         (VectorEq.eqb eqb (A:=X) (n:=n') (m:=m))
         (fun A _ => (1,fun B _ => (list_eqbTime eqbT (Vector.to_list A) (Vector.to_list B) + 9,tt))).
   Proof.
@@ -370,7 +370,7 @@ Section loopM.
   Definition transTime := (length (elem (states M) )*17 + n * 17 * (length ( elem sig )+ 4) + 71) * length (funTable (trans (m:=M))) + 16.
 
   (** *** Computability of transition relation *)
-  Instance term_trans : computableTime (trans (m:=M)) (fun _ _ => (transTime,tt)).
+  Instance term_trans : computableTime' (trans (m:=M)) (fun _ _ => (transTime,tt)).
   Proof.
     pose (t:= (funTable (trans (m:=M)))).
     apply computableTimeExt with (x:= fun c => lookup (prod_eqb finType_eqb (Vector.eqb (LOptions.option_eqb finType_eqb))) c t (start M,Vector.const (None,N) _)).
@@ -398,13 +398,13 @@ Section loopM.
     apply prod_eqb_spec. apply finType_eqb_reflect. apply vector_eqb_spec,LOptions.option_eqb_spec,finType_eqb_reflect.
   Qed.
 
-  Instance term_current: computableTime ((current (sig:=sig))) (fun _ _ => (10,tt)).
+  Instance term_current: computableTime' ((current (sig:=sig))) (fun _ _ => (10,tt)).
   Proof.
     extract.
     solverec.
   Qed.
 
-  Instance term_current_chars: computableTime (current_chars (sig:=sig) (n:=n))  (fun _ _ => (n * 22 +12,tt)).
+  Instance term_current_chars: computableTime' (current_chars (sig:=sig) (n:=n))  (fun _ _ => (n * 22 +12,tt)).
   Proof.
     extract.
     solverec.
@@ -418,13 +418,13 @@ Section loopM.
     mk_mconfig news (doAct_multi (ctapes c) actions).
 
 
-  Instance term_doAct: computableTime (doAct (sig:=sig)) (fun _ _ => (1,fun _ _ => (89,tt))).
+  Instance term_doAct: computableTime' (doAct (sig:=sig)) (fun _ _ => (1,fun _ _ => (89,tt))).
   Proof.
     extract.
     solverec.
   Qed.
 
-  Instance term_doAct_multi: computableTime (doAct_multi (n:=n) (sig:=sig)) (fun _ _ => (1,fun _ _ =>(n * 108 + 19,tt))).
+  Instance term_doAct_multi: computableTime' (doAct_multi (n:=n) (sig:=sig)) (fun _ _ => (1,fun _ _ =>(n * 108 + 19,tt))).
   Proof.
     extract.
     solverec.
@@ -434,7 +434,7 @@ Section loopM.
   Qed.
 
 
-  Instance term_step' : computableTime (step (M:=M)) (fun _ _ => (n* 130+ transTime + 64,tt)).
+  Instance term_step' : computableTime' (step (M:=M)) (fun _ _ => (n* 130+ transTime + 64,tt)).
   Proof.
     extract.
     solverec.
@@ -442,7 +442,7 @@ Section loopM.
 
   Definition haltTime := length (funTable (halt (m:=M))) * (length (elem (states M)) * 17 + 37) + 12.
 
-  Instance term_halt : computableTime (halt (m:=M)) (fun _ _ => (haltTime,tt)).
+  Instance term_halt : computableTime' (halt (m:=M)) (fun _ _ => (haltTime,tt)).
   Proof.
     pose (t:= (funTable (halt (m:=M)))).
     apply computableTimeExt with (x:= fun c => lookup finType_eqb c t false).
@@ -460,7 +460,7 @@ Section loopM.
     apply finType_eqb_reflect.
   Qed.
 
-  Instance term_haltConf : computableTime (haltConf (M:=M)) (fun _ _ => (haltTime+8,tt)).
+  Instance term_haltConf : computableTime' (haltConf (M:=M)) (fun _ _ => (haltTime+8,tt)).
   Proof.
     extract.
     solverec.
@@ -470,7 +470,7 @@ Section loopM.
   Global Instance term_loopM :
     let c1 := (haltTime + n*130 + transTime + 85) in
     let c2 := 15 + haltTime in
-    computableTime (loopM (M:=M)) (fun _ _ => (5,fun k _ => (c1 * k + c2,tt))).
+    computableTime' (loopM (M:=M)) (fun _ _ => (5,fun k _ => (c1 * k + c2,tt))).
   Proof.
     unfold loopM. (* as loop is already an registered instance, this here is a bit out of the scope. Therefore, we unfold manually here. *)
     extract.

--- a/theories/L/TM/TMinL.v
+++ b/theories/L/TM/TMinL.v
@@ -1,0 +1,184 @@
+From Undecidability.L.Tactics Require Import LTactics GenEncode.
+From Undecidability.L.Datatypes Require Import LNat Lists LProd LFinType LVector.
+From Undecidability.L Require Import Computability.MuRec Functions.FinTypeLookup.
+From Undecidability.L Require Export TM.TMEncoding.
+From Undecidability.L Require Import TM.TapeFuns.
+
+
+From Undecidability Require Import TM.TM.
+
+Definition Halt' Sigma n (M: mTM Sigma n) (start: mconfig Sigma (states M) n) :=
+  exists (f: mconfig _ (states M) _), halt (cstate f)=true /\ exists k, loopM start k = Some f.
+
+Definition Halt :{ '(Sigma, n) : _ & mTM Sigma n & tapes Sigma n} -> _ :=
+  fun '(existT2 _ _ (Sigma, n) M tp) =>
+    exists (f: mconfig _ (states M) _), halt (cstate f) = true
+                                   /\ exists k, loopM (mk_mconfig (start M) tp) k = Some f.
+
+Fixpoint loopTime {X} `{registered X} f (fT: timeComplexity (X -> X)) (p: X -> bool) (pT : timeComplexity (X -> bool)) (a:X) k :=
+  fst (pT a tt) +
+  match k with
+    0 => 7
+  |  S k =>
+     fst (fT a tt) + 13 + loopTime f fT p pT (f a) k
+  end.
+
+Instance term_loop A `{registered A} :
+  computableTime' (@loop A)
+                 (fun f fT => (1,fun p pT => (1,fun a _ => (5,fun k _ =>(loopTime f fT p pT a k,tt))))).
+Proof.
+  extract.
+  solverec.
+Qed.
+
+Section loopM.
+  Context (sig : finType).
+  Let reg_sig := @registered_finType sig.
+  Existing Instance reg_sig.
+  Variable n : nat.
+  Variable M : mTM sig n.
+
+  Let reg_states := @registered_finType (states M).
+  Existing Instance reg_states.
+
+  Definition transTime := (length (elem (states M) )*17 + n * 17 * (length ( elem sig )+ 4) + 71) * length (funTable (trans (m:=M))) + 16.
+
+  (** *** Computability of transition relation *)
+  Instance term_trans : computableTime' (trans (m:=M)) (fun _ _ => (transTime,tt)).
+  Proof.
+    pose (t:= (funTable (trans (m:=M)))).
+    apply computableTimeExt with (x:= fun c => lookup (prod_eqb finType_eqb (Vector.eqb (LOptions.option_eqb finType_eqb))) c t (start M,Vector.const (None,N) _)).
+    2:{extract.
+       cbn [fst snd]. intuition ring_simplify.
+
+
+       rewrite lookupTime_leq with (k:=(17* length (elem (states M)) + 17 * n * (length (elem sig) + 4) + 52)).
+       -unfold transTime.
+
+        repeat match goal with
+                 |- context C[length _] =>let G:= context C [length t] in progress change G
+               end.
+        ring_simplify.  omega.
+       -intros y. unfold callTime2.
+        cbn [fst snd]. ring_simplify.
+        setoid_rewrite index_leq at 1 2. rewrite Nat.min_id.
+        rewrite list_eqbTime_leq with (k:= | elem sig| * 17 + 29).
+        +rewrite to_list_length. ring_simplify. omega.
+        +intros [] [];unfold callTime2;cbn [fst snd].
+         setoid_rewrite index_leq at 1 2. rewrite Nat.min_id.
+         all:ring_simplify. all:omega.
+    }
+    cbn -[t] ;intro. subst t.  setoid_rewrite lookup_funTable. reflexivity.
+    apply prod_eqb_spec. apply finType_eqb_reflect. apply vector_eqb_spec,LOptions.option_eqb_spec,finType_eqb_reflect.
+  Qed.
+
+  Instance term_current: computableTime' ((current (sig:=sig))) (fun _ _ => (10,tt)).
+  Proof.
+    extract.
+    solverec.
+  Qed.
+
+  Instance term_current_chars: computableTime' (current_chars (sig:=sig) (n:=n))  (fun _ _ => (n * 22 +12,tt)).
+  Proof.
+    extract.
+    solverec.
+    rewrite map_time_const,to_list_length.  omega.
+  Qed.
+
+  Definition step' (c :  mconfig sig (states M) n) : mconfig sig (states M) n :=
+    let (news, actions) := trans (cstate c, current_chars (ctapes c)) in
+    mk_mconfig news (doAct_multi (ctapes c) actions).
+
+
+  Instance term_doAct: computableTime' (doAct (sig:=sig)) (fun _ _ => (1,fun _ _ => (89,tt))).
+  Proof.
+    extract.
+    solverec.
+  Qed.
+
+  Instance term_doAct_multi: computableTime' (doAct_multi (n:=n) (sig:=sig)) (fun _ _ => (1,fun _ _ =>(n * 108 + 19,tt))).
+  Proof.
+    extract.
+    solverec.
+    rewrite time_map2_leq with (k:=90).
+    2:now solverec.
+    solverec. now rewrite to_list_length.
+  Qed.
+
+
+  Instance term_step' : computableTime' (step (M:=M)) (fun _ _ => (n* 130+ transTime + 64,tt)).
+  Proof.
+    extract.
+    solverec.
+  Qed.
+
+  Definition haltTime := length (funTable (halt (m:=M))) * (length (elem (states M)) * 17 + 37) + 12.
+
+  Instance term_halt : computableTime' (halt (m:=M)) (fun _ _ => (haltTime,tt)).
+  Proof.
+    pose (t:= (funTable (halt (m:=M)))).
+    apply computableTimeExt with (x:= fun c => lookup finType_eqb c t false).
+    2:{extract.
+       solverec.
+       rewrite lookupTime_leq with (k:=17 * (| elem (states M) |) + 18).
+       2:{
+         intros. cbn [callTime2 fst].
+         repeat rewrite index_leq. rewrite Nat.min_id. omega.
+       }
+       unfold haltTime. subst t.
+       ring_simplify. reflexivity.
+    }
+    cbn;intro. subst t. setoid_rewrite lookup_funTable. reflexivity.
+    apply finType_eqb_reflect.
+  Qed.
+
+  Instance term_haltConf : computableTime' (haltConf (M:=M)) (fun _ _ => (haltTime+8,tt)).
+  Proof.
+    extract.
+    solverec.
+  Qed.
+
+  (** *** Computability of step-ndexed interpreter *)
+  Global Instance term_loopM :
+    let c1 := (haltTime + n*130 + transTime + 85) in
+    let c2 := 15 + haltTime in
+    computableTime' (loopM (M:=M)) (fun _ _ => (5,fun k _ => (c1 * k + c2,tt))).
+  Proof.
+    unfold loopM. (* as loop is already an registered instance, this here is a bit out of the scope. Therefore, we unfold manually here. *)
+    extract.
+    solverec. 
+  Qed.
+
+  Instance term_test cfg :
+    computable (fun k => LOptions.isSome (loopM (M := M) cfg k)).
+  Proof.
+    extract.
+  Qed.
+
+  Lemma Halt_red cfg :
+    Halt' cfg <-> converges (mu (ext ((fun k => LOptions.isSome (loopM (M := M) cfg k))))).
+  Proof.
+    split; intros.
+    - destruct H as (f & ? & k & ?).
+      edestruct (mu_complete).
+      + eapply term_test.
+      + intros. eexists. rewrite !ext_is_enc. now Lsimpl.
+      + Lsimpl. now rewrite H0.
+      + exists (ext x). split. eauto. Lproc.
+    - destruct H as (v & ? & ?). edestruct mu_sound as (k & ? & ? & _).
+      + eapply term_test.
+      + intros. eexists. now Lsimpl.
+      + eassumption.
+      + eauto.
+      + subst.
+        assert ((ext (fun k : nat => LOptions.isSome (loopM cfg k))) (ext k) ==
+                ext (LOptions.isSome (loopM cfg k))) by Lsimpl.
+        rewrite H1 in H2. clear H1.
+        eapply unique_normal_forms in H2; try Lproc. eapply inj_enc in H2.
+        destruct (loopM cfg k) eqn:E.
+        * exists m. split. 2: eauto.
+          unfold loopM in E. now eapply loop_fulfills in E.
+        * inv H2.
+  Qed.
+
+End loopM.

--- a/theories/L/TM/TapeFuns.v
+++ b/theories/L/TM/TapeFuns.v
@@ -1,0 +1,62 @@
+From Undecidability.L.Tactics Require Import LTactics GenEncode.
+From Undecidability.L.Datatypes Require Import LNat Lists LProd LFinType LVector.
+From Undecidability.L Require Import TM.TMEncoding.
+
+
+From Undecidability Require Import TM.TM.
+Require Import PslBase.FiniteTypes.FinTypes.
+
+
+Section fix_sig.
+  Variable sig : finType.
+  Context `{reg_sig : registered sig}.
+
+  Section reg_tapes.
+
+    Global Instance term_tape_move_left' : computableTime' (@tape_move_left' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_tape_move_left : computableTime' (@tape_move_left sig) (fun _ _ => (23,tt)).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_tape_move_right' : computableTime' (@tape_move_right' sig) (fun _ _ => (1, fun _ _ => (1,fun _ _ => (12,tt)))).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_tape_move_right : computableTime' (@tape_move_right sig) (fun _ _ => (23,tt)).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_tape_move : computableTime' (@tape_move sig) (fun _ _ => (1,fun _ _ => (48,tt))).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_left : computableTime' (@left sig) (fun _ _ => (10,tt)).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_right : computableTime' (@right sig) (fun _ _ => (10,tt)).
+    Proof.
+      extract. solverec.
+    Qed.
+
+    Global Instance term_tape_write : computableTime' (@tape_write sig) ((fun _ _ => (1,fun _ _ => (28,tt)))).
+    Proof.
+      extract. solverec.
+    Qed.
+
+  End reg_tapes.
+End fix_sig.
+
+
+
+
+

--- a/theories/L/Tactics/Computable.v
+++ b/theories/L/Tactics/Computable.v
@@ -12,6 +12,8 @@ Class registered (X : Type) := mk_registered
     inj_enc : injective enc (* encoding is injective *)
   }.
 
+Hint Mode registered + : typeclass_instances. (* treat argument as input and force evar-freeness*)
+
 Arguments enc : simpl never.  (* Never unfold with cbn/simpl *)
 
 (** ** Correctness *)
@@ -29,6 +31,8 @@ Existing Instance TyArr.
   
 Arguments TyB _ {_}.
 Arguments TyArr {_} {_} _ _.
+
+Hint Mode TT + : typeclass_instances. (* treat argument as input and force evar-freeness*)
 
 Notation "! X" := (TyB X) (at level 69).
 Notation "X ~> Y" := (TyArr X Y) (right associativity, at level 70).
@@ -58,6 +62,8 @@ Class computable X {ty : TT X} (x : X) : Type :=
     ext : extracted x;
     extCorrect : computes ty x ext;
   }.
+
+Hint Mode computable + - +: typeclass_instances. (* treat argument as input and force evar-freeness*)
 
 Existing Instance ext | 5.
 

--- a/theories/L/Tactics/Computable.v
+++ b/theories/L/Tactics/Computable.v
@@ -5,6 +5,7 @@ Require Import PslBase.Bijection String.
 
 (* Typeclass for registering types *)
 
+
 Class registered (X : Type) := mk_registered
   {
     enc :> encodable X ; (* the encoding function for X *)

--- a/theories/L/Tactics/ComputableDemo.v
+++ b/theories/L/Tactics/ComputableDemo.v
@@ -47,7 +47,7 @@ Section PaperExample.
   Print cnst.
 
   (** Comming up with the conditions for the time bound *)
-  Goal forall fT, computableTime orb fT.
+  Goal forall fT, computableTime' orb fT.
     intros.
     extractAs s.
     computable_using_noProof s.
@@ -61,11 +61,11 @@ Section PaperExample.
 
   (** Finding the Time Bound *)
   
-  Goal computableTime orb (fun _ _ => (cnst "c1",fun _ _ => (cnst "c2",tt))).
+  Goal computableTime' orb (fun _ _ => (cnst "c1",fun _ _ => (cnst "c2",tt))).
     extract. solverec. (* Now the values are clear *)
   Abort.
 
-  Goal computableTime orb (fun _ _ => (1,fun _ _ => (3,tt))).
+  Goal computableTime' orb (fun _ _ => (1,fun _ _ => (3,tt))).
     extract. solverec.
   Abort.
   
@@ -140,7 +140,7 @@ Section PaperExample.
   (*comming up with the condition *)
 
    Lemma termT_map A B (Rx : registered A)  (Ry: registered B):
-    computableTime (@map A B) (fun f fT => (cnst "c",fun xs _ => (cnst ("f",xs),tt))).
+    computableTime' (@map A B) (fun f fT => (cnst "c",fun xs _ => (cnst ("f",xs),tt))).
     extractAs s.
     computable_using_noProof s.
     cstep.
@@ -151,12 +151,12 @@ Section PaperExample.
   (* comming up with the time bound *)
 
   Lemma termT_map A B (Rx : registered A)  (Ry: registered B):
-    computableTime (@map A B) (fun f fT => (cnst "c",fun xs _ => (cnst ("f",xs),tt))).
+    computableTime' (@map A B) (fun f fT => (cnst "c",fun xs _ => (cnst ("f",xs),tt))).
     extract. solverec.
   Abort.
 
   Lemma term_map (X Y:Type) (Hx : registered X) (Hy:registered Y):
-    computableTime (@map X Y)
+    computableTime' (@map X Y)
                    (fun f fT => (1,fun l _ => (fold_right (fun x res => fst (fT x tt) + res + 12) 8 l,tt))).
   Proof.
     extract.
@@ -180,10 +180,5 @@ Proof.
   compute auto. 
 Qed.
    *)
-
-  Instance term_nat_eqb : computable Nat.eqb.
-  Proof.
-    extract. fold Nat.eqb. repeat ComputableTactics.Intern.cstep. 
-  Defined.
 
 End demo.

--- a/theories/L/Tactics/Extract.v
+++ b/theories/L/Tactics/Extract.v
@@ -55,7 +55,7 @@ Definition hd {X : Type} (l : list X) : TemplateMonad X :=
 Definition tmTypeOf (s : Ast.term) :=
   u <- tmUnquote s ;;
     tmEval hnf (my_projT1 u) >>= tmQuote.
-
+Set Printing Universes.
 (** Try to infer instance, otherwise make lemma *)
 Definition tmTryInfer (n : ident) (red : option reductionStrategy) (A : Type) : TemplateMonad A :=
   r <- tmInferInstance red A ;;

--- a/theories/L/Tactics/Extract.v
+++ b/theories/L/Tactics/Extract.v
@@ -436,7 +436,7 @@ Fixpoint head_of_const (t : term) :=
 Definition tmUnfoldTerm {A}(a:A) :=
   t <- tmQuote a;;
   match head_of_const t with
-  | Some h => tmEval (unfold (name_after_dot h)) a >>=tmQuote
+  | Some h => tmEval (unfold h) a >>=tmQuote
   | _ => ret t
   end.
 

--- a/theories/L/Tactics/GenEncode.v
+++ b/theories/L/Tactics/GenEncode.v
@@ -1,6 +1,8 @@
 From Undecidability.L Require Import L Tactics.Computable Tactics.ComputableTactics Tactics.Extract.
 From Template Require Import All TemplateMonad.Core Ast.
 
+Require Import Program.Tactics.
+
 Import MonadNotation String.
 Open Scope string_scope.
 

--- a/theories/L/Tactics/GenEncode.v
+++ b/theories/L/Tactics/GenEncode.v
@@ -48,7 +48,7 @@ Definition tmMatchCorrect (A : Type) : Core.TemplateMonad Prop :=
                                (((fun s => mkAppList s C) (tRel (args + 2 * (num - i) - 1)))))
            ) ;;
    E' <- Core.tmInferInstance None (registered A);;
-   E <- tmGetOption E' "failed" ;;        
+   E <- tmGetMyOption E' "failed" ;;        
    t' <- ret (@enc A E);;
    l <- tmQuote t';;
    encn <- ret (tApp l [tRel (2*num) ]) ;;

--- a/theories/L/Tactics/LTactics.v
+++ b/theories/L/Tactics/LTactics.v
@@ -1,5 +1,5 @@
 From Template Require Export TemplateMonad.Core.
 
 (** * Certifying extraction from Coq to L with time bounds *)
-From Undecidability.L.Tactics Require Export Lsimpl mixedTactics ComputableTime Computable ComputableTactics Lproc Lrewrite GenEncode.
+From Undecidability.L.Tactics Require Export Lsimpl mixedTactics ComputableTime Lbeta Computable ComputableTactics Lproc Lrewrite.
 

--- a/theories/L/Tactics/mixedTactics.v
+++ b/theories/L/Tactics/mixedTactics.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Base.
+Require Import PslBase.Base Lia.
 
 Tactic Notation "destruct" "_":= 
   match goal with
@@ -22,3 +22,7 @@ Ltac trace :=
   match goal with
     |- ?G => idtac "Trace:";idtac G
   end.
+
+Ltac leq_crossout :=
+       try zify;try apply Zle_0_minus_le; ring_simplify;
+       repeat eapply Z.add_nonneg_nonneg;try now (repeat eapply Z.mul_nonneg_nonneg;easy).

--- a/theories/LAM/Prelims.v
+++ b/theories/LAM/Prelims.v
@@ -289,7 +289,7 @@ Definition stutterSimulatedWith {X Y} (stepX: X -> X -> Prop) (stepY: Y -> Y -> 
 
 Definition stutterTerminal Y P stepY (y:Y):= exists y', stutterStep P stepY y y' /\ terminal stepY y'.
 
-Definition stutterTerminalSensitive X Y stepX stepY (sim :X->Y->Prop) :=
+Definition stutterTerminalSensitive X Y (stepX : X -> X -> Prop) stepY (sim :X->Y->Prop) :=
   forall x y, sim x y -> terminal stepX x -> stutterTerminal (sim x) stepY y.
 
 Definition star_preserves X (R:X->X-> Prop) (P:X->Prop):

--- a/theories/LAM/TM/HaltingProblem.v
+++ b/theories/LAM/TM/HaltingProblem.v
@@ -33,23 +33,6 @@ Fixpoint Loop_size (T V : list HClos) (H : Heap) (k : nat) {struct k} : Vector.t
     end
   end.
 
-(*
-Lemma Loop_size_eq T V H k :
-  Loop_size T V H k =
-  match k with
-  | 0 => Step_size T V H
-  | S k' =>
-    match step_fun (T, V, H) with
-    | Some (T',V',H') =>
-      if is_halt_state (T',V',H')
-      then Step_size T V H >>> Step_size T' V' H'
-      else Step_size T V H >>> Loop_size T' V' H' k'
-    | _ => Step_size T V H
-    end
-  end.
-Proof. now destruct k. Qed.
-*)
-
 Lemma step_k_inv T V H T2 V2 H2 k :
   steps_k k (T, V, H) (T2, V2, H2) ->
   (k=0/\T=T2/\V=V2/\H=H2) \/

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -254,10 +254,14 @@ L/Datatypes/LSum.v
 L/Datatypes/LBinNums.v
 L/Datatypes/LTerm.v
 L/Datatypes/LComparison.v
+L/Datatypes/LFinType.v
+L/Datatypes/LVector.v
+L/Datatypes/LDepPair.v
 
 
 L/Functions/Equality.v
 L/Functions/Encoding.v
+L/Functions/Decoding.v
 L/Functions/Proc.v
 L/Functions/Size.v
 L/Functions/Subst.v
@@ -269,12 +273,16 @@ L/Functions/BinNums.v
 L/Functions/BinNumsAdd.v
 L/Functions/BinNumsSub.v
 L/Functions/BinNumsCompare.v
+L/Functions/FinTypeLookup.v
+
 
 L/Functions/EnumInt.v
 L/Functions/Unenc.v
 L/Functions/Ackermann.v
 
 L/TM/TMEncoding.v
+L/TM/TMinL.v
+L/TM/TapeFuns.v
 L/Reductions/TM_to_L.v
 
 L/Reductions/SRH_SR_computable.v
@@ -299,7 +307,9 @@ L/AbstractMachines/Computable/HeapMachine.v
 L/AbstractMachines/Computable/SubstMachine.v
 L/AbstractMachines/Computable/Unfolding.v
 L/AbstractMachines/Computable/Lookup.v
-L/AbstractMachines/Computable/LargestVar.v
+L/AbstractMachines/Computable/UnivDecTime.v
+L/AbstractMachines/Computable/EvalForTime.v
+L/AbstractMachines/Computable/EvalForTimeBool.v        
 
 L/Computability/Acceptability.v
 #L/Computability/AD.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -309,7 +309,7 @@ L/AbstractMachines/Computable/Unfolding.v
 L/AbstractMachines/Computable/Lookup.v
 L/AbstractMachines/Computable/UnivDecTime.v
 L/AbstractMachines/Computable/EvalForTime.v
-L/AbstractMachines/Computable/EvalForTimeBool.v        
+L/AbstractMachines/Computable/EvalForTimeBool.v
 
 L/Computability/Acceptability.v
 #L/Computability/AD.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -218,6 +218,7 @@ L/Prelim/MoreBase.v
 L/Prelim/ARS.v
 L/Prelim/StringBase.v
 L/Prelim/MoreList.v
+L/Prelim/LoopSum.v
 
 L/L.v
 
@@ -249,8 +250,11 @@ L/Datatypes/Lists.v
 L/Datatypes/LNat.v
 L/Datatypes/LOptions.v
 L/Datatypes/LProd.v
+L/Datatypes/LSum.v
 L/Datatypes/LBinNums.v
 L/Datatypes/LTerm.v
+L/Datatypes/LComparison.v
+
 
 L/Functions/Equality.v
 L/Functions/Encoding.v
@@ -259,6 +263,12 @@ L/Functions/Size.v
 L/Functions/Subst.v
 L/Functions/Eval.v
 L/Functions/IterupN.v
+L/Functions/LoopSum.v
+L/Functions/UnboundIteration.v
+L/Functions/BinNums.v
+L/Functions/BinNumsAdd.v
+L/Functions/BinNumsSub.v
+L/Functions/BinNumsCompare.v
 
 L/Functions/EnumInt.v
 L/Functions/Unenc.v
@@ -279,11 +289,17 @@ L/Complexity/SpaceBoundsTime.v
 L/AbstractMachines/Programs.v
 L/AbstractMachines/AbstractSubstMachine.v
 L/AbstractMachines/AbstractHeapMachine.v
+L/AbstractMachines/AbstractHeapMachineDef.v
+L/AbstractMachines/LargestVar.v
 L/AbstractMachines/UnfoldHeap.v
 L/AbstractMachines/FunctionalDefinitions.v
+L/AbstractMachines/UnfoldTailRec.v
 L/AbstractMachines/Computable/Shared.v
 L/AbstractMachines/Computable/HeapMachine.v
 L/AbstractMachines/Computable/SubstMachine.v
+L/AbstractMachines/Computable/Unfolding.v
+L/AbstractMachines/Computable/Lookup.v
+L/AbstractMachines/Computable/LargestVar.v
 
 L/Computability/Acceptability.v
 #L/Computability/AD.v


### PR DESCRIPTION
This commit includes several improvements for L, the extraction framework and the extracted methods:
-improved functions for binary numbers
-improved abstract machines for L (with extraction)
-more extractions with time bounds
-better support for transforming non-tail-recursive functions to tail-recursive functions using a explicit recursion stack. This approach makes verifying space bounds easier, once implemented.