### PR TITLE
Fixing the induction-on mess

### DIFF
--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -421,9 +421,6 @@ Proof.
   simpl; split; intros H n Hn; apply H; revert Hn; rewrite Ha; auto.
 Defined.
 
-Check dio_rel_fall_lt.
-Print Assumptions dio_rel_fall_lt.
-
 Hint Resolve dio_rel_fall_lt.
 
 Theorem dio_rel_fall_lt_bound a (K : nat -> nat -> (nat -> nat) -> Prop) : 

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -92,6 +92,3 @@ Section df_rel_iter.
 End df_rel_iter.
 
 Hint Resolve dio_rel_rel_iter.
-
-Check dio_rel_rt.
-Print Assumptions dio_rel_rt.

--- a/theories/H10/Fractran/fractran_dio.v
+++ b/theories/H10/Fractran/fractran_dio.v
@@ -161,6 +161,3 @@ Proof.
   apply dio_rel_compose with (R := fun x v => l /F/ x ↓); auto.
   apply FRACTRAN_HALTING_on_diophantine; auto.
 Qed.
-
-Check FRACTRAN_HALTING_on_exp_diophantine.
-Print Assumptions FRACTRAN_HALTING_on_exp_diophantine.

--- a/theories/H10/Matija/alpha.v
+++ b/theories/H10/Matija/alpha.v
@@ -918,9 +918,6 @@ Proof.
   + apply alpha_nat_divides_k_ge_1; auto.
 Qed.
 
-Check alpha_nat_divisibility_1.
-Print Assumptions alpha_nat_divisibility_1.
-
 Section divisibility_2.
 
   Variable (b : nat) (Hb : 2 <= b) (k : nat) (Hk : k <> 0).
@@ -1102,9 +1099,6 @@ Proof.
   * apply alpha_nat_divides_2_pos; omega.
 Qed.
 
-Check alpha_nat_divisibility_2.
-Print Assumptions alpha_nat_divisibility_2.
-
 Section congruence_1.
 
   Variable (b1 b2 : nat) (Hb1 : 2 <= b1) (Hb2 : 2 <= b2)
@@ -1150,9 +1144,6 @@ Proof.
   replace b with ((b-2)+2) at 1 by omega.
   apply rem_erase with 1; omega.
 Qed.
-
-Check alpha_nat_congruence_0.
-Check alpha_nat_congruence_1.
 
 Section congruence_2.
 

--- a/theories/H10/Matija/cipher.v
+++ b/theories/H10/Matija/cipher.v
@@ -1697,7 +1697,3 @@ Section sums.
   End inc_seq.
 
 End sums.  
-
-Check Code_plus_spec.
-Check Code_mult_spec.
-Check CodeNat_dio.


### PR DESCRIPTION
Cleanup the `induction-on` tactic mess. remember induction-on revealed
a bug in `8.10.0`, hopefully getting fixed in `8.10.1` (see https://github.com/coq/coq/issues/10894)

Also remove unnecessary `Check` and `Print Assumptions` that were bloating the output of make all

The one should compile under `8.9.1` (I tested it)