### PR TITLE
A BIG commit containing the DIO_SINGLE -> µ-REC -> MM reductions

### DIFF
--- a/theories/H10/DPRM.v
+++ b/theories/H10/DPRM.v
@@ -11,7 +11,6 @@
 
 Require Import List Arith Omega.
 
-
 From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
 From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list sums.
 From Undecidability.ILL.Code Require Import sss.
@@ -28,7 +27,7 @@ Local Notation "'⟦' p '⟧'" := (fun φ ν => dp_eval φ ν p).
 (** Definitions of n-ary recursive enumerable predicates *)
 
 Definition mm_recognisable_n n (R : vec nat n -> Prop) := 
-  { m & { M : list (mm_instr (n+m)) | forall v, R v <-> (1,M) /MM/ (1,vec_app v vec_zero) ↓ } }.
+  { m & { M : list (mm_instr (pos (n+m))) | forall v, R v <-> (1,M) /MM/ (1,vec_app v vec_zero) ↓ } }.
 
 Definition diophantine_n n (R : vec nat n -> Prop) :=
   { m : nat &

--- a/theories/H10/Fractran/mm_fractran.v
+++ b/theories/H10/Fractran/mm_fractran.v
@@ -57,13 +57,13 @@ Definition encode_inc n  i (u : pos n) := (ps (i + 1) * qs u, ps i).
 Definition encode_dec n  i (u : pos n) (_ : nat) := (ps (i + 1), ps i * qs u).
 Definition encode_dec2 n i (u : pos n) j := (ps j, ps i).
 
-Definition encode_one_instr m i (rho : mm_instr m) :=
+Definition encode_one_instr m i (rho : mm_instr (pos m)) :=
   match rho with
     | INC u   => encode_inc i u :: nil
     | DEC u j => encode_dec i u j :: encode_dec2 i u j :: nil
   end.
 
-Fixpoint encode_mm_instr m i (l : list (mm_instr m)) : list (nat * nat) :=
+Fixpoint encode_mm_instr m i (l : list (mm_instr (pos m))) : list (nat * nat) :=
   match l with
     | nil          => nil
     | rho :: l => encode_one_instr i rho ++ encode_mm_instr (S i) l
@@ -347,7 +347,7 @@ Proof.
       subst P; apply in_sss_step; auto.
 Qed.
 
-Theorem mm_fractran_not_zero n (P : list (mm_instr n)) : 
+Theorem mm_fractran_not_zero n (P : list (mm_instr (pos n))) : 
         { l |  Forall (fun c => fst c <> 0 /\ snd c <> 0) l
             /\ forall v, (1,P) /MM/ (1,v) ↓ <-> l /F/ ps 1 * exp 1 v ↓ }.
 Proof.
@@ -359,7 +359,7 @@ Proof.
      simpl exp; rewrite Nat.add_0_r; tauto.
 Qed.
 
-Theorem mm_fractran_n n (P : list (mm_instr n)) : 
+Theorem mm_fractran_n n (P : list (mm_instr (pos n))) : 
         { l |  Forall (fun c => snd c <> 0) l
             /\ forall v, (1,P) /MM/ (1,v) ↓ <-> l /F/ ps 1 * exp 1 v ↓ }.
 Proof.
@@ -368,7 +368,7 @@ Proof.
    revert H1; apply Forall_impl; intros; tauto.
 Qed.
 
-Theorem mm_fractran n (P : list (mm_instr (S n))) : 
+Theorem mm_fractran n (P : list (mm_instr (pos (S n)))) : 
      { l | forall x, (1,P) /MM/ (1,x##vec_zero) ↓ <-> l /F/ ps 1 * qs 1^x ↓ }.
 Proof.
    destruct mm_fractran_n with (P := P) as (l & _ & Hl).

--- a/theories/H10/Fractran/mm_no_self.v
+++ b/theories/H10/Fractran/mm_no_self.v
@@ -12,7 +12,6 @@
 
 Require Import List Arith Omega.
 
-
 From Undecidability.Shared.Libs.DLW Require Import Utils.utils Vec.pos Vec.vec.
 From Undecidability.ILL.Code Require Import subcode sss.
 From Undecidability.ILL.Mm Require Import mm_defs.
@@ -33,7 +32,7 @@ Local Notation "P // s ↓" := (sss_terminates (@mm_sss _) P s).
 
 Section self_loops.
 
-  Variables (n : nat) (P : list (mm_instr n)).
+  Variables (n : nat) (P : list (mm_instr (pos n))).
 
   Lemma mm_self_loop_no_term_1 i x s v : 
               (i,DEC x i::nil) <sc (1,P) 
@@ -89,9 +88,9 @@ Section no_self_loops.
 
   Variables (n : nat).
 
-  Definition mm_no_self_loops (Q : nat * list (mm_instr n)) := forall i x, ~ (i,DEC x i::nil) <sc Q.
+  Definition mm_no_self_loops (Q : nat * list (mm_instr (pos n))) := forall i x, ~ (i,DEC x i::nil) <sc Q.
 
-  Implicit Types (P Q : list (mm_instr n)).
+  Implicit Types (P Q : list (mm_instr (pos n))).
 
   Fact mm_no_self_loops_app i P Q : mm_no_self_loops (i,P) 
                                  -> mm_no_self_loops (length P +i,Q)
@@ -119,9 +118,9 @@ Section remove_self_loops.
 
   Variables (n : nat).
 
-  Implicit Types (P Q : list (mm_instr n)).
+  Implicit Types (P Q : list (mm_instr (pos n))).
 
-  Let f k i (ρ : mm_instr n) := 
+  Let f k i (ρ : mm_instr (pos n)) := 
     match ρ with
       | INC x   => INC (pos_nxt x)
       | DEC x j => DEC (pos_nxt x) (if eq_nat_dec i j     then 1+k 
@@ -190,11 +189,12 @@ Section remove_self_loops.
     destruct (le_lt_dec k q); omega.
   Qed.
 
-  Variable P : list (mm_instr n).
+  Variable P : list (mm_instr (pos n)).
 
   Notation lP := (length P).
 
-  Let R : list (mm_instr (S n)) := DEC pos0 0 
+  Let R : list (mm_instr (pos (S n))) := 
+                                   DEC pos0 0 
                                 :: DEC pos0 (3+lP)
                                 :: DEC pos0 (2+lP)
                                 :: nil.

--- a/theories/ILL/Ll/eill_mm.v
+++ b/theories/ILL/Ll/eill_mm.v
@@ -110,7 +110,7 @@ Section Minsky.
 
   (* k is a position outside the program were execution has to stop *)
    
-  Variable (P : nat*(list (mm_instr n))) (k : nat) (Hk : out_code k P).
+  Variable (P : nat*(list (mm_instr (pos n)))) (k : nat) (Hk : out_code k P).
 
   (* This encodes P into EILL commands 
   

--- a/theories/ILL/Mm/mm_comp.v
+++ b/theories/ILL/Mm/mm_comp.v
@@ -272,9 +272,9 @@ Section simulator.
 End simulator.
 
 Theorem bsm_mm_compiler_1 n i (P : list (bsm_instr n)) :
-  { Q : list (mm_instr (2+n)) | forall v, (i,P) /BSM/ (i,v) ↓ <-> (1,Q) /MM/ (1,0##0##vec_map stack_enc v) ↓ }.
+  { Q : list (mm_instr (pos (2+n))) | forall v, (i,P) /BSM/ (i,v) ↓ <-> (1,Q) /MM/ (1,0##0##vec_map stack_enc v) ↓ }.
 Proof. exists (bsm_mm_sim i P); apply bsm_mm_sim_spec. Qed.
 
 Theorem bsm_mm_compiler_2 n i (P : list (bsm_instr n)) :
-  { Q : list (mm_instr (2+n)) | forall v, (i,P) /BSM/ (i,v) ↓ <-> (1,Q) /MM/ (1,0##0##vec_map stack_enc v) ~~> (0,vec_zero) }.
+  { Q : list (mm_instr (pos (2+n))) | forall v, (i,P) /BSM/ (i,v) ↓ <-> (1,Q) /MM/ (1,0##0##vec_map stack_enc v) ~~> (0,vec_zero) }.
 Proof. exists (bsm_mm i P); apply bsm_mm_spec. Qed.

--- a/theories/ILL/Mm/mm_defs.v
+++ b/theories/ILL/Mm/mm_defs.v
@@ -12,6 +12,7 @@ Require Import List Arith Omega.
 
 From Undecidability.Shared.Libs.DLW Require Import Utils.utils Vec.pos Vec.vec.
 From Undecidability.ILL.Code Require Import subcode sss.
+From Undecidability.MM Require Export mm_instr.
 
 Set Implicit Arguments.
 
@@ -30,13 +31,13 @@ Local Notation "e [ v / x ]" := (vec_change e x v).
 
   *)
 
-Inductive mm_instr n : Set :=
+(* Inductive mm_instr n : Set :=
   | mm_inc : pos n -> mm_instr n
   | mm_dec : pos n -> nat -> mm_instr n
   .
 
 Notation INC := mm_inc.
-Notation DEC := mm_dec.
+Notation DEC := mm_dec. *)
 
 (** ** Semantics for MM *)
 
@@ -48,7 +49,7 @@ Section Minsky_Machine.
 
   (* Minsky machine small step semantics *)
 
-  Inductive mm_sss : mm_instr n -> mm_state -> mm_state -> Prop :=
+  Inductive mm_sss : mm_instr (pos n) -> mm_state -> mm_state -> Prop :=
     | in_mm_sss_inc   : forall i x v,                   INC x   // (i,v) -1> (1+i,v[(S (v#>x))/x])
     | in_mm_sss_dec_0 : forall i x k v,   v#>x = O   -> DEC x k // (i,v) -1> (k,v)
     | in_mm_sss_dec_1 : forall i x k v u, v#>x = S u -> DEC x k // (i,v) -1> (1+i,v[u/x])
@@ -235,7 +236,7 @@ Tactic Notation "mm" "sss" "stop" := exists 0; apply sss_steps_0; auto.
    to a very specific halting problem. Starting from (1,v), does the
    MM halt at state (0,vec_zero) *)
 
-Definition MM_PROBLEM := { n : nat & { P : list (mm_instr n) & vec nat n } }.
+Definition MM_PROBLEM := { n : nat & { P : list (mm_instr (pos n)) & vec nat n } }.
 
 Local Notation "i // s -1> t" := (@mm_sss _ i s t).
 Local Notation "P // s ~~> t" := (sss_output (@mm_sss _) P s t).
@@ -249,7 +250,7 @@ Definition MM_HALTING (P : MM_PROBLEM) :=
 
 Section mm_special_ind.
 
-  Variables (n : nat) (P : nat*list (mm_instr n)) (se : nat * vec nat n)
+  Variables (n : nat) (P : nat*list (mm_instr (pos n))) (se : nat * vec nat n)
             (Q : nat * vec nat n -> Prop).
 
   Hypothesis (HQ0 : Q se)
@@ -274,7 +275,7 @@ End mm_special_ind.
 
 Section mm_term_ind.
 
-  Variables (n : nat) (P : nat*list (mm_instr n)) (se : nat * vec nat n)
+  Variables (n : nat) (P : nat*list (mm_instr (pos n))) (se : nat * vec nat n)
             (Q : nat * vec nat n -> Prop).
 
   Hypothesis (HQ0 : out_code (fst se) P -> Q se)

--- a/theories/MM/env.v
+++ b/theories/MM/env.v
@@ -1,0 +1,85 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Max Omega Wellfounded.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils.
+
+Set Implicit Arguments.
+
+Reserved Notation " e '⇢' x " (at level 58).
+Reserved Notation " e [ v / x ] " (at level 57, v at level 0, x at level 0, left associativity).
+Reserved Notation " e ⦃  x '⇠' v ⦄ " (at level 57, v at level 0, x at level 0, left associativity).
+
+Section env.
+
+  Variable (X Y : Type) (X_eq_dec : eqdec X) (Y_default : Y).
+  
+  Definition env := X -> Y.
+  
+  Implicit Type e : env.
+
+  Definition get_env e x := e x.
+    
+  Definition set_env e x v : env := fun y => if X_eq_dec x y then v else e y.
+  
+  Definition nil_env : env := fun _ => Y_default.
+  
+  Fact get_set_env_eq e v p q : p = q -> get_env (set_env e p v) q = v.
+  Proof. intros []; unfold set_env, get_env; destruct (X_eq_dec p p) as [ | [] ]; auto. Qed.
+  
+  Fact get_set_env_neq e v p q : p <> q -> get_env (set_env e p v) q = get_env e q.
+  Proof. simpl; intros H; unfold set_env, get_env; destruct (X_eq_dec p q); auto; destruct H; auto. Qed.
+  
+End env.
+
+Arguments nil_env {X}.
+
+Opaque get_env.
+Opaque set_env.
+
+Local Notation " e ⇢ x " := (@get_env _ _ e x).
+Local Notation " e ⦃  x ⇠ v ⦄ " := (@set_env _ _ _ e x v).
+
+(* find the value of x inside the environment t *)
+
+Ltac find_val x t :=
+  match t with
+    | ?s⦃x⇠?v⦄ => v
+    | ?s⦃_⇠_⦄ => find_val x s
+  end.
+
+Tactic Notation "rew" "env" :=
+  repeat lazymatch goal with 
+    |              |- context[ _⦃ ?x⇠_⦄⇢?x ] => rewrite get_set_env_eq  with (1 := eq_refl x)
+    | _ : ?x = ?y  |- context[ _⦃ ?x⇠_⦄⇢?y ] => rewrite get_set_env_eq  with (p := x) (q := y)
+    | _ : ?y = ?x  |- context[ _⦃ ?x⇠_⦄⇢?y ] => rewrite get_set_env_eq  with (p := x) (q := y)
+    | _ : ?x <> ?y |- context[ _⦃ ?x⇠_⦄⇢?y ] => rewrite get_set_env_neq with (p := x) (q := y)
+    | _ : ?y <> ?x |- context[ _⦃ ?x⇠_⦄⇢?y ] => rewrite get_set_env_neq with (p := x) (q := y)
+    |              |- context[ _⦃ ?x⇠_⦄⇢?y ] => rewrite get_set_env_neq with (p := x) (q := y);
+                                                  [ | discriminate ]
+  end; auto.
+
+(*
+Tactic Notation "rew" "envi" :=
+  repeat lazymatch goal with 
+    | |- context f[ _[_/?l]#>?l ] => rewrite get_set_env_eq with (x := l) 
+    | _ : ?l <> ?m |- context f[ _[_/?l]#>?m ] => rewrite get_set_env_neq with (x := l) (y := m)
+    | _ : ?m <> ?l |- context f[ _[_/?l]#>?m ] => rewrite get_set_env_neq with (x := l) (y := m)
+    | |- context f[ _[_/?l]#>?m ] => rewrite get_set_env_neq with (x := l) (y := m); [ | discriminate ]
+  end; auto.
+*)
+
+Tactic Notation "rew" "env" "in" hyp(H) := revert H; rew env; intros H.
+
+
+
+
+

--- a/theories/MM/mm_env_utils.v
+++ b/theories/MM/mm_env_utils.v
@@ -1,0 +1,468 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.MM 
+  Require Import env mm_instr. 
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+From Undecidability.MuRec 
+  Require Import recalg. 
+
+Set Implicit Arguments.
+
+Tactic Notation "rew" "length" := autorewrite with length_db.
+
+Local Notation "P // s ->> t" := (sss_compute (mm_sss_env eq_nat_dec) P s t).
+Local Notation "P // s -+> t" := (sss_progress (mm_sss_env eq_nat_dec) P s t).
+Local Notation "P // s -[ k ]-> t" := (sss_steps (mm_sss_env eq_nat_dec) P k s t).
+Local Notation "P // s ↓" := (sss_terminates (mm_sss_env eq_nat_dec ) P s). 
+
+Local Notation " e ⇢ x " := (@get_env _ _ e x).
+Local Notation " e ⦃  x ⇠ v ⦄ " := (@set_env _ _ eq_nat_dec e x v).
+Local Notation "x '⋈' y" := (forall i : nat, x⇢i = y⇢i :> nat) (at level 70, no associativity).
+
+Section mm_env_utils.
+
+  Ltac dest x y := destruct (eq_nat_dec x y) as [ | ]; [ subst x | ]; rew env.
+
+  Section mm_transfert.
+
+    Variables (src dst zero : nat).
+
+    Hypothesis (Hsd : src <> dst) (Hsz : src <> zero) (Hdz : dst <> zero).
+
+    Definition mm_transfert i := DEC src (3+i) :: INC dst :: DEC zero i :: nil.
+
+    Fact mm_transfert_length i : length (mm_transfert i) = 3.
+    Proof. reflexivity. Qed.
+
+    Let mm_transfert_spec i e k x :  
+           e⇢src = k
+        -> e⇢dst = x
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃src⇠0⦄⦃dst⇠k+x⦄
+                   /\ (i,mm_transfert i) // (i,e) -+> (3+i,e').
+    Proof.
+      unfold mm_transfert.
+      revert e x.
+      induction k as [ | k IHk ]; intros e x H1 H2 H3.
+      + exists e; split.
+        * intros j; dest j src; dest j dst.
+        * mm env DEC 0 with src (3+i).
+          mm env stop; f_equal; auto.
+      + destruct IHk with (e := e⦃src⇠k⦄⦃dst⇠1+x⦄) (x := 1+x)
+          as (e' & H4 & H5); rew env.
+        exists e'; split.
+        * intros j; rewrite H4.
+          dest j dst; try omega.
+          dest j src.
+        * mm env DEC S with src (3+i) k.
+          mm env INC with dst.
+          mm env DEC 0 with zero i; rew env.
+          rewrite H2.
+          apply sss_progress_compute; auto.
+    Qed.
+
+    Fact mm_transfert_progress i e : 
+           e⇢dst = 0
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃src⇠0⦄⦃dst⇠(e⇢src)⦄
+                  /\ (i,mm_transfert i) // (i,e) -+> (3+i,e').
+    Proof.
+      intros H1 H2.
+      destruct mm_transfert_spec with (e := e) (x := 0) (i := i) (k := e⇢src)
+        as (e' & H3 & H4); auto.
+      exists e'; split; auto.
+      intros j; rewrite H3, plus_comm; auto.
+    Qed.
+
+  End mm_transfert.
+
+  Hint Rewrite mm_transfert_length : length_db.
+
+  Section mm_erase.
+
+    Variables (dst zero : nat).
+
+    Hypothesis (Hdz : dst <> zero).
+
+    Definition mm_erase i := DEC dst (2+i) :: DEC zero i :: nil.
+
+    Fact mm_erase_length i : length (mm_erase i) = 2.
+    Proof. reflexivity. Qed.
+
+    Let mm_erase_spec i e x :
+           e⇢dst = x
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃dst⇠0⦄
+                   /\ (i,mm_erase i) // (i,e) -+> (2+i,e').
+    Proof.
+      unfold mm_erase.
+      revert e.
+      induction x as [ | x IHx ]; intros e H1 H2.
+      + exists e; split.
+        * intros j; dest j dst.
+        * mm env DEC 0 with dst (2+i).
+          mm env stop; f_equal; auto.
+      + destruct IHx with (e := e⦃dst⇠x⦄)
+          as (e' & H4 & H5); rew env.
+        exists e'; split.
+        * intros j; rewrite H4; dest j dst.
+        * mm env DEC S with dst (2+i) x.
+          mm env DEC 0 with zero i; rew env.
+          apply sss_progress_compute; auto.
+    Qed.
+
+    Fact mm_erase_progress i e : 
+           e⇢zero = 0
+        -> exists e', e' ⋈  e⦃dst⇠0⦄
+                  /\ (i,mm_erase i) // (i,e) -+> (2+i,e').
+    Proof.
+      intros H1.
+      destruct mm_erase_spec with (e := e) (i := i) (x := e⇢dst)
+        as (e' & H3 & H4); auto.
+      exists e'; split; auto.
+    Qed.
+
+  End mm_erase.
+
+  Hint Rewrite mm_erase_length : length_db.
+
+  Opaque mm_erase.
+
+  Section mm_list_erase.
+
+    Variable (zero : nat).
+
+    Fixpoint mm_list_erase ll i := 
+      match ll with
+        | nil     => nil
+        | dst::ll => mm_erase dst zero i ++ mm_list_erase ll (2+i)
+      end.
+
+    Fact mm_list_erase_length ll i : length (mm_list_erase ll i) = 2*length ll.
+    Proof.
+      revert i; induction ll as [ | dst ll IH ]; simpl; intros i; rew length; auto.
+      rewrite IH; ring.
+    Qed.
+
+    Fact mm_list_erase_compute ll i e : 
+            Forall (fun x => x <> zero) ll 
+         -> e⇢zero = 0
+         -> exists e', (forall x,   In x ll -> e'⇢x = 0)
+                    /\ (forall x, ~ In x ll -> e'⇢x = e⇢x)
+                    /\ (i,mm_list_erase ll i) // (i,e) ->> (2*length ll+i,e').
+    Proof.
+      intros H; revert H i e.
+      induction 1 as [ | dst ll H1 H2 IH2 ]; intros i e H3.
+      + simpl; exists e; repeat split; try tauto; mm env stop.
+      + destruct mm_erase_progress with (dst := dst) (zero := zero) (i := i) (e := e)
+          as (e1 & H4 & H5); auto.
+        destruct IH2 with (i := 2+i) (e := e1) as (e2 & H6 & H7 & H8).
+        { rewrite H4; rew env. }
+        exists e2; split; [ | split ].
+        * intros x [ H | H ]; subst; auto.
+          destruct in_dec with (1 := eq_nat_dec) (a := x) (l := ll) as [ H9 | H9 ]; auto.
+          rewrite H7; auto; rewrite H4; rew env.
+        * simpl; intros x Hx.
+          rewrite H7, H4; try tauto.
+          dest x dst; destruct Hx; auto.
+        * apply sss_compute_trans with (2+i,e1).
+          - apply sss_progress_compute.
+            simpl; revert H5; apply subcode_sss_progress; auto.
+          - replace (2*length (dst::ll)+i) with (2*length ll+(2+i)) by (rew length; omega).
+            revert H8; simpl; apply subcode_sss_compute; auto.
+            subcode_tac; rewrite <- app_nil_end; auto.
+    Qed.
+
+  End mm_list_erase.
+
+  Hint Rewrite mm_list_erase_length : length_db.
+
+  Section mm_multi_erase.
+
+    Variables (dst zero k : nat).
+
+    Definition mm_multi_erase := mm_list_erase zero (list_an dst k).
+
+    Fact mm_multi_erase_length i : length (mm_multi_erase i) = 2*k.
+    Proof. unfold mm_multi_erase; rew length; auto. Qed.
+
+    Hypothesis (Hdz : dst+k <= zero).
+
+    Fact mm_multi_erase_compute i e :
+                    e⇢zero = 0
+      -> exists e', (forall j, dst <= j < k+dst -> e'⇢j = 0)
+                 /\ (forall j, ~ dst <= j < k+dst -> e'⇢j = e⇢j)
+                 /\ (i,mm_multi_erase i) // (i,e) ->> (2*k+i,e').
+    Proof.
+      intros H; unfold mm_multi_erase.
+      destruct mm_list_erase_compute 
+        with (zero := zero) (ll := list_an dst k) (i := i) (e := e)
+        as (e' & H1 & H2 & H3); auto.
+      * rewrite Forall_forall; intros j; rewrite list_an_spec; intros; omega.
+      * rew length in H3; exists e'; msplit 2; auto. 
+        + intros; apply H1, list_an_spec; omega.
+        + intros; apply H2; rewrite list_an_spec; omega.
+    Qed.
+
+  End mm_multi_erase.
+
+  Hint Rewrite mm_multi_erase_length : length_db.
+
+  Section mm_dup.
+
+    Variables (src dst tmp zero : nat).
+
+    Hypothesis (Hsd : src <> dst) (Hst : src <> tmp) (Hsz : src <> zero) 
+               (Hdt : dst <> tmp) (Hdz : dst <> zero)
+               (Htz : tmp <> zero).
+
+    Definition mm_dup i := DEC src (4+i) :: INC dst :: INC tmp :: DEC zero i :: nil.
+
+    Fact mm_dup_length i : length (mm_dup i) = 4.
+    Proof. reflexivity. Qed.
+
+    Let mm_dup_spec i e k x y :  
+           e⇢src = k
+        -> e⇢dst = x
+        -> e⇢tmp = y
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃src⇠0⦄⦃dst⇠k+x⦄⦃tmp⇠k+y⦄
+                   /\ (i,mm_dup i) // (i,e) -+> (4+i,e').
+    Proof.
+      unfold mm_dup.
+      revert e x y.
+      induction k as [ | k IHk ]; intros e x y H1 H2 H3 H4.
+      + exists e; split.
+        * intros j; dest j src; dest j dst; dest j tmp.
+        * mm env DEC 0 with src (4+i).
+          mm env stop; f_equal; auto.
+      + destruct IHk with (e := e⦃src⇠k⦄⦃dst⇠1+x⦄⦃tmp⇠1+y⦄) (x := 1+x) (y := 1+y)
+          as (e' & H5 & H6); rew env.
+        exists e'; split.
+        * intros j; rewrite H5.
+          dest j tmp; try omega.
+          dest j dst; try omega.
+          dest j src.
+        * mm env DEC S with src (4+i) k.
+          mm env INC with dst.
+          mm env INC with tmp.
+          mm env DEC 0 with zero i; rew env.
+          rewrite H2, H3.
+          apply sss_progress_compute; auto.
+    Qed.
+
+    Fact mm_dup_progress i e : 
+           e⇢dst = 0
+        -> e⇢tmp = 0
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃src⇠0⦄⦃dst⇠(e⇢src)⦄⦃tmp⇠(e⇢src)⦄
+                  /\ (i,mm_dup i) // (i,e) -+> (4+i,e').
+    Proof.
+      intros H1 H2 H3.
+      destruct mm_dup_spec with (e := e) (x := 0) (y := 0) (i := i) (k := e⇢src)
+        as (e' & H4 & H5); auto.
+      exists e'; split; auto.
+      intros j; rewrite H4, plus_comm; auto.
+    Qed.
+
+  End mm_dup.
+
+  Hint Rewrite mm_dup_length : length_db.
+
+  Section mm_copy.
+
+    Variables (src dst tmp zero : nat).
+
+    Hypothesis (Hsd : src <> dst) (Hst : src <> tmp) (Hsz : src <> zero) 
+               (Hdt : dst <> tmp) (Hdz : dst <> zero)
+               (Htz : tmp <> zero).
+
+    Definition mm_copy i := mm_erase dst zero i
+                         ++ mm_transfert src tmp zero (2+i) 
+                         ++ mm_dup tmp src dst zero (5+i).
+
+    Fact mm_copy_length i : length (mm_copy i) = 9.
+    Proof. reflexivity. Qed.
+
+    Fact mm_copy_progress i e : 
+           e⇢tmp = 0
+        -> e⇢zero = 0
+        -> exists e', e' ⋈  e⦃dst⇠(e⇢src)⦄
+                  /\ (i,mm_copy i) // (i,e) -+> (9+i,e').
+    Proof.
+      intros H0 H1.
+      unfold mm_copy.
+      destruct mm_erase_progress with (1 := Hdz) (i := i) (e := e)
+        as (e0 & H2 & H3); auto.
+      destruct mm_transfert_progress 
+        with (src := src) (dst := tmp) (zero := zero) (i := 2+i) (e := e0)
+        as (e1 & H4 & H5); auto.
+      1,2: rewrite H2; rew env.
+      destruct mm_dup_progress 
+        with (src := tmp) (dst := src) (tmp := dst) (zero := zero) (i := 5+i) (e := e1)
+        as (e2 & H6 & H7); auto.
+      1,2,3: rewrite H4; rew env; rewrite H2; rew env.
+      exists e2; split.
+      * intros j. 
+        rewrite H6; dest j dst.
+        - rewrite H4; rew env.
+          rewrite H2; rew env. 
+        - dest j src.
+          + rewrite H4; rew env.
+            rewrite H2; rew env.
+          + dest j tmp. 
+            rewrite H4; rew env.
+            rewrite H2; rew env.
+      * apply sss_progress_trans with (2+i,e0).
+        { revert H3; apply subcode_sss_progress; auto. }
+        apply sss_progress_trans with (5+i,e1).
+        { revert H5; apply subcode_sss_progress; auto. }
+        { revert H7; apply subcode_sss_progress; auto. }
+    Qed.
+
+  End mm_copy.
+
+  Hint Rewrite mm_copy_length : length_db.
+
+  Section mm_multi_copy.
+
+    Variables (tmp zero : nat).
+
+    Fixpoint mm_multi_copy k src dst i :=
+      match k with 
+        | 0   => nil
+        | S k => mm_copy src dst tmp zero i ++ mm_multi_copy k (S src) (S dst) (9+i)
+      end.
+
+    Fact mm_multi_copy_length k src dst i : length (mm_multi_copy k src dst i) = 9*k.
+    Proof.
+      revert src dst i; induction k as [ | k IHk ]; intros src dst i; simpl; auto.
+      rew length; rewrite IHk; omega.
+    Qed.
+
+    Fact mm_multi_copy_compute k src dst i e :
+            k+src <= dst
+         -> k+dst <= tmp
+         -> k+dst <= zero 
+         -> tmp <> zero
+         -> e⇢tmp = 0
+         -> e⇢zero = 0
+         -> exists e', (forall j, j < k -> e'⇢(j+dst) = e⇢(j+src))
+                    /\ (forall j, ~ dst <= j < k+dst -> e'⇢j = e⇢j)
+                    /\ (i,mm_multi_copy k src dst i) // (i,e) ->> (9*k+i,e').
+    Proof.
+      revert src dst i e; induction k as [ | k IHk ]; intros src dst i e; intros H1 H2 H3 H4 H5 H6.
+      + exists e; split; [ | split ]; try (intros; omega).
+        mm env stop.
+      + destruct (@mm_copy_progress src dst tmp zero) with (i := i) (e := e)
+          as (e1 & G1 & G2); try omega.
+        destruct (IHk (S src) (S dst) (9+i)) with (e := e1) 
+          as (e2 & G3 & G4 & G5); try omega.
+        { rewrite G1; assert (dst <> tmp); try omega; rew env. }
+        { rewrite G1; assert (dst <> zero); try omega; rew env. }
+        exists e2; split; [ | split ].
+        * intros [ | j ] Hj.
+          - rewrite G4; try omega; simpl; rewrite G1; rew env.
+          - replace (S j + dst) with (j+S dst) by omega.
+            replace (S j + src) with (j+S src) by omega.
+            rewrite G3; try omega.
+            rewrite G1.
+            assert (dst <> j+S src) by omega; rew env.
+        * intros j Hj.
+          rewrite G4; try omega.
+          rewrite G1.
+          assert (j <> dst) by omega; rew env.
+        * unfold mm_multi_copy; fold mm_multi_copy. 
+          apply sss_compute_trans with (9+i,e1).
+          - apply sss_progress_compute.
+            revert G2; apply subcode_sss_progress; auto.
+          - replace (9*S k+i) with (9*k+(9+i)) by omega.
+            revert G5; apply subcode_sss_compute.
+            subcode_tac; rewrite <- app_nil_end; auto.
+    Qed.
+
+  End mm_multi_copy.
+
+  Hint Rewrite mm_multi_copy_length : length_db.
+
+  Section mm_set.
+
+    Variables (dst zero : nat) (Hdz : dst <> zero).
+
+    Let mm_incs : nat -> list (mm_instr nat) :=
+      fix loop n := match n with
+        | 0   => nil
+        | S n => INC dst :: loop n
+      end.
+
+    Let mm_incs_length n : length (mm_incs n) = n.
+    Proof. induction n; simpl; f_equal; auto. Qed.
+
+    Let mm_incs_spec i e n :
+      exists e', e' ⋈  e⦃dst⇠(n+(e⇢dst))⦄
+              /\ (i,mm_incs n) // (i,e) ->> (n+i,e').
+    Proof.
+      revert i e; induction n as [ | n IHn ]; intros i e; simpl.
+      + exists e; split.
+        * intros j; dest j dst.
+        * mm env stop.
+      + destruct (IHn (1+i) (e⦃dst⇠1+(e⇢dst)⦄)) as (e' & H1 & H2).
+        exists e'; split.
+        * intros j; rewrite H1; dest j dst.
+        * mm env INC with dst.
+          replace (S (n+i)) with (n+(1+i)) by omega.
+          revert H2; apply subcode_sss_compute.
+          subcode_tac; simpl; rewrite <- app_nil_end; auto.
+    Qed.
+
+    Definition mm_set n i := mm_erase dst zero i ++ mm_incs n.
+
+    Fact mm_set_length n i : length (mm_set n i) = 2+n.
+    Proof.
+      unfold mm_set; rew length; rewrite mm_incs_length; auto.
+    Qed.
+
+    Fact mm_set_progress n i e :
+            e⇢zero = 0
+         -> exists e', e' ⋈  e⦃dst⇠n⦄
+                   /\ (i,mm_set n i) // (i,e) -+> (2+n+i,e').
+    Proof.
+      intros H; unfold mm_set.
+      destruct (@mm_erase_progress _ _ Hdz i _ H) as (e1 & H1 & H2).
+      destruct (mm_incs_spec (2+i) e1 n) as (e2 & H3 & H4).
+      exists e2; split.
+      + intros j; rewrite H3, H1.
+        dest j dst; rewrite H1; rew env.
+      + apply sss_progress_compute_trans with (2+i,e1).
+        * revert H2; apply subcode_sss_progress; auto.
+        * replace (2+n+i) with (n+(2+i)) by omega.
+          revert H4; apply subcode_sss_compute; auto.
+          subcode_tac; rewrite <- app_nil_end; auto.
+    Qed.
+
+  End mm_set.
+
+End mm_env_utils.
+
+Hint Rewrite mm_set_length mm_transfert_length mm_erase_length
+             mm_list_erase_length mm_multi_erase_length
+             mm_dup_length mm_copy_length mm_multi_copy_length
+             mm_set_length : length_db.

--- a/theories/MM/mm_instr.v
+++ b/theories/MM/mm_instr.v
@@ -1,0 +1,246 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils.
+
+From Undecidability.MM 
+  Require Import env. 
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+Set Implicit Arguments.
+
+(** * Minsky Machines
+
+    A Minsky machine has n registers and there are just two instructions
+ 
+    1/ INC x   : increment register x by 1
+    2/ DEC x k : decrement register x by 1 if x > 0
+                 or jump to k if x = 0
+
+  *)
+
+Inductive mm_instr (X : Set) : Set :=
+  | mm_inc : X -> mm_instr X
+  | mm_dec : X -> nat -> mm_instr X
+  .
+
+Notation INC := mm_inc.
+Notation DEC := mm_dec.
+
+(** Semantics for MM based on environments *)
+
+Section Minsky_Machine_env_based.
+
+  Variable (X : Set) (X_eq_dec : eqdec X).
+
+  Definition mm_state := (nat*env X nat)%type.
+
+  Local Notation " e ⇢ x " := (@get_env _ _ e x).
+  Local Notation " e ⦃  x ⇠ v ⦄ " := (@set_env _ _ X_eq_dec e x v).
+
+  (* Minsky machine small step semantics *)
+
+  Inductive mm_sss_env : mm_instr X -> mm_state -> mm_state -> Prop :=
+    | in_mm_sss_env_inc   : forall i x v,                   INC x  // (i,v) -1> (1+i,v⦃x⇠S(v⇢x)⦄)
+    | in_mm_sss_env_dec_0 : forall i x k v,   v⇢x = O   -> DEC x k // (i,v) -1> (k,v)
+    | in_mm_sss_env_dec_1 : forall i x k v u, v⇢x = S u -> DEC x k // (i,v) -1> (1+i,v⦃x⇠u⦄)
+  where "i // s -1> t" := (mm_sss_env i s t).
+
+  Fact mm_sss_env_fun i s t1 t2 : i // s -1> t1 -> i // s -1> t2 -> t1 = t2.
+  Proof.
+    intros []; subst.
+    inversion 1; subst; auto.
+    inversion 1; subst; auto.
+    rewrite H in H6; discriminate.
+    inversion 1; subst; auto.
+    rewrite H in H6; discriminate.
+    rewrite H in H6; inversion H6; subst; auto.
+  Qed.
+  
+  Fact mm_sss_env_total ii s : { t | ii // s -1> t }.
+  Proof.
+    destruct s as (i,v).
+    destruct ii as [ x | x j ]; [ | case_eq (v⇢x); [ | intros k ]; intros E ].
+    * exists (1+i,v⦃x⇠S(v⇢x)⦄); constructor.
+    * exists (j,v); constructor; auto.
+    * exists (1+i,v⦃x⇠k⦄); constructor; auto.
+  Qed.
+  
+  Fact mm_sss_env_INC_inv x i v j w : INC x // (i,v) -1> (j,w) -> j=1+i /\ w = v⦃x⇠S(v⇢x)⦄.
+  Proof. inversion 1; subst; auto. Qed.
+  
+  Fact mm_sss_env_DEC0_inv x k i v j w : v⇢x = O -> DEC x k // (i,v) -1> (j,w) -> j = k /\ w = v.
+  Proof. 
+    intros H; inversion 1; subst; auto; rewrite H in H2; try discriminate.
+  Qed.
+  
+  Fact mm_sss_env_DEC1_inv x k u i v j w : v⇢x = S u -> DEC x k // (i,v) -1> (j,w) -> j=1+i /\ w = v⦃x⇠u⦄.
+  Proof. 
+    intros H; inversion 1; subst; auto; rewrite H in H2; try discriminate.
+    inversion H2; subst; auto.
+  Qed.
+
+  Notation "P // s -[ k ]-> t" := (sss_steps mm_sss_env P k s t).
+  Notation "P // s -+> t" := (sss_progress mm_sss_env P s t).
+  Notation "P // s ->> t" := (sss_compute mm_sss_env P s t).
+  
+  Fact mm_env_progress_INC P i x v st :
+         (i,INC x::nil) <sc P
+      -> P // (1+i,v⦃x⇠S(v⇢x)⦄) ->> st
+      -> P // (i,v) -+> st.
+  Proof.
+    intros H1 H2.
+    apply sss_progress_compute_trans with (2 := H2).
+    apply subcode_sss_progress with (1 := H1).
+    exists 1; split; auto; apply sss_steps_1.
+    apply in_sss_step with (l := nil).
+    simpl; omega.
+    constructor; auto.
+  Qed.
+  
+  Corollary mm_env_compute_INC P i x v st : 
+         (i,INC x::nil) <sc P 
+      -> P // (1+i,v⦃x⇠S(v⇢x)⦄) ->> st 
+      -> P // (i,v) ->> st.
+  Proof. intros; apply sss_progress_compute; eapply mm_env_progress_INC; eauto. Qed.
+  
+  Fact mm_env_progress_DEC_0 P i x k v st :
+         (i,DEC x k::nil) <sc P
+      -> v⇢x = O 
+      -> P // (k,v) ->> st
+      -> P // (i,v) -+> st.
+  Proof.
+    intros H1 H2 H3.
+    apply sss_progress_compute_trans with (2 := H3).
+    apply subcode_sss_progress with (1 := H1).
+    exists 1; split; auto; apply sss_steps_1.
+    apply in_sss_step with (l := nil).
+    simpl; omega.
+    constructor; auto.
+  Qed.
+  
+  Corollary mm_env_compute_DEC_0 P i x k v st : 
+         (i,DEC x k::nil) <sc P 
+      -> v⇢x = O 
+      -> P // (k,v) ->> st 
+      -> P // (i,v) ->> st.
+  Proof. intros; apply sss_progress_compute; eapply mm_env_progress_DEC_0; eauto. Qed.
+  
+  Fact mm_env_progress_DEC_S P i x k v u st :
+         (i,DEC x k::nil) <sc P
+      -> v⇢x = S u 
+      -> P // (1+i,v⦃x⇠u⦄) ->> st
+      -> P // (i,v) -+> st.
+  Proof.
+    intros H1 H2 H3.
+    apply sss_progress_compute_trans with (2 := H3).
+    apply subcode_sss_progress with (1 := H1).
+    exists 1; split; auto; apply sss_steps_1.
+    apply in_sss_step with (l := nil).
+    simpl; omega.
+    constructor; auto.
+  Qed.
+  
+  Corollary mm_env_compute_DEC_S P i x k v u st : 
+           (i,DEC x k::nil) <sc P 
+        -> v⇢x = S u 
+        -> P // (1+i,v⦃x⇠u⦄) ->> st 
+        -> P // (i,v) ->> st.
+  Proof. intros; apply sss_progress_compute; eapply mm_env_progress_DEC_S; eauto. Qed.
+  
+  Fact mm_env_steps_INC_inv k P i x v st :
+         (i,INC x::nil) <sc P
+      -> k <> 0
+      -> P // (i,v) -[k]-> st
+      -> exists k', k' < k /\ P // (1+i,v⦃x⇠S(v⇢x)⦄) -[k']-> st.
+  Proof.
+    intros H1 H2 H4.
+    apply sss_steps_inv in H4.
+    destruct H4 as [ (? & ?) | (k' & st2 & ? & H4 & H5) ]; subst; auto.
+    destruct H2; auto.
+    apply sss_step_subcode_inv with (1 := H1) in H4.
+    exists k'; split.
+    omega.
+    inversion H4; subst; auto.
+  Qed.
+  
+  Fact mm_env_steps_DEC_0_inv k P i x p v st :
+         (i,DEC x p::nil) <sc P
+      -> k <> 0
+      -> v⇢x = 0
+      -> P // (i,v) -[k]-> st
+      -> exists k', k' < k /\ P // (p,v) -[k']-> st.
+  Proof.
+    intros H1 H2 H3 H4.
+    apply sss_steps_inv in H4.
+    destruct H4 as [ (? & ?) | (k' & st2 & ? & H4 & H5) ]; subst; auto.
+    destruct H2; auto.
+    apply sss_step_subcode_inv with (1 := H1) in H4.
+    exists k'; split.
+    omega.
+    inversion H4; subst; auto.
+    rewrite H3 in H9; discriminate.
+  Qed.
+  
+  Fact mm_env_steps_DEC_1_inv k P i x p v u st :
+         (i,DEC x p::nil) <sc P
+      -> k <> 0
+      -> v⇢x = S u
+      -> P // (i,v) -[k]-> st
+      -> exists k', k' < k /\ P // (1+i,v⦃x⇠u⦄) -[k']-> st.
+  Proof.
+    intros H1 H2 H3 H4.
+    apply sss_steps_inv in H4.
+    destruct H4 as [ (? & ?) | (k' & st2 & ? & H4 & H5) ]; subst; auto.
+    destruct H2; auto.
+    apply sss_step_subcode_inv with (1 := H1) in H4.
+    exists k'; split.
+    omega.
+    inversion H4; subst; auto; rewrite H3 in H9.
+    discriminate.
+    inversion H9; subst; auto.
+  Qed.
+  
+End Minsky_Machine_env_based.
+
+Local Notation "P // s -[ k ]-> t" := (sss_steps (@mm_sss_env _ _) P k s t).
+Local Notation "P // s -+> t" := (sss_progress (@mm_sss_env _ _) P s t).
+Local Notation "P // s ->> t" := (sss_compute (@mm_sss_env _ _) P s t).
+
+Tactic Notation "mm" "env" "INC" "with" uconstr(a) := 
+  match goal with
+    | |- _ // _ -+> _ => apply mm_env_progress_INC with (x := a)
+    | |- _ // _ ->> _ => apply mm_env_compute_INC with (x := a)
+  end; auto.
+
+Tactic Notation "mm" "env" "DEC" "0" "with" uconstr(a) uconstr(b) := 
+  match goal with
+    | |- _ // _ -+> _ => apply mm_env_progress_DEC_0 with (x := a) (k := b)
+    | |- _ // _ ->> _ => apply mm_env_compute_DEC_0 with (x := a) (k := b)
+  end; auto.
+
+Tactic Notation "mm" "env" "DEC" "S" "with" uconstr(a) uconstr(b) uconstr(c) := 
+  match goal with
+    | |- _ // _ -+> _ => apply mm_env_progress_DEC_S with (x := a) (k := b) (u := c)
+    | |- _ // _ ->> _ => apply mm_env_compute_DEC_S with (x := a) (k := b) (u := c)
+  end; auto.
+    
+Tactic Notation "mm" "env" "stop" := exists 0; apply sss_steps_0; auto.
+
+(* The Halting problem for MM, for linear logic encoding, we restrict
+   to a very specific halting problem. Starting from (1,v), does the
+   MM halt at state (0,vec_zero) *)
+
+
+

--- a/theories/MM/mma_defs.v
+++ b/theories/MM/mma_defs.v
@@ -25,12 +25,14 @@ Local Notation "e [ v / x ]" := (vec_change e x v).
     Minsky machine has n registers and there are just two instructions
  
     1/ INC x   : increment register x by 1
-    2/ DEC x k : decrement register x by 1 if x > 0 and jump to k
+    2/ DEC x k : if x > 0 then decrement register x by 1 and jump to k
+
+    If no jump occurs, then implicitly, the jump is to the next instruction
 
     We show that they simulated FRACTRAN
   *)
 
-(** ** Semantics for MM2 based on vectors *)
+(** ** Semantics for MMA based on vectors *)
 
 Section Minsky_Machine_alternate.
 
@@ -38,7 +40,7 @@ Section Minsky_Machine_alternate.
 
   (* Minsky machine small step semantics *)
 
-  Inductive mma_sss : mm_instr n -> mm_state n -> mm_state n -> Prop :=
+  Inductive mma_sss : mm_instr (pos n) -> mm_state _ -> mm_state _ -> Prop :=
     | in_mma_sss_inc   : forall i x v,                   INC x   // (i,v) -1> (1+i,v[(S (v#>x))/x])
     | in_mma_sss_dec_0 : forall i x k v,   v#>x = O   -> DEC x k // (i,v) -1> (1+i,v)
     | in_mma_sss_dec_1 : forall i x k v u, v#>x = S u -> DEC x k // (i,v) -1> (k,v[u/x])
@@ -214,7 +216,7 @@ Tactic Notation "mma" "sss" "DEC" "S" "with" uconstr(a) uconstr(b) uconstr(c) :=
     
 Tactic Notation "mma" "sss" "stop" := exists 0; apply sss_steps_0; auto.
 
-Definition MMA2_PROBLEM := (list (mm_instr 2) * vec nat 2)%type.
+Definition MMA2_PROBLEM := (list (mm_instr (pos 2)) * vec nat 2)%type.
 Definition MMA2_HALTING (P : MMA2_PROBLEM) := (1,fst P) // (1,snd P) ↓.
 
 

--- a/theories/MuRec/ra_comp.v
+++ b/theories/MuRec/ra_comp.v
@@ -1,0 +1,54 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_nat.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+From Undecidability.ILL.Mm
+  Require Import mm_defs.
+
+From Undecidability.MuRec 
+  Require Import recalg ra_mm. 
+
+Set Implicit Arguments.
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Local Notation "P // s -+> t" := (sss_progress (@mm_sss _) P s t).
+Local Notation "P // s ->> t" := (sss_compute (@mm_sss _) P s t).
+Local Notation "P // s ~~> t" := (sss_output (@mm_sss _) P s t).
+Local Notation "P // s ↓"     := (sss_terminates (@mm_sss _) P s).
+
+Theorem ra_mm_simulator n (f : recalg n) :
+      { m & { P : list (mm_instr (pos (n+S m))) | forall v, ex (⟦f⟧ v) <-> (1,P) // (1,vec_app v vec_zero) ↓ } }.
+Proof.
+  destruct (ra_mm_compiler f) as (m & P & H1 & H2).
+  exists m, P; split.
+  + intros (x & Hx).
+    destruct (H1 _ _ Hx) as (j & Hj); exists (j,vec_app v (x##vec_zero)); auto.
+  + intros H; apply H2; eq goal H; do 2 f_equal.
+Qed.
+
+Corollary ra_mm_simulator_0 (f : recalg 0) :
+      { m & { P : list (mm_instr (pos (S m))) | ex (⟦f⟧ vec_nil) <-> (1,P) // (1,vec_zero) ↓ } }.
+Proof.
+  destruct (ra_mm_simulator f) as (m & P & HP).
+  exists m, P; rewrite (HP vec_nil), vec_app_nil; tauto.
+Qed.
+
+Check ra_mm_simulator.
+Print Assumptions ra_mm_simulator.

--- a/theories/MuRec/ra_dio_poly.v
+++ b/theories/MuRec/ra_dio_poly.v
@@ -1,0 +1,328 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Eqdep_dec Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_nat.
+
+From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
+
+From Undecidability.MuRec Require Import recalg ra_utils.
+
+From Undecidability.H10.Dio Require Import dio_single.
+
+Set Implicit Arguments.
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Section dio_poly.
+
+  Variable (n m : nat).
+
+  Fixpoint ra_dio_poly (p : dio_polynomial (pos n) (pos m)) : recalg (n+m).
+  Proof.
+    destruct p as [ c | i | x | [] p q ].
+    + apply ra_cst_n, c.
+    + apply ra_proj, pos_left, i. 
+    + apply ra_proj, pos_right, x.
+    + apply ra_comp with (1 := ra_plus), (ra_dio_poly p##ra_dio_poly q##vec_nil).
+    + apply ra_comp with (1 := ra_mult), (ra_dio_poly p##ra_dio_poly q##vec_nil).
+  Defined.
+
+  Fact ra_dio_poly_prim p : prim_rec (ra_dio_poly p).
+  Proof.
+    induction p as [ | | | [] ]; simpl; repeat (split; auto);
+      intros j; analyse pos j; simpl; auto.
+  Qed.
+
+  Opaque ra_cst_n ra_plus ra_mult ra_inject ra_project ra_eq.
+
+  Section ra_dio_poly_eval.
+
+    Variable (v : vec nat (n+m)).
+
+    Notation φ := (fun i => vec_pos v (pos_left _ i)).
+    Notation ν := (fun i => vec_pos v (pos_right _ i)).
+
+    Fact ra_dio_poly_val p : ⟦ra_dio_poly p⟧ v (dp_eval φ ν p).
+    Proof.
+      induction p as [ c | i | x | [] p Hp q Hq ]; simpl.
+      + apply ra_cst_n_val.
+      + cbv; auto.
+      + cbv; auto.
+      + exists (dp_eval φ ν p ## dp_eval φ ν q ## vec_nil); split.
+        * apply ra_plus_val.
+        * intros j; analyse pos j; simpl; auto.
+      + exists (dp_eval φ ν p ## dp_eval φ ν q ## vec_nil); split.
+        * apply ra_mult_val.
+        * intros j; analyse pos j; simpl; auto.
+    Qed.
+
+    Variable (p q : dio_polynomial (pos n) (pos m)).
+
+    Definition ra_dio_poly_eq : recalg (n+m).
+    Proof.
+      apply ra_comp with (1 := ra_eq).
+      refine (_##_##vec_nil); apply ra_dio_poly.
+      + exact p.
+      + exact q.
+    Defined.
+
+    Hint Resolve ra_dio_poly_prim.
+  
+    Fact ra_dio_poly_eq_prim : prim_rec ra_dio_poly_eq.
+    Proof.
+      simpl; split; auto.
+      intros j; analyse pos j; auto.
+    Qed. 
+
+    Fact ra_dio_poly_eq_val : { e | ⟦ra_dio_poly_eq⟧ v e /\ (e = 0 <-> dp_eval φ ν p = dp_eval φ ν q) }.
+    Proof.
+      destruct ra_eq_rel with (v := dp_eval φ ν p ## dp_eval φ ν q ## vec_nil) as (e & H1 & H2); simpl in H2.
+      exists e; split; auto.
+      simpl.
+      exists (dp_eval φ ν p ## dp_eval φ ν q ## vec_nil); split; auto.
+      intros i; analyse pos i; simpl; apply ra_dio_poly_val.
+    Qed.
+
+    Opaque ra_dio_poly_eq.
+
+    Hint Resolve ra_dio_poly_eq_prim.
+
+    Definition ra_dio_poly_test : recalg (S m).
+    Proof.
+      apply ra_comp with (1 := ra_dio_poly_eq).
+      apply vec_set_pos; intros i.
+      destruct (pos_both _ _ i) as [ j | j ].
+      + apply ra_comp with (1 := ra_project j), (ra_proj pos0 ## vec_nil).
+      + apply ra_proj, pos_nxt, j.
+    Defined.
+
+    Fact ra_dio_poly_test_prim : prim_rec ra_dio_poly_test.
+    Proof.
+      simpl; split; auto.
+      intros i.
+      rewrite vec_pos_set.
+      destruct (pos_both n m i).
+      + simpl; split; auto.
+        intros j; analyse pos j; simpl; auto.
+      + simpl; auto.
+    Qed.
+
+    Fact ra_dio_poly_test_total : total ⟦ra_dio_poly_test⟧.
+    Proof. apply prim_rec_tot, ra_dio_poly_test_prim. Qed.
+
+  End ra_dio_poly_eval.
+
+  Notation φ := (fun x w i => vec_pos (vec_app (project n x) w) (pos_left _ i)).
+  Notation ν := (fun x w i => vec_pos (vec_app (project n x) w) (pos_right _ i)).
+
+  Variable (p q : dio_polynomial (pos n) (pos m)).
+
+  Fact ra_dio_poly_test_val x w : { e | ⟦ra_dio_poly_test p q⟧ (x##w) e /\ (e = 0 <-> dp_eval (φ x w) (ν x w) p 
+                                                                                    = dp_eval (φ x w) (ν x w) q) }.
+  Proof.
+    destruct (ra_dio_poly_eq_val (vec_app (project n x) w) p q) as (e & H1 & H2).
+    exists e; split; auto.
+    exists (vec_app (project n x) w); split; auto.
+    intros i; repeat rewrite vec_pos_set.
+    generalize (pos_lr_both n m i). 
+    destruct (pos_both n m i) as [ j | j ]; intros Hj; subst i; simpl.
+    * unfold vec_app; rewrite vec_pos_set, pos_both_left.
+      exists (x##vec_nil); split.
+      - apply ra_project_val.
+      - intros k; analyse pos k; simpl; cbv; auto.
+    * unfold vec_app; rewrite vec_pos_set, pos_both_right; reflexivity.
+  Qed.
+
+  Fact ra_dio_poly_test_rel v e : ⟦ra_dio_poly_test p q⟧ v e
+                               -> e = 0 <-> dp_eval (φ (vec_head v) (vec_tail v)) 
+                                                    (ν (vec_head v) (vec_tail v)) p 
+                                          = dp_eval (φ (vec_head v) (vec_tail v)) 
+                                                    (ν (vec_head v) (vec_tail v)) q.
+  Proof.
+    vec split v with x; intros H; simpl vec_head; simpl vec_tail.
+    destruct (ra_dio_poly_test_val x v) as (e' & H1 & H2).
+    rewrite <- H2; clear H2.
+    generalize (ra_rel_fun _ _ _ _ H H1); intros []; tauto.
+  Qed.
+
+  Opaque ra_dio_poly_test.
+
+  Definition ra_dio_poly_find : recalg m.
+  Proof. apply ra_min, (ra_dio_poly_test p q). Defined.
+
+  Lemma ra_dio_poly_find_rel w : (exists e, ⟦ra_dio_poly_find⟧ w e) <-> exists x, ⟦ra_dio_poly_test p q⟧ (x##w) 0.
+  Proof.
+    simpl; unfold s_min.
+    apply μ_min_of_total.
+    + intros ? ? ?; apply ra_rel_fun.
+    + intros x; destruct (ra_dio_poly_test_val x w) as (e & ? & _).
+      exists e; auto.
+  Qed.
+
+  (** ra_dio_poly_find terminates on w iff some solution of p(w,x1,...,xn) = q(w,x1,...,xn) exists 
+
+      so termination of ra_dio_poly_find terminates on w simulates the existence of a solution
+      to a given diophantine equation *)
+
+  Theorem ra_dio_poly_find_spec w :  ex (⟦ra_dio_poly_find⟧ w) 
+                                <-> exists v, dp_eval (vec_pos v) (vec_pos w) p 
+                                            = dp_eval (vec_pos v) (vec_pos w) q.
+  Proof.
+    rewrite ra_dio_poly_find_rel; split.
+    + intros (x & Hx).
+      destruct (ra_dio_poly_test_val x w) as (e & H1 & H2).
+      generalize (ra_rel_fun _ _ _ _ H1 Hx); rewrite H2.
+      exists (project n x); auto.
+      eq goal H; f_equal; apply dp_eval_ext; intro; try rewrite vec_pos_app_left; auto;
+        rewrite vec_pos_app_right; auto.
+    + intros (v & Hv).
+      exists (inject v).
+      destruct (ra_dio_poly_test_val (inject v) w) as (e & H1 & H2).
+      rewrite project_inject in H2.
+      assert (e=0); try (subst; auto; fail).
+      apply H2.
+      eq goal Hv; f_equal; apply dp_eval_ext; intro; try rewrite vec_pos_app_left; auto;
+        rewrite vec_pos_app_right; auto.
+  Qed.
+
+End dio_poly.
+
+Opaque ra_dio_poly_find.
+
+Section dio_ra_enum.
+
+  (* Given p = q in dio_eq (pos 1) (pos m), given a total
+     µ-rec function of type recalg 1 that enumerates the solutions 
+
+     given n compute x#w in vec nat (1+m). Compute 
+     p[x][w] = q[x][w]. If equal, return (S x), otherwise return 0 *)
+
+   Variable (m : nat) (p q : dio_polynomial (pos m) (pos 1)).
+
+   Let f := ra_dio_poly_test p q.
+ 
+   Let Hf x w : {e : nat |
+       ⟦ f ⟧ (x ## w) e /\
+       (e = 0 <->
+        dp_eval
+          (fun i => vec_pos (vec_app (project m x) w) (pos_left 1 i))
+          (fun i => vec_pos (vec_app (project m x) w) (pos_right m i))
+          p =
+        dp_eval
+          (fun i => vec_pos (vec_app (project m x) w) (pos_left 1 i))
+          (fun i => vec_pos (vec_app (project m x) w) (pos_right m i)) q) }.
+  Proof. apply ra_dio_poly_test_val. Qed.
+
+  Opaque f.
+
+  Let g : recalg 1.
+  Proof.
+    apply ra_comp with (1 := ra_ite).
+    refine (_##_##_##vec_nil).
+    + apply ra_comp with (1 := f), ra_vec_project.
+    + apply ra_comp with (1 := ra_succ).
+      refine (_##vec_nil).
+      apply (@ra_project 2 pos1).
+    + apply ra_cst_n, 0.
+  Defined.
+
+  Opaque ra_decomp_l ra_decomp_r ra_project.
+
+  Let Hg0 : prim_rec g.
+  Proof.
+    simpl; split; auto.
+    intros j; analyse pos j; auto.
+    + simpl; split; auto.
+      * apply ra_dio_poly_test_prim.
+      * intros j; analyse pos j; simpl; auto; split; auto.
+    + simpl; split; auto.
+      intros j; analyse pos j; auto.
+  Qed.
+
+  Let Hg1 x : ex (⟦g⟧ (x##vec_nil)).
+  Proof. apply prim_rec_tot; auto. Qed.
+
+  (* Not a very nice proof ... *)
+
+  Let Hg x : (exists n, ⟦g⟧ (n##vec_nil) (S x)) <-> exists w, dp_eval (vec_pos w) (fun _ => x) p
+                                                            = dp_eval (vec_pos w) (fun _ => x) q.
+  Proof.
+    split.
+    + intros (n & w & H1 & H2).
+      apply ra_ite_rel in H1.
+      generalize (H2 pos0) (H2 pos1) (H2 pos2).
+      clear H2; revert H1.
+      repeat rewrite vec_pos_set.
+      vec split w with a; vec split w with b; vec split w with c; vec nil w; clear w.
+      simpl; intros H1 H2 H3 H4.
+      destruct H3 as (w & H3 & H5).
+      generalize (H5 pos0); revert H3; clear H5.
+      vec split w with d; vec nil w; clear w; simpl; intros H3 H5.
+      red in H3; simpl in H3.
+      apply ra_project_rel in H5; simpl in H5.
+      destruct H4 as (w & H4 & _); red in H4; clear w.
+      destruct H2 as (w & H2 & H6).
+      generalize (H6 pos0) (H6 pos1); clear H6.
+      revert H2; vec split w with u; vec split w with v; vec nil w; clear w; simpl.
+      intros H2 H6 H7.
+      apply ra_project_rel in H6.
+      apply ra_project_rel in H7.
+      simpl in H5, H6, H7.
+      subst c b d u v.
+      apply ra_dio_poly_test_rel in H2; simpl in H2.
+      exists (project m (decomp_l n)).
+      apply proj1 in H2.
+      destruct a; try discriminate.
+      simpl in H1; injection H1; clear H1; intros H1.
+      specialize (H2 eq_refl); subst x.
+      eq goal H2; f_equal; apply dp_eval_ext;
+        try (intros; rewrite vec_pos_app_left; auto);
+        intros j _; analyse pos j; rewrite vec_pos_app_right; simpl; auto.
+    + intros (w & Hw).
+      destruct (Hf (inject w) (x##vec_nil)) as (e & H1 & H2).
+      assert (e = 0) as He.
+      { apply H2.
+        eq goal Hw; f_equal; apply dp_eval_ext;
+          try (intros j _; rewrite vec_pos_app_left; rewrite project_inject; auto);
+          intros j _; analyse pos j; rewrite vec_pos_app_right; simpl; auto. }
+      clear H2; subst e.
+      exists (inject (inject w##x##vec_nil)).
+      unfold g.
+      exists (0##S x##0##vec_nil); split.
+      * apply ra_ite_rel; simpl; auto.
+      * intros j; rewrite vec_pos_set; analyse pos j; simpl.
+        - exists (inject w ## x ## vec_nil); split; auto.
+          intros j; analyse pos j; simpl.
+          { apply ra_project_rel; simpl.
+            rewrite decomp_l_recomp; auto. }
+          { apply ra_project_rel; simpl.
+            rewrite decomp_r_recomp, decomp_l_recomp; auto. }
+        - exists (x##vec_nil); split; try (red; auto; fail).
+          intros j; analyse pos j; simpl.
+          apply ra_project_rel; simpl.
+          rewrite decomp_r_recomp, decomp_l_recomp; auto.
+        - exists vec_nil; split; try (red; auto; fail).
+          intros j; analyse pos j.
+  Qed.
+
+  Theorem dio_poly_eq_2_ra_prim : 
+          { g : recalg 1 | prim_rec g 
+               /\ forall x, (exists n, ⟦g⟧ (n##vec_nil) (S x)) 
+                         <-> exists w, dp_eval (vec_pos w) (fun _ => x) p
+                                     = dp_eval (vec_pos w) (fun _ => x) q }.
+  Proof. exists g; split; auto. Qed. 
+
+End dio_ra_enum.
+
+ 
+
+ 

--- a/theories/MuRec/ra_enum.v
+++ b/theories/MuRec/ra_enum.v
@@ -1,0 +1,107 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Eqdep_dec Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_nat.
+
+From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
+
+From Undecidability.MuRec Require Import recalg ra_utils.
+
+Set Implicit Arguments.
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Section ra_enum.
+
+  Variable f : recalg 1.
+
+  Let a : recalg 2.
+  Proof. apply ra_comp with (1 := f), (ra_proj pos0##vec_nil). Defined.
+
+  Let Ha v x : ⟦a⟧ v x <-> ⟦f⟧ (vec_pos v pos0##vec_nil) x.
+  Proof.
+    unfold a.
+    rewrite ra_rel_fix_comp; simpl.
+    split.
+    + intros (w & H1 & H2); revert H1 H2.
+      vec split w with y; vec nil w; intros H1 H2.
+      specialize (H2 pos0); simpl in H2; red in H2; subst; auto.
+    + intros H; exists (vec_pos v pos0##vec_nil); split; auto.
+      intros p; analyse pos p; simpl; red; auto.
+  Qed.
+  
+  Let b : recalg 2.
+  Proof.
+    apply ra_comp with (1 := ra_succ), (ra_proj pos1##vec_nil).
+  Defined.
+
+  Let Hb v x : ⟦b⟧ v x <-> x = S (vec_pos v pos1).
+  Proof.
+    unfold b; simpl; split.
+    + intros (w & H1 & H2); revert H1 H2.
+      vec split w with y; vec nil w; intros H1 H2.
+      specialize (H2 pos0); simpl in H2; red in H2; subst; auto.
+    + intros H; exists (vec_pos v pos1##vec_nil); subst; split; auto.
+      * red; auto.
+      * intros p; analyse pos p; simpl; red; auto.
+  Qed.
+
+  Opaque a b.
+
+  Let g : recalg 2.
+  Proof.
+    apply ra_comp with (1 := ra_eq), (a##b##vec_nil).
+  Defined.
+
+  Hypothesis Hf : forall v, exists x, ⟦f⟧ v x.
+
+  Let Hg v : exists e, ⟦g⟧ v e /\ (e = 0 <-> ⟦f⟧ (vec_pos v pos0##vec_nil) (S (vec_pos v pos1))).
+  Proof.
+    unfold g.
+    destruct (Hf (vec_pos v pos0##vec_nil)) as (x & Hx).
+    destruct (ra_eq_rel (x##S (vec_pos v pos1)##vec_nil)) as (e & H1 & H2).
+    exists e; split.
+    + exists (x##S (vec_pos v pos1)##vec_nil); split; auto.
+      intros p; analyse pos p; simpl.
+      * apply Ha; auto.
+      * apply Hb; auto.
+    + simpl in H2; rewrite H2; split.
+      * intros; subst; auto.
+      * revert Hx; apply ra_rel_fun.
+  Qed.
+
+  Opaque g.
+
+  Definition ra_enum : recalg 1.
+  Proof. apply ra_min, g. Defined.
+
+  (* A reduction of listability into recursive computability *)
+
+  Fact ra_enum_spec x : ex (⟦ra_enum⟧ (x##vec_nil)) <-> exists n, ⟦f⟧ (n##vec_nil) (S x).
+  Proof.
+    unfold ra_enum; simpl; unfold s_min.
+    rewrite μ_min_of_total.
+    + split.
+      * intros (r & Hr).
+        destruct (Hg (r##x##vec_nil)) as (e & H1 & H2).
+        simpl in H2.
+        exists r; apply H2.
+        revert H1 Hr; apply ra_rel_fun.
+      * intros (n & Hn); exists n.
+        destruct (Hg (n##x##vec_nil)) as (e & H1 & H2).
+        apply H2 in Hn; subst; auto.
+    + intros ? ? ?; apply ra_rel_fun.
+    + intros y; destruct (Hg (y##x##vec_nil)) as (e & ? & _).
+      exists e; auto.
+  Qed.
+  
+End ra_enum.

--- a/theories/MuRec/ra_mm.v
+++ b/theories/MuRec/ra_mm.v
@@ -1,0 +1,306 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega Max.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.MM 
+  Require Import env mm_instr. 
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+From Undecidability.ILL.Mm
+  Require Import mm_defs.
+
+From Undecidability.MuRec 
+  Require Import recalg ra_mm_env. 
+
+Set Implicit Arguments.
+
+Tactic Notation "rew" "length" := autorewrite with length_db.
+
+Local Notation "i /e/ s '-1>' t" := (mm_sss_env eq_nat_dec i s t)  (at level 70, no associativity).
+Local Notation "P /e/ s ->> t" := (sss_compute (mm_sss_env eq_nat_dec) P s t) (at level 70, no associativity).
+Local Notation "P /e/ s ~~> t" := (sss_output (mm_sss_env eq_nat_dec) P s t) (at level 70, no associativity).
+Local Notation "P /e/ s -[ k ]-> t" := (sss_steps (mm_sss_env eq_nat_dec) P k s t) (at level 70, no associativity).
+Local Notation "P /e/ s ↓" := (sss_terminates (mm_sss_env eq_nat_dec) P s) (at level 70, no associativity).
+
+Local Notation "i /v/ s '-1>' t" := (@mm_sss _ i s t)  (at level 70, no associativity).
+Local Notation "P /v/ s ->> t" := (sss_compute (@mm_sss _) P s t) (at level 70, no associativity).
+Local Notation "P /v/ s ~~> t" := (sss_output (@mm_sss _) P s t) (at level 70, no associativity).
+Local Notation "P /v/ s -[ k ]-> t" := (sss_steps (@mm_sss _) P k s t) (at level 70, no associativity).
+Local Notation "P /v/ s ↓" := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity). 
+
+Local Notation " e ⇢ x " := (@get_env _ _ e x).
+Local Notation " e ⦃  x ⇠ v ⦄ " := (@set_env _ _ eq_nat_dec e x v).
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Section mm_nat_pos.
+
+  Definition mm_var_map (X Y : Set) (f : X -> Y) (i : mm_instr X) :=
+    match i with
+      | INC x   => INC (f x)
+      | DEC x p => DEC (f x) p
+    end.
+
+  Definition mm_instr_var X (i : mm_instr X) :=
+    match i with
+      | INC x => x
+      | DEC x _ => x
+    end.
+
+  Definition mm_linstr_vars X := map (@mm_instr_var X).
+
+  Definition mm_pos_nat n := map (mm_var_map (@pos2nat n)).
+  
+  Definition mm_nat_pos_full n l : Forall (fun x => x < n) (mm_linstr_vars l) -> { m | l = @mm_pos_nat n m }.
+  Proof.
+    induction l as [ | [ x | x p ] l IHl ]; simpl; intros H.
+    { exists nil; auto. }
+    1,2: rewrite Forall_cons_inv in H; destruct H as [ H1 H2 ];
+         destruct (IHl H2) as (m & Hm).
+    + exists (INC (nat2pos H1) :: m); simpl; f_equal; auto; f_equal.
+      rewrite pos2nat_nat2pos; auto.
+    + exists (DEC (nat2pos H1) p :: m); simpl; f_equal; auto; f_equal.
+      rewrite pos2nat_nat2pos; auto.
+  Qed.
+
+  Definition mm_nat_bound l := S (lmax (mm_linstr_vars l)).
+
+  Fact mm_nat_bound_spec l : Forall (fun x => x < mm_nat_bound l) (mm_linstr_vars l).
+  Proof.
+    cut (Forall (fun x => x <= lmax (mm_linstr_vars l)) (mm_linstr_vars l)).
+    + apply Forall_impl; intros; unfold mm_nat_bound; omega.
+    + apply lmax_spec; auto.
+  Qed.
+
+  Definition mm_nat_pos n l : mm_nat_bound l <= n -> { m | l = @mm_pos_nat n m }.
+  Proof.
+    intros H; apply mm_nat_pos_full.
+    generalize (mm_nat_bound_spec l).
+    apply Forall_impl; intros; omega.
+  Qed.
+
+End mm_nat_pos.
+
+Section mm_pos_nat_sem.
+
+  Variable (n : nat).
+
+  Implicit Types (e : nat -> nat) (v : vec nat n).
+
+  Ltac dest x y := destruct (pos_eq_dec x y) as [ | ]; [ subst x | ]; rew env.
+
+  Notation "v '⋈' e" := (forall p, vec_pos v p = e⇢pos2nat p) (at level 70, no associativity).
+
+  Fact sss_mm_pos_nat rho st1 st2 e1 :
+            snd st1 ⋈ e1
+         -> rho /v/ st1 -1> st2
+         -> exists e2, snd st2 ⋈ e2
+                    /\ mm_var_map (@pos2nat n) rho /e/ (fst st1,e1) -1> (fst st2,e2). 
+  Proof.
+    revert st1 st2; intros (j1,v1) (j2,v2); simpl.
+    intros H1 H2.
+    destruct rho as [ x | x p ]; simpl in *;
+      [ | case_eq (vec_pos v1 x); [ intros He1 | intros q Hq ] ].
+    - exists (e1⦃pos2nat x ⇠ S (e1⇢pos2nat x)⦄).
+      apply mm_sss_INC_inv in H2.
+      destruct H2 as (? & ?); subst; split.
+      2: constructor.
+      intros p.
+      destruct (pos_eq_dec x p) as [ -> | C ]; rew vec; rew env. 
+      rewrite H1; assert (pos2nat x <> pos2nat p); rew env.
+      contradict C; revert C; apply pos2nat_inj.
+    - exists e1. 
+      apply mm_sss_DEC0_inv in H2; destruct H2; subst; auto.
+      split; auto; constructor; rewrite <- H1; auto.
+    - exists (e1⦃pos2nat x ⇠ q⦄).
+      apply mm_sss_DEC1_inv with (1 := Hq) in H2.
+      destruct H2; subst; split.
+      2: constructor; rewrite <- H1; auto.
+      intros j. 
+      destruct (pos_eq_dec x j) as [ -> | C ]; rew vec; rew env.
+      rewrite H1; assert (pos2nat x <> pos2nat j); rew env.
+      contradict C; revert C; apply pos2nat_inj.
+  Qed.
+
+  Fact sss_mm_pos_nat_inv rho st1 st2 v1 :
+            v1 ⋈ snd st1
+         -> mm_var_map (@pos2nat n) rho /e/ st1 -1> st2 
+         -> exists v2, v2 ⋈ snd (st2)
+                    /\ rho /v/ (fst st1,v1) -1> (fst st2,v2).
+  Proof.
+    revert st1 st2; intros (j1,e1) (j2,e2); simpl.
+    intros H1 H2.
+    destruct rho as [ x | x p ]; simpl in *;
+      [ | case_eq (e1⇢pos2nat x); [ intros He1 | intros q Hq ] ].
+    - exists (vec_change v1 x (S (vec_pos v1 x))).
+      apply mm_sss_env_INC_inv in H2.
+      destruct H2 as (? & ?); subst; split.
+      2: constructor.
+      intros p.
+      destruct (pos_eq_dec x p) as [ -> | C ]; rew vec; rew env. 
+      rewrite H1; assert (pos2nat x <> pos2nat p); rew env.
+      contradict C; revert C; apply pos2nat_inj.
+    - exists v1. 
+      apply mm_sss_env_DEC0_inv in H2; destruct H2; subst; auto.
+      split; auto; constructor; rewrite H1; auto.
+    - exists (vec_change v1 x q).
+      apply mm_sss_env_DEC1_inv with (1 := Hq) in H2.
+      destruct H2; subst; split.
+      2: constructor; rewrite H1; auto.
+      intros j. 
+      destruct (pos_eq_dec x j) as [ -> | C ]; rew vec; rew env.
+      rewrite H1; assert (pos2nat x <> pos2nat j); rew env.
+      contradict C; revert C; apply pos2nat_inj.
+  Qed.
+
+  Fact sss_steps_mm_pos_nat i P k st1 st2 e1 :
+            snd st1 ⋈ e1
+         -> (i,P) /v/ st1 -[k]-> st2
+         -> exists e2, snd st2 ⋈ e2
+                    /\ (i,@mm_pos_nat n P) /e/ (fst st1,e1) -[k]-> (fst st2,e2). 
+  Proof.
+    intros H1 H2; revert H2 e1 H1.
+    induction 1 as [ (j,v) | k (j1,v1) (j2,v2) (j3,v3) H1 H2 IH2 ];
+      simpl; intros e1 H3.
+    + exists e1; split; auto; constructor.
+    + destruct H1 as (q & l & rho & r & e & [= <- G2] & [= -> <-] & G3).
+      destruct sss_mm_pos_nat with (2 := G3) (1 := H3) as (e2 & G4 & G5); simpl in *.
+      destruct IH2 with (1 := G4) as (e3 & G6 & G7).
+      exists e3; split; auto.
+      constructor 2 with (st2 := (j2,e2)); auto.
+      exists i, (mm_pos_nat l), (mm_var_map (@pos2nat _) rho), (mm_pos_nat r), e1; msplit 2; auto.
+      * f_equal; subst P; unfold mm_pos_nat; repeat (rewrite map_app; simpl); auto.
+      * unfold mm_pos_nat; rew length; auto.
+  Qed. 
+ 
+  Fact sss_steps_mm_pos_nat_inv i P k st1 st2 v1 :
+            v1 ⋈ snd st1
+         -> (i,@mm_pos_nat n P) /e/ st1 -[k]-> st2 
+         -> exists v2, v2 ⋈ snd (st2)
+                    /\ (i,P) /v/ (fst st1,v1) -[k]-> (fst st2,v2).
+  Proof.
+    intros H1 H2; revert H2 v1 H1.
+    induction 1 as [ (j,e) | k (j1,e1) (j2,e2) (j3,e3) H1 H2 IH2 ];
+      simpl; intros v1 H3.
+    + exists v1; split; auto; constructor.
+    + destruct H1 as (q & l & rho & r & e & [= <- G2] & [= -> <-] & G3).
+      unfold mm_pos_nat in G2; apply map_middle_inv in G2.
+      destruct G2 as (l' & rho' & r' & G2 & G4 & G5 & G6).
+      subst rho l r.
+      destruct sss_mm_pos_nat_inv with (2 := G3) (1 := H3) as (v2 & G7 & G8); simpl in *.
+      destruct IH2 with (1 := G7) as (v3 & G9 & G10).
+      exists v3; split; auto.
+      constructor 2 with (st2 := (j2,v2)); auto.
+      exists i, l', rho', r', v1; msplit 2; subst; auto; rew length; auto.
+  Qed.
+
+End mm_pos_nat_sem.
+
+Section ra_mm_comp.
+
+  Theorem ra_mm_compiler (n : nat) (f : recalg n) :
+      { m & { P : list (mm_instr (pos (n+S m))) 
+            |  (forall x v, ⟦f⟧ v x -> exists j, (1,P) /v/ (1,vec_app v vec_zero) ~~> (j,vec_app v (x##vec_zero)))
+            /\ (forall v, (1,P) /v/ (1,vec_app v vec_zero) ↓ -> ex (⟦f⟧ v)) } }.
+  Proof.
+    destruct ra_mm_env_simulator with (f := f) as (P & H1 & H2).
+    set (k := max (S n) (mm_nat_bound P)).
+    assert (S n <= k) as H3 by apply le_max_l.
+    assert { m | k = n+S m } as H4.
+    { exists (k-S n); omega. }
+    clear H3.
+    destruct H4 as (m & Hm).
+    exists m.
+    destruct mm_nat_pos with (n := k) (l := P) as (Q & HQ).
+    + apply le_max_r.
+    + revert Q HQ; rewrite Hm; clear k Hm; intros Q HQ.
+      exists Q; split.
+      * intros x v H.
+        destruct (H1 v x (fun j => match le_lt_dec n j with left _ => 0 | right Hj => vec_pos v (nat2pos Hj) end))
+          as (e' & G1 & k & G2); auto.
+        - intros p; generalize (pos2nat_prop p); intros H0; unfold get_env.
+          destruct (le_lt_dec n (pos2nat p)); try omega.
+          f_equal; apply nat2pos_pos2nat.
+        - intros j Hj; unfold get_env.
+          destruct (le_lt_dec n j); omega.
+        - exists (1+length P); split.
+          2: rewrite HQ; unfold mm_pos_nat; rew length; simpl; omega.
+          exists k.
+          rewrite HQ in G2 at 1.
+          apply sss_steps_mm_pos_nat_inv with (v1 := vec_app v vec_zero) in G2.
+          ++ destruct G2 as (v2 & G2 & G3); simpl in G3.
+             eq goal G3; do 2 f_equal.
+             apply vec_pos_ext, pos_left_right_rect.
+             ** intros p; rewrite G2, vec_pos_app_left, G1; simpl.
+                rewrite pos2nat_left.
+                generalize (pos2nat_prop p); intros G4.
+                rewrite get_set_env_neq; try omega.
+                unfold get_env.
+                destruct (le_lt_dec n (pos2nat p)); try omega.
+                f_equal; apply nat2pos_pos2nat.
+             ** intros p.
+                rewrite vec_pos_app_right, G2, pos2nat_right; simpl snd.
+                rewrite plus_comm.
+                analyse pos p.
+                -- rewrite pos2nat_fst; simpl.
+                   rewrite G1; rew env.
+                -- rewrite pos2nat_nxt; simpl.
+                   unfold vec_zero; rewrite vec_pos_set.
+                   rewrite G1, get_set_env_neq; try omega.
+                   unfold get_env; simpl.
+                   destruct (le_lt_dec n (S (pos2nat p+n))); omega.
+          ++ simpl; apply pos_left_right_rect.
+             ** intros p; rewrite vec_pos_app_left, pos2nat_left.
+                unfold get_env.
+                generalize (pos2nat_prop p); intros.
+                destruct (le_lt_dec n (pos2nat p)); try omega; f_equal.
+                rewrite nat2pos_pos2nat; auto.
+             ** intros p; rewrite vec_pos_app_right, pos2nat_right.
+                unfold vec_zero; rewrite vec_pos_set.
+                unfold get_env.
+                destruct (le_lt_dec n (n+pos2nat p)); try omega.
+      * intros v ((j,w) & (k & G1) & G2); simpl in G2.
+        set (e1 := fun j => match le_lt_dec n j with left _ => 0 | right Hj => vec_pos v (nat2pos Hj) end).
+        apply sss_steps_mm_pos_nat with (e1 := e1) in G1.
+        destruct G1 as (e2 & G1 & G3); simpl in G3.
+        apply H2 with e1.
+        - rewrite HQ; exists (j,e2); split.
+          ++ exists k; auto.
+          ++ simpl; unfold mm_pos_nat; rew length; auto.
+        - intros p; unfold e1, get_env.
+          generalize (pos2nat_prop p); intros.
+          destruct (le_lt_dec n (pos2nat p)); try omega.
+          rewrite nat2pos_pos2nat; auto.
+        - intros p Hp.
+          unfold e1, get_env.
+          destruct (le_lt_dec n p); omega.
+        - simpl; apply pos_left_right_rect.
+          ++ intros p; rewrite vec_pos_app_left, pos2nat_left.
+             unfold e1, get_env.
+             generalize (pos2nat_prop p); intros.
+             destruct (le_lt_dec n (pos2nat p)); try omega.
+             rewrite nat2pos_pos2nat; auto.
+          ++ intros p; rewrite vec_pos_app_right, pos2nat_right, vec_zero_spec.
+             unfold e1, get_env.
+             destruct (le_lt_dec n (n+pos2nat p)); try omega.
+  Qed.
+
+End ra_mm_comp.
+
+Check ra_mm_compiler.
+Print Assumptions ra_mm_compiler.

--- a/theories/MuRec/ra_mm_env.v
+++ b/theories/MuRec/ra_mm_env.v
@@ -1,0 +1,1143 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.MM 
+  Require Import env mm_instr mm_env_utils. 
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+From Undecidability.MuRec 
+  Require Import recalg. 
+
+Set Implicit Arguments.
+
+Tactic Notation "rew" "length" := autorewrite with length_db.
+
+Local Notation "P // s ->> t" := (sss_compute (mm_sss_env eq_nat_dec) P s t).
+Local Notation "P // s -+> t" := (sss_progress (mm_sss_env eq_nat_dec) P s t).
+Local Notation "P // s -[ k ]-> t" := (sss_steps (mm_sss_env eq_nat_dec) P k s t).
+Local Notation "P // s ↓" := (sss_terminates (mm_sss_env eq_nat_dec ) P s). 
+
+Local Notation " e ⇢ x " := (@get_env _ _ e x).
+Local Notation " e ⦃  x ⇠ v ⦄ " := (@set_env _ _ eq_nat_dec e x v).
+Local Notation "x '⋈' y" := (forall i : nat, x⇢i = y⇢i :> nat) (at level 70, no associativity).
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Section ra_compiler.
+
+  Ltac dest x y := destruct (eq_nat_dec x y) as [ | ]; [ subst x | ]; rew env.
+
+  (** We compile f : recalg n 
+      into (nat indexed) MM code at i where 
+       a) inputs are indexed with registers between [p,p+n[, 
+       b) output is indexed by o
+       c) spare registers are indexed above m 
+
+      Generally, the hypotheses 
+       h0) o < m, 
+       h1) n+p <= m, 
+       h2) ~ p <= o < n+p
+      are needed to ensure compilation is possible. They avoid
+      clashes between inputs, output and spare registers 
+
+      Doing so allows us great freedom in the choice of
+      registers during compilation.
+
+      The result should be MM code that simulates the computation
+      of f from a state where spare registers value 0,
+      and the only register that is allowed to be modified 
+      is the output register
+    *)
+
+  Definition ra_compiled n (f : recalg n) i p o m :=
+    { P : list (mm_instr nat) |
+       (forall x v e, ⟦f⟧ v x 
+                   -> (forall i, m <= i -> e⇢i = 0)
+                   -> (forall q, e⇢(pos2nat q+p) = vec_pos v q) 
+                   -> exists e', e' ⋈ e⦃o⇠x⦄
+                              /\ (i,P) // (i,e) ->> (length P + i,e')) 
+    /\ (forall v e, (i,P) // (i,e) ↓
+                 -> (forall i, m <= i -> e⇢i = 0)
+                 -> (forall q, e⇢(pos2nat q+p) = vec_pos v q) 
+                 -> exists x, ⟦f⟧ v x) }.
+
+  Definition ra_compiler_spec n f :=
+    forall i p o m, o < m
+                 -> ~ p <= o < n+p
+                 -> n+p <= m
+                 -> @ra_compiled n f i p o m.
+
+  Hint Resolve sss_progress_compute.
+
+  Fact ra_compiler_cst c : ra_compiler_spec (ra_cst c). 
+  Proof.
+    red; simpl; intros i p o m H1 H2 H3.
+    exists (mm_set o m c i); split.
+    2: exists c; cbv; auto.
+    intros x v e; vec nil v; clear v.
+    intros E; simpl in E; red in E; subst x.
+    intros H4 H5.
+    rewrite mm_set_length.
+    destruct mm_set_progress 
+      with (dst := o) (zero := m) (n := c) (i := i) (e := e)
+      as (e' & G1 & G2); auto; try omega.
+    exists e'; split; auto.
+  Qed.
+
+  Fact ra_compiler_zero : ra_compiler_spec ra_zero. 
+  Proof.
+    red; simpl; intros i p o m H1 H2 H3.
+    exists (mm_set o m 0 i); split.
+    2: exists 0; cbv; auto.
+    intros x v e.
+    vec split v with a; vec nil v; clear v.
+    intros H4; cbv in H4; subst x.
+    intros H4 H5.
+    rewrite mm_set_length.
+    destruct mm_set_progress 
+      with (dst := o) (zero := m) (n := 0) (i := i) (e := e)
+      as (e' & G1 & G2); auto; try omega.
+    exists e'; split; auto.
+  Qed.
+
+  Fact ra_compiler_succ : ra_compiler_spec ra_succ.
+  Proof.
+    red; simpl; intros i p o m H1 H2 H3.
+    exists (mm_copy p o m (m+1) i ++ INC o :: nil); split.
+    2: intros v; exists (S (vec_head v)); cbv; auto.
+    intros x v e; vec split v with a; vec nil v; clear v.
+    intros H; simpl in H; red in H; simpl in H; subst x.
+    intros H4 H5.
+    specialize (H5 pos0); rewrite pos2nat_fst in H5; simpl in H5.
+    destruct mm_copy_progress 
+      with (src := p) (dst := o) (tmp := m) (zero := m+1) (i := i) (e := e)
+      as (e' & H7 & H8); try omega; try (apply H4; omega).
+    exists (e'⦃o⇠S a⦄); split.
+    * intros j; dest j o; rewrite H7; rew env.
+    * rew length. 
+      apply sss_compute_trans with (9+i, e').
+      - apply sss_progress_compute.
+        revert H8; apply subcode_sss_progress; auto.
+      - mm env INC with o.
+        mm env stop.
+        rewrite H7, H5; rew env.
+  Qed.
+
+  Fact ra_compiler_proj n q : ra_compiler_spec (@ra_proj n q).
+  Proof.
+    red; simpl; intros i p o m H1 H2 H3.
+    exists (mm_copy (pos2nat q+p) o m (m+1) i); split.
+    2: intros v; exists (vec_pos v q); cbv; auto.
+    intros x v e H; simpl in H; red in H; subst x.
+    intros H4 H5.
+    destruct mm_copy_progress 
+      with (src := pos2nat q+p) (dst := o) (tmp := m) (zero := m+1) (i := i) (e := e)
+      as (e' & H7 & H8); try omega; try (apply H4; omega);
+        try (generalize (pos2nat_prop q); omega).
+    exists e'; split.
+    * intros j; rewrite H7; dest j o.
+    * rew length; apply sss_progress_compute; auto.
+  Qed.
+
+  Section ra_compiler_comp.
+
+    Variable (n : nat).
+
+    Let ra_compiler_vec k (g : vec (recalg n) k) : 
+           (forall p, ra_compiler_spec (vec_pos g p))
+        -> forall i p o m,  
+                    o+k <= m
+                 -> n+p <= o
+                 -> { P : list (mm_instr nat) |
+       (forall v w e, (forall q, ⟦vec_pos g q⟧ v (vec_pos w q)) 
+                   -> (forall i, m <= i -> e⇢i = 0)
+                   -> (forall j, e⇢(pos2nat j+p) = vec_pos v j) 
+                   -> exists e', (forall j, ~ o <= j < o+k -> e'⇢j = e⇢j)
+                              /\ (forall q, e'⇢(pos2nat q+o) = vec_pos w q)
+                              /\ (i,P) // (i,e) ->> (length P + i,e')) 
+      /\ (forall v e, (i,P) // (i,e) ↓
+                   -> (forall i, m <= i -> e⇢i = 0)
+                   -> (forall q, e⇢(pos2nat q+p) = vec_pos v q) 
+                   -> (forall q, exists x, ⟦vec_pos g q⟧ v x)) }.
+    Proof.
+      induction g as [ | k f g IHg ]; intros Hg i p o m H1 H2.
+      + exists nil; split.
+        2: intros v e H3 H4 H5 q; analyse pos q.
+        intros v w e; vec nil w; clear w.
+        intros _ H3 H4.
+        exists e; split; [ | split ]; auto.
+        * intros q; analyse pos q.
+        * simpl; mm env stop.
+      + destruct (Hg pos0) with (i := i) (p := p) (o := o) (m := m)
+          as (P & HP1 & HP2); try omega.
+        destruct IHg with (i := length P+i) (p := p) (o := S o) (m := m)
+          as (Q & HQ1 & HQ2); try omega.
+        { intros q; apply (Hg (pos_nxt q)). }
+        exists (P++Q); split.
+        * intros v w e; vec split w with a. 
+          intros H3 H4 H5.
+          generalize (H3 pos0) (fun q => H3 (pos_nxt q)); clear H3; intros H6 H7.
+          simpl in H6, H7.
+          destruct (HP1 a v e) as (e1 & G1 & G2); auto.
+          destruct (HQ1 v w e1) as (e2 & G3 & G4 & G5); auto.
+          { intros j Hj; rewrite G1; dest j o; omega. }
+          { intros q; rewrite G1.
+            assert (pos2nat q+p <> o); try rew env.
+            generalize (pos2nat_prop q); omega. }
+          exists e2; split; [ | split ].
+          - intros j Hj.
+            rewrite G3, G1; try omega.
+            dest j o; omega.
+          - intros q; analyse pos q; simpl.
+            ++ rewrite pos2nat_fst, G3, G1; try omega.
+               simpl; rew env.
+            ++ rewrite pos2nat_nxt, <- G4; f_equal; omega.
+          - apply sss_compute_trans with (length P+i,e1).
+            ++ revert G2; apply subcode_sss_compute; auto.
+            ++ rew length.
+               revert G5; rewrite plus_assoc, (plus_comm _ (length _)).
+               apply subcode_sss_compute.
+               subcode_tac; rewrite <- app_nil_end; auto.
+        * intros v e H3 H4 H5.
+          assert ((i,P) // (i,e) ↓) as H6.
+          { apply subcode_sss_terminates with (2 := H3); auto. }
+          destruct (HP2 v) with (1 := H6) as (a & Ha); auto.
+          simpl in Ha.
+          destruct HP1 with (1 := Ha) (e := e)
+            as (e1 & G1 & G2); auto.
+          intros q; analyse pos q; simpl.
+          1: exists a; auto.
+          apply HQ2 with e1.
+          - assert ((i,P++Q) // (length P+i,e1) ↓) as H7.
+            { apply subcode_sss_terminates_inv 
+               with (2 := H3) (P := (i,P)) (st1 := (length P+i,e1)); auto.
+             * apply mm_sss_env_fun.
+             * split; simpl; auto; omega. }
+            destruct H7 as (st & H7 & H8).
+            assert ( (length P+i,Q) <sc (i,P++Q) ) as H9.
+            { subcode_tac; rewrite <- app_nil_end; auto. }
+            destruct subcode_sss_compute_inv 
+              with (P := (length P+i,Q)) (3 := H7)
+              as (st2 & F1 & _ & F2); auto.
+            { revert H8; apply subcode_out_code; auto. }
+            exists st2; split; auto.
+          - intros j Hj; rewrite G1; dest j o; omega.
+          - clear q; intros q; rewrite G1.
+            assert (pos2nat q+p <> o); try rew env.
+            generalize (pos2nat_prop q); omega.
+    Qed.
+
+    Variable (k : nat) (f : recalg k) (g : vec (recalg n) k)
+             (Hf : ra_compiler_spec f)
+             (Hg : forall q, ra_compiler_spec (vec_pos g q)).
+
+    (* compile (g[0])   input [p,p+n[   output m+0      spare m+k
+       compile (g[1])   input [p,p+n[   output m+1      spare m+k
+       ...
+       compile (g[k-1]) input [p,p+n[   output m+k-1    spare m+k
+       compile f        input [m,m+k[   output o        spare m+k
+       mm_multi_erase (m+k) (list_an m k) ...
+
+     *)
+
+    Fact ra_compiler_comp : ra_compiler_spec (ra_comp f g).
+    Proof.
+      red; simpl; intros i p o m H1 H2 H3.
+      destruct ra_compiler_vec with (1 := Hg) (i := i) (p := p) (o := m) (m := m+k)
+        as (P & HP1 & HP2); auto.
+      destruct Hf with (i := length P+i) (p := m) (o := o) (m := m+k)
+        as (Q & HQ1 & HQ2); try omega; auto.
+      exists (P++Q++mm_multi_erase m (k+m) k (length P+length Q+i)); split.
+      + intros x v e; simpl; intros (w & H4 & H8) H6 H7.
+        assert (forall q, ⟦vec_pos g q⟧ v (vec_pos w q)) as H5.
+        { intros q; generalize (H8 q); rewrite vec_pos_set; auto. }
+        clear H8.
+        destruct (HP1 v w e) as (e1 & G1 & G2 & G3); auto.
+        { intros; apply H6; omega. }
+        destruct (HQ1 x w e1) as (e2 & G4 & G5); auto.
+        { intros j Hj; rewrite G1, H6; omega. }
+        destruct mm_multi_erase_compute 
+          with (zero := k+m) (dst := m) (k := k) (i := length P+length Q+i) (e := e2)
+          as (e3 & G6 & G7 & G8); try omega; auto.
+        { rewrite G4, get_set_env_neq, G1, H6; omega. }
+        exists e3; split.
+        * intros j.
+          destruct (interval_dec m (k+m) j) as [ H | H ].
+          - rewrite G6, get_set_env_neq, H6; omega.
+          - rewrite G7, G4; try omega; dest j o.
+            apply G1; omega.
+        * rew length.
+          apply sss_compute_trans with (length P+i,e1).
+          { revert G3; apply subcode_sss_compute; auto. }
+          apply sss_compute_trans with (length P+length Q+i,e2).
+          { revert G5; rewrite plus_assoc, (plus_comm _ (length _)).
+            apply subcode_sss_compute; auto. }
+          replace (length P+(length Q+2*k)+i) 
+            with  (2*k+(length P+length Q+i)) by omega.
+          revert G8; apply subcode_sss_compute; auto.
+          subcode_tac; rewrite <- app_nil_end; auto. 
+    + intros v e H4 H5 H6.
+      assert ((i,P) // (i,e) ↓) as H7.
+      { revert H4; apply subcode_sss_terminates; auto. }
+      assert (forall q, ex (⟦vec_pos g q⟧ v)) as H8. 
+      { apply HP2 with (1 := H7) (3 := H6).
+        intros; apply H5; omega. }
+      apply vec_reif in H8; destruct H8 as (w & Hw).
+      destruct (HP1 v w e) as (e1 & G1 & G2 & G3); auto.
+      { intros; apply H5; omega. }
+      destruct (@HQ2 w e1) as (x & Hx); auto.
+      - apply subcode_sss_terminates 
+          with (Q := (i,P++Q++mm_multi_erase m (k + m) k (length P+length Q+i))); auto.
+        apply subcode_sss_terminates_inv with (2 := H4) (P := (i,P)); auto.
+        { apply mm_sss_env_fun. }
+        split; simpl; auto; omega.
+      - intros j Hj; rewrite G1, H5; omega.
+      - exists x, w; split; auto.
+        intros q; rewrite vec_pos_set; auto.
+    Qed.
+
+  End ra_compiler_comp.
+
+  Section ra_compiler_rec.
+
+    Variables (n : nat) (f : recalg n) (g : recalg (S (S n)))
+              (Hf : ra_compiler_spec f)
+              (Hg : ra_compiler_spec g).
+
+    (* i p o m 
+             
+              input = v0##<v>
+              
+              p : v0
+              [p+1,p+n] : v
+
+              m+0 : 0,...,v0
+              m+1 : g^_(f v)
+              [m+2,m+n+1] : <v>
+              m+n+1 : v0,v0-1,....,0
+              m+n+2 : 0 (zero)
+              m+n+3 : 0 (tmp)
+             
+    i:         copy [1+p,n+S p[ -> [m+2,n+m+2[
+    9n+i:      copy p           -> m+n+1
+    9+9n+i:    erase  m (utiliser m pour zero)
+   11+9n+i:    compile f ? (3+m) o (3+n+m)
+  11+l1+9n+i:  DEC p sauter vers 23+l1+l2+9n+i
+  12+l1+9n+i:  copier o -> m+1
+  21+l1+9n+i:  compile g ? m o (3+n+m)
+21+l1+l2+9n+i: INC m+1
+22+l1+l2+9n+i: DEC zero jmp (11+l1+9n+i)
+23+l1+l2+9n+i: efface [m+1,3+n+m[
+
+      *)
+
+    Variables (i p o m : nat)
+              (H1 : o < m) 
+              (H2 : ~ p <= o < S (n + p))
+              (H3 : S (n + p) <= m).
+
+    Notation v0   := (2+n+m).
+    Notation zero := (3+n+m).
+    Notation tmp  := (4+n+m).
+
+    Let Q1 := mm_multi_copy tmp zero n (1+p) (2+m) i
+           ++ mm_copy p v0 tmp zero (9*n+i)
+           ++ mm_erase m zero (9+9*n+i).
+
+    Let Q1_length : length Q1 = 11+9*n.
+    Proof. unfold Q1; rew length; omega. Qed.
+
+    Let F_full : ra_compiled f (11+9*n+i) (2+m) o zero.
+    Proof. apply Hf; omega. Qed.
+
+    Notation F := (proj1_sig F_full).
+    Let HF1 := proj1 (proj2_sig F_full).
+    Let HF2 := proj2 (proj2_sig F_full).
+
+    Let G_full : ra_compiled g (21+length F+9*n+i) m o zero.
+    Proof. apply Hg; omega. Qed.
+
+    Notation G := (proj1_sig G_full).
+    Let HG1 := proj1 (proj2_sig G_full).
+    Let HG2 := proj2 (proj2_sig G_full).
+
+    Let s2 := 11+length F+9*n+i.
+
+    Let Q2 := DEC v0 (23+length F+length G+9*n+i)
+           :: mm_copy o (1+m) tmp zero (12+length F+9*n+i)
+           ++ G
+           ++ INC m :: DEC zero s2 :: nil.
+
+    Let Q2_progress_O e :
+               e⇢v0 = 0
+            -> (s2,Q2) // (s2,e) -+> (length Q2+s2,e).
+    Proof.
+      intros G1.
+      unfold Q2.
+      mm env DEC 0 with v0 (23+length F+length G+9*n+i).
+      mm env stop; f_equal; rew length.
+      unfold s2; omega.
+    Qed.
+
+    Let Q2_progress_S x y v e :
+              (forall j, zero <= j -> e⇢j = 0)
+           -> (forall j, vec_pos v j = e⇢(pos2nat j+2+m))
+           -> e⇢v0 = S x
+           -> ⟦g⟧ (e⇢m##e⇢o##v) y
+           -> exists e', (forall j, j <> o -> j <> v0 -> j <> m -> j <> 1+m -> e'⇢j = e⇢j)
+                      /\ e'⇢o = y
+                      /\ e'⇢v0 = x
+                      /\ e'⇢m = S (e⇢m) 
+                      /\ e'⇢(1+m) = e⇢o
+                      /\ (s2,Q2) // (s2,e) -+> (s2,e').
+    Proof.
+      intros G1 G2 G3 G4.
+      set (e1 := e⦃v0⇠x⦄).
+      destruct (@mm_copy_progress o (1+m) tmp zero) 
+        with (i := 12+length F+9*n+i) (e := e1)
+        as (e2 & G5 & G6); try omega.
+      1,2: unfold e1; rewrite get_set_env_neq, G1; omega.
+      destruct HG1 with (e := e2) (1 := G4)
+        as (e3 & G7 & G8).
+      { intros j Hj; rewrite G5; unfold e1.
+        dest j (1+m); try omega.
+        dest j (2+n+m); try omega. }
+      { intros j.
+        rewrite G5; unfold e1.
+        analyse pos j.
+        * rewrite pos2nat_fst; simpl.
+          do 2 (rewrite get_set_env_neq; try omega).
+        * rewrite pos2nat_nxt, pos2nat_fst; rew env.
+          rewrite get_set_env_neq; auto; omega.
+        * do 2 rewrite pos2nat_nxt.
+          generalize (pos2nat_prop j); intro Hj.
+          do 2 (rewrite get_set_env_neq; try omega).
+          simpl; rewrite G2; f_equal; omega. }
+      exists (e3⦃m⇠S(e⇢m)⦄); msplit 5.
+      * intros j F1 F2 F3 F4; rew env.
+        rewrite G7; rew env.
+        rewrite G5; unfold e1; rew env.
+      * rewrite get_set_env_neq, G7; try omega; rew env.
+      * rewrite get_set_env_neq, G7; try omega.
+        rewrite get_set_env_neq, G5; try omega.
+        unfold e1; rewrite get_set_env_neq; try omega.
+        rew env.
+      * rew env.
+      * rewrite get_set_env_neq, G7; try omega.
+        rewrite get_set_env_neq, G5; try omega.
+        rew env; unfold e1.
+        rewrite get_set_env_neq; omega.
+      * unfold Q2.
+        mm env DEC S with v0 (23 + length F + length G + 9 * n + i) x.
+        apply sss_compute_trans with (21+length F+9*n+i,e2).
+        { apply sss_progress_compute.
+          unfold s2, Q2; revert G6; apply subcode_sss_progress; auto. }
+        apply sss_compute_trans with (length G+(21+length F+9*n+i), e3).
+        { unfold s2, Q2; revert G8; apply subcode_sss_compute; auto. }
+        mm env INC with m.
+        mm env DEC 0 with zero s2.
+        { rewrite get_set_env_neq; try omega.
+          rewrite G7, get_set_env_neq; try omega.
+          rewrite G5, get_set_env_neq; try omega.
+          unfold e1; rewrite get_set_env_neq; try omega.
+          apply G1; omega. }
+        mm env stop; do 3 f_equal.
+        rewrite G7, get_set_env_neq; try omega.
+        rewrite G5, get_set_env_neq; try omega.
+        unfold e1; rewrite get_set_env_neq; omega.
+    Qed.
+
+    Let Q2_progress_S_inv x v e :
+              (forall j, zero <= j -> e⇢j = 0)
+           -> (forall j, vec_pos v j = e⇢(pos2nat j+2+m))
+           -> e⇢v0 = S x
+           -> (s2,Q2) // (s2,e) ↓
+           -> exists y, ⟦g⟧ (e⇢m##e⇢o##v) y.
+    Proof.
+      intros G1 G2 G3 ((s & e') & (k & G4) & G5).
+      unfold fst in G5.
+      assert (G6 : exists e1, e1 ⋈  e⦃v0⇠x⦄⦃1+m⇠(e⇢o)⦄
+                           /\ (s2,Q2) // (s2,e) -+> (10+s2,e1)).
+      { destruct mm_copy_progress 
+          with (src := o) (dst := 1+m) (tmp := tmp) (zero := zero) 
+               (i := 12+length F+9*n+i) (e := e⦃v0⇠x⦄)
+          as (e2 & G6 & G7); try omega.
+        1,2: rewrite get_set_env_neq, G1; omega.
+        exists e2; split.
+        + intros j; rewrite G6; auto.
+          rewrite get_set_env_neq with (q := o); auto; omega.
+        + unfold Q2.
+          mm env DEC S with v0 (23+length F+length G+9*n+i) x.
+          replace (1+s2) with (12+length F+9*n+i).
+          replace (10+s2) with (9+(12+length F+9*n+i)).
+          apply sss_progress_compute.
+          revert G7; apply subcode_sss_progress; auto.
+          unfold s2; omega.
+          unfold s2; omega. }
+      destruct G6 as (e1 & G6 & G7).
+      destruct subcode_sss_progress_inv with (4 := G7) (5 := G4)
+        as (k' & G8 & G9); auto.
+      { apply mm_sss_env_fun. }
+      { apply subcode_refl. }
+      apply HG2 with (e := e1).
+      apply subcode_sss_terminates with (Q := (s2,Q2)).
+      * unfold Q2; auto.
+      * exists (s,e'); split; auto.
+        exists k'; apply G9.
+      * intros j Hj; rewrite G6, get_set_env_neq, get_set_env_neq; auto; omega.
+      * intros j; rewrite G6; analyse pos j.
+        + rewrite pos2nat_fst; simpl. 
+          do 2 (rewrite get_set_env_neq; try omega).
+        + rewrite pos2nat_nxt, pos2nat_fst; rew env.
+        + do 2 rewrite pos2nat_nxt; simpl.
+          generalize (pos2nat_prop j); intros G10.
+          do 2 (rewrite get_set_env_neq; try omega).
+          rewrite G2; f_equal; omega.
+    Qed.
+ 
+    Let Q2_compute_rec (v : vec nat n) e s k :
+              (forall j, zero <= j -> e⇢j = 0)
+           -> (forall j, vec_pos v j = e⇢(pos2nat j+2+m))
+           -> e⇢o = s 0
+           -> e⇢v0 = k
+           -> (forall i, i < k -> ⟦g⟧ (i+(e⇢m)##s i##v) (s (S i)))
+  -> exists e', (forall j, j <> o -> j <> v0 -> j <> m -> j <> 1+m -> e'⇢j = e⇢j)
+             /\ e'⇢o     = s k
+             /\ e'⇢v0    = 0
+             /\ e'⇢m     = (e⇢v0)+(e⇢m)
+             /\ (s2,Q2) // (s2,e) -+> (length Q2+s2,e').
+    Proof.
+      revert e s; induction k as [ | k IHk ]; intros e s G1 G2 G3 G4 G5.
+      + exists e; msplit 4; auto; rewrite G4; auto.
+      + generalize (G5 0); intros G6; spec in G6; try omega.
+        rewrite <- G3 in G6; simpl in G6.
+        destruct Q2_progress_S with (3 := G4) (4 := G6)
+          as (e1 & F1 & F2 & F3 & F4 & F5 & F6); auto.
+        destruct IHk with (s := fun i => s (S i)) (e := e1)
+          as (e2 & T1 & T2 & T3 & T4 & T5); auto.
+        * intros; rewrite F1, G1; omega.
+        * intros j; generalize (pos2nat_prop j); intro.
+          rewrite F1, G2; auto; omega.
+        * intros j Hj.
+          rewrite F4.
+          replace (j+S(e⇢m)) with ((S j)+(e⇢m)) by omega. 
+          apply G5; omega.
+        * exists e2; msplit 4; auto.
+          - intros j ? ? ? ?; rewrite T1; auto.
+          - rewrite T4, F3, F4, G4; omega.
+          - apply sss_progress_trans with (1 := F6); auto.
+    Qed.
+
+    Let Q2_compute_rev (v : vec nat n) e  :
+              (forall j, zero <= j -> e⇢j = 0)
+           -> (forall j, vec_pos v j = e⇢(pos2nat j+2+m))
+           -> (s2,Q2) // (s2,e) ↓
+           -> exists s, s 0 = e⇢o /\ forall i, i < e⇢v0 -> ⟦g⟧ (i+(e⇢m)##s i##v) (s (S i)).
+    Proof.
+      intros G1 G2 ((u & e') & (k & G3) & G4).
+      unfold fst in G4.
+      revert e e' G1 G2 G3 G4.
+      induction on k as IHk with measure k.
+      intros e e' G1 G2 G3 G0.
+      case_eq (e⇢v0).
+      + intros ?; exists (fun _ => e⇢o); split; auto; intros; omega.
+      + intros x Hx.
+        destruct Q2_progress_S_inv 
+          with (1 := G1) (2 := G2) (3 := Hx)
+          as (y & Hy).
+        { exists (u,e'); split; auto; exists k; auto. }
+        destruct Q2_progress_S with (3 := Hx) (4 := Hy)
+          as (e1 & G4 & G5 & G6 & G7 & G8 & G9); auto.
+        destruct subcode_sss_progress_inv with (4 := G9) (5 := G3)
+          as (k' & F1 & F2); auto.
+        { apply mm_sss_env_fun. }
+        { apply subcode_refl. }
+        apply IHk in F2; auto.
+        * destruct F2 as (s & Hs1 & Hs2).
+          exists (fun i => match i with 0 => e⇢o | S i => s i end); split; auto.
+          intros [ | j ] Hj; simpl.
+          - rewrite Hs1, G5; auto.
+          - specialize (Hs2 j).
+            rewrite G7 in Hs2.
+            replace (S (j+(e⇢m))) with (j+S(e⇢m)) by omega.
+            apply Hs2; omega.
+        * intros j Hj; rewrite G4, G1; omega.
+        * intros j; rewrite G2, G4; try omega.
+          generalize (pos2nat_prop j); intro; omega.
+    Qed.
+
+    Let Q2_length : length Q2 = 12+length G.
+    Proof. unfold Q2; rew length; ring. Qed.
+
+    Let Q3 := mm_multi_erase m zero (2+n) (23+length F+length G+9*n+i).
+
+    Let Q3_length : length Q3 = 4+2*n.
+    Proof. unfold Q3; rew length; ring. Qed.
+    
+    Let Q1_progress e :
+                (forall j, zero <= j -> e⇢j = 0)
+  -> exists e', (forall j, j < n -> e'⇢(j+2+m) = e⇢(j+1+p))
+             /\ e'⇢v0 = e⇢p  
+             /\ e'⇢m = 0 
+             /\ (forall j, j <> m -> ~ 2+m <= j <= v0 -> e'⇢j = e⇢j)
+             /\ (i,Q1) // (i,e) -+> (length Q1+i,e').
+    Proof.
+      intros G3.
+      destruct (@mm_multi_copy_compute tmp zero n (1+p) (2+m))
+        with (i := i) (e := e) 
+        as (e1 & G4 & G5 & G6); try omega.
+      1,2: apply G3; omega.
+      destruct (@mm_copy_progress p v0 tmp zero) 
+        with (i := 9*n+i) (e := e1) 
+        as (e2 & G7 & G8); try omega.
+      1,2: rewrite G5, G3; omega.
+      destruct (@mm_erase_progress m zero)
+        with (i := 9+9*n+i) (e := e2)
+        as (e3 & G9 & G10); try omega.
+      1: rewrite G7, get_set_env_neq, G5, G3; omega.
+      exists e3; msplit 4.
+      * intros j Hj.
+        rewrite G9, get_set_env_neq,
+                G7, get_set_env_neq, 
+                <- plus_assoc, G4; try omega.
+        f_equal; omega.
+      * rewrite G9, get_set_env_neq, G7; rew env; try omega.
+        rewrite G5; omega.
+      * rewrite G9; rew env.
+      * intros j Hj1 Hj2.
+        rewrite G9; rew env.
+        rewrite G7, get_set_env_neq, G5; omega.
+      * rewrite Q1_length; unfold Q1.
+        apply sss_compute_progress_trans with (9*n+i,e1).
+        { revert G6; apply subcode_sss_compute; auto. }
+        apply sss_progress_trans with (9+(9*n+i), e2).
+        { revert G8; apply subcode_sss_progress; auto. }
+        { rewrite plus_assoc; revert G10.
+          apply subcode_sss_progress; auto. }
+    Qed.
+
+    Notation Q4 := (Q1++F++Q2++Q3).
+
+    Let Q4_progress (v : vec nat (S n)) x e :
+                 (forall j, m <= j -> e⇢j = 0)
+              -> (forall j, vec_pos v j = e⇢(pos2nat j+p))
+              -> s_rec ⟦f⟧ ⟦g⟧ v x
+  -> exists e', (forall j, j <> o -> e'⇢j = e⇢j)
+              /\ e'⇢o     = x
+              /\ (i,Q4) // (i,e) -+> (length Q4+i,e').
+    Proof.
+      vec split v with k.
+      intros G1 G2 G3.
+      rewrite s_rec_eq in G3.
+      destruct G3 as (s & G3 & G4 & G5); simpl vec_head in *; simpl vec_tail in *.
+      generalize (G2 pos0); rewrite pos2nat_fst; intros G0; simpl in G0.
+      generalize (fun j => G2 (pos_nxt j)); clear G2; intros G2; simpl in G2.
+      destruct Q1_progress with (e := e) as (e1 & F1 & F2 & F3 & F4 & F5).
+      { intros; apply G1; omega. }
+      assert (forall j, e1 ⇢ pos2nat j + (2 + m) = vec_pos v j) as G6.
+      { intros j; rewrite G2, pos2nat_nxt.
+        replace (S (pos2nat j)+p) with (pos2nat j+1+p) by omega.
+        generalize (pos2nat_prop j); intros H.
+        rewrite <- F1; auto; f_equal; omega. }
+      destruct HF1 with (1 := G3) (e := e1) as (e2 & F6 & F7); auto.
+      { intros j Hj; rewrite F4, G1; omega. }
+      destruct Q2_compute_rec with (e := e2) (v := v) (s := s) (k := k)
+        as (e3 & F10 & F11 & F12 & _ & F14).
+      { intros j Hj; rewrite F6, get_set_env_neq, F4, G1; try omega. }
+      { intros j; rewrite <- G6, F6, get_set_env_neq; try omega.
+        f_equal; omega. }
+      { rewrite F6; rew env. }
+      { rewrite F6, get_set_env_neq, F2; omega. }
+      { intros j Hj.
+        rewrite F6, get_set_env_neq, F3, plus_comm; try omega.
+        simpl; apply G5; auto. }
+      destruct mm_multi_erase_compute 
+        with (zero := zero) (dst := m) (k := 2+n) (e := e3)
+             (i := 23+length F+length G+9*n+i)
+        as (e4 & F20 & F21 & F22); try omega.
+      { rewrite F10, F6, get_set_env_neq, F4, G1; omega. }
+      exists e4; msplit 2.
+      * intros j Hj.
+        dest j (2+n+m).
+        { rewrite F21, F12, G1; omega. }
+        destruct (interval_dec m v0 j).
+        - rewrite F20, G1; omega.
+        - rewrite F21, F10, F6, get_set_env_neq, F4; try omega.
+      * rewrite F21; try omega.
+      * rew length.
+        apply sss_progress_trans with (length Q1+i,e1).
+        { revert F5; apply subcode_sss_progress; auto. }
+        apply sss_compute_progress_trans with (length F+length Q1+i,e2).
+        { rewrite Q1_length.
+          replace (length F+(11+9*n)+i) with (length F+(11+9*n+i)) by omega.
+          revert F7; apply subcode_sss_compute; auto. }
+        apply sss_progress_compute_trans with (length Q2+s2,e3).
+        { replace (length F+length Q1+i) with s2.
+          revert F14; apply subcode_sss_progress; auto.
+          unfold s2; rewrite Q1_length; omega. }
+        { replace (length Q2+s2) with (23+length F+length G+9*n+i).
+          replace (length Q1+(length F+(length Q2+length Q3))+i)
+             with (2*(2+n)+(23+length F+length G+9*n+i)).
+          revert F22; apply subcode_sss_compute; auto.
+          unfold Q3; subcode_tac; rewrite <- app_nil_end; auto.
+          rewrite Q1_length, Q2_length, Q3_length; omega.
+          rewrite Q2_length; unfold s2; omega. }
+    Qed.
+
+    Let Q4_compute_rev (v : vec nat (S n)) e :
+                 (forall j, m <= j -> e⇢j = 0)
+              -> (forall j, vec_pos v j = e⇢(pos2nat j+p))
+              -> (i,Q4) // (i,e) ↓
+              -> exists x, s_rec ⟦f⟧ ⟦g⟧ v x.
+    Proof.
+      vec split v with k.
+      intros G1 G2 G3.
+      destruct Q1_progress with (e := e)
+        as (e1 & G4 & G5 & G6 & G7 & G8); auto.
+      { intros; apply G1; omega. }
+      generalize G3; intros G0.
+      apply subcode_sss_terminates_inv 
+        with (P := (i,Q1)) (st1 := (length Q1+i,e1)) in G3; auto.
+      2: apply mm_sss_env_fun.
+      2: { split.
+           + apply sss_progress_compute; auto.
+           + unfold out_code, code_end, fst, snd; omega. }
+      assert (G9 : forall q : pos n, e1 ⇢ pos2nat q + (2 + m) = vec_pos v q).
+      { intros j; specialize (G2 (pos_nxt j)); simpl in G2.
+        rewrite G2, pos2nat_nxt, plus_assoc, G4.
+        + f_equal; omega.
+        + apply pos2nat_prop. }
+      destruct HF2 with (v := v) (e := e1)
+        as (x & Hx); auto.
+      { rewrite Q1_length in G3.
+        revert G3; apply subcode_sss_terminates; auto. }
+      { intros j Hj; rewrite G7, G1; omega. }
+      destruct HF1 with (1 := Hx) (e := e1)
+        as (e2 & F1 & F2); auto.
+      { intros j Hj; rewrite G7, G1; omega. }
+      destruct Q2_compute_rev with (v := v) (e := e2)
+        as (s & Hs1 & Hs2).
+      { intros j Hj; rewrite F1, get_set_env_neq, G7, G1; omega. }
+      { intros j; rewrite <- G9, F1, get_set_env_neq.
+        + f_equal; omega.
+        + omega. }
+      { apply subcode_sss_terminates with (i, Q4).
+        1: unfold s2; auto.
+        apply subcode_sss_terminates_inv with (P := (i,Q1++F)) (2 := G3); auto.
+        1: apply mm_sss_env_fun.
+        1: rewrite <- app_ass; apply subcode_left; auto.
+        split.
+        + rewrite Q1_length.
+          replace s2 with (length F+(11+9*n+i)).
+          revert F2; apply subcode_sss_compute; auto.
+          subcode_tac; rewrite <- app_nil_end; auto.
+          unfold s2; omega.
+        + unfold out_code, code_end, fst, snd.
+          rew length; rewrite Q1_length; unfold s2; omega. }
+      assert (k = e2⇢v0) as Hk.
+      { rewrite F1, get_set_env_neq; try omega.
+        rewrite G5; apply (G2 pos0). }
+      exists (s k).
+      apply s_rec_eq; exists s; msplit 2; auto.
+      * simpl; rewrite Hs1, F1; rew env.
+      * simpl; rewrite Hk; intros j Hj.
+        specialize (Hs2 j Hj).
+        rewrite F1, get_set_env_neq, G6, plus_comm in Hs2; auto; omega.
+    Qed.
+
+    Fact ra_compiler_rec : ra_compiled (ra_rec f g) i p o m.
+    Proof.
+      exists Q4; split.
+      + intros x v e; simpl ra_rel; intros G1 G2 G3.
+        destruct Q4_progress with (3 := G1) (e := e)
+          as (e' & G4 & G5 & G6); auto.
+        exists e'; split.
+        * intros j; dest j o.
+        * apply sss_progress_compute; auto.
+      + intros v e G1 G2 G3.
+        apply Q4_compute_rev with (e := e); auto.
+    Qed.
+
+  End ra_compiler_rec.
+
+  Section ra_compiler_min.
+
+    Variables (n : nat) (f : recalg (S n)) (Hf : ra_compiler_spec f).
+
+    (* i p o m 
+             
+              input = <v>
+              
+              [p,p+n[ : v
+
+              m+0 : 0,1,...,
+              [m+1,m+n] : <v>
+              m+n+1 : 0 (zero)
+              m+n+2 : 0 (tmp)
+             
+           i:  copy [p,p+n[ -> [m+1,n+m+1[
+        9n+i:  erase  m 
+      2+9n+i:  compile f ? m o zero
+   2+l1+9n+i:  DEC o sauter vers ?
+   3+l1+9n+i:  INC m
+   4+l1+9n+i:  DEC zero jmp (2+9n+i)
+   5+l1+9n+i:  copy m -> o
+  14+l1+9n+i:  efface [m,n+m]
+
+    *)
+
+    Variables (i p o m : nat)
+              (H1 : o < m) 
+              (H2 : ~ p <= o < n + p)
+              (H3 : n + p <= m).
+
+    Notation zero := (1+n+m).
+    Notation tmp  := (2+n+m).
+
+    Let Q1 := mm_multi_copy tmp zero n p (1+m) i
+           ++ mm_erase m zero (9*n+i).
+
+    Let Q1_length : length Q1 = 2+9*n.
+    Proof. unfold Q1; rew length; omega. Qed.
+
+    Let s1 := length Q1 + i.
+
+    Let F_full : ra_compiled f s1 m o zero.
+    Proof. apply Hf; omega. Qed.
+
+    Notation F := (proj1_sig F_full).
+    Let HF1 := proj1 (proj2_sig F_full).
+    Let HF2 := proj2 (proj2_sig F_full).
+
+    Let Q2 := F
+           ++ DEC o (3+length F+s1)
+           :: INC m 
+           :: DEC zero s1 
+           :: nil.
+
+    Let Q2_length : length Q2 = 3+length F.
+    Proof. unfold Q2; rew length; omega. Qed.
+
+    Let Q1_progress e :
+                (forall j, zero <= j -> e⇢j = 0)
+  -> exists e', (forall j, j < n -> e'⇢(j+1+m) = e⇢(j+p)) 
+             /\ e'⇢m = 0 
+             /\ (forall j, ~ m <= j <= n+m -> e'⇢j = e⇢j)
+             /\ (i,Q1) // (i,e) -+> (length Q1+i,e').
+    Proof.
+      intros G1.
+      destruct (@mm_multi_copy_compute tmp zero n p (1+m))
+        with (i := i) (e := e) 
+        as (e1 & G4 & G5 & G6); try omega.
+      1,2: apply G1; omega.
+      destruct (@mm_erase_progress m zero)
+        with (i := 9*n+i) (e := e1)
+        as (e2 & G9 & G10); try omega.
+      1: rewrite G5, G1; omega.
+      exists e2; msplit 3.
+      * intros; rewrite G9, get_set_env_neq, <- plus_assoc, G4; auto; omega.
+      * rewrite G9; rew env.
+      * intros; rewrite G9, get_set_env_neq, G5; auto; omega. 
+      * rewrite Q1_length; unfold Q1.
+        apply sss_compute_progress_trans with (9*n+i,e1).
+        { revert G6; apply subcode_sss_compute; auto. }
+        { replace (2+9*n+i) with (2+(9*n+i)) by omega.
+          revert G10; apply subcode_sss_progress; auto. }
+    Qed.
+
+    Let Q2_0_progress v e : 
+                (forall j, zero <= j -> e⇢j = 0)
+             -> (forall j, vec_pos v j = e⇢(pos2nat j+1+m))
+             -> ⟦f⟧ (e⇢m##v) 0
+  -> exists e', (forall j, j <> o -> e'⇢j = e⇢j)
+             /\ e'⇢o = 0 
+             /\ (s1,Q2) // (s1,e) -+> (length Q2+s1,e').
+    Proof.
+      intros G1 G2 G3.
+      destruct HF1 with (1 := G3) (e := e) as (e1 & G4 & G5); auto.
+      { intros j; analyse pos j; simpl.
+        * rewrite pos2nat_fst; auto.
+        * rewrite pos2nat_nxt, G2; f_equal; omega. }
+      exists e1; msplit 2.
+      1,2: intros; rewrite G4; rew env.
+      apply sss_compute_progress_trans with (length F+s1,e1).
+      * unfold Q2; revert G5; apply subcode_sss_compute; auto.
+      * rewrite Q2_length; unfold Q2.
+        mm env DEC 0 with o (3+length F+s1).
+        1: rewrite G4; rew env.
+        mm env stop.
+    Qed.
+
+    Let Q2_S_progress x v e : 
+                (forall j, zero <= j -> e⇢j = 0)
+             -> (forall j, vec_pos v j = e⇢(pos2nat j+1+m))
+             -> ⟦f⟧ (e⇢m##v) (S x)
+  -> exists e', (forall j, j <> o -> j <> m -> e'⇢j = e⇢j)
+             /\ e'⇢o = x
+             /\ e'⇢m = S (e⇢m)
+             /\ (s1,Q2) // (s1,e) -+> (s1,e').
+    Proof.
+      intros G1 G2 G3.
+      destruct HF1 with (1 := G3) (e := e) as (e1 & G4 & G5); auto.
+      { intros j; analyse pos j; simpl.
+        * rewrite pos2nat_fst; auto.
+        * rewrite pos2nat_nxt, G2; f_equal; omega. }
+      exists (e1⦃o⇠x⦄⦃m⇠S (e⇢m)⦄); msplit 3.
+      1,3: intros; rew env; rewrite G4; rew env.
+      1: dest o m; omega.
+      apply sss_compute_progress_trans with (length F+s1,e1).
+      { unfold Q2; revert G5; apply subcode_sss_compute; auto. }
+      unfold Q2.
+      mm env DEC S with o (3 + length F + s1) x.
+      { rewrite G4; rew env. }
+      mm env INC with m.
+      mm env DEC 0 with zero s1.
+      { do 2 (rewrite get_set_env_neq; try omega).
+        rewrite G4, get_set_env_neq, G1; omega. }
+      mm env stop; f_equal.
+      dest o m; try omega.
+      rewrite G4; rew env.
+    Qed.
+
+    Let Q2_progress_rec v e k :
+                (forall j, zero <= j -> e⇢j = 0)
+             -> (forall j, vec_pos v j = e⇢(pos2nat j+1+m))
+             -> (forall i, i < k -> exists x, ⟦f⟧ (i+(e⇢m)##v) (S x))
+  -> exists e', (forall j, j <> o -> j <> m -> e'⇢j = e⇢j)
+             /\ e'⇢m = k+(e⇢m)
+             /\ (s1,Q2) // (s1,e) ->> (s1,e').
+    Proof.
+      revert e; induction k as [ | k IHk ]; intros e G1 G2 G3.
+      + exists e; msplit 2; auto; mm env stop.
+      + destruct (G3 0) as (x & Hx); try omega; simpl in Hx.
+        destruct Q2_S_progress 
+          with (v := v) (e := e) (x := x)
+          as (e1 & G4 & _ & G5 & G6); auto.
+        destruct IHk with (e := e1)
+          as (e2 & G7 & G8 & G9).
+        { intros; rewrite G4, G1; omega. }
+        { intros j; rewrite G2, G4; auto; omega. }
+        { intros j Hj; rewrite G5.
+          replace (j+S(e⇢m)) with ((S j)+(e⇢m)) by omega.
+          apply G3; omega. }
+        exists e2; msplit 2.
+        * intros; rewrite G7, G4; auto.
+        * rewrite G8, G5; omega.
+        * apply sss_compute_trans with (2 := G9).
+          apply sss_progress_compute; auto.
+    Qed.
+
+    Let Q2_compute_rev v e :
+              (forall j, zero <= j -> e⇢j = 0)
+           -> (forall j, vec_pos v j = e⇢(pos2nat j+1+m))
+           -> (s1,Q2) // (s1,e) ↓
+           -> exists k, ⟦f⟧ (k+(e⇢m)##v) 0 /\ forall j, j < k -> exists x, ⟦f⟧ (j+(e⇢m)##v) (S x).
+    Proof.
+      intros G1 G2 ((s2,e') & (q & G3) & G4); simpl fst in G4.
+      revert e G1 G2 G3.
+      induction on q as IHq with measure q.
+      intros e G1 G2 G3.
+      destruct HF2 with (e := e) (v := (e⇢m)##v)
+        as ([ | x ] & Hx); auto.
+      { apply subcode_sss_terminates with (Q := (s1,Q2)).
+        + unfold Q2; auto.
+        + exists (s2,e'); split; auto; exists q; auto. }
+      { intros j; analyse pos j.
+        + rewrite pos2nat_fst; auto.
+        + rewrite pos2nat_nxt; simpl.
+          rewrite G2; f_equal; omega. }
+      * exists 0; split; auto; intros; omega.
+      * destruct Q2_S_progress with (v := v) (e := e) (x := x)
+          as (e1 & F1 & F2 & F3 & F4); auto.
+        destruct subcode_sss_progress_inv with (4 := F4) (5 := G3)
+          as (q' & F5 & F6); auto.
+        { apply mm_sss_env_fun. }
+        { apply subcode_refl. }
+        destruct IHq with (4 := F6)
+          as (k & Hk1 & Hk2); try omega.
+        { intros; rewrite F1, G1; omega. }
+        { intros; rewrite G2, F1; auto; omega. }
+        exists (S k); split.
+        + rewrite F3 in Hk1.
+          eq goal Hk1; do 2 f_equal; omega.
+        + intros [ | j ] Hj.
+          - simpl; exists x; auto.
+          - replace (S j + (e⇢m)) with (j+(e1⇢m)).
+            apply Hk2; omega.
+            rewrite F3; omega.
+    Qed.
+
+    Let Q2_progress v e k :
+                (forall j, zero <= j -> e⇢j = 0)
+             -> (forall j, vec_pos v j = e⇢(pos2nat j+1+m))
+             -> e⇢m = 0
+             -> s_min ⟦f⟧ v k
+  -> exists e', (forall j, j <> o -> j <> m -> e'⇢j = e⇢j)
+             /\ e'⇢m = k
+             /\ (s1,Q2) // (s1,e) -+> (length Q2+s1,e').
+    Proof.
+      intros G1 G2 G3 (G4 & G5).
+      destruct Q2_progress_rec with (e := e) (k := k) (v := v)
+        as (e1 & G6 & G7 & G8); auto.
+      { intros; rewrite G3, plus_comm; auto. }
+      destruct Q2_0_progress with (v := v) (e := e1)
+        as (e2 & G9 & _ & G11).
+      { intros; rewrite G6, G1; omega. }
+      { intros j; rewrite G2, G6; omega. }
+      { rewrite G7, G3, plus_comm; auto. }
+      exists e2; msplit 2.
+      * intros; rewrite G9, G6; auto.
+      * rewrite G9, G7, G3; omega.
+      * apply sss_compute_progress_trans with (s1,e1); auto.
+    Qed.
+
+    Let s4 := length Q1+length Q2+i.
+
+    Let Q4 := Q1 ++ Q2 
+           ++ mm_copy m o tmp zero s4
+           ++ mm_multi_erase m zero (1+n) (9+s4).
+
+    Let Q4_progress v e x :
+                 (forall j, m <= j -> e⇢j = 0)
+              -> (forall j, vec_pos v j = e⇢(pos2nat j+p))
+              -> s_min ⟦f⟧ v x
+  -> exists e', (forall j, j <> o -> e'⇢j = e⇢j)
+              /\ e'⇢o = x
+              /\ (i,Q4) // (i,e) -+> (length Q4+i,e').
+    Proof.
+      intros G1 G2 G3.
+      destruct Q1_progress with (e := e)
+        as (e1 & G4 & G5 & G6 & G7).
+      { intros j Hj; apply G1; omega. }
+      destruct Q2_progress with (v := v) (e := e1) (k := x)
+        as (e2 & G8 & G9 & G10); auto.
+      { intros j Hj; rewrite G6, G1; omega. }
+      { intros j; rewrite G2, G4; auto; apply pos2nat_prop. }
+      destruct mm_copy_progress
+        with (src := m) (dst := o) (tmp := tmp) (zero := zero)
+             (i := s4) (e := e2)
+        as (e3 & F1 & F2); try omega.
+      1,2: rewrite G8, G6, G1; omega.
+      destruct mm_multi_erase_compute 
+        with (dst := m) (zero := zero) (k := 1+n)
+             (i := 9+s4) (e := e3)
+        as (e4 & F3 & F4 & F5); try omega.
+      { rewrite F1, get_set_env_neq, G8, G6, G1; omega. }
+      exists e4; msplit 2.
+      * intros j Hj.
+        destruct (interval_dec m zero j).
+        + rewrite F3, G1; omega.
+        + rewrite F4, F1; rew env; try omega.
+          rewrite G8, G6; omega.
+      * rewrite F4, F1, G9; rew env; omega.
+      * apply sss_progress_trans with (length Q1+i,e1).
+        { unfold Q4; revert G7; apply subcode_sss_progress; auto. }
+        apply sss_progress_trans with (length Q2+s1,e2).
+        { unfold s1 at 1 in G10; revert G10; unfold Q4; apply subcode_sss_progress; auto. }
+        apply sss_progress_compute_trans with (9+s4,e3).
+        { replace (length Q2+s1) with s4.
+          unfold Q4; revert F2; apply subcode_sss_progress; auto.
+          unfold s4, s1; omega. }
+        { replace (length Q4+i) with (2*(1+n)+(9+s4)).
+          unfold Q4; revert F5; apply subcode_sss_compute; auto.
+          subcode_tac; rewrite <- app_nil_end; auto.
+          unfold s4, Q4; rew length; omega. }
+    Qed.
+
+    Let Q4_terminates v e :
+                 (forall j, m <= j -> e⇢j = 0)
+              -> (forall j, vec_pos v j = e⇢(pos2nat j+p))
+              -> (i,Q4) // (i,e) ↓
+              -> exists x, s_min ⟦f⟧ v x.
+    Proof.
+      intros G1 G2 G3.
+       destruct Q1_progress with (e := e)
+        as (e1 & G4 & G5 & G6 & G7).
+      { intros j Hj; apply G1; omega. }
+      apply subcode_sss_terminates_inv 
+        with (P := (i,Q1)) (st1 := (s1,e1)) in G3.
+      * apply subcode_sss_terminates with (P := (s1,Q2)) in G3.
+        + apply Q2_compute_rev with (v := v) in G3.
+          - destruct G3 as (x & F1 & F2).
+            rewrite G5, plus_comm in F1.
+            exists x; split; auto.
+            intros j Hj; specialize (F2 _ Hj).
+            rewrite G5, plus_comm in F2; auto.
+          - intros; rewrite G6, G1; omega.
+          - intros; rewrite G2, G4; auto; apply pos2nat_prop.
+        + unfold Q4, s1; auto.
+      * apply mm_sss_env_fun.
+      * unfold Q4; auto.
+      * unfold s1; split.
+        + apply sss_progress_compute; auto.
+        + unfold out_code, code_end, fst, snd; omega.
+    Qed.
+
+    Fact ra_compiler_min : ra_compiled (ra_min f) i p o m.
+    Proof.
+      exists Q4; split.
+      + intros x v e; simpl ra_rel; intros G1 G2 G3.
+        destruct Q4_progress with (3 := G1) (e := e)
+          as (e' & G4 & G5 & G6); auto.
+        exists e'; split.
+        * intros j; dest j o.
+        * apply sss_progress_compute; auto.
+      + intros v e G1 G2 G3.
+        apply Q4_terminates with (e := e); auto.
+    Qed.
+
+  End ra_compiler_min.
+
+  Theorem ra_compiler n f : @ra_compiler_spec n f.
+  Proof.
+    induction f as [ c | | | n q | n k f g Hf Hg | | ].
+    + apply ra_compiler_cst.
+    + apply ra_compiler_zero.
+    + apply ra_compiler_succ.
+    + apply ra_compiler_proj.
+    + apply ra_compiler_comp; trivial.
+    + intros i p o m ? ? ?; apply ra_compiler_rec; auto.
+    + intros i p o m ? ? ?; apply ra_compiler_min; auto.
+  Qed. 
+
+  Corollary ra_mm_env_simulator n (f : recalg n) : 
+              { P | (forall v x e, ⟦f⟧ v x 
+                               -> (forall p, e⇢(pos2nat p) = vec_pos v p)
+                               -> (forall j, n < j -> e⇢j = 0)
+                               -> exists e', e' ⋈ e⦃n⇠x⦄
+                                          /\ (1,P) // (1,e) ->> (1+length P,e'))
+                 /\ (forall v e,  (1,P) // (1,e) ↓
+                               -> (forall p, e⇢(pos2nat p) = vec_pos v p)
+                               -> (forall j, n < j -> e⇢j = 0)
+                               -> exists x, ⟦f⟧ v x) }.
+  Proof.
+    destruct (ra_compiler f) with (i := 1) (p := 0) (o := n) (m := S n)
+      as (P & H1 & H2); try omega.
+    exists P; split.
+    + intros v x e H3 H4 H5.
+      rewrite plus_comm; apply H1 with (v := v); auto.
+      intros; rewrite plus_comm; simpl; auto.
+    + intros v e H3 H4 H5.
+      apply H2 with (1 := H3); auto.
+      intros; rewrite plus_comm; simpl; auto.
+  Qed.
+
+End ra_compiler.
+
+Check ra_mm_env_simulator.

--- a/theories/MuRec/ra_utils.v
+++ b/theories/MuRec/ra_utils.v
@@ -1,0 +1,1299 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Eqdep_dec Omega.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_nat gcd sums.
+
+From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
+
+From Undecidability.MuRec Require Import recalg.
+
+Set Implicit Arguments.
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+
+Local Notation power := (mscal mult 1).
+
+Section iter.
+
+  Variable (X : Type) (f : X -> X). 
+
+  Fixpoint iter n x :=
+    match n with 
+      | 0   => x
+      | S n => f (iter n x)
+    end.
+
+  Fact iter_plus n m x : iter (n+m) x = iter n (iter m x).
+  Proof. induction n; simpl; f_equal; auto. Qed.
+
+  Fact iter_S n x : iter (S n) x = iter n (f x).
+  Proof. replace (S n) with (n+1) by omega; apply iter_plus. Qed.
+
+End iter.
+
+Section div_mult.
+
+  Variable (p q : nat) (Hp : p <> 0) (Hq : q <> 0).
+
+  Fact div_rem_mult n : div n (p*q) = div (div n p) q /\ rem n (p*q) = rem n p + p*rem (div n p) q.
+  Proof.
+    assert (p*q <> 0) as Hpq.
+    { intros E; apply mult_is_O in E; omega. }
+    apply div_rem_uniq with (p := p*q); auto.
+    + generalize (div_rem_spec1 n p)
+                 (div_rem_spec1 (div n p) q)
+                 (div_rem_spec1 n (p*q)); intros H1 H2 H3.
+      rewrite <- H3; rewrite H1 at 1; rewrite H2 at 1; ring.
+    + apply div_rem_spec2; auto.
+    + generalize (div_rem_spec2 n Hp)
+                 (div_rem_spec2 (div n p) Hq); intros H1 H2.
+      replace q with (1+(q-1)) at 2 by omega.
+      rewrite Nat.mul_add_distr_l.
+      apply plus_lt_le_compat; try omega.
+      apply mult_le_compat; omega.
+  Qed.
+
+  Corollary div_mult n : div n (p*q) = div (div n p) q.
+  Proof. apply div_rem_mult. Qed.
+
+  Corollary rem_mult n : rem n (p*q) = rem n p + p*rem (div n p) q.
+  Proof. apply div_rem_mult. Qed.
+
+End div_mult.
+
+Section nat_nat2_bij.
+
+  (* An easy to implement bijection nat <-> nat * nat *)
+
+  Let decomp_recomp_full n : n <> 0 -> { a & { b | n = power a 2 * (2*b+1) } }.
+  Proof.
+    induction on n as IHn with measure n; intros Hn.
+    generalize (euclid_2_div n); intros (H1 & H2).
+    case_eq (rem n 2).
+    + intros H.
+      destruct (IHn (div n 2)) as (a & b & H3); try omega.
+      exists (S a), b.
+      rewrite H1, H, H3, power_S; ring.
+    + intros [ | [ | k ] ] Hk; try omega.
+      exists 0, (div n 2); rewrite power_0.
+      rewrite H1 at 1; rewrite Hk; ring.
+  Qed.
+
+  Definition decomp_l n := projT1 (@decomp_recomp_full (S n) (Nat.neq_succ_0 _)).
+  Definition decomp_r n := proj1_sig (projT2 (@decomp_recomp_full (S n) (Nat.neq_succ_0 _))).
+ 
+  Fact decomp_lr_spec n : S n = power (decomp_l n) 2 * (2 * (decomp_r n) + 1).
+  Proof. apply (proj2_sig (projT2 (@decomp_recomp_full (S n) (Nat.neq_succ_0 _)))). Qed.
+
+  Definition recomp a b := power a 2 * (2*b+1) - 1.
+  
+  Fact recomp_decomp n : n = recomp (decomp_l n) (decomp_r n).
+  Proof. unfold recomp; rewrite <- decomp_lr_spec; omega. Qed.
+
+  Let power_mult_lt_inj a1 b1 a2 b2 : a1 < a2 -> power a1 2 * (2*b1+1) <> power a2 2 * b2.
+  Proof.
+    intros H1 H.
+    replace a2 with (a1+(S (a2-a1-1))) in H by omega.
+    rewrite power_plus in H.
+    rewrite <- mult_assoc, Nat.mul_cancel_l in H.
+    2: generalize (power2_gt_0 a1); omega.
+    revert H; rewrite power_S, <- mult_assoc.
+    generalize (power (a2-a1-1) 2*b1); intros; omega.
+  Qed.
+
+  Let comp_gt a b : power a 2 *(2*b+1) <> 0.
+  Proof. 
+    intros E; apply mult_is_O in E.
+    generalize (power2_gt_0 a); intros; omega.
+  Qed. 
+
+  Fact decomp_uniq a1 b1 a2 b2 : power a1 2 * (2*b1+1) = power a2 2 * (2*b2+1) -> a1 = a2 /\ b1 = b2.
+  Proof.
+    intros H.
+    destruct (lt_eq_lt_dec a1 a2) as [ [ H1 | H1 ] | H1 ].
+    + exfalso; revert H; apply power_mult_lt_inj; auto.
+    + split; auto; subst a2.
+      rewrite Nat.mul_cancel_l in H; try omega.
+      generalize (power2_gt_0 a1); omega.
+    + exfalso; symmetry in H.
+      revert H; apply power_mult_lt_inj; auto.
+  Qed.
+
+  Let decomp_lr_recomp a b : decomp_l (recomp a b) = a /\ decomp_r (recomp a b) = b.
+  Proof.
+    apply decomp_uniq; symmetry.
+    replace (power a 2 * (2*b+1)) with (S (recomp a b)).
+    + apply decomp_lr_spec.
+    + unfold recomp; generalize (power a 2 * (2*b+1)) (comp_gt a b); intros; omega.
+  Qed.
+
+  Fact decomp_l_recomp a b : decomp_l (recomp a b) = a.
+  Proof. apply decomp_lr_recomp. Qed.
+
+  Fact decomp_r_recomp a b : decomp_r (recomp a b) = b.
+  Proof. apply decomp_lr_recomp. Qed.
+
+End nat_nat2_bij.
+
+Section prim_min.
+
+  Variable (X : Type) (f : nat -> nat).
+
+  Let min_f n : f n = 0 -> { k | k <= n /\ f k = 0 /\ forall i, i < k -> f i <> 0 }.
+  Proof. 
+    intros Hn.
+    destruct first_which with (P := fun i => f i = 0) as (k & H1 & H2). 
+    + intros; apply eq_nat_dec.
+    + exists n; auto.
+    + exists k; split; auto.
+      destruct (le_lt_dec k n); auto.
+      destruct (H2 n); auto. 
+  Qed.
+ 
+  Let g i := match f i with 0 => i | _ => S i end.
+
+  Let prim_min_rec n a := iter g n a.
+
+  Let prim_min_rec_spec_0 n a : (forall i, i < n -> f (i+a) <> 0) -> forall i, i <= n -> prim_min_rec i a = i+a.
+  Proof.
+    unfold prim_min_rec.
+    revert a; induction n as [ | n IHn ]; intros a Hn.
+    + intros i Hi; replace i with 0 by omega; auto.
+    + intros [ | i ] Hi; auto.
+      * rewrite iter_S.
+        unfold g at 2.
+        generalize (Hn 0); simpl; intros E.
+        destruct (f a); try omega.
+        rewrite IHn; try omega.
+        intros j Hj.
+        replace (j+S a) with (S j+a) by omega.
+        apply Hn; omega.
+  Qed.
+
+  Let prim_min_rec_spec_1 n a : f a = 0 -> prim_min_rec n a = a.
+  Proof.
+    intros Ha; unfold prim_min_rec.
+    induction n as [ | n IHn ]; auto.
+    rewrite iter_S.
+    unfold g at 2; rewrite Ha; auto.
+  Qed.
+
+  Definition prim_min n := prim_min_rec n 0.
+
+  Fact prim_min_spec n : f n = 0 -> f (prim_min n) = 0 /\ forall i, i < prim_min n -> f i <> 0.
+  Proof.
+    intros Hn.
+    destruct (min_f Hn) as (k & H1 & H2 & H3).
+    assert (prim_min n = k) as H4.
+    { unfold prim_min. 
+      unfold prim_min_rec.
+      replace n with (n-k+k) by omega.
+      rewrite iter_plus.
+      fold (prim_min_rec k 0).
+      rewrite prim_min_rec_spec_0 with (n := k) (a := 0); auto.
+      rewrite plus_comm; apply prim_min_rec_spec_1; auto.
+      intros; apply H3; omega. }
+    rewrite H4; auto.
+  Qed.
+
+End prim_min.
+
+Section utils.
+ 
+  Definition ra_cst_n n x : recalg n := ra_comp (ra_cst x) vec_nil.
+
+  Fact ra_cst_n_prim n x : prim_rec (ra_cst_n n x).
+  Proof. apply prim_rec_bool_spec; reflexivity. Qed. 
+
+  Fact ra_cst_n_val n x v : ⟦ra_cst_n n x⟧ v x.
+  Proof.
+    exists vec_nil; split.
+    + cbv; auto.
+    + intro i; analyse pos i.
+  Qed.
+
+  Fact ra_cst_n_rel n x v e : ⟦ra_cst_n n x⟧ v e <-> e = x.
+  Proof.
+    split.
+    + intros H; apply ra_rel_fun with (1 := H), ra_cst_n_val.
+    + intro; subst; apply ra_cst_n_val.
+  Qed.
+
+  Opaque ra_cst_n.
+
+  Hint Resolve ra_cst_n_prim.
+
+  Section ra_iter_n.
+
+    Variable (n : nat) (f : vec nat n -> nat) (af : recalg n) 
+                       (Hf : forall v, ⟦af⟧ v (f v))
+                       (Haf : prim_rec af)
+                       (g : vec nat n -> nat -> nat) (ag : recalg (S n)) 
+                       (Hg : forall i v, ⟦ag⟧ (i##v) (g v i))
+                       (Hag : prim_rec ag).
+
+    Definition ra_iter_n : recalg (S n).
+    Proof.
+      apply ra_rec.
+      + apply af.
+      + apply ra_comp with (S n).
+        * apply ag.
+        * apply vec_set_pos; intros p.
+          apply (ra_proj (pos_nxt p)).
+    Defined.
+
+    Fact ra_iter_n_prim : prim_rec ra_iter_n.
+    Proof. 
+      simpl; repeat (split; auto).
+      intros p; analyse pos p.
+      + simpl; auto.
+      + rewrite vec_pos_set; simpl; auto.
+    Qed.
+
+    Fact ra_iter_n_val i v : ⟦ra_iter_n⟧ (i##v) (iter (g v) i (f v)).
+    Proof.
+      simpl; unfold s_rec.
+      induction i as [ | i IHi ]; simpl.
+      + apply Hf; auto.
+      + exists (iter (g v) i (f v)); split; auto.
+        exists (iter (g v) i (f v)## v); split.
+        * apply Hg; auto.
+        * intros p; analyse_pos p; simpl.
+          - red; simpl; auto.
+          - repeat rewrite vec_pos_set.
+            simpl; red; simpl; auto.
+    Qed.
+
+    Fact ra_iter_n_rel v e : ⟦ra_iter_n⟧ v e <-> e = iter (g (vec_tail v)) (vec_pos v pos0) (f (vec_tail v)).
+    Proof.
+      vec split v with i.
+      split.
+      + intros H; apply ra_rel_fun with (1 := H), ra_iter_n_val.
+      + intros; subst; apply ra_iter_n_val.
+    Qed.
+      
+  End ra_iter_n.
+
+  Hint Resolve ra_iter_n_prim.
+
+  Opaque ra_iter_n.
+
+  Fact eq_equiv X (e a b : X) : a = b -> (e = a <-> e = b).
+  Proof. intros []; tauto. Qed.
+
+  Section ra_iter.
+
+    Variable (n : nat) (f : nat -> nat) (af : recalg 1) 
+             (Hf : forall v e, ⟦af⟧ v e <-> e = f (vec_head v))
+             (Haf : prim_rec af).
+
+    Definition ra_iter : recalg 2.
+    Proof.
+      apply ra_iter_n.
+      + apply (ra_proj pos0).
+      + apply ra_comp with 1.
+        * apply af.
+        * apply (ra_proj pos0 ## vec_nil).
+    Defined.
+
+    Fact ra_iter_prim : prim_rec ra_iter.
+    Proof. 
+      apply ra_iter_n_prim; simpl; auto; split; auto.
+      intros p; analyse pos p; simpl; auto.
+    Qed.
+
+    Fact ra_iter_rel v e : ⟦ra_iter⟧ v e <-> e = iter f (vec_pos v pos0) (vec_pos v pos1).
+    Proof.
+      unfold ra_iter; rewrite ra_iter_n_rel with (f := @vec_head _ _) (g := fun _ => f).
+      + apply eq_equiv; f_equal.
+        vec split v with a; vec split v with b; auto.
+      + intros w; simpl; unfold s_proj.
+        vec split w with a; simpl; split; auto.
+      + intros i w; simpl; unfold s_comp.
+          exists (i##vec_nil).
+          rewrite Hf; split; auto.
+          intro p; analyse pos p; cbv; auto.
+    Qed.
+
+  End ra_iter.
+
+  Hint Resolve ra_iter_prim.
+
+  Opaque ra_iter.
+
+  Definition ra_pred := ra_rec (ra_cst 0) (ra_proj pos0).
+
+  Fact ra_pred_prim : prim_rec ra_pred.
+  Proof. apply prim_rec_bool_spec; auto. Qed.
+
+  Fact ra_pred_val n : ⟦ra_pred⟧ (n##vec_nil) (n-1).
+  Proof.
+    simpl; unfold s_rec.
+    induction n as [ | n IHn ]; simpl.
+    + cbv; trivial.
+    + simpl in IHn; exists (n-1); split; auto.
+      replace (n-0) with n by omega; cbv; auto.
+  Qed.
+
+  Hint Resolve ra_pred_prim.
+
+  Opaque ra_pred.
+
+  Fact ra_pred_rel v e : ⟦ra_pred⟧ v e <-> e = vec_head v - 1.
+  Proof.
+    vec split v with n; vec nil v; simpl.
+    split.
+    + intros H.
+      apply ra_rel_fun with (1 := H) (2 := ra_pred_val _).
+    + intros; subst; apply ra_pred_val.
+  Qed.
+
+  Definition ra_plus : recalg 2.
+  Proof. apply ra_iter, ra_succ. Defined.
+
+  Fact ra_plus_prim : prim_rec ra_plus.
+  Proof. apply prim_rec_bool_spec; auto. Qed.
+
+  Fact ra_plus_rel v e : ⟦ra_plus⟧ v e <-> e = vec_head v + vec_head (vec_tail v).
+  Proof.
+    unfold ra_plus; simpl.
+    rewrite ra_iter_rel with (f := S).
+    + vec split v with n; vec split v with m; vec nil v; simpl.
+      apply eq_equiv; induction n; simpl; f_equal; auto.
+    + intros; simpl; unfold s_succ; simpl; tauto.
+  Qed.
+
+  Fact ra_plus_val n m : ⟦ra_plus⟧ (n##m##vec_nil) (n+m).
+  Proof. apply ra_plus_rel; simpl; auto. Qed.
+
+  Hint Resolve ra_plus_prim.
+
+  Opaque ra_plus.
+
+  Section ra_minus.
+
+    Let ra_minus_inv : recalg 2.
+    Proof. apply ra_iter, ra_pred. Defined.
+ 
+    Let ra_minus_inv_rel v e : ⟦ra_minus_inv⟧ v e <-> e = vec_pos v pos1 - vec_pos v pos0.
+    Proof.
+      unfold ra_minus_inv; simpl.
+      rewrite ra_iter_rel with (f := pred).
+      + vec split v with n; vec split v with m; vec nil v; simpl.
+        apply eq_equiv; induction n; simpl; omega.
+      + intros; simpl; rewrite ra_pred_rel.
+        apply eq_equiv; omega.
+    Qed.
+
+    Definition ra_minus : recalg 2.
+    Proof.
+      apply ra_comp with 2.
+      + apply ra_minus_inv.
+      + refine (_##_##vec_nil).
+        * apply (ra_proj pos1).
+        * apply (ra_proj pos0).
+    Defined.
+
+    Fact ra_minus_prim : prim_rec ra_minus.
+    Proof. apply prim_rec_bool_spec; auto. Qed.
+
+    Fact ra_minus_val n m : ⟦ra_minus⟧ (n##m##vec_nil) (n-m).
+    Proof.
+      exists (m##n##vec_nil); split; auto.
+      + rewrite ra_minus_inv_rel; simpl; auto.
+      + intro i; analyse pos i; cbv; auto.
+    Qed.
+
+    Fact ra_minus_rel v e : ⟦ra_minus⟧ v e <-> e = vec_pos v pos0 - vec_pos v pos1.
+    Proof.
+      vec split v with n; vec split v with m; vec nil v.
+      split.
+      + intros H; apply ra_rel_fun with (1 := H), ra_minus_val.
+      + intros; subst; apply ra_minus_val.
+    Qed.
+
+  End ra_minus.
+
+  Hint Resolve ra_minus_prim.
+
+  Opaque ra_minus.
+
+  Definition ra_mult : recalg 2.
+  Proof.
+    apply ra_rec.
+    apply (ra_zero).
+    apply ra_comp with 2.
+    apply ra_plus.
+    apply vec_cons.
+    apply (ra_proj pos1).
+    apply vec_cons.
+    apply (ra_proj pos2).
+    apply vec_nil.
+  Defined.
+
+  Fact ra_mult_prim : prim_rec ra_mult.
+  Proof. apply prim_rec_bool_spec; auto. Qed.
+
+  Fact ra_mult_val n m : ⟦ra_mult⟧ (n##m##vec_nil) (n*m).
+  Proof.
+    simpl; unfold s_rec; simpl.
+    induction n as [ | n IHn ]; simpl in *.
+    + cbv; trivial.
+    + exists (n*m); split; auto.
+      exists ((n*m)##m##vec_nil); split.
+      * apply ra_plus_rel; simpl; ring.
+      * intros p; analyse pos p; cbv; trivial.
+  Qed.
+
+  Hint Resolve ra_mult_prim.
+
+  Opaque ra_mult.
+
+  Fact ra_mult_rel v e : ⟦ra_mult⟧ v e <-> e = vec_head v * vec_head (vec_tail v).
+  Proof.
+    vec split v with n; vec split v with m; vec nil v.
+    split.
+    + intros H; apply ra_rel_fun with (1 := H), ra_mult_val.
+    + intros; subst; apply ra_mult_val.
+  Qed.
+
+  Definition ra_exp : recalg 2.
+  Proof.
+    apply ra_iter_n.
+    + apply ra_cst_n, 1.
+    + apply ra_comp with (1 := ra_mult).
+      refine (_##_##vec_nil).
+      * apply (ra_proj pos1).
+      * apply (ra_proj pos0).
+  Defined.
+
+  Fact ra_exp_prim : prim_rec ra_exp.
+  Proof. apply prim_rec_bool_spec; auto. Qed.
+
+  Fact ra_exp_val n m : ⟦ra_exp⟧ (n##m##vec_nil) (power n m).
+  Proof.
+    unfold ra_exp.
+    rewrite ra_iter_n_rel with (f := fun _ => 1) (g := fun v i => vec_head v*i).
+    + simpl; induction n.
+      * rewrite power_0; auto.
+      * rewrite power_S; simpl; f_equal; auto.
+    + apply ra_cst_n_val.
+    + intros i v; vec split v with j; vec nil v; simpl.
+      exists (j##i##vec_nil); split.
+      * apply ra_mult_val.
+      * intros p; analyse pos p; simpl; cbv; auto.
+  Qed.
+
+  Fact ra_exp_rel v e : ⟦ra_exp⟧ v e <-> e = power (vec_pos v pos0) (vec_pos v pos1).
+  Proof.
+    vec split v with n; vec split v with m; vec nil v.
+    split.
+    + intros H; apply ra_rel_fun with (1 := H), ra_exp_val.
+    + intros; subst; apply ra_exp_val.
+  Qed.
+
+  Hint Resolve ra_exp_prim.
+
+  Opaque ra_exp.
+
+  Section ite.
+
+    Definition ra_ite : recalg 3.
+    Proof.
+      apply ra_rec.
+      apply (ra_proj pos0).
+      apply (ra_proj pos3).
+    Defined.
+
+    Fact ra_ite_prim : prim_rec ra_ite.
+    Proof. apply prim_rec_bool_spec; auto. Qed.
+
+    Definition ite_rel (b p q : nat) := match b with 0 => p | _ => q end.
+
+    Fact ra_ite_val b p q : ⟦ra_ite⟧ (b##p##q##vec_nil) (ite_rel b p q).
+    Proof.
+      simpl; unfold s_rec.
+      induction b as [ | b IHb ]; simpl.
+      + cbv; trivial.
+      + exists (ite_rel b p q); split; auto.
+        cbv; trivial.
+    Qed.
+
+    Fact ra_ite_rel v e : ⟦ra_ite⟧ v e <-> e = ite_rel (vec_pos v pos0) (vec_pos v pos1) (vec_pos v pos2).
+    Proof.
+      vec split v with b; vec split v with p; vec split v with q; vec nil v.
+      split.
+      + intros H; apply ra_rel_fun with (1 := H), ra_ite_val.
+      + intro; subst; apply ra_ite_val.
+    Qed.
+
+    Fact ra_ite_0 p q : ⟦ra_ite⟧ (0##p##q##vec_nil) p.
+    Proof. apply ra_ite_val. Qed.
+
+    Fact ra_ite_S b p q : ⟦ra_ite⟧ (S b##p##q##vec_nil) q.
+    Proof. apply ra_ite_val. Qed.
+
+  End ite.
+
+  Hint Resolve ra_ite_prim.
+
+  Opaque ra_ite.
+
+  Section ra_eq.
+
+    Definition ra_eq : recalg 2.
+    Proof.
+      apply ra_comp with (1 := ra_ite).
+      refine (_##_##_##vec_nil).
+      + apply ra_minus.
+      + apply ra_comp with (1 := ra_minus).
+        refine (_##_##vec_nil).
+        * apply ra_proj, pos1.
+        * apply ra_proj, pos0.
+      + apply ra_cst_n, 1.
+    Defined.
+
+    Fact ra_eq_prim : prim_rec ra_eq.
+    Proof. apply prim_rec_bool_spec; auto. Qed.
+
+    Fact ra_eq_val a b : ⟦ra_eq⟧ (a##b##vec_nil) (ite_rel (a-b) (b-a) 1).
+    Proof.
+      exists (a-b##b-a##1##vec_nil); split.
+      + apply ra_ite_val.
+      + intros p; analyse pos p; simpl.
+        * apply ra_minus_val.
+        * exists (b##a##vec_nil); split.
+          - apply ra_minus_val.
+          - intros p; analyse pos p; simpl; cbv; auto.
+        * apply ra_cst_n_val.
+    Qed.
+
+    Fact ra_eq_rel v : { e | ⟦ra_eq⟧ v e /\ (e = 0 <-> vec_pos v pos0 = vec_pos v pos1) }.
+    Proof.
+      vec split v with a; vec split v with b; vec nil v.
+      exists (ite_rel (a-b) (b-a) 1); split.
+      + apply ra_eq_val.
+      + simpl; unfold ite_rel.
+        case_eq (a-b); intros; omega.
+    Qed.
+ 
+  End ra_eq.
+
+  Hint Resolve ra_eq_prim.
+
+  Opaque ra_eq.
+
+  Section ra_prim_min.
+
+    Variable (n : nat) (f : vec nat n -> nat -> nat) (af : recalg (S n)) 
+                       (Hf : forall i v, ⟦af⟧ (i##v) (f v i))
+                       (Haf : prim_rec af).
+
+    Let ag : recalg (S n).
+    Proof.
+      apply ra_comp with 3.
+      * apply ra_ite.
+      * refine (_##_##_##vec_nil).
+        - apply af.
+        - apply (ra_proj pos0).
+        - apply ra_comp with 1.
+          ++ apply ra_succ.
+          ++ apply (ra_proj pos0##vec_nil).
+    Defined.
+
+    Let ag_prim : prim_rec ag.
+    Proof.
+      simpl; split; auto.
+      intros p; analyse pos p; auto;
+      apply prim_rec_bool_spec; auto.
+    Qed.
+
+    Let ag_val i v : ⟦ag⟧ (i##v) (ite_rel (f v i) i (S i)).
+    Proof.
+      simpl; unfold s_comp.
+      exists (f v i##i##S i##vec_nil); split.
+      apply ra_ite_val.
+      intros p; analyse pos p.
+      + apply Hf; auto.
+      + cbv; auto.
+      + simpl; exists (i##vec_nil); split; auto.
+        * cbv; auto. 
+        * intros q; analyse pos q; cbv; auto.
+    Qed.
+
+    Definition ra_prim_min : recalg (S n).
+    Proof.
+      apply ra_iter_n.
+      + apply ra_cst_n, 0.
+      + apply ag.
+    Defined.
+
+    Opaque ag.
+
+    Fact ra_prim_min_prim : prim_rec ra_prim_min.
+    Proof. apply ra_iter_n_prim; auto. Qed.
+
+    Fact ra_prim_min_val i v : ⟦ra_prim_min⟧ (i##v) (prim_min (f v) i).
+    Proof.
+      unfold ra_prim_min.
+      rewrite ra_iter_n_rel with (f := fun _ => 0) (g := fun w i => match f w i with 0 => i | _ => S i end).
+      + unfold prim_min; simpl; auto.
+      + intros; rewrite ra_cst_n_rel; tauto.
+      + intros; apply ag_val.
+    Qed.
+
+    Fact ra_prim_min_rel v e : ⟦ra_prim_min⟧ v e <-> e = prim_min (f (vec_tail v)) (vec_head v).
+    Proof.
+      vec split v with a.
+      split.
+      + intros H; apply ra_rel_fun with (1 := H), ra_prim_min_val.
+      + intros; subst; apply ra_prim_min_val.
+    Qed.
+
+  End ra_prim_min.
+
+  Hint Resolve ra_prim_min_prim.
+
+  Opaque ra_prim_min.
+
+  Section ra_prim_max.
+
+    Variable (n : nat) (f : vec nat n -> nat -> nat) (af : recalg (S n)) 
+             (Hf : forall a v, ⟦af⟧ (a##v) (f v a))
+             (Haf : prim_rec af).
+  
+    Let ag : recalg (S (S n)).
+    Proof.
+      apply ra_comp with (1 := ra_minus).
+      refine (_##_##vec_nil).
+      * apply ra_comp with (1 := ra_succ). 
+        apply (ra_proj pos1##vec_nil).
+      * apply ra_comp with (1 := af).
+        apply vec_cons.
+        + apply ra_comp with (1 := ra_succ).
+          apply (ra_proj pos0##vec_nil).
+        + apply vec_set_pos.
+          intros p; apply (ra_proj (pos_nxt (pos_nxt p))).
+    Defined.
+
+    Let ag_prim : prim_rec ag.
+    Proof.
+      simpl; split; auto.
+      intros p; analyse pos p; simpl; split; auto.
+      + intros p; analyse pos p; simpl; auto.
+      + intros p; analyse pos p; simpl; auto.
+        * split; auto.
+          intros p; analyse pos p; simpl; auto.
+        * rewrite vec_pos_set; simpl; auto.
+    Qed.
+
+    Let ag_val a b v : ⟦ag⟧ (a##b##v) ((S b) - f v (S a)).
+    Proof.
+      exists (S b##f v (S a)##vec_nil); split.
+      + apply ra_minus_val.
+      + intros p.
+        repeat rewrite vec_pos_set.
+        analyse pos p.
+        { simpl; exists (b##vec_nil); split.
+          * cbv; auto.
+          * intros q; analyse pos q; cbv; auto. }
+        { simpl; exists (S a##v); split.
+          * apply Hf; auto.
+          * intros q; analyse pos q.
+            { simpl; exists (a##vec_nil); split.
+              - cbv; auto.
+              - intros p; analyse pos p; cbv; auto. }
+            { simpl; repeat rewrite vec_pos_set.
+              simpl; red; simpl; auto. } }
+    Qed.
+
+    Opaque ag.
+
+    Definition ra_prim_max : recalg (S (S n)).
+    Proof. apply ra_prim_min, ag. Defined.
+
+    Fact ra_prim_max_prim : prim_rec ra_prim_max.
+    Proof. apply ra_prim_min_prim; auto. Qed.
+
+    Hypothesis (Hf2 : forall v n, f v n <= f v (S n)).
+
+    Variable (a b : nat) (v : vec nat n).
+
+    Hypothesis (Hb : f v 0 <= b < f v (S a)).
+
+    Fact ra_prim_max_spec : { e | ⟦ra_prim_max⟧ (a##b##v) e /\ f v e <= b /\ b < f v (S e) }.
+    Proof.
+      exists (prim_min (fun i => S b - f v (S i)) a); split.
+      + unfold ra_prim_max.
+        rewrite ra_prim_min_rel with (f := fun w i => S (vec_head w) - f (vec_tail w) (S i)); auto.
+        intros i w; vec split w with j; simpl vec_tail; simpl vec_head; auto.
+      + destruct prim_min_spec with (f := fun i => S b - f v (S i)) (n := a)
+          as (H2 & H3); try omega.
+        split; try omega.
+        revert H3.
+        destruct (prim_min (fun j => S b - f v (S j)) a) as [ | k ]; intros H3; try omega.
+        specialize (H3 k); omega.
+    Qed.
+
+  End ra_prim_max.
+
+  Hint Resolve ra_prim_max_prim.
+
+  Opaque ra_prim_max.
+
+  Section ra_div.
+
+    Let f (v : vec nat 1) k := (vec_head v)*k.
+
+    Let af : recalg 2.
+    Proof.
+      apply ra_comp with (1 := ra_mult).
+      apply (ra_proj pos1##ra_proj pos0##vec_nil).
+    Defined.
+
+    Let af_prim : prim_rec af.
+    Proof. apply prim_rec_bool_spec; auto. Qed.
+
+    Let af_val k v : ⟦af⟧ (k##v) (f v k).
+    Proof.
+      vec split v with b. 
+      exists (b##k##vec_nil); split.
+      + apply ra_mult_val.
+      + intro p; analyse pos p; cbv; auto.
+    Qed.
+
+    Definition ra_div : recalg 2.
+    Proof.
+      apply ra_comp with 3.
+      * apply ra_prim_max, af.
+      * apply (ra_proj pos0##ra_proj pos0##ra_proj pos1##vec_nil).
+    Defined.
+
+    Fact ra_div_prim : prim_rec ra_div.
+    Proof. 
+      simpl; split; auto.
+      intros p; analyse pos p; simpl; auto.
+    Qed. 
+
+    Let ra_div_spec n m : m <> 0 -> { k | ⟦ra_div⟧ (n##m##vec_nil) k /\ m*k <= n < m*(S k) }.
+    Proof.
+      unfold ra_div; intros Hm.
+      destruct ra_prim_max_spec with (f := f) (af := af) (a := n) (b := n) (v := m##vec_nil)
+        as (k & H1 & H2); auto.
+      { unfold f; simpl; rewrite Nat.mul_0_r; split; try omega.
+        apply le_trans with (1*S n); try omega.
+        apply mult_le_compat; omega. }
+      exists k; split; auto.
+      exists (n##n##m##vec_nil); split; auto.
+      intro p; analyse pos p; cbv; auto.
+    Qed.
+
+    Fact ra_div_val n m : m <> 0 -> ⟦ra_div⟧ (n##m##vec_nil) (div n m).
+    Proof.
+      intros Hm.
+      generalize (div_rem_spec1 n m) (div_rem_spec2 n Hm); intros H1 H2.
+      destruct (ra_div_spec n Hm) as (k & H3 & H4).
+      assert (k = div n m); try omega; subst; auto.
+      clear H3.
+      rewrite Nat.mul_succ_r in H4.
+      apply (@div_rem_uniq _ k (n-m*k) (div n m) (rem n m) Hm); try omega. 
+      rewrite mult_comm; omega. 
+    Qed.
+
+    Fact ra_div_rel v e : vec_pos v pos1 <> 0 -> ⟦ra_div⟧ v e <-> e = div (vec_pos v pos0) (vec_pos v pos1).
+    Proof.
+      vec split v with a; vec split v with b; vec nil v; intros H.
+      split.
+      + intros H1; apply ra_rel_fun with (1 := H1), ra_div_val; auto.
+      + intros; subst; apply ra_div_val; auto.
+    Qed.
+
+  End ra_div.
+
+  Hint Resolve ra_div_prim.
+
+  Opaque ra_div.
+
+  Section ra_rem.
+
+    Definition ra_rem : recalg 2.
+    Proof.
+      apply ra_comp with (1 := ra_minus).
+      refine (_##_##vec_nil).
+      + apply (ra_proj pos0).
+      + apply ra_comp with (1 := ra_mult).
+        refine (_##_##vec_nil).
+        * apply (ra_proj pos1).
+        * apply ra_div.
+    Defined.
+
+    Fact ra_rem_prim : prim_rec ra_rem.
+    Proof.
+      simpl; split; auto.
+      intros p; analyse pos p; simpl; split; auto.
+      intros p; analyse pos p; simpl; split; auto.
+      * apply ra_prim_max_prim, prim_rec_bool_spec; auto.
+      * intros p; analyse pos p; simpl; auto.
+    Qed.
+
+    Let ra_rem_val_0 n m : m <> 0 -> ⟦ra_rem⟧ (n##m##vec_nil) (n-m*div n m).
+    Proof.
+      intros Hm.
+      simpl; exists (n##m*div n m##vec_nil); split.
+      + apply ra_minus_val.
+      + intro p; analyse pos p.
+        { cbv; auto. }
+        { simpl; exists (m##div n m##vec_nil); split.
+          * apply ra_mult_val.
+          * intros p; analyse pos p.
+            { cbv; auto. }  
+            { apply ra_div_val; auto. } }
+    Qed.
+
+    Fact ra_rem_val n m : m <> 0 -> ⟦ra_rem⟧ (n##m##vec_nil) (rem n m).
+    Proof.
+      intros Hm.
+      generalize (div_rem_spec1 n m) (ra_rem_val_0 n Hm); intros.
+      replace (rem n m) with (n-m*div n m); auto.
+      rewrite mult_comm; omega.
+    Qed.
+
+    Fact ra_rem_rel v e : vec_pos v pos1 <> 0 -> ⟦ra_rem⟧ v e <-> e = rem (vec_pos v pos0) (vec_pos v pos1).
+    Proof.
+      vec split v with a; vec split v with b; vec nil v; intros H0.
+      split.
+      + intros H; apply ra_rel_fun with (1 := H), ra_rem_val; auto.
+      + intros; subst; apply ra_rem_val; auto.
+    Qed.
+
+  End ra_rem.
+
+  Hint Resolve ra_rem_prim.
+ 
+  Opaque ra_rem.
+
+  Definition ra_div2 : recalg 1.
+  Proof.
+    apply ra_comp with (1 := ra_div); refine (_##_##vec_nil).
+    + apply (ra_proj pos0).
+    + apply ra_cst_n, 2.
+  Defined.
+
+  Fact ra_div2_prim : prim_rec ra_div2.
+  Proof. 
+     simpl; split; auto. 
+     intros p; analyse pos p; simpl; auto. 
+  Qed.
+
+  Fact ra_div2_val n : ⟦ra_div2⟧ (n##vec_nil) (div n 2).
+  Proof.
+    exists (n##2##vec_nil); split.
+    + apply ra_div_val; discriminate.
+    + intros p; analyse pos p; simpl.
+    unfold ra_div2; simpl; cbv; auto.
+    apply ra_cst_n_val.
+  Qed.
+
+  Definition ra_mod2 : recalg 1.
+  Proof.
+    apply ra_comp with (1 := ra_rem); refine (_##_##vec_nil).
+    + apply (ra_proj pos0).
+    + apply ra_cst_n, 2.
+  Defined.
+
+  Fact ra_mod2_prim : prim_rec ra_mod2.
+  Proof. 
+     simpl; split; auto. 
+     intros p; analyse pos p; simpl; auto. 
+  Qed.
+
+  Fact ra_mod2_val n : ⟦ra_mod2⟧ (n##vec_nil) (rem n 2).
+  Proof.
+    exists (n##2##vec_nil); split.
+    + apply ra_rem_val; discriminate.
+    + intros p; analyse pos p; simpl.
+      * cbv; auto.
+      * apply ra_cst_n_val.
+  Qed.
+
+  Definition ra_pow2 : recalg 1.
+  Proof.
+    apply ra_comp with (1 := ra_exp).
+    refine (_##_##vec_nil).
+    + apply ra_proj, pos0.
+    + apply ra_cst_n, 2.
+  Defined.
+
+  Fact ra_pow2_prim : prim_rec ra_pow2.
+  Proof. 
+     simpl; split; auto. 
+     intros p; analyse pos p; simpl; auto. 
+  Qed.
+
+  Fact ra_pow2_val n : ⟦ra_pow2⟧ (n##vec_nil) (power n 2).
+  Proof.
+     exists (n##2##vec_nil); split.
+    + apply ra_exp_val; discriminate.
+    + intros p; analyse pos p; simpl.
+      * cbv; auto.
+      * apply ra_cst_n_val.
+  Qed.
+  
+  Hint Resolve ra_div2_prim ra_mod2_prim ra_pow2_prim.
+
+  Opaque ra_div2 ra_mod2 ra_pow2.
+
+  Section ra_notdiv_pow2.
+
+    (* f n m = 0 if 2^n does not divides m and <> 0 is 2^n divides m *)
+
+    Definition notdiv_pow2 n m := ite_rel (rem m (power n 2)) 1 0.
+
+    Fact notdiv_pow2_spec_1 n m : notdiv_pow2 n m <> 0 <-> divides (power n 2) m.
+    Proof.
+      unfold notdiv_pow2.
+      generalize (power n 2); clear n; intros n.
+      unfold ite_rel; case_eq (rem m n).
+      * intros H; split; try discriminate; intros _.
+        exists (div m n).
+        generalize (div_rem_spec1 m n); omega.
+      * intros k Hk; split; try omega; intros H _.
+        apply divides_rem_eq in H; omega.
+    Qed.
+
+    Fact notdiv_pow2_spec_2 n m : notdiv_pow2 n m = 0 <-> ~ divides (power n 2) m.
+    Proof.
+      rewrite <- notdiv_pow2_spec_1; omega.
+    Qed.
+
+    Definition ra_notdiv_pow2 : recalg 2.
+    Proof.
+      apply ra_comp with (1 := ra_ite).
+      refine (_##_##_##vec_nil).
+      + apply ra_comp with (1 := ra_rem).
+        refine (_##_##vec_nil).
+        * apply ra_proj, pos1.
+        * apply ra_comp with (1 := ra_pow2).
+          apply (ra_proj pos0##vec_nil).
+      + apply ra_cst_n, 1.
+      + apply ra_cst_n, 0.
+    Defined.
+
+    Fact ra_notdiv_pow2_prim : prim_rec ra_notdiv_pow2.
+    Proof.
+      simpl; split; auto.
+      repeat (intros p; analyse pos p; simpl; split; auto).
+    Qed.
+   
+    Fact ra_notdiv_pow2_val n m : ⟦ra_notdiv_pow2⟧ (n##m##vec_nil) (notdiv_pow2 n m).
+    Proof.
+      simpl.
+      exists (rem m (power n 2)##1##0##vec_nil); split.
+      + apply ra_ite_val.
+      + intros p; analyse pos p.
+        * exists (m##power n 2##vec_nil); split.
+          - apply ra_rem_val; generalize (@power_ge_1 n 2); intros; omega.
+          - intros p; analyse pos p.
+            ++ cbv; auto.
+            ++ exists (n##vec_nil); split.
+               ** apply ra_pow2_val.
+               ** intros p; analyse pos p; cbv; auto.
+        * apply ra_cst_n_val.
+        * apply ra_cst_n_val.
+    Qed.
+
+  End ra_notdiv_pow2.
+
+  Hint Resolve ra_notdiv_pow2_prim.
+
+  Opaque ra_notdiv_pow2.
+
+  Section ra_decomp.
+
+    (* given n, find a such that S n = 2^a*(2*b+1) 
+       to get a bijection n -> nat * nat *)
+
+    (* first, given n, find the first a such that 2^(S a) does not divide S n *)
+
+    Definition ra_decomp_l : recalg 1.
+    Proof.
+      apply ra_comp with 2.
+      + apply ra_prim_min.
+        apply ra_comp with (1 := ra_notdiv_pow2).
+        refine (_##_##vec_nil).
+        * apply ra_comp with (1 := ra_succ), (ra_proj pos0##vec_nil).
+        * apply ra_proj, pos1.
+      + refine (_##_##vec_nil);
+        apply ra_comp with (1 := ra_succ), (ra_proj pos0##vec_nil).
+    Defined.
+
+    Fact ra_decomp_l_prim : prim_rec ra_decomp_l.
+    Proof.
+      simpl; split; auto.
+      + apply ra_prim_min_prim; simpl; split; auto.
+        repeat (intros p; analyse pos p; simpl; split; auto).
+      + repeat (intros p; analyse pos p; simpl; split; auto).
+    Qed.
+
+    Fact ra_decomp_l_val_0 n : ⟦ra_decomp_l⟧ (n##vec_nil) (prim_min (fun i => notdiv_pow2 (S i) (S n)) (S n)).
+    Proof.
+      simpl.
+      exists (S n##S n##vec_nil); split.
+      + apply ra_prim_min_val with (f := fun v i => notdiv_pow2 (S i) (vec_head v)).
+        intros i v; vec split v with j; vec nil v.
+        exists (S i##j##vec_nil); split.
+        * apply ra_notdiv_pow2_val.
+        * intros p; analyse pos p.
+          - simpl; exists (i##vec_nil); split; try (cbv; auto; fail).
+            intros p; analyse pos p; cbv; auto.
+          - cbv; auto.
+      + intros p; analyse pos p.
+        * exists (n##vec_nil); split.
+          - cbv; auto.
+          - intros p; analyse pos p; cbv; auto.
+        * exists (n##vec_nil); split.
+          - cbv; auto.
+          - intros p; analyse pos p; cbv; auto.
+    Qed.
+ 
+    Fact ra_decomp_l_rel n : { a | ⟦ra_decomp_l⟧ (n##vec_nil) a /\ divides (power a 2) (S n) /\ ~ divides (power (S a) 2) (S n) }.
+    Proof.
+      exists (prim_min (fun i => notdiv_pow2 (S i) (S n)) (S n)); split.
+      1: apply ra_decomp_l_val_0.
+      generalize (prim_min_spec (fun i => notdiv_pow2 (S i) (S n)) (S n)); intros H.
+      destruct H as (H1 & H2).
+      { apply notdiv_pow2_spec_2; intros C.
+        apply divides_le in C; try discriminate.
+        generalize (@power_ge_n (S (S n)) 2); intros; omega. }
+      apply notdiv_pow2_spec_2 in H1; split; auto.
+      revert H2; generalize (prim_min (fun i : nat => notdiv_pow2 (S i) (S n)) (S n)); intros [ | k ] Hk.
+      + rewrite power_0; apply divides_1.
+      + apply notdiv_pow2_spec_1, Hk; omega.
+    Qed.
+
+    Hint Resolve ra_decomp_l_prim.
+
+    Opaque ra_decomp_l.
+
+    Definition ra_decomp_r : recalg 1.
+    Proof.
+      apply ra_comp with (1 := ra_div).
+      refine (_##_##vec_nil).
+      + apply ra_comp with (1 := ra_succ), (ra_proj pos0##vec_nil).
+      + apply ra_comp with (1 := ra_pow2); refine (_##vec_nil).
+        apply ra_comp with (1 := ra_succ); refine (_##vec_nil).
+        apply ra_comp with (1 := ra_decomp_l), (ra_proj pos0##vec_nil).
+    Defined.
+
+    Fact ra_decomp_r_prim : prim_rec ra_decomp_r.
+    Proof. 
+      simpl; split; auto.
+      repeat (intros p; analyse pos p; simpl; split; auto).
+    Qed.
+     
+    Fact ra_decomp_r_rel n : { b | ⟦ra_decomp_r⟧ (n##vec_nil) b /\ exists a, ⟦ra_decomp_l⟧ (n##vec_nil) a /\ S n = power a 2 * (2*b+1) }.
+    Proof.
+      destruct (ra_decomp_l_rel n) as (a & H1 & H2 & H3).
+      exists (div (S n) (power (S a) 2)); split.
+      + exists (S n##power (S a) 2##vec_nil); split.
+        { apply ra_div_val; generalize (@power_ge_1 (S a) 2); intros; omega. }
+        intros p; analyse pos p; repeat rewrite vec_pos_set; simpl.
+        * exists (n##vec_nil); split; try (cbv; auto; fail).
+          intros p; analyse pos p; cbv; auto.
+        * exists (S a##vec_nil); split.
+          { apply ra_pow2_val. }
+          intros p; analyse pos p; simpl.
+          exists (a##vec_nil); split.
+          { cbv; auto. }
+          intros p; analyse pos p; simpl.
+          exists (n##vec_nil); split; auto.
+          intros p; analyse pos p; cbv; auto.
+      + exists a; split; auto.
+        generalize (div_rem_spec1 (S n) (power a 2)).
+        apply divides_rem_eq in H2; rewrite H2, Nat.add_0_r.
+        rewrite power_S in *.
+        clear H1.
+        revert H2 H3.
+        generalize (S n) (power a 2) (power2_gt_0 a); clear n a; intros n p H1 H2 H3 H4.
+        rewrite H4 at 1; rewrite mult_comm; f_equal.
+        rewrite divides_rem_eq in H3.
+        rewrite (mult_comm _ p), div_mult; try omega.
+        rewrite mult_comm, rem_mult in H3; try omega.
+        rewrite (@div_rem_spec1 (div n p) 2) at 1.
+        rewrite H2 in H3; simpl in H3.
+        generalize (@div_rem_spec2 (div n p) 2); intros H5.
+        rewrite mult_comm in H3.
+        destruct (rem (div n p) 2) as [ | [ | ] ]; omega.
+    Qed.
+
+    Fact ra_decomp_lr_val n : ⟦ra_decomp_l⟧ (n##vec_nil) (decomp_l n) /\ ⟦ra_decomp_r⟧ (n##vec_nil) (decomp_r n).
+    Proof.
+      destruct (ra_decomp_r_rel n) as (b & H1 & a & H2 & H3).
+      rewrite (decomp_lr_spec n) in H3.
+      apply decomp_uniq in H3; destruct H3; subst a b; auto.
+    Qed.
+
+    Fact ra_decomp_l_val n : ⟦ra_decomp_l⟧ (n##vec_nil) (decomp_l n).
+    Proof. apply ra_decomp_lr_val. Qed.
+
+    Fact ra_decomp_r_val n : ⟦ra_decomp_r⟧ (n##vec_nil) (decomp_r n).
+    Proof. apply ra_decomp_lr_val. Qed.
+
+  End ra_decomp.
+
+  Hint Resolve ra_decomp_l_prim ra_decomp_r_prim.
+
+  Definition ra_recomp : recalg 2.
+  Proof.
+    apply ra_comp with (1 := ra_pred); refine (_##vec_nil).
+    apply ra_comp with (1 := ra_mult); refine (_##_##vec_nil).
+    + apply ra_comp with (1 := ra_pow2), (ra_proj pos0##vec_nil).
+    + apply ra_comp with (1 := ra_succ); refine (_##vec_nil).
+      apply ra_comp with (1 := ra_mult); refine (_##_##vec_nil).
+      * apply ra_cst_n, 2.
+      * apply ra_proj, pos1.
+  Defined.
+
+  Fact ra_recomp_prim : prim_rec ra_recomp.
+  Proof.
+    simpl; split; auto.
+    repeat (intros p; analyse pos p; simpl; split; auto).
+  Qed.
+  
+  Fact ra_recomp_val a b : ⟦ra_recomp⟧ (a##b##vec_nil) (recomp a b).
+  Proof.
+    unfold recomp.
+    rewrite plus_comm.
+    exists (power a 2 * (S (2*b)) ## vec_nil); split.
+    { apply ra_pred_val. }
+    intros p; analyse pos p; simpl.
+    exists (power a 2##S (2*b)##vec_nil); split.
+    { apply ra_mult_val. }
+    intros p; analyse pos p; simpl.
+    * exists (a##vec_nil); split. 
+      { apply ra_pow2_val. }
+      intros p; analyse pos p; cbv; auto.
+    * exists (2*b##vec_nil); split.
+      { reflexivity. }
+      intros p; analyse pos p; simpl.
+      exists (2##b##vec_nil); split.
+      { apply ra_mult_val. }
+      intros p; analyse pos p; simpl.
+      - apply ra_cst_n_val.
+      - cbv; auto.
+  Qed.
+
+  Hint Resolve ra_recomp_prim.
+
+  Opaque ra_decomp_l ra_decomp_r ra_recomp.
+
+  Fixpoint inject n (v : vec nat n) : nat :=
+    match v with
+      | vec_nil => 0
+      | x##v    => recomp x (inject v)
+    end.
+
+  Fixpoint project n : nat -> vec nat n :=
+    match n with
+      | 0   => fun _ => vec_nil
+      | S n => fun x => decomp_l x ## project _ (decomp_r x)
+    end.
+
+  Fact project_inject n v : project _ (@inject n v) = v.
+  Proof.
+    induction v as [ | n x v IHv ]; simpl; auto.
+    rewrite decomp_l_recomp, decomp_r_recomp; f_equal; trivial.
+  Qed. 
+
+  Fixpoint ra_inject n : recalg n.
+  Proof.
+    destruct n as [ | n ].
+    + apply ra_cst, 0.
+    + apply ra_comp with (1 := ra_recomp).
+      refine (_##_##vec_nil).
+      * apply ra_proj, pos0.
+      * apply ra_comp with (1 := ra_inject n).
+        apply vec_set_pos.
+        intros p; apply ra_proj, pos_nxt, p.
+  Defined.
+
+  Fact ra_inject_prim n : prim_rec (ra_inject n).
+  Proof.
+    induction n as [ | n IHn ]; simpl; split; auto.
+    intros p; analyse pos p; simpl; split; auto.
+    intros p; rewrite vec_pos_set; simpl; auto.
+  Qed.
+
+  Fact ra_inject_val n v : ⟦ra_inject n⟧ v (inject v).
+  Proof.
+    induction n as [ | n IHn ]; simpl.
+    + vec nil v; cbv; auto.
+    + vec split v with x.
+      exists (x##inject v##vec_nil); split.
+      * apply ra_recomp_val.
+      * intros p; analyse pos p; simpl.
+        - cbv; auto.
+        - exists v; split; auto.
+          intros p; repeat rewrite vec_pos_set.
+          simpl; red; auto.
+  Qed.
+
+  Fixpoint ra_project n (p : pos n) : recalg 1 :=
+    match p with
+      | pos_fst   => ra_decomp_l
+      | pos_nxt p => ra_comp (ra_project p) (ra_decomp_r##vec_nil)
+    end.
+
+  Fact ra_project_prim n p : prim_rec (@ra_project n p).
+  Proof.
+    induction p as [ | n p IHp ]; simpl; auto; split; auto.
+    intros j; analyse pos j; simpl; auto.
+  Qed. 
+
+  Fact ra_project_val n p x : ⟦@ra_project n p⟧ (x##vec_nil) (vec_pos (@project n x) p).
+  Proof.
+    revert x; induction p as [ | n p IHp ]; intros x; simpl.
+    + apply ra_decomp_l_val.
+    + exists (decomp_r x##vec_nil); split.
+      * apply IHp.
+      * intros q; analyse pos q; simpl.
+        apply ra_decomp_r_val.
+  Qed.
+
+  Fact ra_project_rel n p v x : ⟦@ra_project n p⟧ v x <-> x = vec_pos (@project n (vec_head v)) p.
+  Proof.
+    vec split v with a; vec nil v.
+    split.
+    + intros H; apply ra_rel_fun with (1 := H), ra_project_val.
+    + intros; subst; apply ra_project_val.
+  Qed.
+
+  Definition ra_vec_project n : vec (recalg 1) n.
+  Proof. apply vec_set_pos, ra_project. Defined. 
+
+End utils.
+
+(* Now we have inject/project implemented as primitive recursive algorithms *)
+
+Opaque ra_cst_n ra_pred ra_plus ra_minus ra_mult ra_ite
+       ra_div ra_rem ra_div2 ra_mod2 ra_pow2 ra_notdiv_pow2
+       ra_decomp_l ra_decomp_l ra_decomp_r ra_recomp
+       ra_inject ra_project.
+
+Hint Resolve ra_cst_n_prim ra_iter_n_prim ra_iter_prim
+             ra_pred_prim ra_plus_prim ra_minus_prim
+             ra_mult_prim ra_exp_prim ra_ite_prim
+             ra_eq_prim ra_prim_min_prim ra_prim_max_prim
+             ra_div_prim ra_rem_prim ra_div2_prim ra_mod2_prim 
+             ra_pow2_prim ra_notdiv_pow2_prim
+             ra_decomp_l_prim ra_decomp_r_prim ra_recomp_prim
+             ra_project_prim ra_inject_prim.

--- a/theories/MuRec/recalg.v
+++ b/theories/MuRec/recalg.v
@@ -1,0 +1,466 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Eqdep_dec Omega List Bool.
+
+From Undecidability.Shared.Libs.DLW 
+  Require Import Utils.utils_tac Utils.utils_nat Utils.utils_list Vec.pos Vec.vec.
+
+Set Implicit Arguments.
+
+Local Reserved Notation " '[|' f '|]' " (at level 0).
+Local Reserved Notation "'⟦' f '⟧'".
+
+Section Recursive_algorithms.
+
+  Unset Elimination Schemes.
+
+  Inductive recalg : nat -> Set :=
+    | ra_cst  : nat -> recalg 0
+    | ra_zero : recalg 1
+    | ra_succ : recalg 1
+    | ra_proj : forall k, pos k -> recalg k
+    | ra_comp : forall k i, recalg k -> vec (recalg i) k -> recalg i
+    | ra_rec  : forall k, recalg k -> recalg (S (S k)) -> recalg (S k)
+    | ra_min  : forall k, recalg (S k) -> recalg k
+    .
+
+  Set Elimination Schemes.
+
+  Section recalg_rect.
+
+    Variable P : forall k, recalg k -> Type.
+
+    Hypothesis Pcst  : forall n, P (ra_cst n).
+    Hypothesis Pzero : P ra_zero.
+    Hypothesis Psucc : P ra_succ.
+    Hypothesis Pproj : forall k p, P (@ra_proj k p).
+    Hypothesis Pcomp : forall k i f gj, P f -> (forall p, @P i (@vec_pos _ k gj p)) 
+                                     -> P (ra_comp f gj).
+    Hypothesis Prec  : forall k f g, @P k f -> P g -> P (ra_rec f g).
+    Hypothesis Pmin  : forall k f, @P (S k) f -> P (ra_min f).
+
+    Fixpoint recalg_rect k f { struct f } : @P k f :=
+      match f with
+        | ra_cst n     => Pcst n
+        | ra_zero      => Pzero
+        | ra_succ      => Psucc
+        | ra_proj p    => Pproj p 
+        | ra_comp f gj => Pcomp _ [|f|] (fun p => [|vec_pos gj p|])
+        | ra_rec f g   => Prec [|f|] [|g|]
+        | ra_min f     => Pmin [|f|]
+      end
+    where "[| f |]" := (@recalg_rect _ f).
+
+  End recalg_rect.
+
+  Definition recalg_rec (P : forall k, recalg k -> Set) := recalg_rect P.
+  Definition recalg_ind (P : forall k, recalg k -> Prop) := recalg_rect P.
+
+  Section recalg_rec_type.
+
+    Variables (X : Type) (P : nat -> Type).
+    Hypothesis Pcst  : P 0.
+    Hypothesis Pzero : P 1.
+    Hypothesis Psucc : P 1.
+    Hypothesis Pproj : forall k (p : pos k), P k.
+    Hypothesis Pcomp : forall k i, P k -> vec (P i) k -> P i. 
+    Hypothesis Prec  : forall k, P k -> P (S (S k)) -> P (S k).
+    Hypothesis Pmin  : forall k, P (S k) -> P k.
+
+    Fixpoint recalg_rec_type k (f : recalg k) { struct f } : P k :=
+      match f in recalg i return P i with
+        | ra_cst n     => Pcst
+        | ra_zero      => Pzero
+        | ra_succ      => Psucc
+        | ra_proj p    => Pproj p 
+        | ra_comp f gj => Pcomp [|f|] (vec_map (fun f => @recalg_rec_type _ f) gj)
+        | ra_rec f g   => Prec [|f|] [|g|]
+        | ra_min f     => Pmin [|f|]
+      end
+    where "[| f |]" := (@recalg_rec_type _ f).
+
+  End recalg_rec_type.
+  
+  Section recalg_inj.
+ 
+    (* Injectivity is not a given for dependently typed constructors but it holds
+       when the dependent parameter is from a set (ie a Type with decidable equality *)
+  
+    Let nat_dep_inj (P : nat -> Type) n x y : existT P n x = existT P n y -> x = y.
+    Proof. apply inj_pair2_eq_dec, eq_nat_dec. Qed.
+    
+    Local Ltac inj := let H := fresh in intros H; injection H; clear H; auto.
+    
+    Local Ltac diauto := 
+      repeat match goal with 
+        H: existT _ _ _ = existT _ _ _ |- _ => apply nat_dep_inj in H 
+      end; auto.
+      
+    Fact ra_cst_inj n m : ra_cst n = ra_cst m -> n = m.
+    Proof. inj. Qed.
+
+    Fact ra_proj_inj k (p q : pos k) : ra_proj p = ra_proj q -> p = q.
+    Proof. inj. Qed.
+    
+    (* This one is more subtle and requires type casts *)
+
+    Fact ra_comp_inj k k' i f f' gj gj' : 
+         @ra_comp k i f gj = @ra_comp k' i f' gj'
+      -> exists H : k = k', eq_rect _ _ f _ H = f'
+                         /\ eq_rect _ _ gj _ H = gj'.
+    Proof.
+      inj; intros ? ? H; exists H; subst; simpl; diauto.
+    Qed.
+ 
+    Fact ra_rec_inj k f g f' g' : @ra_rec k f g = ra_rec f' g' -> f = f' /\ g = g'.
+    Proof.
+      inj; intros; diauto.
+    Qed.
+
+    Fact ra_min_inj k f f' : @ra_min k f = ra_min f' -> f = f'.
+    Proof.
+      inj; intros; diauto.
+    Qed.
+
+  End recalg_inj.
+
+End Recursive_algorithms.
+
+Definition functional X Y (f : X -> Y -> Prop) := forall x y1 y2, f x y1 -> f x y2 -> y1 = y2.
+Definition total X Y (f : X -> Y -> Prop) := forall x, exists y, f x y.
+
+Section recursor.
+
+  Variables (F : nat -> Prop) (G : nat -> nat -> nat -> Prop).
+  
+  Fixpoint μ_rec n := 
+    match n with
+      | 0   => F
+      | S n => fun x => exists y, μ_rec n y /\ G n y x
+      end.
+
+  Fact μ_rec_inv n x : μ_rec n x -> exists s, F (s 0) 
+                                           /\ s n = x
+                                           /\ forall i, i < n -> G i (s i) (s (S i)).
+  Proof.
+    revert x; induction n as [ | n IHn ]; intros x; simpl.
+    + exists (fun _ => x); msplit 2; auto; intros; omega.
+    + intros (y & H1 & H2).
+      destruct (IHn _ H1) as (s & H3 & H4 & H5).
+      exists (fun i => if le_lt_dec (S n) i then x else s i); msplit 2; auto.
+      * destruct (le_lt_dec (S n) (S n)); auto; omega.
+      * intros i Hi.
+        destruct (le_lt_dec (S n) i); destruct (le_lt_dec (S n) (S i)); auto; try omega.
+        - replace i with n by omega.
+          rewrite H4; auto.
+        - apply H5; omega.
+  Qed.
+
+  Theorem μ_rec_eq n x : μ_rec n x <-> exists s, F (s 0) 
+                                              /\ s n = x
+                                              /\ forall i, i < n -> G i (s i) (s (S i)).
+  Proof.
+    split.
+    + apply μ_rec_inv.
+    + intros (s & H1 & H2 & H3).
+      rewrite <- H2; clear x H2.
+      revert s H1 H3.
+      induction n as [ | n IHn ]; intros s H1 H2; simpl; auto.
+      exists (s n); split; auto.
+  Qed.
+
+  Hypothesis (Ffun : forall n m, F n -> F m -> n = m) 
+             (Gfun : forall x y n m, G x y n -> G x y m -> n = m).
+
+  Fact μ_rec_fun : functional μ_rec. 
+  Proof.
+    intros n; induction n as [ | n IHn ]; simpl; auto.
+    intros x y (a & H1 & H2) (b & H3 & H4).
+    specialize (IHn _ _ H1 H3); subst b.
+    revert H2 H4; apply Gfun.
+  Qed.
+ 
+End recursor.
+
+Section minimization.
+
+  Variables (R : nat -> nat -> Prop)
+            (Rfun : forall n u v, R n u -> R n v -> u = v).
+
+  Definition μ_min n := R n 0 /\ forall i, i < n -> exists u, R i (S u).
+ 
+  Fact μ_min_eq n : μ_min n <-> R n 0 /\ exists s, forall i, i < n -> R i (S (s i)).
+  Proof.
+    unfold μ_min; split; intros [ H0 H ]; split; auto.
+    + apply fin_reif_nat with (1 := H).
+    + clear H0; destruct H as (s & Hs).
+      intros i ?; exists (s i); auto.
+  Qed.
+
+  Fact μ_min_fun n m : μ_min n -> μ_min m -> n = m.
+  Proof.
+    intros (H1 & H2) (H3 & H4).
+    destruct (lt_eq_lt_dec n m) as [ [ H | ] | H ]; auto; 
+      [ apply H4 in H | apply H2 in H ]; destruct H as (u & Hu);
+      [ generalize (Rfun H1 Hu) | generalize (Rfun H3 Hu) ]; discriminate.
+  Qed. 
+
+  Hypothesis HR : forall x, exists y, R x y.
+
+  Fact μ_min_of_total : (exists n, μ_min n) <-> exists x, R x 0.
+  Proof.
+    split.
+    + intros (n & ? & _); exists n; auto.
+    + intros H.
+      destruct first_which_ni with (2 := H) as (n & H1 & H2).
+      * intros n; destruct (HR n) as ([ | k] & Hk); auto.
+        right; intros C; generalize (Rfun Hk C); discriminate.
+      * exists n; split; auto.
+        intros i Hi; apply H2 in Hi.
+        destruct (HR i) as ([ | k] & Hk); try tauto.
+        exists k; auto.
+  Qed.
+
+End minimization.
+
+Section relational_semantics.
+
+  (* Recursive functions can be interpreted in Coq as (functional) relations *)
+
+  Notation natfun := (fun k => vec nat k -> nat -> Prop).
+
+  Section defs.
+
+    Definition s_cst c : natfun 0 := fun _ x => x=c.
+    Definition s_zero  : natfun 1 := fun _ x => x=0.
+    Definition s_succ  : natfun 1 := fun v x => x=S (vec_head v).
+    Definition s_proj k (p : pos k) : natfun k := fun v x => vec_pos v p = x.
+
+    Variable k i : nat.
+    
+    Implicit Types (f : natfun k) (g : natfun (S k)) (h : natfun (S (S k))) (gj : vec (natfun i) k).
+
+    Definition s_comp f gj : natfun i := fun v x => exists gl, f gl x /\ forall p, vec_pos gj p v (vec_pos gl p).
+      
+    (** the recursor s_rec_r f h n v x 
+                 <-> exists x0,...,xn,  f      v  x0,
+                                        h (0##x0##v) x1,
+                                        h (1##x1##v) x2,
+                                        ...
+                                        h (.##..##v) xn, 
+                                    and xn = x 
+    **)
+   
+    Definition s_rec f h v := μ_rec (f (vec_tail v)) (fun x y => h (x##y##vec_tail v)) (vec_head v).
+
+    Theorem s_rec_eq f h v x : s_rec f h v x <-> exists s, f (vec_tail v) (s 0) 
+                                                        /\ s (vec_head v) = x
+                                                        /\ forall i, i < vec_head v -> h (i##s i##vec_tail v) (s (S i)).
+    Proof. vec split v with n; apply μ_rec_eq. Qed.
+
+    Definition s_min g v := μ_min (fun n => g (n##v)).
+
+  End defs.
+  
+  (** we define the semantics of a recursive algorithm of arity k 
+      which is a relation vec nat k -> nat -> Prop, obviously functional (see below)
+      We interpret the constants ra_* with the corresponding s_* operator on relations
+   **) 
+
+  Definition ra_rel : forall k, recalg k -> natfun k.
+  Proof.
+    apply recalg_rect with (P := fun k _ => natfun k).
+    exact s_cst.
+    exact s_zero.
+    exact s_succ.
+    exact s_proj.
+    intros ? ? ? ? hf hgj; exact (s_comp hf (vec_set_pos hgj)).
+    intros ? ? ? hf hg; exact (s_rec hf hg).
+    intros ? ? hf; exact (s_min hf).
+  Defined.
+  
+  Notation "[| f |]" := (@ra_rel _ f) (at level 0).
+ 
+  Fact ra_rel_fix_cst i :         [| ra_cst i     |]      = s_cst i.                   Proof. reflexivity. Qed.
+  Fact ra_rel_fix_zero :          [| ra_zero      |]      = s_zero.                    Proof. reflexivity. Qed.
+  Fact ra_rel_fix_succ :          [| ra_succ      |]      = s_succ.                    Proof. reflexivity. Qed.
+  Fact ra_rel_fix_proj k p :      [| @ra_proj k p |]      = s_proj p.                  Proof. reflexivity. Qed.
+  Fact ra_rel_fix_rec k f g :     [| @ra_rec k f g |]     = s_rec [|f|] [|g|].         Proof. reflexivity. Qed.
+  Fact ra_rel_fix_min k f :       [| @ra_min k f |]       = s_min [|f|].               Proof. reflexivity. Qed.
+  Fact ra_rel_fix_comp k i f gj : [| @ra_comp k i f gj |] = s_comp [|f|] (vec_map (fun x => [|x|]) gj).
+  Proof.
+    simpl ra_rel; f_equal.
+    apply vec_pos_ext; intros p.
+    rewrite vec_pos_set, vec_pos_map; trivial.
+  Qed.
+ 
+  Section functional.
+
+    Lemma s_cst_fun c : functional (s_cst c).
+    Proof. intros v x y Hx Hy; rewrite Hy; trivial. Qed.
+
+    Lemma s_zero_fun : functional s_zero.
+    Proof. intros v x y Hx Hy; rewrite Hy; trivial. Qed.
+
+    Lemma s_succ_fun : functional s_succ.
+    Proof. intros v x y Hx Hy; rewrite Hy; trivial. Qed.
+    
+    Lemma s_proj_fun k p : functional (@s_proj k p).
+    Proof.
+      intros v x y Hx Hy.
+      red in Hx, Hy. 
+      rewrite <- Hx.
+      trivial.
+    Qed.
+
+    Variable k i : nat.
+    Implicit Types (f : natfun k) (gj : vec (natfun i) k) (g : natfun (S k)) (h : natfun (S (S k))).
+
+    Lemma s_comp_fun f gj : functional f -> (forall p, functional (vec_pos gj p)) -> functional (s_comp f gj).   
+    Proof.
+      intros f_fun gj_fun v x y [ gx [ Hx1 Hx2 ] ] [ gy [ Hy1 Hy2 ] ].
+      cutrewrite (gx = gy) in Hx1.
+      apply (@f_fun gy); trivial.
+      apply vec_pos_ext.
+      intros p; apply (gj_fun p v); auto.
+    Qed.
+
+    Lemma s_rec_fun f h : functional f -> functional h -> functional (s_rec f h).
+    Proof.
+      intros Hf Hh ? ? ?. 
+      apply μ_rec_fun. 
+      * apply Hf.
+      * intros ? ? ? ? ?; apply Hh; auto.
+    Qed.
+
+    Lemma s_min_fun g : functional g -> functional (s_min g).
+    Proof.
+      intros Hg ? ? ?; apply μ_min_fun.
+      intros ? ? ?; apply Hg.
+    Qed.
+
+  End functional.
+
+  Hint Resolve s_cst_fun s_zero_fun s_succ_fun s_proj_fun s_rec_fun s_min_fun.
+
+  (* [| f |] is a functional/deterministic relation *)
+
+  Theorem ra_rel_fun k (f : recalg k) v x y : [|f|] v x -> [|f|] v y -> x = y.
+  Proof.
+    revert v x y; change (functional [|f|]).
+    induction f; try (simpl; auto; fail).
+    rewrite ra_rel_fix_comp.
+    apply s_comp_fun; auto. 
+    intro; rewrite vec_pos_map; auto.
+  Qed.
+
+  Section total.
+
+    Fact ra_cst_tot n : total [| ra_cst n |].
+    Proof. intros ?; exists n; simpl; red; auto. Qed.
+
+    Fact ra_zero_tot : total [| ra_zero |].
+    Proof. intros ?; exists 0; simpl; red; auto. Qed.
+
+    Fact ra_succ_tot : total [| ra_succ |].
+    Proof. intros v; exists (S (vec_head v)); simpl; red; auto. Qed.
+  
+    Fact ra_proj_tot n p : total [| @ra_proj n p |].
+    Proof. intros v; exists (vec_pos v p); simpl; red; auto. Qed.
+
+    Fact ra_rec_tot n f g : total [|f|] -> total [|g|] -> total [|@ra_rec n f g|].
+    Proof.
+      intros Hf Hg v; vec split v with x.
+      simpl; induction x as [ | x IHx ]; simpl.
+      + destruct (Hf v) as (y & Hy).
+        exists y; red; simpl; auto.
+      + destruct IHx as (y & Hy).
+        destruct (Hg (x##y##v)) as (z & Hz).
+        exists z, y; simpl; split; auto.
+    Qed.
+
+    Variables (k i : nat) (f : recalg k) (g : vec (recalg i) k)
+              (Hf : total [|f|]) (Hg : forall p, total [|vec_pos g p|]).
+
+    Fact ra_comp_tot : total [|ra_comp f g|].
+    Proof.
+      intros v.
+      assert (H1 : forall p, exists x, [|vec_pos g p|] v x) by (intro; apply Hg).
+      apply vec_reif in H1; destruct H1 as (w & Hw).
+      destruct (Hf w) as (y & Hy).
+      exists y, w; split; auto.
+      intro; rewrite vec_pos_set; auto.
+    Qed.
+
+  End total.
+
+  Section prim_rec.
+
+    Definition prim_rec : forall n, recalg n -> Prop.
+    Proof.
+      apply recalg_rect.
+      + intros; exact True.
+      + exact True.
+      + exact True.
+      + intros; exact True.
+      + intros k i _ _ H1 H2; exact (H1 /\ forall p, H2 p).
+      + intros k _ _ H1 H2; exact (H1 /\ H2).
+      + intros; exact False.
+    Defined. 
+
+    Definition prim_rec_bool : forall n, recalg n -> bool.
+    Proof.
+      apply recalg_rect.
+      + intros; exact true.
+      + exact true.
+      + exact true.
+      + intros; exact true.
+      + intros k i _ _ H1 H2.
+        exact (andb H1 (fold_right andb true (map H2 (pos_list _)))).
+      + intros k _ _ H1 H2; exact (andb H1 H2).
+      + intros; exact false.
+    Defined. 
+
+    Let fold_right_andb l : fold_right andb true l = true <-> forall x, In x l -> x = true.
+    Proof.
+      induction l as [ | x l IHl ]; simpl; try tauto.
+      rewrite andb_true_iff, IHl; firstorder; subst; auto.
+    Qed.
+
+    Fact prim_rec_bool_spec n f : @prim_rec_bool n f = true <-> prim_rec f.
+    Proof.
+      induction f as [ x | | | n p | n i f g Hf Hg | n f g Hf Hg | n f Hf ]; simpl; try tauto.
+      + rewrite andb_true_iff, fold_right_andb, <- Forall_forall.
+        rewrite Forall_map, Forall_forall, Hf.
+        split; intros (? & H); split; auto.
+        * intros p; apply Hg, H, pos_list_prop.
+        * intros x Hx; apply Hg, H.
+      + rewrite andb_true_iff, Hf, Hg; tauto.
+      + split; try tauto; discriminate.
+    Qed.
+
+    Hint Resolve ra_cst_tot ra_zero_tot ra_succ_tot ra_proj_tot ra_rec_tot.
+
+    Fact prim_rec_tot k f : @prim_rec k f -> total [|f|].
+    Proof.
+      induction f as [ x | | | n p | n i f g Hf Hg | n f g Hf Hg | n f Hf ]; intros H; simpl in H; auto.
+      + apply ra_comp_tot; try tauto; intros; apply Hg, H.
+      + apply ra_rec_tot; tauto.
+      + tauto.
+    Qed.
+
+  End prim_rec.
+
+End relational_semantics.
+
+Definition MUREC_PROBLEM := recalg 0.
+Definition MUREC_HALTING : MUREC_PROBLEM -> Prop.
+Proof. intros f; exact (ex (ra_rel f vec_nil)). Defined.
+

--- a/theories/Reductions/DIO_MUREC.v
+++ b/theories/Reductions/DIO_MUREC.v
@@ -1,0 +1,61 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List.
+
+From Undecidability.ILL Require Import Definitions.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_nat.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.H10.Dio 
+  Require Import dio_single.
+
+From Undecidability.MuRec 
+  Require Import recalg ra_dio_poly.
+
+Definition DIO_SINGLE_PROBLEM := { n : nat & dio_polynomial (pos n) (pos 0) 
+                                           * dio_polynomial (pos n) (pos 0) }%type.
+
+Definition DIO_SINGLE_SAT : DIO_SINGLE_PROBLEM -> Prop.
+Proof.
+  intros (n & p & q).
+  apply (dio_single_pred (p,q)), pos_O_any.
+Defined.
+
+Section DIO_SINGLE_SAT_MUREC_HALTING.
+
+  Let f : DIO_SINGLE_PROBLEM -> MUREC_PROBLEM.
+  Proof.
+    intros (n & p & q).
+    exact (ra_dio_poly_find p q).
+  Defined.
+
+  Theorem DIO_SINGLE_SAT_MUREC_HALTING : DIO_SINGLE_SAT ⪯ MUREC_HALTING.
+  Proof.
+    exists f.
+    intros (n & p & q); simpl; unfold MUREC_HALTING.
+    rewrite ra_dio_poly_find_spec; unfold dio_single_pred.
+    split.
+    + intros (phi & Hphi); exists (vec_set_pos phi).
+      simpl in Hphi; eq goal Hphi; f_equal; apply dp_eval_ext; auto;
+        try (intros; rewrite vec_pos_set; auto; fail);
+        intros j; analyse pos j.
+    + intros (v & Hw); exists (vec_pos v).
+      eq goal Hw; f_equal; apply dp_eval_ext; auto;
+        intros j; analyse pos j.
+  Qed.
+
+End DIO_SINGLE_SAT_MUREC_HALTING.
+
+Check DIO_SINGLE_SAT_MUREC_HALTING.
+Print Assumptions DIO_SINGLE_SAT_MUREC_HALTING.

--- a/theories/Reductions/MMA2_to_MM2.v
+++ b/theories/Reductions/MMA2_to_MM2.v
@@ -17,7 +17,6 @@ From Undecidability.H10.Fractran Require Import fractran_defs prime_seq mm_fract
 From Undecidability.MM Require Import mma_defs fractran_mma.
 From Undecidability.Problems Require Import MM2.
 
-
 (* Require Import utils pos vec subcode sss. *)
 (* Require Import fractran_defs prime_seq mm_fractran.  *)
 (* Require Import mm_defs mma_defs fractran_mma. *)
@@ -42,7 +41,7 @@ Section MMA2_to_MM2.
   Notation "P '/2/' x ↠ y" := (clos_refl_trans _ (mm2_step P) x y) (at level 70, no associativity).
   Notation "P '/2/' s ↓" := (mm2_terminates P s) (at level 70, no associativity).
 
-  Definition mma_mm2_instr : mm_instr 2 -> mm2_instr.
+  Definition mma_mm2_instr : mm_instr (pos 2) -> mm2_instr.
   Proof.
     intros [ [ | p ] | [ | p ] j ].
     + exact mm2_inc_a.
@@ -51,7 +50,7 @@ Section MMA2_to_MM2.
     + exact (mm2_dec_b j).
   Defined.
 
-  Definition mm2_mma_instr : mm2_instr -> mm_instr 2.
+  Definition mm2_mma_instr : mm2_instr -> mm_instr (pos 2).
   Proof.
     intros [ | | j | j ].
     + exact (INC pos0).

--- a/theories/Reductions/MM_to_MMA2.v
+++ b/theories/Reductions/MM_to_MMA2.v
@@ -31,8 +31,8 @@ Set Implicit Arguments.
 Local Notation "P /MM/ s ↓" := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity). 
 Local Notation "P /MMA/ s ↓" := (sss_terminates (@mma_sss 2) P s) (at level 70, no associativity). 
 
-Theorem mm_mma2 n (P : list (mm_instr n)) : 
-               {   Q : list (mm_instr 2) 
+Theorem mm_mma2 n (P : list (mm_instr (pos n))) : 
+               {   Q : list (mm_instr (pos 2)) 
                & { f : vec nat n -> vec nat 2 
                  | forall v, (1,P) /MM/ (1,v) ↓ <-> (1,Q) /MMA/ (1,f v) ↓ } }.
 Proof.

--- a/theories/Reductions/MUREC_MM.v
+++ b/theories/Reductions/MUREC_MM.v
@@ -1,0 +1,52 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega.
+
+From Undecidability Require Import ILL.Definitions.
+
+Require Import Undecidability.Shared.Libs.DLW.Utils.utils.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+From Undecidability.ILL.Code
+  Require Import sss subcode.
+
+From Undecidability.ILL.Mm
+  Require Import mm_defs.
+
+From Undecidability.MuRec 
+  Require Import recalg ra_comp. 
+
+Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
+Local Notation "P /MM/ s ↓"     := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity).
+
+Section MUREC_MM_HALTING.
+
+ Let f : MUREC_PROBLEM -> MM_PROBLEM.
+  Proof.
+    intros g.
+    destruct (ra_mm_simulator g) as (m & P & _).
+    exists (S m), P; apply vec_zero.
+  Defined.
+
+  Theorem MUREC_MM_HALTING : MUREC_HALTING ⪯ MM_HALTING.
+  Proof.
+    exists f; unfold f.
+    intros g; simpl; unfold MUREC_HALTING, MM_HALTING.
+    destruct (ra_mm_simulator g) as (m & P & H); simpl.
+    rewrite H, vec_app_nil; tauto.
+  Qed.
+
+End MUREC_MM_HALTING.
+
+Check MUREC_MM_HALTING.
+Print Assumptions MUREC_MM_HALTING.
+

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -102,6 +102,17 @@ ILL/UNDEC.v
 MM/mma_defs.v
 MM/mma_utils.v
 MM/fractran_mma.v
+MM/env.v
+MM/mm_instr.v
+MM/mm_env_utils.v
+
+MuRec/recalg.v
+MuRec/ra_utils.v
+MuRec/ra_enum.v
+MuRec/ra_dio_poly.v
+MuRec/ra_mm_env.v
+MuRec/ra_mm.v
+MuRec/ra_comp.v
 
 H10/Fractran/mm_no_self.v
 H10/Fractran/prime_seq.v
@@ -395,6 +406,7 @@ Problems/FOL.v
 Problems/TM.v
 Problems/SR.v
 Problems/MM.v
+Problems/MM2.v
 Problems/BSM.v
 Problems/ILL.v
 Problems/FRACTRAN.v
@@ -411,6 +423,10 @@ Reductions/BPCP_to_BSM.v
 Reductions/BSM_to_MM.v  
 Reductions/MM_to_ILL.v  
 Reductions/BPCP_to_FOL.v
+Reductions/DIO_MUREC.v
+Reductions/MUREC_MM.v
+Reductions/MMA2_to_MM2.v
+Reductions/MM_to_MMA2.v
 Reductions/MM_to_FRACTRAN.v
 Reductions/FRACTRAN_to_H10C.v
 Reductions/L_to_mTM.v


### PR DESCRIPTION
Notice that to avoid having several definitions of MM, I needed to generalize the definition of `mm_instr` to an arbitrary type `X : Type` of registers (in `MM/mm_instr.v`) of which only the instances `X = nat` and `X = pos n` are actually used. But this implied changing `mm_instr n` into `mm_instr (pos n)` at (not so many but still) several places in the code.

- `MM/env.v` : environments `env` to work with `mm_instr nat`; values of registers cannot be stored in a finitary vector `vec nat n` but need to be stored into `nat -> nat` instead
- `MM/mm_env_utils.v` : library for `env`
- `MM/mm_instr.v` : the general definition of `mm_instr X`; `MM/mma_defs.v` and `ILL/Mm/mm_defs.v` inherit/specialize this definition 
- `MuRec/recalg.v` : definition the type `recalg` of µ-recursive algorithms
- `MuRec/ra_utils.v`, `MuRec/ra_enum.v` : libraries for `recalg` (coming from the ITP'17 paper) 
- `MuRec/ra_dio_poly.v` : maps single Diophantine equations to `recalg`
- `MuRec/ra_mm_env.v`, `MuRec/ra_mm.v`, `MuRec/ra_comp.v` : implementation of a simulator for any `recalg` as a MM; there is a compiler in the middle which is the hard work and it takes ages for Coq to typecheck that stuff (misuse of `omega` ?)
	
New reductions follow (and old one get activated) :

- `Reductions/DIO_MUREC.v` : DIO_SINGLE to µ-REC
- `Reductions/MUREC_MM.v` : µ-REC to MM
- `Reductions/MMA2_to_MM2.v` : two equivalent definitions MM with just 2 registers but beware **that these jump on not 0**, contrary of the pre-existing ones in `ILL/Mm` that jump on 0; the `A` is for alternate !!
- `Reductions/MM_to_MMA2.v` : from MM to MMA2 via FRACTRAN

