### PR TITLE
A fork for smoother reduction dio_form -> dio_elem

### DIFF
--- a/theories/H10/ArithLibs/Zp.v
+++ b/theories/H10/ArithLibs/Zp.v
@@ -702,6 +702,60 @@ Section Zp.
       rewrite Z2Zp_plus; f_equal.
       apply Z2Zp_opp.
     Qed.
+   
+    Section Z2Zp_canon.
+
+      (** Find a representative in the A interval [0,Z.of_nat p[ *) 
+
+      Let Z2Zp_canon_pos u : 0 <= u -> { v | 〘u〙=〘v〙 /\ 0 <= v < Z.of_nat p }.
+      Proof.
+        intros H1. 
+        rewrite Z2Zp_pos; auto.
+        exists (Z.of_nat (rem (Z.to_nat u) p)); split.
+        rewrite Z2Zp_of_nat.
+        apply nat2Zp_inj.
+        rewrite rem_rem; auto.
+        split.
+        * apply Zle_0_nat.
+        * apply inj_lt, div_rem_spec2; auto.
+      Qed.
+
+      Let Z2Zp_canon_neg u : u <= 0 -> { v | 〘u〙=〘v〙 /\ 0 <= v < Z.of_nat p }.
+      Proof.
+        intros H1.
+        rewrite Z2Zp_neg; try omega.
+        rewrite Z2Zp_opp, Zp_opp_inv.
+        destruct (Zp_eq_dec (Z2Zp u) Zp_zero) as [ E | D ].
+        + exists 0; split.
+          * rewrite E, Z2Zp_zero; auto.
+          * split; omega.
+        + destruct Z2Zp_canon_pos with (u := -u)
+          as (v & H2 & H3); try omega.
+          exists (Z.of_nat p - v); split.
+          * rewrite Z2Zp_minus, Z2Zp_of_nat, nat2Zp_p, <- H2, Z2Zp_opp; ring.
+          * split; try omega.
+            destruct (Z.eq_dec v 0) as [ E | ]; try omega.
+            subst; destruct D.
+            rewrite Z2Zp_opp in H2.
+            rewrite <- (Zp_opp_inv 〘 _ 〙), H2, Z2Zp_zero; ring.
+      Qed.
+ 
+      Fact Z2Zp_repr_canon u : { v |〘u〙=〘v〙 /\ 0 <= v < Z.of_nat p }.
+      Proof.
+        destruct (Z_pos_or_neg u); auto.
+        apply Z2Zp_canon_neg; omega.
+      Qed.
+
+    End Z2Zp_canon.
+
+    Fact Zp_repr_interval a b u :
+            Z.of_nat p <= b-a -> { v |〘u〙=〘v〙/\ a <= v < b }.
+    Proof.
+      intros Hab.
+      destruct (Z2Zp_repr_canon (u-a)) as (v & H1 & H2).
+      exists (a+v)%Z; split; try omega.
+      rewrite Z2Zp_plus, <- H1, Z2Zp_minus; ring.
+    Qed.
 
     Section Z2Zp_mult.
   

--- a/theories/H10/ArithLibs/Zp.v
+++ b/theories/H10/ArithLibs/Zp.v
@@ -835,6 +835,17 @@ Section Zp.
 
     End Z2Zp_inj.
 
+    Fact Z2Zp_zero_inv u : 
+          〘u〙= Zp_zero 
+        -> exists v, (u = Z.of_nat p * v)%Z.
+    Proof.
+      intros H.
+      rewrite <- Z2Zp_zero in H.
+      apply Z2Zp_inj in H.
+      destruct H as (y & Hy); exists y.
+      rewrite Zmult_comm, <- Hy; ring.
+    Qed.
+
     Fact nat2Zp_choose : forall x, x = Zp \/ x = Op \/ x = ∸ Op \/ exists m,  (1 < m < p-1)%nat /\〚m〛= x.
     Proof.
       intros (x & Hx).

--- a/theories/H10/ArithLibs/lagrange.v
+++ b/theories/H10/ArithLibs/lagrange.v
@@ -7,20 +7,25 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Arith Omega Eqdep_dec ZArith List.
+Require Import Arith ZArith Lia List.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list gcd prime php utils_nat.
-From Undecidability.H10.ArithLibs Require Import Zp.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_list gcd prime php utils_nat.
+
+From Undecidability.H10.ArithLibs 
+  Require Import Zp.
 
 Set Implicit Arguments.
 
-Section lagrange.
+Ltac omega := idtac "replace with lia"; fail.
+
+Section utils.
 
   Fact prime_2_or_odd p : prime p -> p = 2 \/ exists n, 0 < n /\ p = 2*n+1.
   Proof.
     intros Hp.
     assert (H1 : p <> 0).
-    { generalize (prime_ge_2 Hp); omega. }
+    { generalize (prime_ge_2 Hp); lia. }
     assert (H3 : 2 <> 0) by discriminate.
     destruct (eq_nat_dec p 2) as [ | H2 ]; auto; right.
     assert (rem p 2 = 1) as Hp1.
@@ -29,186 +34,21 @@ Section lagrange.
       + intros H _.
         apply divides_rem_eq in H.
         apply proj2 in Hp.
-        destruct (Hp _ H); subst; omega.
-      + intros; omega. }
+        destruct (Hp _ H); subst; lia.
+      + intros; lia. }
     exists (div p 2); split.
     + generalize (div_rem_spec1 p 2) (prime_ge_2 Hp).
-      destruct (div p 2); intros;  omega.
+      destruct (div p 2); intros; lia.
     + rewrite mult_comm.
       rewrite (div_rem_spec1 p 2) at 1.
       f_equal; auto.
   Qed.
 
-  Lemma lagrange_prelim p n : prime p -> p = 2*n+1 -> 0 < n -> exists a b, divides p (1+a*a+b*b) /\ 2*a <= p-1 /\ 2*b <= p-1.
-  Proof.
-    intros H2 Hn2 Hn1.
-    assert (Hp : p <> 0) by omega.
-    set (l := list_an 0 (1+n)).
-    assert (Hl : forall x, In x l <-> x <= n).
-    { unfold l; intros x; rewrite list_an_spec; omega. }
-    set (f x := nat2Zp Hp (x*x)).
-    assert (Hf : forall x y, In x l -> In y l -> f x = f y -> x = y).
-    { unfold f; intros x y G1 G2 H.
-      do 2 rewrite nat2Zp_mult in H.
-      apply Zp_prime_square_eq_square in H; auto.
-      destruct H as [ H | H ].
-      + rewrite nat2Zp_inj in H.
-        rewrite <- (@rem_idem x p), H, rem_idem; auto.
-        - apply Hl in G2; subst; omega.
-        - apply Hl in G1; subst; omega.
-      + apply f_equal with (f := @proj1_sig _ _) in H; simpl in H.
-        rewrite rem_idem in H.
-        2: apply Hl in G1; subst; omega.
-        case_eq (rem y p).
-        - intros Hy.
-          rewrite Hy, Nat.sub_0_r, rem_diag in H; auto.
-          rewrite rem_idem in Hy; try omega.
-          apply Hl in G2; subst; omega.
-        - intros w Hw.
-          rewrite rem_idem in H; try omega.
-          rewrite H.
-          apply Hl in G2.
-          apply Hl in G1.
-          rewrite rem_idem in H; omega. }
-    set (g y := Zp_opp Hp (Zp_plus Hp (Zp_one Hp) (f y))).
-    assert (Hg : forall x y, In x l -> In y l -> g x = g y -> x = y).
-    { intros x y G1 G2 G3.
-      unfold g in G3.
-      apply Zp_opp_inj, Zp_plus_inj_l in G3.
-      revert G3; apply Hf; auto. }
-    destruct partition_intersection with (l := map f l) (m := map g l) (k := Zp_list Hp)
-        as [ G | [ G | (u & G1 & G2) ] ].
-    * rewrite Zp_list_length, app_length, map_length, map_length.
-      unfold l; rewrite list_an_length; omega.
-    * intros ? _; apply Zp_list_spec.
-    * apply list_has_dup_map_inv in G; auto.
-      apply not_list_has_dup_an in G; tauto.
-    * apply list_has_dup_map_inv in G; auto.
-      apply not_list_has_dup_an in G; tauto.
-    * rewrite in_map_iff in G1.
-      rewrite in_map_iff in G2.
-      destruct G1 as (a & G3 & G4).
-      destruct G2 as (b & G5 & G6).
-      exists a, b; split; [ | split ].
-      + rewrite divides_nat2Zp with (Hp := Hp).
-        rewrite (plus_comm 1), <- plus_assoc.
-        do 2 rewrite nat2Zp_plus.
-        rewrite nat2Zp_one.
-        fold (f a).
-        apply Zp_opp_plus_eq.
-        fold (f b); fold (g b).
-        rewrite G3, G5, Zp_plus_zero.
-        trivial.
-      + apply Hl in G4; rewrite Hn2; omega.
-      + apply Hl in G6; rewrite Hn2; omega.
-  Qed.
-
-  Let square_lemma x y : (x+y)*(x+y) = x*x+2*(x*y)+y*y.
+  Fact remarkable_id1_nat x y : (x+y)*(x+y) = x*x+2*(x*y)+y*y.
   Proof. ring. Qed.
 
-  Lemma lagrange_prelim' p : prime p -> exists n a b, n*p = 1+a*a+b*b /\ 0 < n < p.
-  Proof.
-    intros Hp.
-    destruct (prime_2_or_odd Hp) as [ | (n & Hn1 & Hn2) ].
-    + exists 1, 1, 0; subst; auto.
-    + destruct (lagrange_prelim Hp Hn2 Hn1) as (a & b & (k & Hk) & Ha & Hb).
-      exists k, a, b; split; auto.
-      split.
-      1: destruct k; simpl in Hk; try omega; discriminate.
-      assert (a <= n) as Ha' by omega.
-      assert (b <= n) as Hb' by omega.
-      destruct (le_lt_dec p k) as [ H | H ]; auto.
-      exfalso.
-      assert (a*a+2*(1*1)+b*b <= k*p) as C; try omega.
-      apply le_trans with ((n+n)*(n+n)).
-      2: apply mult_le_compat; omega.
-      rewrite square_lemma.
-      apply plus_le_compat.
-      2: apply mult_le_compat; auto.
-      apply plus_le_compat.
-      1: apply mult_le_compat; auto.
-      apply mult_le_compat_l.
-      apply mult_le_compat; omega.
-  Qed.
-
-  Section rem_square_opp.
-
-    Variable (x m : nat) (Hx : x < m).
-
-    Let Hm : m <> 0. Proof. omega. Qed.
-
-    Add Ring Zp_ring : (Zp_is_ring Hm).
-
-    Fact rem_square_opp : rem (x*x) m = rem ((m-x)*(m-x)) m.
-    Proof.
-      rewrite <- nat2Zp_inj with (Hp := Hm).
-      rewrite (nat2Zp_mult Hm (m-x)), nat2Zp_mult.
-      rewrite !nat2Zp_minus; try omega.
-      rewrite !nat2Zp_p; ring.
-    Qed.
-
-  End rem_square_opp.
-
-  Section rem_square_div2. 
-
-    Variable (m : nat) (Hm : 0 < m).
-
-    Let Hm2 : 2*m <> 0. Proof. omega. Qed.
-
-    Fact rem_square_div2_even x : exists y, rem (x*x) (2*m) = rem (y*y) (2*m) /\ y <= m.
-    Proof.
-      destruct (le_lt_dec (rem x (2*m)) m) as [ H | H ].
-      + exists (rem x (2*m)); split; auto.
-        rewrite rem_mult_rem, (mult_comm (rem _ _)), rem_mult_rem; auto.
-      + generalize (div_rem_spec2 x Hm2); intros H1.
-        exists (2*m - rem x (2*m)); split; try omega.
-        rewrite <- rem_square_opp; auto.
-        rewrite rem_mult_rem, (mult_comm (rem _ _) x), rem_mult_rem; auto.
-    Qed.
-
-    Let Hm3 : 1+2*m <> 0. Proof. omega. Qed.
-
-    Fact rem_square_div2_odd x : exists y, rem (x*x) (1+2*m) = rem (y*y) (1+2*m) /\ y <= m.
-    Proof.
-      destruct (le_lt_dec (rem x (1+2*m)) m) as [ H | H ].
-      + exists (rem x (1+2*m)); split; auto.
-        rewrite rem_mult_rem, (mult_comm (rem _ _)), rem_mult_rem; auto.
-      + generalize (div_rem_spec2 x Hm3); intros H1.
-        exists (1+2*m - rem x (1+2*m)); split; try omega.
-        rewrite <- rem_square_opp; auto.
-        rewrite rem_mult_rem, (mult_comm (rem _ _) x), rem_mult_rem; auto.
-    Qed.
-
-  End rem_square_div2.
-
-  Fact rem_square_div2 x m : 1 < m -> exists y, rem (x*x) m = rem (y*y) m /\ y <= div m 2.
-  Proof.
-    intros Hm.
-    destruct (euclid_2 m) as (p & [ Hp | Hp ]).
-    + subst m; rewrite div_2_fix_1.
-      apply rem_square_div2_even; omega.
-    + subst; rewrite div_2_fix_2.
-      apply rem_square_div2_odd; omega.
-  Qed.
-
-  Fact rem_sum_fun a b c m : rem a m = rem b m -> rem (a+c) m = rem (b+c) m.
-  Proof. intros H; rewrite rem_plus, H, <- rem_plus; auto. Qed.
-
-  Fact rem_sum4_rem a b c d m : rem (a+b+c+d) m = rem (rem a m+rem b m+rem c m+rem d m) m.
-  Proof.
-    do 3 (rewrite rem_plus; apply rem_sum_fun; rewrite rem_rem); auto.
-  Qed.
-
-  Fact Z2Zp_div m (Hm : m <> 0) x : 
-          Z2Zp Hm x = Zp_zero Hm 
-       -> exists y, (x = Z.of_nat m * y)%Z.
-  Proof.
-    intros H.
-    rewrite <- Z2Zp_zero in H.
-    apply Z2Zp_inj in H.
-    destruct H as (y & Hy); exists y.
-    rewrite Zmult_comm, <- Hy; ring.
-  Qed.
+  Fact remarkable_id1_Z (a b : Z) : ((a+b)*(a+b) = a*a + 2*a*b + b*b)%Z.
+  Proof. ring. Qed.
 
   Fact Zsquare_bound x y : (-y <= x <= y -> x*x <= y*y)%Z.
   Proof.
@@ -216,56 +56,48 @@ Section lagrange.
     destruct (Z_pos_or_neg x).
     + apply Z.square_le_mono_nonneg; auto.
     + replace (y*y)%Z with ((-y)*(-y))%Z by ring.
-      apply Z.square_le_mono_nonpos; omega.
+      apply Z.square_le_mono_nonpos; lia.
   Qed.
 
-  Fact Zrem_double m (Hm : m <> 0) x :  exists y, Z2Zp Hm x = Z2Zp Hm y
-                                              /\ (4*(y*y) <= Z.of_nat m * Z.of_nat m)%Z.
-  Proof.
-    destruct (euclid_2 m) as (p & [ H | H ]).
-    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (Z.of_nat p) x) as (y & H1 & H2).
-      * rewrite H, Nat2Z.inj_mul; simpl Z_of_nat; omega.
-      * exists y; split; auto.
-        rewrite H, Nat2Z.inj_mul.
-        simpl Z.of_nat.
-        replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
-        with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
-        apply Zmult_le_compat_l; try omega.
-        apply Zsquare_bound; omega.
-    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (1+Z.of_nat p) x) as (y & H1 & H2).
-      * rewrite H, Nat2Z.inj_add, Nat2Z.inj_mul; simpl Z_of_nat; omega.
-      * exists y; split; auto.
-        apply Z.le_trans with (Z.of_nat (2*p) * Z.of_nat (2*p))%Z.
-        - rewrite Nat2Z.inj_mul.
-          simpl Z.of_nat.
-          replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
-          with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
-          apply Zmult_le_compat_l; try omega.
-          apply Zsquare_bound; omega.
-        - apply Zsquare_bound; subst.
-          rewrite !Nat2Z.inj_add, !Nat2Z.inj_mul; simpl Z.of_nat; omega.
-  Qed.
- 
-  Fact bounded_four x1 x2 x3 x4 m : 
-            (x1 <= m -> x2 <= m -> x3 <= m -> x4 <= m
-         -> x1+x2+x3+x4 = 4*m -> x1 = m /\ x2 = m /\ x3 = m /\ x4 = m)%Z.
-  Proof. omega. Qed.
+  Local Fact bounded_upper_limit_4 a b c d m : 
+           (a <= m 
+         -> b <= m 
+         -> c <= m 
+         -> d <= m
+         -> a+b+c+d = 4*m 
+         -> a = m 
+         /\ b = m 
+         /\ c = m 
+         /\ d = m)%Z.
+  Proof. lia. Qed.
 
-  Fact positive_sum_4 a b c d : 
-    (0 <= a -> 0 <= b -> 0 <= c -> 0 <= d -> a + b + c + d = 0 -> a = 0 /\ b = 0 /\ c = 0 /\ d = 0)%Z.
-  Proof. intros; omega. Qed.
+  Local Fact bounded_lower_limit_4 a b c d : 
+           (0 <= a 
+         -> 0 <= b 
+         -> 0 <= c 
+         -> 0 <= d 
+         -> a+b+c+d = 0 
+         -> a = 0 
+         /\ b = 0 
+         /\ c = 0 
+         /\ d = 0)%Z.
+  Proof. lia. Qed.
 
-  Fact four_square_zero x1 x2 x3 x4 : 
-          (x1*x1+x2*x2+x3*x3+x4*x4 = 0)%Z -> (x1 = 0 /\ x2 = 0 /\ x3 = 0 /\ x4 = 0)%Z.
+  Local Fact four_squares_zero a b c d : 
+           (a*a+b*b+c*c+d*d = 0 
+         -> a = 0 
+         /\ b = 0 
+         /\ c = 0 
+         /\ d = 0)%Z.
   Proof.
     intros H.
-    apply positive_sum_4 in H; try apply Z.square_nonneg.
+    apply bounded_lower_limit_4 in H; try apply Z.square_nonneg.
     destruct H as (H1 & H2 & H3 & H4).
     apply Zmult_integral in H1.
     apply Zmult_integral in H2.
     apply Zmult_integral in H3.
     apply Zmult_integral in H4.
-    omega.
+    destruct H1; destruct H2; destruct H3; destruct H4; auto.
   Qed.
  
   Fact Zsquare_inj x y : (x*x = y*y -> { x = y } + { - x = y } )%Z.
@@ -275,170 +107,363 @@ Section lagrange.
     { rewrite Z.mul_sub_distr_l, !Z.mul_add_distr_r, H; ring. }
     apply Zmult_integral in E.
     destruct (Z.eq_dec x y); auto.
-    right; omega.
+    right; lia.
   Qed.
 
-  Fact four_square_simpl x m : (4*(x*x) = Z.of_nat m*Z.of_nat m)%Z -> { n | m = 2*n /\ (x = Z.of_nat n \/ (x = - Z.of_nat n)%Z) }.
+  Fact square_4_simpl x m : 
+        (4*(x*x) = Z.of_nat m*Z.of_nat m)%Z 
+     -> { n | m = 2*n 
+           /\   (x = Z.of_nat n 
+             \/ (x = - Z.of_nat n)%Z) }.
   Proof.
     intros H.
     replace (4*(x*x))%Z with ((2*x)*(2*x))%Z in H by ring.
     apply Zsquare_inj in H.
     destruct H as [ H | H ].
     + destruct Z_of_nat_complete_inf with x as (k & ->).
-      * generalize (Zle_0_nat m); omega.
+      * generalize (Zle_0_nat m); lia.
       * exists k; split; auto.
         apply Nat2Z.inj.
         rewrite Nat2Z.inj_mul, <- H; auto.
     + destruct (Z_of_nat_complete_inf (Z.opp x)) as (k & Hk).
-      * generalize (Zle_0_nat m); omega.
+      * generalize (Zle_0_nat m); lia.
       * exists k; split.
         - apply Nat2Z.inj.
           rewrite Nat2Z.inj_mul, <- H, <- Hk; ring.
         - right; rewrite <- Hk; ring.
   Qed.
 
-  Fact four_square_simpl' x m : (4*(x*x) = Z.of_nat (2*m)*Z.of_nat (2*m))%Z 
-                             -> x = Z.of_nat m \/ (x = - Z.of_nat m)%Z.
+  Fact square_4_simpl' x m : 
+         (4*(x*x) = Z.of_nat (2*m)*Z.of_nat (2*m) 
+       -> x = Z.of_nat m \/ x = - Z.of_nat m)%Z.
   Proof.
     intros H.
     replace (4*(x*x))%Z with ((2*x)*(2*x))%Z in H by ring.
     apply Zsquare_inj in H.
     destruct H as [ H | H  ]; rewrite Nat2Z.inj_mul in H; 
-     change (Z.of_nat 2) with 2%Z in H; omega.
+      change (Z.of_nat 2) with 2%Z in H; lia.
   Qed.
 
-  Fact Zsquare_plus (a b : Z) : ((a+b)*(a+b) = a*a + 2*a*b + b*b)%Z.
-  Proof. ring. Qed.
+  (* We can find a small representative in absolute value *)
 
-  Section half_modulus_lemma.
+  Lemma Zp_small_repr m (Hm : m <> 0) x : 
+         exists y, Z2Zp Hm x = Z2Zp Hm y
+               /\ (4*(y*y) <= Z.of_nat m * Z.of_nat m)%Z.
+  Proof.
+    destruct (euclid_2 m) as (p & [ H | H ]).
+    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (Z.of_nat p) x) as (y & H1 & H2).
+      * rewrite H, Nat2Z.inj_mul; simpl Z_of_nat; lia.
+      * exists y; split; auto.
+        rewrite H, Nat2Z.inj_mul.
+        simpl Z.of_nat.
+        replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
+        with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
+        apply Zmult_le_compat_l; try lia.
+        apply Zsquare_bound; lia.
+    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (1+Z.of_nat p) x) as (y & H1 & H2).
+      * rewrite H, Nat2Z.inj_add, Nat2Z.inj_mul; simpl Z_of_nat; lia.
+      * exists y; split; auto.
+        apply Z.le_trans with (Z.of_nat (2*p) * Z.of_nat (2*p))%Z.
+        - rewrite Nat2Z.inj_mul.
+          simpl Z.of_nat.
+          replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
+          with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
+          apply Zmult_le_compat_l; try lia.
+          apply Zsquare_bound; lia.
+        - apply Zsquare_bound; subst.
+          rewrite !Nat2Z.inj_add, !Nat2Z.inj_mul; simpl Z.of_nat; lia.
+  Qed.
 
-    (* x = +- m [ 2*m ] -> x² = m² [4*m²] 
+  Lemma Zp_square_zero m (Hm : m <> 0) (Hm2 : m*m <> 0) x :
+            Z2Zp Hm x      = Zp_zero Hm 
+         -> Z2Zp Hm2 (x*x) = Zp_zero Hm2.
+  Proof.
+    intros H.
+    apply Z2Zp_zero_inv in H.
+    destruct H as (v & ->).
+    replace (Z.of_nat m*v*(Z.of_nat m*v))%Z
+    with    (Z.of_nat m*Z.of_nat m*(v*v))%Z by ring.
+    now rewrite <- Nat2Z.inj_mul, Z2Zp_mult, Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
+  Qed.
 
-       x = m+2*k*m
-       x² = m²+2*2*k*m²+4*k²m²
-    *)
+End utils.
 
-    Variable (m : nat) (H2m : 2*m <> 0) (Hm2 : 4*m*m <> 0).
+Section half_modulus_lemma.
 
-    Let lemma1 x :
+  (** If x = +- m [ 2m ] then x² = m² [4m²] *)
+
+  Variable (m : nat) (H2m : 2*m <> 0) (Hm2 : 4*m*m <> 0).
+
+  Let lemma1 x :
           Z2Zp H2m x = nat2Zp H2m m 
        -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
-    Proof.
-      intros H.
-      rewrite <- Z2Zp_of_nat in H.
-      apply Z2Zp_inj in H.
-      destruct H as (k & H).
-      assert (x = Z.of_nat m+2*k*Z.of_nat m)%Z as Hx.
-      { rewrite Nat2Z.inj_mul, Zmult_assoc, (Zmult_comm k) in H.
-        change 2%Z with (Z.of_nat 2); omega. }
-      rewrite Hx, Zsquare_plus, !Z2Zp_plus.
-      replace (2*Z.of_nat m * (2*k*Z.of_nat m))%Z
-      with    (Z.of_nat (4*m*m)*k)%Z.
-      2:{ rewrite !Nat2Z.inj_mul; ring. }
-      replace (2*k*Z.of_nat m * (2*k*Z.of_nat m))%Z
-        with    (Z.of_nat (4*m*m)*(k*k))%Z.
-      2:{ rewrite !Nat2Z.inj_mul; ring. }
-      rewrite (Z2Zp_mult _ _ k), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
-      rewrite (Z2Zp_mult _ _ (k*k)), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
-      rewrite !Zp_plus_zero_r, <- Nat2Z.inj_mul, Z2Zp_of_nat; auto.
-    Qed.
+  Proof.
+    intros H.
+    rewrite <- Z2Zp_of_nat in H.
+    apply Z2Zp_inj in H.
+    destruct H as (k & H).
+    assert (x = Z.of_nat m+2*k*Z.of_nat m)%Z as Hx.
+    { rewrite Nat2Z.inj_mul, Zmult_assoc, (Zmult_comm k) in H.
+      change 2%Z with (Z.of_nat 2); lia. }
+    rewrite Hx, remarkable_id1_Z, !Z2Zp_plus.
+    replace (2*Z.of_nat m * (2*k*Z.of_nat m))%Z
+    with    (Z.of_nat (4*m*m)*k)%Z.
+    2:{ rewrite !Nat2Z.inj_mul; ring. }
+    replace (2*k*Z.of_nat m * (2*k*Z.of_nat m))%Z
+    with    (Z.of_nat (4*m*m)*(k*k))%Z.
+    2:{ rewrite !Nat2Z.inj_mul; ring. }
+    rewrite (Z2Zp_mult _ _ k), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
+    rewrite (Z2Zp_mult _ _ (k*k)), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
+    rewrite !Zp_plus_zero_r, <- Nat2Z.inj_mul, Z2Zp_of_nat; auto.
+  Qed.
 
-    Let lemma2 x :
-          (Z2Zp H2m x = Zp_opp H2m (nat2Zp H2m m))%Z 
-       -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
-    Proof.
-      intros H.
-      replace (x*x)%Z with ((-x)*(-x))%Z by ring.
-      apply lemma1.
-      rewrite Z2Zp_opp, H, Zp_opp_inv; auto.
-    Qed.
+  Let lemma2 x :
+        (Z2Zp H2m x = Zp_opp H2m (nat2Zp H2m m))%Z 
+      -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+  Proof.
+    intros H.
+    replace (x*x)%Z with ((-x)*(-x))%Z by ring.
+    apply lemma1.
+    rewrite Z2Zp_opp, H, Zp_opp_inv; auto.
+  Qed.
 
-    Fact half_modulus_lemma' x :
+  Fact half_modulus_lemma' x :
            Z2Zp H2m x = nat2Zp H2m m 
        \/ (Z2Zp H2m x = Zp_opp H2m (nat2Zp H2m m))%Z
        -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
-    Proof. intros []; auto. Qed.
+  Proof. intros []; auto. Qed.
 
-    Fact half_modulus_lemma x y : Z2Zp H2m x = Z2Zp H2m y
-                 -> y = Z.of_nat m \/ y = (- Z.of_nat m)%Z
-                 -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
-    Proof.
-      intros H1 H2.
-      apply half_modulus_lemma'.
-      rewrite H1.
-      destruct H2; subst y; [ left | right ].
-      + rewrite Z2Zp_of_nat; auto.
-      + rewrite Z2Zp_opp, Z2Zp_of_nat; auto.
-    Qed.
+  Fact half_modulus_lemma x y : 
+           Z2Zp H2m x = Z2Zp H2m y
+        -> y = Z.of_nat m 
+        \/ y = (- Z.of_nat m)%Z
+        -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+  Proof.
+    intros H1 H2.
+    apply half_modulus_lemma'.
+    rewrite H1.
+    destruct H2; subst y; [ left | right ].
+    + rewrite Z2Zp_of_nat; auto.
+    + rewrite Z2Zp_opp, Z2Zp_of_nat; auto.
+  Qed.
 
-  End half_modulus_lemma.
+End half_modulus_lemma.
 
-  Let four_squares a b c d := (a*a+b*b+c*c+d*d)%Z.
+Section lagrange_prelim_odd.
 
-  Fact Euler_squares x y a1 b1 c1 d1 a2 b2 c2 d2 :
+  Variable (p n : nat) (Hp1 : prime p) (Hp2 : p = 2*n+1).
+
+  Let Hn : 0 < n.
+  Proof.
+    destruct n; try lia.
+    simpl in Hp2; subst.
+    exfalso; apply Hp1; trivial.
+  Qed.
+
+  Let Hp : p <> 0.
+  Proof. lia. Qed.
+
+  Let l := list_an 0 (1+n).
+
+  Let Hl : forall x, In x l <-> x <= n.
+  Proof.
+    unfold l; intros x; rewrite list_an_spec; lia.
+  Qed.
+
+  (* Let us defined to injective functions from l to Z/Zp *)
+
+  Let f x := nat2Zp Hp (x*x).
+  Let g y := Zp_opp Hp (Zp_plus Hp (Zp_one Hp) (f y)).
+
+  Let Hf x y : In x l -> In y l -> f x = f y -> x = y.
+  Proof.
+    unfold f; intros G1 G2 H.
+    do 2 rewrite nat2Zp_mult in H.
+    apply Zp_prime_square_eq_square in H; auto.
+    destruct H as [ H | H ].
+    + rewrite nat2Zp_inj in H.
+      rewrite <- (@rem_idem x p), H, rem_idem; auto.
+      * apply Hl in G2; lia.
+      * apply Hl in G1; lia.
+    + apply f_equal with (f := @proj1_sig _ _) in H; simpl in H.
+      rewrite rem_idem in H.
+      2: apply Hl in G1; lia.
+      case_eq (rem y p).
+      * intros Hy.
+        rewrite Hy, Nat.sub_0_r, rem_diag in H; auto.
+        rewrite rem_idem in Hy; try lia.
+        apply Hl in G2; lia.
+      * intros w Hw.
+        rewrite rem_idem in H; try lia.
+        rewrite H.
+        apply Hl in G2.
+        apply Hl in G1.
+        rewrite rem_idem in H; lia.
+  Qed.
+
+  Let Hg x y : In x l -> In y l -> g x = g y -> x = y.
+  Proof. 
+      unfold g; intros G1 G2 G3.
+      apply Zp_opp_inj, Zp_plus_inj_l in G3.
+      revert G3; apply Hf; auto.
+  Qed.
+
+  (* Since |map f l| = n+1 and |map g l| = n+1
+     and the domain has cardinal 2*n+1, they must intersect *)
+
+  Let intersection : exists y, In y (map f l) /\ In y (map g l).
+  Proof.
+    destruct partition_intersection with (l := map f l) (m := map g l) (k := Zp_list Hp)
+        as [ G | [ G | ] ]; auto.
+    * rewrite Zp_list_length, app_length, map_length, map_length.
+      unfold l; rewrite list_an_length; lia.
+    * intros ? _; apply Zp_list_spec.
+    * apply list_has_dup_map_inv in G; auto.
+      apply not_list_has_dup_an in G; tauto.
+    * apply list_has_dup_map_inv in G; auto.
+      apply not_list_has_dup_an in G; tauto.
+  Qed.
+
+  Local Lemma lagrange_prelim_odd : 
+              exists a b, divides p (1+a*a+b*b) 
+                       /\ 2*a <= p-1 
+                       /\ 2*b <= p-1.
+  Proof.
+    destruct intersection as (u & G1 & G2).
+    rewrite in_map_iff in G1.
+    rewrite in_map_iff in G2.
+    destruct G1 as (a & G3 & G4).
+    destruct G2 as (b & G5 & G6).
+    exists a, b; msplit 2.
+    + rewrite divides_nat2Zp with (Hp := Hp),
+              (plus_comm 1), <- plus_assoc, 
+              !nat2Zp_plus, nat2Zp_one.
+      fold (f a).
+      apply Zp_opp_plus_eq.
+      fold (f b); fold (g b).
+      now rewrite G3, G5, Zp_plus_zero.
+    + apply Hl in G4; lia.
+    + apply Hl in G6; lia.
+  Qed.
+
+End lagrange_prelim_odd.
+
+(** Preliminary lemma : primes p have a multiple n*p of the form 1+a²+b² with 0 < n < p *)
+
+Lemma lagrange_prelim p : prime p -> exists n a b, n*p = 1+a*a+b*b /\ 0 < n < p.
+Proof.
+  intros Hp.
+  destruct (prime_2_or_odd Hp) as [ | (n & Hn1 & Hn2) ].
+  + exists 1, 1, 0; subst; auto.
+  + destruct (lagrange_prelim_odd _ Hp Hn2)
+      as (a & b & (k & Hk) & Ha & Hb).
+    exists k, a, b; split; auto.
+    split.
+    1: destruct k; simpl in Hk; try lia; discriminate.
+    assert (a <= n) as Ha' by lia.
+    assert (b <= n) as Hb' by lia.
+    destruct (le_lt_dec p k) as [ H | H ]; auto.
+    exfalso.
+    assert (a*a+2*(1*1)+b*b <= k*p) as C; try lia.
+    apply le_trans with ((n+n)*(n+n)).
+    2: apply mult_le_compat; lia.
+    rewrite remarkable_id1_nat.
+    apply plus_le_compat.
+    2: apply mult_le_compat; auto.
+    apply plus_le_compat.
+    1: apply mult_le_compat; auto.
+    apply mult_le_compat_l.
+    now apply mult_le_compat.
+Qed.
+
+Local Notation four_squares := (fun a b c d => a*a+b*b+c*c+d*d)%Z.
+
+Fact Euler_squares x y a1 b1 c1 d1 a2 b2 c2 d2 :
          (x = four_squares a1 b1 c1 d1
        -> y = four_squares a2 b2 c2 d2
        -> x*y = four_squares (a1*a2+b1*b2+c1*c2+d1*d2)
                              (a1*b2-b1*a2+d1*c2-c1*d2)
                              (a1*c2-c1*a2+b1*d2-d1*b2)
                              (a1*d2-d1*a2+c1*b2-b1*c2))%Z.
-  Proof. intros -> ->; unfold four_squares; ring. Qed.
+Proof. intros -> ->; ring. Qed.
 
-  Section lagrange_prime.
+(** The primes are sums of four square, the hard part *)
 
-    Variable (p : nat) (Hp : prime p).
+Section lagrange_for_primes.
 
-    Let P n := 1 <= n < p /\ exists a b c d, Z.of_nat (n*p) = (a*a+b*b+c*c+d*d)%Z.
+  Variable (p : nat) (Hp : prime p).
 
-    (** DLW: This one was a pain in the ... *)
+  (* P n is "n*p is sum of four squares" *)
 
-    Let lagrange_prime_step m : P m -> 1 < m -> exists n, n < m /\ P n.
+  Let P n := exists a b c d, Z.of_nat (n*p) = four_squares a b c d.
+
+  (** DLW: This one was a pain in the ... *)
+
+  Section lagrange_prime_step.
+
+    (* We show P m /\ 1 < m < p -> P r for some 1 <= r < m *) 
+
+    Variable (m : nat) (H1 : m < p) (H3 : 1 < m) (x1 x2 x3 x4 : Z) 
+             (H2 : Z.of_nat (m*p) = four_squares x1 x2 x3 x4).
+
+    Let Hm : m <> 0.
+    Proof. lia. Qed.
+
+    Local Fact lagrange_prime_step' : exists r, 1 <= r < m /\ P r.
     Proof.
-      intros (H1 & x1 & x2 & x3 & x4 & H2) H3.
-      assert (Hm : m <> 0) by omega.
-      generalize (Zrem_double Hm x1)
-                 (Zrem_double Hm x2)
-                 (Zrem_double Hm x3)
-                 (Zrem_double Hm x4).
+      (* we get small representatives for x1 ... x4 
+         as y1 ... y4 *)
+      generalize (Zp_small_repr Hm x1) (Zp_small_repr Hm x2)
+                 (Zp_small_repr Hm x3) (Zp_small_repr Hm x4).
       intros (y1 & E1 & Q1) (y2 & E2 & Q2) (y3 & E3 & Q3) (y4 & E4 & Q4).
+      (* they satisfy the same eq for another value r *)
       assert (Z2Zp Hm (y1*y1+y2*y2+y3*y3+y4*y4) = Z2Zp Hm 0) as H4.
       { rewrite !Z2Zp_plus, !Z2Zp_mult, <- E1, <- E2, <- E3, <- E4.
         rewrite <- !Z2Zp_mult, <- !Z2Zp_plus, <- H2.
         rewrite Nat2Z.inj_mul, Z2Zp_mult.
         rewrite Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero, Z2Zp_zero; auto. }
       apply Z2Zp_inj in H4.
-      destruct H4 as (r & Hr).
+      destruct H4 as (r' & Hr).
       rewrite Z.sub_0_r in Hr.
-      assert (4 * (r * Z.of_nat m) <= 4 * (Z.of_nat m * Z_of_nat m))%Z as Hr'.
-      { rewrite <- Hr, !Z.mul_add_distr_l; omega. }
+      (* r is smaller than m *)
+      assert (4 * (r' * Z.of_nat m) <= 4 * (Z.of_nat m * Z_of_nat m))%Z as Hr'.
+      { rewrite <- Hr, !Z.mul_add_distr_l; lia. }
       rewrite !(Zmult_comm 4) in Hr'.
-      apply Zmult_le_reg_r in Hr'; try omega.
-      apply Zmult_le_reg_r in Hr'; try omega.
-      assert (0 <= r * Z_of_nat m)%Z as Hr''.
+      apply Zmult_le_reg_r in Hr'; try lia.
+      apply Zmult_le_reg_r in Hr'; try lia.
+      (* r is positive *)
+      assert (0 <= r' * Z_of_nat m)%Z as Hr''.
       { rewrite <- Hr; repeat apply Z.add_nonneg_nonneg; apply Z.square_nonneg. }
       apply Zmult_le_0_reg_r in Hr''.
-      2:{ apply (inj_gt m 0); omega. }
+      2:{ apply (inj_gt m 0); lia. }
+      (* So r is a nat below m *)
       apply Z_of_nat_complete_inf in Hr''.
-      destruct Hr'' as (k & ?); subst r.
+      destruct Hr'' as (r & ?); subst r'.
       apply Nat2Z.inj_le in Hr'.
-      destruct (eq_nat_dec m k) as [ <- | Hk1 ].
-      { apply f_equal with (f := fun i => (4*i)%Z) in Hr.
+      (* Let us show r is not m *)
+      destruct (eq_nat_dec m r) as [ <- | Hr1 ].
+      { (* Because r = m implies an absurdity *)
+        (* first we show m = 2q and y1 ... y4 = +- q *)
+        clear Hr'.
+        apply f_equal with (f := fun i => (4*i)%Z) in Hr.
         rewrite !Z.mul_add_distr_l in Hr.
-        apply bounded_four in Hr; auto.
+        apply bounded_upper_limit_4 in Hr; auto.
         destruct Hr as (F1 & F2 & F3 & F4).
-        apply four_square_simpl in F1.
+        apply square_4_simpl in F1.
         destruct F1 as (q & Hq & F1).
         rewrite Hq in F2, F3, F4. 
-        apply four_square_simpl' in F2.
-        apply four_square_simpl' in F3.
-        apply four_square_simpl' in F4.
+        apply square_4_simpl' in F2.
+        apply square_4_simpl' in F3.
+        apply square_4_simpl' in F4.
+        (* then we show xi² = q² [4q²] *)
         subst m. 
         assert (4*q*q <> 0) as Hq.
-        { destruct q; simpl; try discriminate; omega. }
+        { destruct q; simpl; try discriminate; lia. }
         apply half_modulus_lemma with (1 := E1) (Hm2 := Hq) in F1.
         apply half_modulus_lemma with (1 := E2) (Hm2 := Hq) in F2.
         apply half_modulus_lemma with (1 := E3) (Hm2 := Hq) in F3.
         apply half_modulus_lemma with (1 := E4) (Hm2 := Hq) in F4.
+        (* thus 2q*p = m*p = x1²+...+x4² = 0 [4q²] *)
         assert (Z2Zp Hq (Z.of_nat (2 * q * p)) = Zp_zero Hq) as C.
         { rewrite H2, !Z2Zp_plus, F1, F2, F3, F4.
           rewrite <- !nat2Zp_plus.
@@ -447,50 +472,46 @@ Section lagrange.
         rewrite Z2Zp_of_nat in C.
         apply divides_nat2Zp in C.
         destruct C as (d & Hd).
+        (* thus 2q divides p *)
         assert (divides (2*q) p) as C.
         { replace (d*(4*q*q)) with (2*q*(d*(2*q))) in Hd by ring.
-          apply Nat.mul_cancel_l in Hd; try omega.
+          apply Nat.mul_cancel_l in Hd; try lia.
           exists d; auto. }
-        apply Hp in C.
-        destruct C as [ C | C ]; try omega. }
-      destruct (eq_nat_dec k 0) as [ -> | Hk2 ].
-      { simpl in Hr.
-        apply four_square_zero in Hr.
+        (* Not possible because p is prime *)
+        apply Hp in C; destruct C; try lia. }
+      (* Let us show that r is not 0 *)
+      destruct (eq_nat_dec r 0) as [ -> | Hr2 ].
+      { (* all the yi are zero *)
+        apply four_squares_zero in Hr.
         destruct Hr as (? & ? & ? & ?); subst y1 y2 y3 y4.
+        (* xi² = 0 [ m² ] *)
         assert (Hm2 : m*m <> 0).
-        { destruct m; simpl; try discriminate; omega. }
-        assert (forall x, Z2Zp Hm x = Z2Zp Hm 0 -> Z2Zp Hm2 (x*x) = Zp_zero Hm2) as L.
-        { intros x Hx.
-          apply Z2Zp_inj in Hx.
-          destruct Hx as (d & Hd).
-          rewrite Z.sub_0_r in Hd.
-          rewrite Hd.
-          replace (d*Z.of_nat m*(d*Z.of_nat m))%Z
-          with    (Z.of_nat (m*m)*(d*d))%Z.
-          2:{ rewrite Nat2Z.inj_mul; ring. }
-          rewrite Z2Zp_mult, Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero; auto. }
-        apply L in E1.
-        apply L in E2.
-        apply L in E3.
-        apply L in E4.
-        clear L.
+        { destruct m; simpl; try discriminate; lia. }
+        rewrite Z2Zp_zero in E1; apply Zp_square_zero with (Hm2 := Hm2) in E1.
+        rewrite Z2Zp_zero in E2; apply Zp_square_zero with (Hm2 := Hm2) in E2.
+        rewrite Z2Zp_zero in E3; apply Zp_square_zero with (Hm2 := Hm2) in E3.
+        rewrite Z2Zp_zero in E4; apply Zp_square_zero with (Hm2 := Hm2) in E4.
+        (* mp = 0 [ m² ] *)
         assert (Z2Zp Hm2 (Z.of_nat (m*p)) = Zp_zero Hm2) as C.
         { rewrite H2, !Z2Zp_plus, E1, E2, E3, E4, !Zp_plus_zero; auto. }
+        (* m divides p *)
         rewrite Z2Zp_of_nat in C.
         apply divides_nat2Zp in C.
         destruct C as (d & Hd).
         assert (divides m p) as C.
         { replace (d*(m*m)) with (m*(d*m)) in Hd by ring.
-          apply Nat.mul_cancel_l in Hd; try omega.
+          apply Nat.mul_cancel_l in Hd; try lia.
           exists d; auto. }
+        (* impossible because p is prime *)
         apply Hp in C.
-        destruct C as [ C | C ]; try omega. }
-      assert (0 < k < m) as Hk by omega.
-      clear Hr' Hk1 Hk2.
+        destruct C as [ C | C ]; lia. }
+      (* Hence we have y1²+...+y4² = mr with 0 < r < m *)  
+      assert (0 < r < m) as Hk by lia.
+      clear Hr' Hr1 Hr2 Q1 Q2 Q3 Q4.
       symmetry in Hr.
       rewrite <- Nat2Z.inj_mul in Hr.
-      clear Q1 Q2 Q3 Q4.
-      assert (exists a b c d, Z.of_nat (k*p*m*m) = four_squares a b c d%Z
+      (* rpm² = a²+...+d² with m dividing a, b, c, d *)
+      assert (exists a b c d, Z.of_nat (r*p*m*m) = four_squares a b c d%Z
                            /\ Z2Zp Hm a = Zp_zero Hm
                            /\ Z2Zp Hm b = Zp_zero Hm
                            /\ Z2Zp Hm c = Zp_zero Hm
@@ -498,80 +519,82 @@ Section lagrange.
       { exists (x1 * y1 + x2 * y2 + x3 * y3 + x4 * y4)%Z,
                (x1 * y2 - x2 * y1 + x4 * y3 - x3 * y4)%Z, 
                (x1 * y3 - x3 * y1 + x2 * y4 - x4 * y2)%Z,
-               (x1 * y4 - x4 * y1 + x3 * y2 - x2 * y3)%Z; split.
+               (x1 * y4 - x4 * y1 + x3 * y2 - x2 * y3)%Z; msplit 4.
         + rewrite <- (Euler_squares _ _ _ _ _ _ _ _ H2 Hr).
           rewrite <- Nat2Z.inj_mul; f_equal; ring.
-        + msplit 3.
-          * rewrite !Z2Zp_plus, !Z2Zp_mult. 
-            rewrite <- E1, <- E2, <- E3, <- E4.
-            rewrite <- !Z2Zp_mult, <- !Z2Zp_plus.
-            rewrite <- H2, Nat2Z.inj_mul, Z2Zp_mult, 
-                    Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero; auto.
-          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
-            rewrite !Z2Zp_mult.
-            rewrite <- E1, <- E2, <- E3, <- E4.
-            rewrite <- !Z2Zp_mult.
-            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
-            rewrite <- Z2Zp_zero; f_equal; ring.
-          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
-            rewrite !Z2Zp_mult.
-            rewrite <- E1, <- E2, <- E3, <- E4.
-            rewrite <- !Z2Zp_mult.
-            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
-            rewrite <- Z2Zp_zero; f_equal; ring.
-          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
-            rewrite !Z2Zp_mult.
-            rewrite <- E1, <- E2, <- E3, <- E4.
-            rewrite <- !Z2Zp_mult.
-            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
-            rewrite <- Z2Zp_zero; f_equal; ring. }
+        + rewrite !Z2Zp_plus, !Z2Zp_mult. 
+          rewrite <- E1, <- E2, <- E3, <- E4.
+          rewrite <- !Z2Zp_mult, <- !Z2Zp_plus.
+          rewrite <- H2, Nat2Z.inj_mul, Z2Zp_mult, 
+                  Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero; auto.
+        + repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+          rewrite !Z2Zp_mult.
+          rewrite <- E1, <- E2, <- E3, <- E4.
+          rewrite <- !Z2Zp_mult.
+          repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+          rewrite <- Z2Zp_zero; f_equal; ring.
+        + repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+          rewrite !Z2Zp_mult.
+          rewrite <- E1, <- E2, <- E3, <- E4.
+          rewrite <- !Z2Zp_mult.
+          repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+          rewrite <- Z2Zp_zero; f_equal; ring.
+        + repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+          rewrite !Z2Zp_mult.
+          rewrite <- E1, <- E2, <- E3, <- E4.
+          rewrite <- !Z2Zp_mult.
+          repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+          rewrite <- Z2Zp_zero; f_equal; ring. }
       clear x1 x2 x3 x4 H2 H3 y1 E1 y2 E2 y3 E3 y4 E4 Hr.
+      (* then we built a smaller solution *)
       destruct Q as (a & b & c & d & H & Ha & Hb & Hc & Hd).
-      apply Z2Zp_div in Ha; destruct Ha as (x & ->).
-      apply Z2Zp_div in Hb; destruct Hb as (y & ->).
-      apply Z2Zp_div in Hc; destruct Hc as (z & ->).
-      apply Z2Zp_div in Hd; destruct Hd as (w & ->).
-      exists k; split; try omega; split; try omega.
+      apply Z2Zp_zero_inv in Ha; destruct Ha as (x & ->).
+      apply Z2Zp_zero_inv in Hb; destruct Hb as (y & ->).
+      apply Z2Zp_zero_inv in Hc; destruct Hc as (z & ->).
+      apply Z2Zp_zero_inv in Hd; destruct Hd as (w & ->).
+      exists r; split; try lia.
       exists x, y, z, w.
       apply Z.mul_cancel_r with (p := Z.of_nat (m*m)).
       { intros E.
         apply Nat2Z.inj with (m := 0) in E.
-        destruct m; try discriminate; omega. }
+        destruct m; try discriminate; lia. }
       rewrite <- Nat2Z.inj_mul, mult_assoc, H.
-      rewrite Nat2Z.inj_mul; unfold four_squares; ring.
+      rewrite Nat2Z.inj_mul; ring.
     Qed.
 
-    Let lagrange_prime_rec : P 1.
-    Proof.
-      destruct (lagrange_prelim' Hp) as (n & a & b & H1 & H2 & H3).
-      cut (P n).
-      + revert H2 H3; clear H1.
-        induction on n as IH with measure n.
-        intros H2 H3 H.
-        destruct (le_lt_dec n 1) as [ | Hn ].
-        * now replace 1 with n by omega.
-        * destruct (lagrange_prime_step H) as (m & H4 & H5); auto.
-          generalize H5; destruct H5; apply IH; auto; omega.
-      + split; try omega.
-        exists 0%Z, 1%Z, (Z.of_nat a), (Z.of_nat b).
-        rewrite H1, !Nat2Z.inj_add, !Nat2Z.inj_mul.
-        simpl Z.of_nat at 1; omega.
-    Qed.
+  End lagrange_prime_step.
 
-    Theorem lagrange_prime : exists a b c d, Z.of_nat p = (a*a+b*b+c*c+d*d)%Z.
-    Proof.
-      replace p with (1*p) by omega.
-      apply lagrange_prime_rec.
-    Qed.
+  Let lagrange_prime_step m : 1 < m < p -> P m -> exists r, 1 <= r < m /\ P r.
+  Proof.
+    intros H1 (x1 & x2 & x3 & x4 & H2); apply lagrange_prime_step' with (3 := H2); lia.
+  Qed.
 
-  End lagrange_prime.
+  (* Now that P 1 holfs ie p is sum of 4 squares *)
 
-  Check lagrange_prime.
-  Print Assumptions lagrange_prime.
+  Lemma lagrange_prime : exists a b c d, Z.of_nat p = (a*a+b*b+c*c+d*d)%Z.
+  Proof.
+    replace p with (1*p) by lia; change (P 1).
+    destruct (lagrange_prelim Hp) as (n & a & b & H1 & H2 & H3).
+    cut (P n).
+    + revert H2 H3; clear H1.
+      induction on n as IH with measure n.
+      intros H2 H3 H.
+      destruct (le_lt_dec n 1) as [ | Hn ].
+      * now replace 1 with n by lia.
+      * destruct lagrange_prime_step with (2 := H) as (m & H4 & H5); auto.
+        generalize H5; destruct H5; apply IH; auto; lia.
+    + exists 0%Z, 1%Z, (Z.of_nat a), (Z.of_nat b).
+      rewrite H1, !Nat2Z.inj_add, !Nat2Z.inj_mul.
+      simpl Z.of_nat at 1; lia.
+  Qed.
+
+End lagrange_for_primes.
+
+Section lagrange.
 
   Open Scope Z_scope.
 
-  Lemma lagrange_theorem_nat : forall n, exists a b c d, Z.of_nat n = a*a+b*b+c*c+d*d.
+  Theorem lagrange_theorem_nat : forall n, exists a b c d, Z.of_nat n = a*a+b*b+c*c+d*d.
   Proof.
     induction n as [ | | p Hp | x y Hx Hy ] using prime_rect.
     + exists 0, 0, 0, 0; auto.
@@ -589,7 +612,7 @@ Section lagrange.
 
   (** An relative integer is positive iff it is the sum of four squares *)
 
-  Lemma lagrange_theorem_Z n : 0 <= n <-> exists a b c d, n = a*a+b*b+c*c+d*d.
+  Corollary lagrange_theorem_Z n : 0 <= n <-> exists a b c d, n = a*a+b*b+c*c+d*d.
   Proof.
     split.
     + intros H.
@@ -599,7 +622,7 @@ Section lagrange.
       generalize (a*a) (b*b) (c*c) (d*d) 
                  (Z.square_nonneg a) (Z.square_nonneg b)
                  (Z.square_nonneg c) (Z.square_nonneg d).
-      intros; omega.
+      intros; lia.
   Qed.
 
 End lagrange.

--- a/theories/H10/ArithLibs/lagrange.v
+++ b/theories/H10/ArithLibs/lagrange.v
@@ -1,0 +1,609 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Omega Eqdep_dec ZArith List.
+
+From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list gcd prime php utils_nat.
+From Undecidability.H10.ArithLibs Require Import Zp.
+
+Set Implicit Arguments.
+
+Section lagrange.
+
+  Fact prime_2_or_odd p : prime p -> p = 2 \/ exists n, 0 < n /\ p = 2*n+1.
+  Proof.
+    intros Hp.
+    assert (H1 : p <> 0).
+    { generalize (prime_ge_2 Hp); omega. }
+    assert (H3 : 2 <> 0) by discriminate.
+    destruct (eq_nat_dec p 2) as [ | H2 ]; auto; right.
+    assert (rem p 2 = 1) as Hp1.
+    { generalize (div_rem_spec2 p H3).
+      case_eq (rem p 2).
+      + intros H _.
+        apply divides_rem_eq in H.
+        apply proj2 in Hp.
+        destruct (Hp _ H); subst; omega.
+      + intros; omega. }
+    exists (div p 2); split.
+    + generalize (div_rem_spec1 p 2) (prime_ge_2 Hp).
+      destruct (div p 2); intros;  omega.
+    + rewrite mult_comm.
+      rewrite (div_rem_spec1 p 2) at 1.
+      f_equal; auto.
+  Qed.
+
+  Lemma lagrange_prelim p n : prime p -> p = 2*n+1 -> 0 < n -> exists a b, divides p (1+a*a+b*b) /\ 2*a <= p-1 /\ 2*b <= p-1.
+  Proof.
+    intros H2 Hn2 Hn1.
+    assert (Hp : p <> 0) by omega.
+    set (l := list_an 0 (1+n)).
+    assert (Hl : forall x, In x l <-> x <= n).
+    { unfold l; intros x; rewrite list_an_spec; omega. }
+    set (f x := nat2Zp Hp (x*x)).
+    assert (Hf : forall x y, In x l -> In y l -> f x = f y -> x = y).
+    { unfold f; intros x y G1 G2 H.
+      do 2 rewrite nat2Zp_mult in H.
+      apply Zp_prime_square_eq_square in H; auto.
+      destruct H as [ H | H ].
+      + rewrite nat2Zp_inj in H.
+        rewrite <- (@rem_idem x p), H, rem_idem; auto.
+        - apply Hl in G2; subst; omega.
+        - apply Hl in G1; subst; omega.
+      + apply f_equal with (f := @proj1_sig _ _) in H; simpl in H.
+        rewrite rem_idem in H.
+        2: apply Hl in G1; subst; omega.
+        case_eq (rem y p).
+        - intros Hy.
+          rewrite Hy, Nat.sub_0_r, rem_diag in H; auto.
+          rewrite rem_idem in Hy; try omega.
+          apply Hl in G2; subst; omega.
+        - intros w Hw.
+          rewrite rem_idem in H; try omega.
+          rewrite H.
+          apply Hl in G2.
+          apply Hl in G1.
+          rewrite rem_idem in H; omega. }
+    set (g y := Zp_opp Hp (Zp_plus Hp (Zp_one Hp) (f y))).
+    assert (Hg : forall x y, In x l -> In y l -> g x = g y -> x = y).
+    { intros x y G1 G2 G3.
+      unfold g in G3.
+      apply Zp_opp_inj, Zp_plus_inj_l in G3.
+      revert G3; apply Hf; auto. }
+    destruct partition_intersection with (l := map f l) (m := map g l) (k := Zp_list Hp)
+        as [ G | [ G | (u & G1 & G2) ] ].
+    * rewrite Zp_list_length, app_length, map_length, map_length.
+      unfold l; rewrite list_an_length; omega.
+    * intros ? _; apply Zp_list_spec.
+    * apply list_has_dup_map_inv in G; auto.
+      apply not_list_has_dup_an in G; tauto.
+    * apply list_has_dup_map_inv in G; auto.
+      apply not_list_has_dup_an in G; tauto.
+    * rewrite in_map_iff in G1.
+      rewrite in_map_iff in G2.
+      destruct G1 as (a & G3 & G4).
+      destruct G2 as (b & G5 & G6).
+      exists a, b; split; [ | split ].
+      + rewrite divides_nat2Zp with (Hp := Hp).
+        rewrite (plus_comm 1), <- plus_assoc.
+        do 2 rewrite nat2Zp_plus.
+        rewrite nat2Zp_one.
+        fold (f a).
+        apply Zp_opp_plus_eq.
+        fold (f b); fold (g b).
+        rewrite G3, G5, Zp_plus_zero.
+        trivial.
+      + apply Hl in G4; rewrite Hn2; omega.
+      + apply Hl in G6; rewrite Hn2; omega.
+  Qed.
+
+  Let square_lemma x y : (x+y)*(x+y) = x*x+2*(x*y)+y*y.
+  Proof. ring. Qed.
+
+  Lemma lagrange_prelim' p : prime p -> exists n a b, n*p = 1+a*a+b*b /\ 0 < n < p.
+  Proof.
+    intros Hp.
+    destruct (prime_2_or_odd Hp) as [ | (n & Hn1 & Hn2) ].
+    + exists 1, 1, 0; subst; auto.
+    + destruct (lagrange_prelim Hp Hn2 Hn1) as (a & b & (k & Hk) & Ha & Hb).
+      exists k, a, b; split; auto.
+      split.
+      1: destruct k; simpl in Hk; try omega; discriminate.
+      assert (a <= n) as Ha' by omega.
+      assert (b <= n) as Hb' by omega.
+      destruct (le_lt_dec p k) as [ H | H ]; auto.
+      exfalso.
+      assert (a*a+2*(1*1)+b*b <= k*p) as C; try omega.
+      apply le_trans with ((n+n)*(n+n)).
+      2: apply mult_le_compat; omega.
+      rewrite square_lemma.
+      apply plus_le_compat.
+      2: apply mult_le_compat; auto.
+      apply plus_le_compat.
+      1: apply mult_le_compat; auto.
+      apply mult_le_compat_l.
+      apply mult_le_compat; omega.
+  Qed.
+
+  Section rem_square_opp.
+
+    Variable (x m : nat) (Hx : x < m).
+
+    Let Hm : m <> 0. Proof. omega. Qed.
+
+    Add Ring Zp_ring : (Zp_is_ring Hm).
+
+    Fact rem_square_opp : rem (x*x) m = rem ((m-x)*(m-x)) m.
+    Proof.
+      rewrite <- nat2Zp_inj with (Hp := Hm).
+      rewrite (nat2Zp_mult Hm (m-x)), nat2Zp_mult.
+      rewrite !nat2Zp_minus; try omega.
+      rewrite !nat2Zp_p; ring.
+    Qed.
+
+  End rem_square_opp.
+
+  Section rem_square_div2. 
+
+    Variable (m : nat) (Hm : 0 < m).
+
+    Let Hm2 : 2*m <> 0. Proof. omega. Qed.
+
+    Fact rem_square_div2_even x : exists y, rem (x*x) (2*m) = rem (y*y) (2*m) /\ y <= m.
+    Proof.
+      destruct (le_lt_dec (rem x (2*m)) m) as [ H | H ].
+      + exists (rem x (2*m)); split; auto.
+        rewrite rem_mult_rem, (mult_comm (rem _ _)), rem_mult_rem; auto.
+      + generalize (div_rem_spec2 x Hm2); intros H1.
+        exists (2*m - rem x (2*m)); split; try omega.
+        rewrite <- rem_square_opp; auto.
+        rewrite rem_mult_rem, (mult_comm (rem _ _) x), rem_mult_rem; auto.
+    Qed.
+
+    Let Hm3 : 1+2*m <> 0. Proof. omega. Qed.
+
+    Fact rem_square_div2_odd x : exists y, rem (x*x) (1+2*m) = rem (y*y) (1+2*m) /\ y <= m.
+    Proof.
+      destruct (le_lt_dec (rem x (1+2*m)) m) as [ H | H ].
+      + exists (rem x (1+2*m)); split; auto.
+        rewrite rem_mult_rem, (mult_comm (rem _ _)), rem_mult_rem; auto.
+      + generalize (div_rem_spec2 x Hm3); intros H1.
+        exists (1+2*m - rem x (1+2*m)); split; try omega.
+        rewrite <- rem_square_opp; auto.
+        rewrite rem_mult_rem, (mult_comm (rem _ _) x), rem_mult_rem; auto.
+    Qed.
+
+  End rem_square_div2.
+
+  Fact rem_square_div2 x m : 1 < m -> exists y, rem (x*x) m = rem (y*y) m /\ y <= div m 2.
+  Proof.
+    intros Hm.
+    destruct (euclid_2 m) as (p & [ Hp | Hp ]).
+    + subst m; rewrite div_2_fix_1.
+      apply rem_square_div2_even; omega.
+    + subst; rewrite div_2_fix_2.
+      apply rem_square_div2_odd; omega.
+  Qed.
+
+  Fact rem_sum_fun a b c m : rem a m = rem b m -> rem (a+c) m = rem (b+c) m.
+  Proof. intros H; rewrite rem_plus, H, <- rem_plus; auto. Qed.
+
+  Fact rem_sum4_rem a b c d m : rem (a+b+c+d) m = rem (rem a m+rem b m+rem c m+rem d m) m.
+  Proof.
+    do 3 (rewrite rem_plus; apply rem_sum_fun; rewrite rem_rem); auto.
+  Qed.
+
+  Fact Z2Zp_div m (Hm : m <> 0) x : 
+          Z2Zp Hm x = Zp_zero Hm 
+       -> exists y, (x = Z.of_nat m * y)%Z.
+  Proof.
+    intros H.
+    rewrite <- Z2Zp_zero in H.
+    apply Z2Zp_inj in H.
+    destruct H as (y & Hy); exists y.
+    rewrite Zmult_comm, <- Hy; ring.
+  Qed.
+
+  Fact Zsquare_bound x y : (-y <= x <= y -> x*x <= y*y)%Z.
+  Proof.
+    intros (H1 & H2).
+    destruct (Z_pos_or_neg x).
+    + apply Z.square_le_mono_nonneg; auto.
+    + replace (y*y)%Z with ((-y)*(-y))%Z by ring.
+      apply Z.square_le_mono_nonpos; omega.
+  Qed.
+
+  Fact Zrem_double m (Hm : m <> 0) x :  exists y, Z2Zp Hm x = Z2Zp Hm y
+                                              /\ (4*(y*y) <= Z.of_nat m * Z.of_nat m)%Z.
+  Proof.
+    destruct (euclid_2 m) as (p & [ H | H ]).
+    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (Z.of_nat p) x) as (y & H1 & H2).
+      * rewrite H, Nat2Z.inj_mul; simpl Z_of_nat; omega.
+      * exists y; split; auto.
+        rewrite H, Nat2Z.inj_mul.
+        simpl Z.of_nat.
+        replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
+        with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
+        apply Zmult_le_compat_l; try omega.
+        apply Zsquare_bound; omega.
+    + destruct (Zp_repr_interval Hm (- Z.of_nat p)%Z (1+Z.of_nat p) x) as (y & H1 & H2).
+      * rewrite H, Nat2Z.inj_add, Nat2Z.inj_mul; simpl Z_of_nat; omega.
+      * exists y; split; auto.
+        apply Z.le_trans with (Z.of_nat (2*p) * Z.of_nat (2*p))%Z.
+        - rewrite Nat2Z.inj_mul.
+          simpl Z.of_nat.
+          replace (2*Z.of_nat p*(2*Z.of_nat p))%Z 
+          with    (4*(Z.of_nat p*Z.of_nat p))%Z by ring.
+          apply Zmult_le_compat_l; try omega.
+          apply Zsquare_bound; omega.
+        - apply Zsquare_bound; subst.
+          rewrite !Nat2Z.inj_add, !Nat2Z.inj_mul; simpl Z.of_nat; omega.
+  Qed.
+ 
+  Fact bounded_four x1 x2 x3 x4 m : 
+            (x1 <= m -> x2 <= m -> x3 <= m -> x4 <= m
+         -> x1+x2+x3+x4 = 4*m -> x1 = m /\ x2 = m /\ x3 = m /\ x4 = m)%Z.
+  Proof. omega. Qed.
+
+  Fact positive_sum_4 a b c d : 
+    (0 <= a -> 0 <= b -> 0 <= c -> 0 <= d -> a + b + c + d = 0 -> a = 0 /\ b = 0 /\ c = 0 /\ d = 0)%Z.
+  Proof. intros; omega. Qed.
+
+  Fact four_square_zero x1 x2 x3 x4 : 
+          (x1*x1+x2*x2+x3*x3+x4*x4 = 0)%Z -> (x1 = 0 /\ x2 = 0 /\ x3 = 0 /\ x4 = 0)%Z.
+  Proof.
+    intros H.
+    apply positive_sum_4 in H; try apply Z.square_nonneg.
+    destruct H as (H1 & H2 & H3 & H4).
+    apply Zmult_integral in H1.
+    apply Zmult_integral in H2.
+    apply Zmult_integral in H3.
+    apply Zmult_integral in H4.
+    omega.
+  Qed.
+ 
+  Fact Zsquare_inj x y : (x*x = y*y -> { x = y } + { - x = y } )%Z.
+  Proof.
+    intros H.
+    assert ( (x+y)*(x-y) = 0 )%Z as E.
+    { rewrite Z.mul_sub_distr_l, !Z.mul_add_distr_r, H; ring. }
+    apply Zmult_integral in E.
+    destruct (Z.eq_dec x y); auto.
+    right; omega.
+  Qed.
+
+  Fact four_square_simpl x m : (4*(x*x) = Z.of_nat m*Z.of_nat m)%Z -> { n | m = 2*n /\ (x = Z.of_nat n \/ (x = - Z.of_nat n)%Z) }.
+  Proof.
+    intros H.
+    replace (4*(x*x))%Z with ((2*x)*(2*x))%Z in H by ring.
+    apply Zsquare_inj in H.
+    destruct H as [ H | H ].
+    + destruct Z_of_nat_complete_inf with x as (k & ->).
+      * generalize (Zle_0_nat m); omega.
+      * exists k; split; auto.
+        apply Nat2Z.inj.
+        rewrite Nat2Z.inj_mul, <- H; auto.
+    + destruct (Z_of_nat_complete_inf (Z.opp x)) as (k & Hk).
+      * generalize (Zle_0_nat m); omega.
+      * exists k; split.
+        - apply Nat2Z.inj.
+          rewrite Nat2Z.inj_mul, <- H, <- Hk; ring.
+        - right; rewrite <- Hk; ring.
+  Qed.
+
+  Fact four_square_simpl' x m : (4*(x*x) = Z.of_nat (2*m)*Z.of_nat (2*m))%Z 
+                             -> x = Z.of_nat m \/ (x = - Z.of_nat m)%Z.
+  Proof.
+    intros H.
+    replace (4*(x*x))%Z with ((2*x)*(2*x))%Z in H by ring.
+    apply Zsquare_inj in H.
+    destruct H as [ H | H  ]; rewrite Nat2Z.inj_mul in H; 
+     change (Z.of_nat 2) with 2%Z in H; omega.
+  Qed.
+
+  Fact Zsquare_plus (a b : Z) : ((a+b)*(a+b) = a*a + 2*a*b + b*b)%Z.
+  Proof. ring. Qed.
+
+  Section half_modulus_lemma.
+
+    (* x = +- m [ 2*m ] -> x² = m² [4*m²] 
+
+       x = m+2*k*m
+       x² = m²+2*2*k*m²+4*k²m²
+    *)
+
+    Variable (m : nat) (H2m : 2*m <> 0) (Hm2 : 4*m*m <> 0).
+
+    Let lemma1 x :
+          Z2Zp H2m x = nat2Zp H2m m 
+       -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+    Proof.
+      intros H.
+      rewrite <- Z2Zp_of_nat in H.
+      apply Z2Zp_inj in H.
+      destruct H as (k & H).
+      assert (x = Z.of_nat m+2*k*Z.of_nat m)%Z as Hx.
+      { rewrite Nat2Z.inj_mul, Zmult_assoc, (Zmult_comm k) in H.
+        change 2%Z with (Z.of_nat 2); omega. }
+      rewrite Hx, Zsquare_plus, !Z2Zp_plus.
+      replace (2*Z.of_nat m * (2*k*Z.of_nat m))%Z
+      with    (Z.of_nat (4*m*m)*k)%Z.
+      2:{ rewrite !Nat2Z.inj_mul; ring. }
+      replace (2*k*Z.of_nat m * (2*k*Z.of_nat m))%Z
+        with    (Z.of_nat (4*m*m)*(k*k))%Z.
+      2:{ rewrite !Nat2Z.inj_mul; ring. }
+      rewrite (Z2Zp_mult _ _ k), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
+      rewrite (Z2Zp_mult _ _ (k*k)), Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero.
+      rewrite !Zp_plus_zero_r, <- Nat2Z.inj_mul, Z2Zp_of_nat; auto.
+    Qed.
+
+    Let lemma2 x :
+          (Z2Zp H2m x = Zp_opp H2m (nat2Zp H2m m))%Z 
+       -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+    Proof.
+      intros H.
+      replace (x*x)%Z with ((-x)*(-x))%Z by ring.
+      apply lemma1.
+      rewrite Z2Zp_opp, H, Zp_opp_inv; auto.
+    Qed.
+
+    Fact half_modulus_lemma' x :
+           Z2Zp H2m x = nat2Zp H2m m 
+       \/ (Z2Zp H2m x = Zp_opp H2m (nat2Zp H2m m))%Z
+       -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+    Proof. intros []; auto. Qed.
+
+    Fact half_modulus_lemma x y : Z2Zp H2m x = Z2Zp H2m y
+                 -> y = Z.of_nat m \/ y = (- Z.of_nat m)%Z
+                 -> Z2Zp Hm2 (x*x) = nat2Zp Hm2 (m*m).
+    Proof.
+      intros H1 H2.
+      apply half_modulus_lemma'.
+      rewrite H1.
+      destruct H2; subst y; [ left | right ].
+      + rewrite Z2Zp_of_nat; auto.
+      + rewrite Z2Zp_opp, Z2Zp_of_nat; auto.
+    Qed.
+
+  End half_modulus_lemma.
+
+  Let four_squares a b c d := (a*a+b*b+c*c+d*d)%Z.
+
+  Fact Euler_squares x y a1 b1 c1 d1 a2 b2 c2 d2 :
+         (x = four_squares a1 b1 c1 d1
+       -> y = four_squares a2 b2 c2 d2
+       -> x*y = four_squares (a1*a2+b1*b2+c1*c2+d1*d2)
+                             (a1*b2-b1*a2+d1*c2-c1*d2)
+                             (a1*c2-c1*a2+b1*d2-d1*b2)
+                             (a1*d2-d1*a2+c1*b2-b1*c2))%Z.
+  Proof. intros -> ->; unfold four_squares; ring. Qed.
+
+  Section lagrange_prime.
+
+    Variable (p : nat) (Hp : prime p).
+
+    Let P n := 1 <= n < p /\ exists a b c d, Z.of_nat (n*p) = (a*a+b*b+c*c+d*d)%Z.
+
+    (** DLW: This one was a pain in the ... *)
+
+    Let lagrange_prime_step m : P m -> 1 < m -> exists n, n < m /\ P n.
+    Proof.
+      intros (H1 & x1 & x2 & x3 & x4 & H2) H3.
+      assert (Hm : m <> 0) by omega.
+      generalize (Zrem_double Hm x1)
+                 (Zrem_double Hm x2)
+                 (Zrem_double Hm x3)
+                 (Zrem_double Hm x4).
+      intros (y1 & E1 & Q1) (y2 & E2 & Q2) (y3 & E3 & Q3) (y4 & E4 & Q4).
+      assert (Z2Zp Hm (y1*y1+y2*y2+y3*y3+y4*y4) = Z2Zp Hm 0) as H4.
+      { rewrite !Z2Zp_plus, !Z2Zp_mult, <- E1, <- E2, <- E3, <- E4.
+        rewrite <- !Z2Zp_mult, <- !Z2Zp_plus, <- H2.
+        rewrite Nat2Z.inj_mul, Z2Zp_mult.
+        rewrite Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero, Z2Zp_zero; auto. }
+      apply Z2Zp_inj in H4.
+      destruct H4 as (r & Hr).
+      rewrite Z.sub_0_r in Hr.
+      assert (4 * (r * Z.of_nat m) <= 4 * (Z.of_nat m * Z_of_nat m))%Z as Hr'.
+      { rewrite <- Hr, !Z.mul_add_distr_l; omega. }
+      rewrite !(Zmult_comm 4) in Hr'.
+      apply Zmult_le_reg_r in Hr'; try omega.
+      apply Zmult_le_reg_r in Hr'; try omega.
+      assert (0 <= r * Z_of_nat m)%Z as Hr''.
+      { rewrite <- Hr; repeat apply Z.add_nonneg_nonneg; apply Z.square_nonneg. }
+      apply Zmult_le_0_reg_r in Hr''.
+      2:{ apply (inj_gt m 0); omega. }
+      apply Z_of_nat_complete_inf in Hr''.
+      destruct Hr'' as (k & ?); subst r.
+      apply Nat2Z.inj_le in Hr'.
+      destruct (eq_nat_dec m k) as [ <- | Hk1 ].
+      { apply f_equal with (f := fun i => (4*i)%Z) in Hr.
+        rewrite !Z.mul_add_distr_l in Hr.
+        apply bounded_four in Hr; auto.
+        destruct Hr as (F1 & F2 & F3 & F4).
+        apply four_square_simpl in F1.
+        destruct F1 as (q & Hq & F1).
+        rewrite Hq in F2, F3, F4. 
+        apply four_square_simpl' in F2.
+        apply four_square_simpl' in F3.
+        apply four_square_simpl' in F4.
+        subst m. 
+        assert (4*q*q <> 0) as Hq.
+        { destruct q; simpl; try discriminate; omega. }
+        apply half_modulus_lemma with (1 := E1) (Hm2 := Hq) in F1.
+        apply half_modulus_lemma with (1 := E2) (Hm2 := Hq) in F2.
+        apply half_modulus_lemma with (1 := E3) (Hm2 := Hq) in F3.
+        apply half_modulus_lemma with (1 := E4) (Hm2 := Hq) in F4.
+        assert (Z2Zp Hq (Z.of_nat (2 * q * p)) = Zp_zero Hq) as C.
+        { rewrite H2, !Z2Zp_plus, F1, F2, F3, F4.
+          rewrite <- !nat2Zp_plus.
+          replace (q*q+q*q+q*q+q*q) with (4*q*q) by ring.
+          rewrite nat2Zp_p; auto. }
+        rewrite Z2Zp_of_nat in C.
+        apply divides_nat2Zp in C.
+        destruct C as (d & Hd).
+        assert (divides (2*q) p) as C.
+        { replace (d*(4*q*q)) with (2*q*(d*(2*q))) in Hd by ring.
+          apply Nat.mul_cancel_l in Hd; try omega.
+          exists d; auto. }
+        apply Hp in C.
+        destruct C as [ C | C ]; try omega. }
+      destruct (eq_nat_dec k 0) as [ -> | Hk2 ].
+      { simpl in Hr.
+        apply four_square_zero in Hr.
+        destruct Hr as (? & ? & ? & ?); subst y1 y2 y3 y4.
+        assert (Hm2 : m*m <> 0).
+        { destruct m; simpl; try discriminate; omega. }
+        assert (forall x, Z2Zp Hm x = Z2Zp Hm 0 -> Z2Zp Hm2 (x*x) = Zp_zero Hm2) as L.
+        { intros x Hx.
+          apply Z2Zp_inj in Hx.
+          destruct Hx as (d & Hd).
+          rewrite Z.sub_0_r in Hd.
+          rewrite Hd.
+          replace (d*Z.of_nat m*(d*Z.of_nat m))%Z
+          with    (Z.of_nat (m*m)*(d*d))%Z.
+          2:{ rewrite Nat2Z.inj_mul; ring. }
+          rewrite Z2Zp_mult, Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero; auto. }
+        apply L in E1.
+        apply L in E2.
+        apply L in E3.
+        apply L in E4.
+        clear L.
+        assert (Z2Zp Hm2 (Z.of_nat (m*p)) = Zp_zero Hm2) as C.
+        { rewrite H2, !Z2Zp_plus, E1, E2, E3, E4, !Zp_plus_zero; auto. }
+        rewrite Z2Zp_of_nat in C.
+        apply divides_nat2Zp in C.
+        destruct C as (d & Hd).
+        assert (divides m p) as C.
+        { replace (d*(m*m)) with (m*(d*m)) in Hd by ring.
+          apply Nat.mul_cancel_l in Hd; try omega.
+          exists d; auto. }
+        apply Hp in C.
+        destruct C as [ C | C ]; try omega. }
+      assert (0 < k < m) as Hk by omega.
+      clear Hr' Hk1 Hk2.
+      symmetry in Hr.
+      rewrite <- Nat2Z.inj_mul in Hr.
+      clear Q1 Q2 Q3 Q4.
+      assert (exists a b c d, Z.of_nat (k*p*m*m) = four_squares a b c d%Z
+                           /\ Z2Zp Hm a = Zp_zero Hm
+                           /\ Z2Zp Hm b = Zp_zero Hm
+                           /\ Z2Zp Hm c = Zp_zero Hm
+                           /\ Z2Zp Hm d = Zp_zero Hm) as Q.
+      { exists (x1 * y1 + x2 * y2 + x3 * y3 + x4 * y4)%Z,
+               (x1 * y2 - x2 * y1 + x4 * y3 - x3 * y4)%Z, 
+               (x1 * y3 - x3 * y1 + x2 * y4 - x4 * y2)%Z,
+               (x1 * y4 - x4 * y1 + x3 * y2 - x2 * y3)%Z; split.
+        + rewrite <- (Euler_squares _ _ _ _ _ _ _ _ H2 Hr).
+          rewrite <- Nat2Z.inj_mul; f_equal; ring.
+        + msplit 3.
+          * rewrite !Z2Zp_plus, !Z2Zp_mult. 
+            rewrite <- E1, <- E2, <- E3, <- E4.
+            rewrite <- !Z2Zp_mult, <- !Z2Zp_plus.
+            rewrite <- H2, Nat2Z.inj_mul, Z2Zp_mult, 
+                    Z2Zp_of_nat, nat2Zp_p, Zp_mult_zero; auto.
+          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+            rewrite !Z2Zp_mult.
+            rewrite <- E1, <- E2, <- E3, <- E4.
+            rewrite <- !Z2Zp_mult.
+            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+            rewrite <- Z2Zp_zero; f_equal; ring.
+          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+            rewrite !Z2Zp_mult.
+            rewrite <- E1, <- E2, <- E3, <- E4.
+            rewrite <- !Z2Zp_mult.
+            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+            rewrite <- Z2Zp_zero; f_equal; ring.
+          * repeat (rewrite !Z2Zp_minus || rewrite !Z2Zp_plus). 
+            rewrite !Z2Zp_mult.
+            rewrite <- E1, <- E2, <- E3, <- E4.
+            rewrite <- !Z2Zp_mult.
+            repeat (rewrite <- !Z2Zp_minus || rewrite <- !Z2Zp_plus).
+            rewrite <- Z2Zp_zero; f_equal; ring. }
+      clear x1 x2 x3 x4 H2 H3 y1 E1 y2 E2 y3 E3 y4 E4 Hr.
+      destruct Q as (a & b & c & d & H & Ha & Hb & Hc & Hd).
+      apply Z2Zp_div in Ha; destruct Ha as (x & ->).
+      apply Z2Zp_div in Hb; destruct Hb as (y & ->).
+      apply Z2Zp_div in Hc; destruct Hc as (z & ->).
+      apply Z2Zp_div in Hd; destruct Hd as (w & ->).
+      exists k; split; try omega; split; try omega.
+      exists x, y, z, w.
+      apply Z.mul_cancel_r with (p := Z.of_nat (m*m)).
+      { intros E.
+        apply Nat2Z.inj with (m := 0) in E.
+        destruct m; try discriminate; omega. }
+      rewrite <- Nat2Z.inj_mul, mult_assoc, H.
+      rewrite Nat2Z.inj_mul; unfold four_squares; ring.
+    Qed.
+
+    Let lagrange_prime_rec : P 1.
+    Proof.
+      destruct (lagrange_prelim' Hp) as (n & a & b & H1 & H2 & H3).
+      cut (P n).
+      + revert H2 H3; clear H1.
+        induction on n as IH with measure n.
+        intros H2 H3 H.
+        destruct (le_lt_dec n 1) as [ | Hn ].
+        * now replace 1 with n by omega.
+        * destruct (lagrange_prime_step H) as (m & H4 & H5); auto.
+          generalize H5; destruct H5; apply IH; auto; omega.
+      + split; try omega.
+        exists 0%Z, 1%Z, (Z.of_nat a), (Z.of_nat b).
+        rewrite H1, !Nat2Z.inj_add, !Nat2Z.inj_mul.
+        simpl Z.of_nat at 1; omega.
+    Qed.
+
+    Theorem lagrange_prime : exists a b c d, Z.of_nat p = (a*a+b*b+c*c+d*d)%Z.
+    Proof.
+      replace p with (1*p) by omega.
+      apply lagrange_prime_rec.
+    Qed.
+
+  End lagrange_prime.
+
+  Check lagrange_prime.
+  Print Assumptions lagrange_prime.
+
+  Open Scope Z_scope.
+
+  Lemma lagrange_theorem_nat : forall n, exists a b c d, Z.of_nat n = a*a+b*b+c*c+d*d.
+  Proof.
+    induction n as [ | | p Hp | x y Hx Hy ] using prime_rect.
+    + exists 0, 0, 0, 0; auto.
+    + exists 1, 0, 0, 0; auto.
+    + apply lagrange_prime; auto.
+    + destruct Hx as (a1 & b1 & c1 & d1 & H1).
+      destruct Hy as (a2 & b2 & c2 & d2 & H2).
+      subst.
+      exists (a1*a2+b1*b2+c1*c2+d1*d2),
+             (a1*b2-b1*a2+d1*c2-c1*d2),
+             (a1*c2-c1*a2+b1*d2-d1*b2),
+             (a1*d2-d1*a2+c1*b2-b1*c2).
+      rewrite Nat2Z.inj_mul; apply Euler_squares; auto.
+  Qed.
+
+  (** An relative integer is positive iff it is the sum of four squares *)
+
+  Lemma lagrange_theorem_Z n : 0 <= n <-> exists a b c d, n = a*a+b*b+c*c+d*d.
+  Proof.
+    split.
+    + intros H.
+      destruct Z_of_nat_complete with (1 := H) as (m & ->).
+      apply lagrange_theorem_nat.
+    + intros (a & b & c & d & ->).
+      generalize (a*a) (b*b) (c*c) (d*d) 
+                 (Z.square_nonneg a) (Z.square_nonneg b)
+                 (Z.square_nonneg c) (Z.square_nonneg d).
+      intros; omega.
+  Qed.
+
+End lagrange.
+
+Check lagrange_theorem_Z.
+
+

--- a/theories/H10/ArithLibs/lagrange.v
+++ b/theories/H10/ArithLibs/lagrange.v
@@ -270,7 +270,12 @@ Section lagrange_prelim_odd.
     unfold l; intros x; rewrite list_an_spec; lia.
   Qed.
 
-  (* Let us defined to injective functions from l to Z/Zp *)
+  (* Let us defined two injective functions from [0,n] to Z/Z(2n+1) 
+
+     f := x => x²
+     g := x => -(1+x²)
+
+   *)
 
   Let f x := nat2Zp Hp (x*x).
   Let g y := Zp_opp Hp (Zp_plus Hp (Zp_one Hp) (f y)).
@@ -348,7 +353,7 @@ Section lagrange_prelim_odd.
 
 End lagrange_prelim_odd.
 
-(** Preliminary lemma : primes p have a multiple n*p of the form 1+a²+b² with 0 < n < p *)
+(** Preliminary lemma : any prime p has a (small) multiple n*p of the form 1+a²+b² with 0 < n < p *)
 
 Lemma lagrange_prelim p : prime p -> exists n a b, n*p = 1+a*a+b*b /\ 0 < n < p.
 Proof.

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -10,10 +10,18 @@
 (** ** Object-level encoding of bounded universal quantification I *)
 
 Require Import Arith Nat Omega List Bool Setoid.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac gcd prime binomial sums bool_nat.
-From Undecidability.H10.ArithLibs Require Import luca.
-From Undecidability.H10.Matija Require Import cipher.
-From Undecidability.H10.Dio Require Import dio_logic dio_expo.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac gcd prime binomial sums bool_nat rel_iter.
+
+From Undecidability.H10.ArithLibs 
+  Require Import luca.
+
+From Undecidability.H10.Matija 
+  Require Import cipher.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic dio_expo.
 
 Set Implicit Arguments.
 
@@ -22,6 +30,111 @@ Local Notation power := (mscal mult 1).
 Local Notation "∑" := (msum plus 0).
 Local Infix "⇣" := nat_meet (at level 40, left associativity).
 Local Infix "⇡" := nat_join (at level 50, left associativity).
+
+Local Notation env_down := (fun (v : nat -> _) n => v (S n)).  
+
+(** This the Diophantine encoding of binomial coefficents *)
+
+Section dio_fun_binomial.
+
+  Notation "∑" := (msum plus 0).
+
+  Let plus_cancel_l : forall a b c, a + b = a + c -> b = c.
+  Proof. intros; omega. Qed.
+
+  Hint Resolve Nat.mul_add_distr_r.
+
+  (** We use this characterization with Newton's devel
+
+      (1+q)^n = ∑ binomial(n,i).q^i   when q > 2^n
+
+    *)
+
+  Let is_binomial_eq b n k :  
+         b = binomial n k
+     <-> exists q, q = power (1+n) 2
+                /\ is_digit (power n (1+q)) q k b.
+  Proof.
+    split.
+    + intros ?; subst.
+      set (q := power (1+n) 2).
+      assert (Hq : q <> 0).
+      { unfold q; generalize (@power_ge_1 (S n) 2); intros; simpl; omega. }
+      set (c := power n (1+q)).
+      exists q; split; auto; split. 
+      * apply binomial_lt_power.
+      * fold c.
+        destruct (le_lt_dec k n) as [ Hk | Hk ].
+        - exists (∑ (n-k) (fun i => binomial n (S k+i) * power i q)),
+                 (∑ k (fun i => binomial n i * power i q)); split; auto.
+          2: { apply sum_power_lt; auto; intros; apply binomial_lt_power. }
+          rewrite Nat.mul_add_distr_r, <- mult_assoc, <- power_S.
+          rewrite <- sum_0n_distr_r with (1 := Nat_plus_monoid) (3 := Nat_mult_monoid); auto.
+          rewrite <- plus_assoc, (plus_comm _ (∑ _ _)).
+          rewrite <- msum_plus1 with (f := fun i => binomial n i * power i q); auto.
+          rewrite plus_comm.
+          unfold c.
+          rewrite Newton_nat_S.
+          replace (S n) with (S k + (n-k)) by omega.
+          rewrite msum_plus; auto; f_equal; apply msum_ext.
+          intros; rewrite power_plus; ring.
+        - exists 0, c.
+          rewrite binomial_gt; auto.
+          rewrite Nat.mul_0_l; split; auto.
+          unfold c.
+          apply lt_le_trans with (power (S n) q).
+          ++ rewrite Newton_nat_S.
+             apply sum_power_lt; auto.
+             intros; apply binomial_lt_power.
+          ++ apply power_mono; omega.
+    + intros (q & H1 & H3).
+      assert (Hq : q <> 0).
+      { rewrite H1; generalize (@power_ge_1 (S n) 2); intros; simpl; omega. }
+      rewrite Newton_nat_S in H3.
+      apply is_digit_fun with (1 := H3).
+      destruct (le_lt_dec k n) as [ Hk | Hk ].
+      * red; split.
+        - subst; apply binomial_lt_power.
+        - exists (∑ (n-k) (fun i => binomial n (S k+i) * power i q)),
+                 (∑ k (fun i => binomial n i * power i q)); split.
+          2: {  apply sum_power_lt; auto; intros; subst; apply binomial_lt_power. }
+          rewrite Nat.mul_add_distr_r, <- mult_assoc, <- power_S.
+          rewrite <- sum_0n_distr_r with (1 := Nat_plus_monoid) (3 := Nat_mult_monoid); auto.
+          rewrite <- plus_assoc, (plus_comm _ (∑ _ _)).
+          rewrite <- msum_plus1 with (f := fun i => binomial n i * power i q); auto.
+          rewrite plus_comm.
+          replace (S n) with (S k + (n-k)) by omega.
+          rewrite msum_plus; auto; f_equal.
+          apply msum_ext.
+          intros; rewrite power_plus; ring.
+      * rewrite binomial_gt; auto.
+        rewrite <- Newton_nat_S.
+        split; try omega.
+        exists 0, (power n (1+q)); split; auto.
+        apply lt_le_trans with (power (S n) q).
+        - rewrite Newton_nat_S.
+          apply sum_power_lt; auto.
+          subst; intros; apply binomial_lt_power.
+        - apply power_mono; omega.
+  Qed.
+
+  Lemma dio_fun_binomial n k : 𝔻F n -> 𝔻F k -> 𝔻F (fun ν => binomial (n ν) (k ν)).
+  Proof.
+    intros H2 H3.
+    apply dio_rel_equiv 
+      with (1 := fun ν => is_binomial_eq (ν 0) (n (env_down ν)) (k (env_down ν))).
+    dio auto.
+  Defined.
+
+End dio_fun_binomial.
+
+Hint Resolve dio_fun_binomial : dio_fun_db.
+
+Local Fact dio_fun_binomial_example : 𝔻F (fun ν => binomial (ν 0) (ν 1)).
+Proof. dio auto. Defined.
+
+Check dio_fun_binomial_example.
+Eval compute in df_size_Z (proj1_sig dio_fun_binomial_example).
 
 (** This result comes from Luca's theorem *)
 
@@ -55,33 +168,21 @@ Proof.
       rewrite binomial_gt, rem_lt in H4; omega.
 Qed.
 
-(* Hint Resolve dio_rel_binomial dio_rel_remainder. *)
-
-Section binary_le_dio.
-
-  Let ble_equiv x y : x ≲ y <-> exists b, b = binomial y x /\ 1 = rem b 2.
-  Proof.
-    rewrite binary_le_binomial; split; eauto.
-    intros (? & ? & ?); subst; auto.
-  Qed.
-
-  Theorem binary_le_diophantine x y : 𝔻P x -> 𝔻P y -> 𝔻R (fun v => x v ≲ y v).
-  Proof.
-    intros. 
-    apply dio_rel_equiv with (1 := fun v => ble_equiv (x v) (y v)).
-    dio_rel_auto.
-  Defined.
-
-End binary_le_dio.
-
-Hint Resolve binary_le_diophantine : dio_rel_db.
-
-Theorem nat_meet_diophantine a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
-                                  -> 𝔻R (fun v => a v = b v ⇣ c v).
+Theorem dio_rel_binary_le x y : 𝔻F x -> 𝔻F y -> 𝔻R (fun v => x v ≲ y v).
 Proof.
   intros.
-  apply dio_rel_equiv with (1 := fun v => nat_meet_dio (a v) (b v) (c v)).
-  dio_rel_auto.
+  by dio equiv (fun v => rem (binomial (y v) (x v)) 2 = 1).
+  abstract (intro; apply binary_le_binomial).
 Defined.
 
-Hint Resolve nat_meet_diophantine : dio_rel_db.
+Hint Resolve dio_rel_binary_le : dio_rel_db.
+
+Theorem dio_fun_nat_meet a b : 𝔻F a -> 𝔻F b -> 𝔻F (fun ν => a ν ⇣ b ν).
+Proof.
+  intros.
+  apply dio_rel_equiv 
+    with (1 := fun v => nat_meet_dio (v 0) (a (env_down v)) (b (env_down v))).
+  dio auto.
+Defined.
+
+Hint Resolve dio_fun_nat_meet : dio_fun_db.

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -120,10 +120,7 @@ Section dio_fun_binomial.
 
   Lemma dio_fun_binomial n k : 𝔻F n -> 𝔻F k -> 𝔻F (fun ν => binomial (n ν) (k ν)).
   Proof.
-    intros H2 H3.
-    apply dio_rel_equiv 
-      with (1 := fun ν => is_binomial_eq (ν 0) (n (env_down ν)) (k (env_down ν))).
-    dio auto.
+    dio by lemma (fun ν => is_binomial_eq (ν 0) (n (env_down ν)) (k (env_down ν))).
   Defined.
 
 End dio_fun_binomial.
@@ -170,19 +167,14 @@ Qed.
 
 Theorem dio_rel_binary_le x y : 𝔻F x -> 𝔻F y -> 𝔻R (fun v => x v ≲ y v).
 Proof.
-  intros.
-  by dio equiv (fun v => rem (binomial (y v) (x v)) 2 = 1).
-  abstract (intro; apply binary_le_binomial).
+  dio by lemma (fun v => binary_le_binomial (x v) (y v)). 
 Defined.
 
 Hint Resolve dio_rel_binary_le : dio_rel_db.
 
 Theorem dio_fun_nat_meet a b : 𝔻F a -> 𝔻F b -> 𝔻F (fun ν => a ν ⇣ b ν).
 Proof.
-  intros.
-  apply dio_rel_equiv 
-    with (1 := fun v => nat_meet_dio (v 0) (a (env_down v)) (b (env_down v))).
-  dio auto.
+  dio by lemma (fun v => nat_meet_dio (v 0) (a (env_down v)) (b (env_down v))).
 Defined.
 
 Hint Resolve dio_fun_nat_meet : dio_fun_db.

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -31,8 +31,6 @@ Local Notation "∑" := (msum plus 0).
 Local Infix "⇣" := nat_meet (at level 40, left associativity).
 Local Infix "⇡" := nat_join (at level 50, left associativity).
 
-Local Notation env_down := (fun (v : nat -> _) n => v (S n)).  
-
 (** This the Diophantine encoding of binomial coefficents *)
 
 Section dio_fun_binomial.
@@ -120,7 +118,7 @@ Section dio_fun_binomial.
 
   Lemma dio_fun_binomial n k : 𝔻F n -> 𝔻F k -> 𝔻F (fun ν => binomial (n ν) (k ν)).
   Proof.
-    dio by lemma (fun ν => is_binomial_eq (ν 0) (n (env_down ν)) (k (env_down ν))).
+    dio by lemma (fun ν => is_binomial_eq (ν 0) (n ν⭳) (k ν⭳)).
   Defined.
 
 End dio_fun_binomial.
@@ -174,7 +172,7 @@ Hint Resolve dio_rel_binary_le : dio_rel_db.
 
 Theorem dio_fun_nat_meet a b : 𝔻F a -> 𝔻F b -> 𝔻F (fun ν => a ν ⇣ b ν).
 Proof.
-  dio by lemma (fun v => nat_meet_dio (v 0) (a (env_down v)) (b (env_down v))).
+  dio by lemma (fun v => nat_meet_dio (v 0) (a v⭳) (b v⭳)).
 Defined.
 
 Hint Resolve dio_fun_nat_meet : dio_fun_db.

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -35,8 +35,6 @@ Local Infix "⇡" := nat_join (at level 50, left associativity).
 
 Section dio_fun_binomial.
 
-  Notation "∑" := (msum plus 0).
-
   Let plus_cancel_l : forall a b c, a + b = a + c -> b = c.
   Proof. intros; omega. Qed.
 
@@ -131,7 +129,7 @@ Proof. dio auto. Defined.
 Check dio_fun_binomial_example.
 Eval compute in df_size_Z (proj1_sig dio_fun_binomial_example).
 
-(** This result comes from Luca's theorem *)
+(** This result comes from Lucas' theorem *)
 
 Theorem binary_le_binomial n m : n ≲ m <-> rem (binomial m n) 2 = 1.
 Proof.

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -55,7 +55,7 @@ Proof.
       rewrite binomial_gt, rem_lt in H4; omega.
 Qed.
 
-Hint Resolve dio_rel_binomial dio_rel_remainder.
+(* Hint Resolve dio_rel_binomial dio_rel_remainder. *)
 
 Section binary_le_dio.
 
@@ -74,7 +74,7 @@ Section binary_le_dio.
 
 End binary_le_dio.
 
-Hint Resolve binary_le_diophantine.
+Hint Resolve binary_le_diophantine : dio_rel_db.
 
 Theorem nat_meet_diophantine a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
                                   -> 𝔻R (fun v => a v = b v ⇣ c v).
@@ -84,4 +84,4 @@ Proof.
   dio_rel_auto.
 Defined.
 
-Hint Resolve nat_meet_diophantine.
+Hint Resolve nat_meet_diophantine : dio_rel_db.

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -90,15 +90,15 @@ Section dio_rel_bounded_fall.
 
     Hint Resolve dio_rel_dc_Code : dio_rel_db.
 
-    (*
+   (*
 
       Eval compute in df_size_Z (proj1_sig (dio_rel_dc_Code (0,dee_comp do_mul 1 2))). 
 
     *)
 
-    (* Case of do_mul gives the overall bound of 962535 
+    (* Case of do_mul gives the overall bound  
 
-    Let dc_Code_size_Z c : (df_size_Z (proj1_sig (dio_rel_dc_Code c)) <= 962535)%Z.
+    Let dc_Code_size_Z c : (df_size_Z (proj1_sig (dio_rel_dc_Code c)) <= 203468)%Z.
     Proof.
       destruct c as (u & [ n | v | [] | [] v w ]); compute; discriminate.
     Qed. *)
@@ -108,7 +108,8 @@ Section dio_rel_bounded_fall.
         i = k     | <0,..,l> |  ?    |
         i = k+1   |          |  q    |  
         i = k+2   |          |  l    |  0
-        i > k+2   |          |       |  i-(k+2)  *)
+        i > k+2   |          |       |  i-(k+2)  
+     *)
 
     Local Fact dc_Code_spec c φ π ν ω : 
           (forall i, i < k -> is_cipher_of (ν 0) (π iq) (φ i) (π i))
@@ -228,7 +229,7 @@ Section dio_rel_bounded_fall.
 
     Let pre_quant ν := ν il+1 < ν iq /\ ciphers ν /\ dc_list_Code ll ν.
 
-    Let dio_rel_pre_quant : dio_rel pre_quant.
+    Let dio_rel_pre_quant : 𝔻R pre_quant.
     Proof. unfold pre_quant; dio auto. Defined.
 
     Let dc_list_bfall ν := exists π, pre_quant (fun i => if le_lt_dec il i then ν (i-il) else π i).

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -90,7 +90,7 @@ Section df_mconj.
     destruct H as (f & Hf).
     exists (df_mconj k f).
     abstract(intros v; rewrite df_mconj_spec; split;
-      intros E i Hi; generalize (E _ Hi); apply Hf; trivial). 
+      intros E i Hi; generalize (E _ Hi); apply Hf; trivial).
   Defined.
 
 End df_mconj.
@@ -123,20 +123,20 @@ Section dio_bounded_fall.
 
     Local Fact dio_rel_dc_Code c : 𝔻R (dc_Code c).
     Proof. 
-      destruct c as (u & [ n | v | [] | [] v w ]); unfold dc_Code; dio_rel_auto.
+      destruct c as (u & [ n | v | [] | [] v w ]); unfold dc_Code; dio auto.
     Defined.
 
     Hint Resolve dio_rel_dc_Code : dio_rel_db.
 
-    (* 
+    (*
 
       Eval compute in df_size_Z (proj1_sig (dio_rel_dc_Code (0,dee_comp do_mul 1 2))). 
 
     *)
 
-    (* Case of do_mul gives the overall bound of 778551 
+    (* Case of do_mul gives the overall bound of 962535 
 
-    Let dc_Code_size_Z c : (df_size_Z (proj1_sig (dio_rel_dc_Code c)) <= 778551)%Z.
+    Let dc_Code_size_Z c : (df_size_Z (proj1_sig (dio_rel_dc_Code c)) <= 962535)%Z.
     Proof.
       destruct c as (u & [ n | v | [] | [] v w ]); compute; discriminate.
     Qed. *)
@@ -149,12 +149,13 @@ Section dio_bounded_fall.
         i > k+2   |          |       |  i-(k+2)  *)
 
     Local Fact dc_Code_spec c φ π ν ω : 
-                                 (forall i, i < k -> is_cipher_of (ν 0) (π iq) (φ i) (π i))
-                              -> (is_cipher_of (ν 0) (π iq) (fun n => n) (π k))
-                              -> (forall x, dc_vars c x -> x < k)
-                              -> (forall i, i < il -> ω i = π i)
-                              -> (forall i, il <= i -> ω i = ν (i-il))
-                             -> dc_Code c ω <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (dv_lift ν j) c.
+          (forall i, i < k -> is_cipher_of (ν 0) (π iq) (φ i) (π i))
+       -> (is_cipher_of (ν 0) (π iq) (fun n => n) (π k))
+       -> (forall x, dc_vars c x -> x < k)
+       -> (forall i, i < il -> ω i = π i)
+       -> (forall i, il <= i -> ω i = ν (i-il))
+       -> dc_Code c ω 
+      <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (dv_lift ν j) c.
     Proof.
       intros G1 G2 G3 G4 G5.
       assert (ω il = ν 0) as G0.
@@ -210,18 +211,18 @@ Section dio_bounded_fall.
     Local Definition dc_list_Code ll ν := fold_right (fun c P => dc_Code c ν /\ P) True ll.
 
     Local Fact dio_rel_dc_list_Code ll : 𝔻R (dc_list_Code ll).
-    Proof. induction ll; unfold dc_list_Code; simpl; dio_rel_auto. Qed.
+    Proof. induction ll; unfold dc_list_Code; simpl; dio auto. Qed.
 
     Hint Resolve dio_rel_dc_list_Code : dio_rel_db.
 
     Local Fact dc_list_Code_spec ll φ π ν ω : 
-                                       (forall i, i < k -> is_cipher_of (ν 0) (π iq) (φ i) (π i))
-                                    -> (is_cipher_of (ν 0) (π iq) (fun n => n) (π k))
-                                    -> (forall c, In c ll -> forall x, dc_vars c x -> x < k)
-                                    -> (forall i, i < il  -> ω i = π i)
-                                    -> (forall i, il <= i -> ω i = ν (i-il))
-                                    -> dc_list_Code ll ω 
-                                   <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
+          (forall i, i < k -> is_cipher_of (ν 0) (π iq) (φ i) (π i))
+       -> (is_cipher_of (ν 0) (π iq) (fun n => n) (π k))
+       -> (forall c, In c ll -> forall x, dc_vars c x -> x < k)
+       -> (forall i, i < il  -> ω i = π i)
+       -> (forall i, il <= i -> ω i = ν (i-il))
+       -> dc_list_Code ll ω 
+      <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
     Proof.
       intros G1 G2 G3 G4 G5; revert G3.
       rewrite <- Forall_forall.
@@ -234,12 +235,14 @@ Section dio_bounded_fall.
             rewrite Forall_cons_inv in E1; tauto.
     Qed.
 
-    Local Definition ciphers ν := CodeNat (ν il) (ν iq) (ν k) /\ forall i, i < k -> Code (ν il) (ν iq) (ν i).
+    Local Definition ciphers ν := 
+             CodeNat (ν il) (ν iq) (ν k) 
+          /\ forall i, i < k -> Code (ν il) (ν iq) (ν i).
 
     Local Fact dio_rel_ciphers : 𝔻R ciphers.
     Proof.
-      unfold ciphers; dio_rel_auto. 
-      apply dio_rel_mconj; intros; dio_rel_auto.
+      unfold ciphers; dio auto.
+      apply dio_rel_mconj; intros; dio auto.
     Defined.
 
     Hint Resolve dio_rel_ciphers : dio_rel_db.
@@ -264,14 +267,15 @@ Section dio_bounded_fall.
     Let pre_quant ν := ν il+1 < ν iq /\ ciphers ν /\ dc_list_Code ll ν.
 
     Let dio_rel_pre_quant : dio_rel pre_quant.
-    Proof. unfold pre_quant; dio_rel_auto. Defined.
+    Proof. unfold pre_quant; dio auto. Defined.
 
     Definition dc_list_bfall ν := exists π, pre_quant (fun i => if le_lt_dec il i then ν (i-il) else π i).
 
     Let dc_list_bfall_spec_1 ν :
-          dc_list_bfall ν <-> exists q φ, ν 0+1 < q 
-                                      /\ (forall i j, i < k -> j < ν 0 -> φ i j < power q 2) 
-                                      /\ forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
+            dc_list_bfall ν 
+        <-> exists q φ, ν 0+1 < q 
+                    /\ (forall i j, i < k -> j < ν 0 -> φ i j < power q 2) 
+                    /\  forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
     Proof.
       split.
       + intros (pi & G0 & G1 & G4).
@@ -321,7 +325,9 @@ Section dio_bounded_fall.
             intros i Hi; destruct (le_lt_dec il i); auto; omega.
     Qed.
 
-    Let dc_list_bfall_spec ν : (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ (dv_lift ν i)) ll) <-> dc_list_bfall ν .
+    Let dc_list_bfall_spec ν : 
+            (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ (dv_lift ν i)) ll) 
+        <-> dc_list_bfall ν .
     Proof.
       rewrite dc_list_bfall_spec_1; split.
       + intros H.
@@ -353,20 +359,20 @@ Section dio_bounded_fall.
       unfold dc_list_bfall.
       destruct dio_rel_pre_quant as (f & Hf).
       eexists (df_mexists il f).
-      intros; rewrite df_mexists_spec; split;
-      intros (phi & H); exists phi; revert H; rewrite <- Hf; auto.
+      abstract(intros; rewrite df_mexists_spec; split;
+        intros (phi & H); exists phi; revert H; rewrite <- Hf; auto).
     Defined.
 
   End dio_bounded_elem.
 
-  Theorem dio_bounded_fall P : dio_rel P -> dio_rel (fun ν => forall i, i < ν 0 -> P (dv_lift ν i)).
+  Theorem dio_bounded_fall P : 𝔻R P -> 𝔻R (fun ν => forall i, i < ν 0 -> P (dv_lift ν i)).
   Proof.
     intros (f & Hf).
     destruct (dio_formula_elem f) as (ll & H1 & H2 & H3).
     revert H2; generalize (4*df_size f); intros k H2.
     generalize (dio_rel_dc_list_bfall _ H2).
     apply dio_rel_equiv; intros v.
-    split; intros H i Hi; generalize (H _ Hi); rewrite <- Hf, H3; auto.
+    abstract(split; intros H i Hi; generalize (H _ Hi); rewrite <- Hf, H3; auto).
   Defined.
 
 End dio_bounded_fall.
@@ -385,18 +391,17 @@ Section dfbfall.
 
   Let rho i := match i with 0 => 0 | S i => S (S i) end. 
 
-  Let dfbfall_full : dio_rel (fun ν => forall i, i < ν 0 -> df_pred f (dv_change ν i)).
+  Let dfbfall_full : 𝔻R (fun ν => forall i, i < ν 0 -> df_pred f (dv_change ν i)).
   Proof.
     assert (dio_rel (df_pred (df_ren rho f))) as H.
     { exists (df_ren rho f); tauto. }
     destruct (dio_bounded_fall H) as (g & Hg).
     exists g.
-    intros v.
-    rewrite Hg. 
-    split; intros G i Hi; generalize (G _ Hi);  
-      rewrite df_pred_ren; apply df_pred_ext;
-      intros [ | [ | x ] ]; simpl; auto.
-  Qed.
+    abstract (intros v; rewrite Hg; 
+      split; intros G i Hi; generalize (G _ Hi);
+        rewrite df_pred_ren; apply df_pred_ext;
+        intros [ | [ | x ] ]; simpl; auto).
+  Defined.
 
   Definition dfbfall := proj1_sig dfbfall_full.
 
@@ -435,7 +440,7 @@ Corollary dio_rel_fall_lt_bound a (K : nat -> nat -> (nat -> nat) -> Prop) :
            𝔻P a
    -> 𝔻R (fun ν => K (ν 0) (a ν↓) ν↓) 
    -> 𝔻R (fun ν => forall x, x < a ν -> K x (a ν) ν).
-Proof. intros; dio_rel_auto. Defined.
+Proof. intros; dio auto. Defined.
 
 Hint Resolve dio_rel_fall_lt_bound : dio_rel_db.
 

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -50,7 +50,9 @@ Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓"
 
 *)
 
-Section df_mconj.
+Section dio_rel_mconj.
+
+  (** Diophantine encoding of finitary conjunction *)
   
   Definition df_true := proj1_sig dio_rel_True.
 
@@ -93,7 +95,7 @@ Section df_mconj.
       intros E i Hi; generalize (E _ Hi); apply Hf; trivial).
   Defined.
 
-End df_mconj.
+End dio_rel_mconj.
 
 Section dio_bounded_fall.
 
@@ -155,7 +157,7 @@ Section dio_bounded_fall.
        -> (forall i, i < il -> ω i = π i)
        -> (forall i, il <= i -> ω i = ν (i-il))
        -> dc_Code c ω 
-      <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (dv_lift ν j) c.
+      <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (ν↑j) c.
     Proof.
       intros G1 G2 G3 G4 G5.
       assert (ω il = ν 0) as G0.
@@ -222,7 +224,7 @@ Section dio_bounded_fall.
        -> (forall i, i < il  -> ω i = π i)
        -> (forall i, il <= i -> ω i = ν (i-il))
        -> dc_list_Code ll ω 
-      <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
+      <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (ν↑j)) ll.
     Proof.
       intros G1 G2 G3 G4 G5; revert G3.
       rewrite <- Forall_forall.
@@ -275,7 +277,7 @@ Section dio_bounded_fall.
             dc_list_bfall ν 
         <-> exists q φ, ν 0+1 < q 
                     /\ (forall i j, i < k -> j < ν 0 -> φ i j < power q 2) 
-                    /\  forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (dv_lift ν j)) ll.
+                    /\  forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (ν↑j)) ll.
     Proof.
       split.
       + intros (pi & G0 & G1 & G4).
@@ -326,7 +328,7 @@ Section dio_bounded_fall.
     Qed.
 
     Let dc_list_bfall_spec ν : 
-            (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ (dv_lift ν i)) ll) 
+            (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ ν↑i) ll) 
         <-> dc_list_bfall ν .
     Proof.
       rewrite dc_list_bfall_spec_1; split.
@@ -353,7 +355,7 @@ Section dio_bounded_fall.
         exists (fun i => phi i j); auto.
     Qed.
 
-    Theorem dio_rel_dc_list_bfall : 𝔻R (fun ν => forall i, i < ν 0 -> exists φ, Forall (dc_eval φ (dv_lift ν i)) ll).
+    Theorem dio_rel_dc_list_bfall : 𝔻R (fun ν => forall i, i < ν 0 -> exists φ, Forall (dc_eval φ ν↑i) ll).
     Proof.
       apply dio_rel_equiv with (1 := dc_list_bfall_spec).
       unfold dc_list_bfall.
@@ -365,7 +367,7 @@ Section dio_bounded_fall.
 
   End dio_bounded_elem.
 
-  Theorem dio_bounded_fall P : 𝔻R P -> 𝔻R (fun ν => forall i, i < ν 0 -> P (dv_lift ν i)).
+  Theorem dio_bounded_fall P : 𝔻R P -> 𝔻R (fun ν => forall i, i < ν 0 -> P ν↑i).
   Proof.
     intros (f & Hf).
     destruct (dio_formula_elem f) as (ll & H1 & H2 & H3).
@@ -422,7 +424,8 @@ Section dio_rel_fall_lt.
   Defined.
 
   Theorem dio_rel_fall_lt a (K : nat -> (nat -> nat) -> Prop) : 
-           𝔻P a -> 𝔻R (fun ν => K (ν 0) ν↓) 
+           𝔻F a 
+   -> 𝔻R (fun ν => K (ν 0) ν↓) 
    -> 𝔻R (fun ν => forall x, x < a ν -> K x ν).
   Proof.
     intros Ha H.
@@ -437,7 +440,7 @@ End dio_rel_fall_lt.
 Hint Resolve dio_rel_fall_lt : dio_rel_db.
 
 Corollary dio_rel_fall_lt_bound a (K : nat -> nat -> (nat -> nat) -> Prop) : 
-           𝔻P a
+           𝔻F a
    -> 𝔻R (fun ν => K (ν 0) (a ν↓) ν↓) 
    -> 𝔻R (fun ν => forall x, x < a ν -> K x (a ν) ν).
 Proof. intros; dio auto. Defined.
@@ -445,7 +448,7 @@ Proof. intros; dio auto. Defined.
 Hint Resolve dio_rel_fall_lt_bound : dio_rel_db.
 
 Theorem dio_rel_fall_le a (K : nat -> (nat -> nat) -> Prop) : 
-           𝔻P a
+           𝔻F a
    -> 𝔻R (fun ν => K (ν 0) ν↓) 
    -> 𝔻R (fun ν => forall x, x <= a ν -> K x ν).
 Proof.

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -357,11 +357,11 @@ Section dio_bounded_fall.
 
     Theorem dio_rel_dc_list_bfall : 𝔻R (fun ν => forall i, i < ν 0 -> exists φ, Forall (dc_eval φ ν↑i) ll).
     Proof.
-      apply dio_rel_equiv with (1 := dc_list_bfall_spec).
+      dio by lemma dc_list_bfall_spec.
       unfold dc_list_bfall.
       destruct dio_rel_pre_quant as (f & Hf).
       eexists (df_mexists il f).
-      abstract(intros; rewrite df_mexists_spec; split;
+      abstract (intros; rewrite df_mexists_spec; split;
         intros (phi & H); exists phi; revert H; rewrite <- Hf; auto).
     Defined.
 
@@ -374,7 +374,7 @@ Section dio_bounded_fall.
     revert H2; generalize (4*df_size f); intros k H2.
     generalize (dio_rel_dc_list_bfall _ H2).
     apply dio_rel_equiv; intros v.
-    abstract(split; intros H i Hi; generalize (H _ Hi); rewrite <- Hf, H3; auto).
+    abstract (split; intros H i Hi; generalize (H _ Hi); rewrite <- Hf, H3; auto).
   Defined.
 
 End dio_bounded_fall.
@@ -454,7 +454,7 @@ Theorem dio_rel_fall_le a (K : nat -> (nat -> nat) -> Prop) :
 Proof.
   intros Ha HK.
   by dio equiv (fun v => forall x, x < 1+a v -> K x v).
-  abstract(intros v; split; intros H x Hx; apply H; omega).
+  abstract (intros v; split; intros H x Hx; apply H; omega).
 Defined.
 
 Hint Resolve dio_rel_fall_le : dio_rel_db.

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -11,17 +11,19 @@
 
 Require Import Arith Nat Omega List Bool.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list sums bounded_quantification.
-From Undecidability.H10.Matija Require Import cipher.
-From Undecidability.H10.Dio Require Import dio_logic dio_cipher dio_elem.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_list sums bounded_quantification.
+
+From Undecidability.H10.Matija 
+  Require Import cipher.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic dio_cipher dio_elem.
 
 Set Implicit Arguments.
 
 Local Notation power := (mscal mult 1).
 Local Notation "∑" := (msum plus 0).
-
-Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
-Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
 (** We show the elimination of bounded universal quantification. The proof is
     based on the paper 
@@ -157,7 +159,7 @@ Section dio_bounded_fall.
        -> (forall i, i < il -> ω i = π i)
        -> (forall i, il <= i -> ω i = ν (i-il))
        -> dc_Code c ω 
-      <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (ν↑j) c.
+      <-> forall j, j < ν 0 -> dc_eval (fun i => φ i j) (j·ν) c.
     Proof.
       intros G1 G2 G3 G4 G5.
       assert (ω il = ν 0) as G0.
@@ -224,7 +226,7 @@ Section dio_bounded_fall.
        -> (forall i, i < il  -> ω i = π i)
        -> (forall i, il <= i -> ω i = ν (i-il))
        -> dc_list_Code ll ω 
-      <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (ν↑j)) ll.
+      <-> forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (j·ν)) ll.
     Proof.
       intros G1 G2 G3 G4 G5; revert G3.
       rewrite <- Forall_forall.
@@ -277,7 +279,7 @@ Section dio_bounded_fall.
             dc_list_bfall ν 
         <-> exists q φ, ν 0+1 < q 
                     /\ (forall i j, i < k -> j < ν 0 -> φ i j < power q 2) 
-                    /\  forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (ν↑j)) ll.
+                    /\  forall j, j < ν 0 -> Forall (dc_eval (fun i => φ i j) (j·ν)) ll.
     Proof.
       split.
       + intros (pi & G0 & G1 & G4).
@@ -328,8 +330,8 @@ Section dio_bounded_fall.
     Qed.
 
     Let dc_list_bfall_spec ν : 
-            (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ ν↑i) ll) 
-        <-> dc_list_bfall ν .
+            (forall i, i < ν 0 -> exists φ, Forall (dc_eval φ i·ν) ll) 
+        <-> dc_list_bfall ν.
     Proof.
       rewrite dc_list_bfall_spec_1; split.
       + intros H.
@@ -355,7 +357,7 @@ Section dio_bounded_fall.
         exists (fun i => phi i j); auto.
     Qed.
 
-    Theorem dio_rel_dc_list_bfall : 𝔻R (fun ν => forall i, i < ν 0 -> exists φ, Forall (dc_eval φ ν↑i) ll).
+    Theorem dio_rel_dc_list_bfall : 𝔻R (fun ν => forall i, i < ν 0 -> exists φ, Forall (dc_eval φ i·ν) ll).
     Proof.
       dio by lemma dc_list_bfall_spec.
       unfold dc_list_bfall.
@@ -367,7 +369,7 @@ Section dio_bounded_fall.
 
   End dio_bounded_elem.
 
-  Theorem dio_bounded_fall P : 𝔻R P -> 𝔻R (fun ν => forall i, i < ν 0 -> P ν↑i).
+  Theorem dio_bounded_fall P : 𝔻R P -> 𝔻R (fun ν => forall i, i < ν 0 -> P i·ν).
   Proof.
     intros (f & Hf).
     destruct (dio_formula_elem f) as (ll & H1 & H2 & H3).
@@ -415,7 +417,7 @@ End dfbfall.
 Section dio_rel_fall_lt.
 
   Let dio_rel_fall_lt_0 (K : nat -> (nat -> nat) -> Prop) : 
-            𝔻R (fun ν => K (ν 0) ν↓) -> 𝔻R (fun ν => forall x, x < ν 0 -> K x ν↓).
+            𝔻R (fun ν => K (ν 0) ν⭳) -> 𝔻R (fun ν => forall x, x < ν 0 -> K x ν⭳).
   Proof.
     intros (fK & HK).
     exists (dfbfall fK).
@@ -425,7 +427,7 @@ Section dio_rel_fall_lt.
 
   Theorem dio_rel_fall_lt a (K : nat -> (nat -> nat) -> Prop) : 
            𝔻F a 
-   -> 𝔻R (fun ν => K (ν 0) ν↓) 
+   -> 𝔻R (fun ν => K (ν 0) ν⭳) 
    -> 𝔻R (fun ν => forall x, x < a ν -> K x ν).
   Proof.
     intros Ha H.
@@ -441,7 +443,7 @@ Hint Resolve dio_rel_fall_lt : dio_rel_db.
 
 Corollary dio_rel_fall_lt_bound a (K : nat -> nat -> (nat -> nat) -> Prop) : 
            𝔻F a
-   -> 𝔻R (fun ν => K (ν 0) (a ν↓) ν↓) 
+   -> 𝔻R (fun ν => K (ν 0) (a ν⭳) ν⭳) 
    -> 𝔻R (fun ν => forall x, x < a ν -> K x (a ν) ν).
 Proof. intros; dio auto. Defined.
 
@@ -449,7 +451,7 @@ Hint Resolve dio_rel_fall_lt_bound : dio_rel_db.
 
 Theorem dio_rel_fall_le a (K : nat -> (nat -> nat) -> Prop) : 
            𝔻F a
-   -> 𝔻R (fun ν => K (ν 0) ν↓) 
+   -> 𝔻R (fun ν => K (ν 0) ν⭳) 
    -> 𝔻R (fun ν => forall x, x <= a ν -> K x ν).
 Proof.
   intros Ha HK.

--- a/theories/H10/Dio/dio_cipher.v
+++ b/theories/H10/Dio/dio_cipher.v
@@ -10,10 +10,17 @@
 (** ** Object-level encoding of bounded universal quantification II *)
 
 Require Import Arith Nat Omega List Bool Setoid.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac gcd prime binomial sums bool_nat.
-From Undecidability.H10.ArithLibs Require Import luca.
-From Undecidability.H10.Matija Require Import cipher.
-From Undecidability.H10.Dio Require Import dio_logic dio_expo dio_binary.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac gcd prime binomial sums bool_nat.
+
+(* From Undecidability.H10.ArithLibs Require Import luca. *)
+
+From Undecidability.H10.Matija 
+  Require Import cipher.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic dio_expo dio_binary.
 
 Set Implicit Arguments.
 
@@ -23,64 +30,66 @@ Local Notation "∑" := (msum plus 0).
 Local Infix "⇣" := nat_meet (at level 40, left associativity).
 Local Infix "⇡" := nat_join (at level 50, left associativity).
 
-Theorem seqs_of_ones_diophantine l q u u1 : 𝔻P l -> 𝔻P q -> 𝔻P u -> 𝔻P u1
+(** seqs_of_ones l q u u1 iff 
+
+            l+1 < q 
+       and  u  = ∑(i<l) r^(2^(1+i))
+       and  u1 = ∑(i<l) r^(2^(2+i)) 
+       with r := 2^(4q)
+ 
+  *)
+
+Theorem dio_rel_seqs_of_ones l q u u1 : 𝔻F l -> 𝔻F q -> 𝔻F u -> 𝔻F u1
           -> 𝔻R (fun v => seqs_of_ones (l v) (q v) (u v) (u1 v)).
-Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => seqs_of_ones_dio (l v) (q v) (u v) (u1 v)).
-  dio_rel_auto.
+Proof. 
+  dio by lemma (fun v => seqs_of_ones_dio (l v) (q v) (u v) (u1 v)). 
 Defined.
 
-Hint Resolve seqs_of_ones_diophantine.
+Hint Resolve dio_rel_seqs_of_ones : dio_rel_db.
 
 (* a is the q-cipher of some l-tuple *)
 
-Theorem Code_diophantine l q a : 𝔻P l -> 𝔻P q -> 𝔻P a
-                              -> 𝔻R (fun v => Code (l v) (q v) (a v)).
+Theorem dio_rel_Code l q a : 𝔻F l -> 𝔻F q -> 𝔻F a
+                          -> 𝔻R (fun v => Code (l v) (q v) (a v)).
 Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => Code_dio (l v) (q v) (a v)).
-  dio_rel_auto.
+  dio by lemma (fun v => Code_dio (l v) (q v) (a v)).
 Defined.
 
-Hint Resolve Code_diophantine.
+Hint Resolve dio_rel_Code : dio_rel_db.
 
 (* c is the q-cipher of the l-tuple <x,...,x> *)
 
-Theorem Const_diophantine l q c x : 𝔻P l -> 𝔻P q -> 𝔻P c -> 𝔻P x
-                                 -> 𝔻R (fun v => Const (l v) (q v) (c v) (x v)).
+Theorem dio_rel_Const l q c x : 𝔻F l -> 𝔻F q -> 𝔻F c -> 𝔻F x
+                             -> 𝔻R (fun v => Const (l v) (q v) (c v) (x v)).
 Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => Const_dio (l v) (q v) (c v) (x v)).
-  dio_rel_auto.
+  dio by lemma (fun v => Const_dio (l v) (q v) (c v) (x v)).
 Defined.
 
-Hint Resolve Const_diophantine.
+Hint Resolve dio_rel_Const : dio_rel_db.
 
 (* a is the q-cipher of the l-tuple <0,...,l-1> *)
 
-Theorem CodeNat_diophantine l q a : 𝔻P l -> 𝔻P q -> 𝔻P a -> 𝔻R (fun v => CodeNat (l v) (q v) (a v)).
+Theorem dio_rel_CodeNat l q a : 𝔻F l -> 𝔻F q -> 𝔻F a 
+                             -> 𝔻R (fun v => CodeNat (l v) (q v) (a v)).
 Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => CodeNat_dio (l v) (q v) (a v)).
-  dio_rel_auto.
+  dio by lemma (fun v => CodeNat_dio (l v) (q v) (a v)).
 Defined.
 
-Hint Resolve CodeNat_diophantine.
+Hint Resolve dio_rel_CodeNat : dio_rel_db.
 
 (* Testing whether a is the q cipher of the sum of the tuples of q-ciphers b and c *)
 
-Theorem Code_plus_diophantine a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
-                                   -> 𝔻R (fun v => Code_plus (a v) (b v) (c v)).
-Proof. intros; unfold Code_plus; dio_rel_auto. Defined.
+Theorem dio_rel_Code_plus a b c : 𝔻F a -> 𝔻F b -> 𝔻F c
+                               -> 𝔻R (fun v => Code_plus (a v) (b v) (c v)).
+Proof. intros; unfold Code_plus; dio auto. Defined.
 
 (* Testing whether a is the q cipher of the product of the tuples of q-ciphers b and c *)
 
-Theorem Code_mult_diophantine l q a b c : 𝔻P l -> 𝔻P q -> 𝔻P a -> 𝔻P b -> 𝔻P c
-                                       -> 𝔻R (fun v => Code_mult (l v) (q v) (a v) (b v) (c v)).
-Proof. intros; unfold Code_mult; dio_rel_auto. Defined.
+Theorem dio_rel_Code_mult l q a b c : 𝔻F l -> 𝔻F q -> 𝔻F a -> 𝔻F b -> 𝔻F c
+                                   -> 𝔻R (fun v => Code_mult (l v) (q v) (a v) (b v) (c v)).
+Proof. intros; unfold Code_mult; dio auto. Defined.
 
-Hint Resolve Code_plus_diophantine Code_mult_diophantine.
+Hint Resolve dio_rel_Code_plus dio_rel_Code_mult : dio_rel_db.
 
 (** Now we have diophantine representations of q-cipher of the following l-tuple
 

--- a/theories/H10/Dio/dio_elem.v
+++ b/theories/H10/Dio/dio_elem.v
@@ -19,9 +19,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
-Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
-
 Section interval.
 
   (** A small interval & valuation library *)
@@ -448,7 +445,7 @@ Section diophantine_system.
   Lemma dio_repr_at_exst R a n m p : 
           dio_repr_at R a n p
        -> m = n+1
-       -> dio_repr_at (fun ν => exists n, R ν↑n) a m p. 
+       -> dio_repr_at (fun ν => exists n, R n·ν) a m p. 
   Proof.
     intros [ l r F0 F1 F2 F3 F4 ] ?; subst m.
     exists (map (dc_dec (a+n)) l) r.

--- a/theories/H10/Dio/dio_elem.v
+++ b/theories/H10/Dio/dio_elem.v
@@ -10,10 +10,17 @@
 (** ** Elementary diophantine constraints *)
 
 Require Import List Arith Nat Omega.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_list gcd prime.
-From Undecidability.H10.Dio Require Import dio_logic.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_list gcd prime.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic.
 
 Set Implicit Arguments.
+
+Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
+Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
 Section interval.
 
@@ -142,8 +149,6 @@ Section diophantine_system.
   Notation dee_add := (dee_comp do_add).
   Notation dee_mul := (dee_comp do_mul).
 
-  (* ρ σ ν φ *)
-
   Definition dee_eval φ ν e := 
     match e with
       | dee_nat n => n
@@ -245,53 +250,33 @@ Section diophantine_system.
                                 end
                               else x0.
 
-  Let g0_0 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 n = x0.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n n); try omega.
-    replace (n-n) with 0 by omega; auto.
-  Qed.
+  Tactic Notation "g0" "auto" constr(n) constr(t) := 
+    unfold g0; destruct (le_lt_dec n (n+t)); try omega;
+    replace (n+t-n) with t by omega; auto.
+
+  Let g0_0 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+0) = x0.
+  Proof. g0 auto n 0. Qed. 
 
   Let g0_1 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+1) = x1.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+1)); try omega.
-    replace (n+1-n) with 1 by omega; auto.
-  Qed.
+  Proof. g0 auto n 1. Qed. 
 
   Let g0_2 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+2) = x2.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+2)); try omega.
-    replace (n+2-n) with 2 by omega; auto.
-  Qed.
-
+  Proof. g0 auto n 2. Qed. 
+ 
   Let g0_3 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+3) = x3.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+3)); try omega.
-    replace (n+3-n) with 3 by omega; auto.
-  Qed.
+  Proof. g0 auto n 3. Qed. 
 
   Let g0_4 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+4) = x4.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+4)); try omega.
-    replace (n+4-n) with 4 by omega; auto.
-  Qed.
+  Proof. g0 auto n 4. Qed. 
 
   Let g0_5 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+5) = x5.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+5)); try omega.
-    replace (n+5-n) with 5 by omega; auto.
-  Qed.
+  Proof. g0 auto n 5. Qed. 
 
   Let g0_6 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+6) = x6.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+6)); try omega.
-    replace (n+6-n) with 6 by omega; auto.
-  Qed.
+  Proof. g0 auto n 6. Qed. 
 
   Let g0_7 (n x0 x1 x2 x3 x4 x5 x6 x7 : nat) : g0 n x0 x1 x2 x3 x4 x5 x6 x7 (n+7) = x7.
-  Proof. 
-    unfold g0; destruct (le_lt_dec n (n+7)); try omega.
-    replace (n+7-n) with 7 by omega; auto.
-  Qed.
+  Proof. g0 auto n 7. Qed. 
 
   Tactic Notation "rew" "g0" := 
     try rewrite !g0_0;
@@ -302,8 +287,7 @@ Section diophantine_system.
     try rewrite !g0_5;
     try rewrite !g0_6;
     try rewrite !g0_7.
-    
-
+ 
   Let complete_lemma x y : { u : nat & { v | u+x = v+y } }.
   Proof.
     destruct (le_lt_dec x y).
@@ -315,8 +299,8 @@ Section diophantine_system.
 
   Lemma dio_repr_at_cst x i a : dio_repr_at (fun ν => ν x = i) a 6 5.
   Proof.
-    exists ( (a+5,dee_add a     (a+1))     (* s = p + q *)
-           ::(a+2,dee_add a     (a+3))     (* u = p + v *)
+    exists ( (a+5,dee_add (a+0) (a+1))     (* s = p + q *)
+           ::(a+2,dee_add (a+0) (a+3))     (* u = p + v *)
            ::(a+2,dee_add (a+1) (a+4))     (* u = q + w *)
            ::(a+3,dee_par x)               (* v = x     *)
            ::(a+4,dee_nat i)               (* w = i     *)
@@ -341,8 +325,8 @@ Section diophantine_system.
 
   Lemma dio_repr_at_op o x y z a : dio_repr_at (fun ν => ν x = de_op_sem o (ν y) (ν z)) a 8 7.
   Proof.
-    exists ( (a+7,dee_add a     (a+1))     (* s = p + q *)
-           ::(a+6,dee_add a     (a+2))     (* t = p + u *)
+    exists ( (a+7,dee_add (a+0) (a+1))     (* s = p + q *)
+           ::(a+6,dee_add (a+0) (a+2))     (* t = p + u *)
            ::(a+6,dee_add (a+1) (a+5))     (* t = q + r *)
            ::(a+5,dee_comp o (a+3) (a+4))  (* r = v o w *)
            ::(a+2,dee_par x)               (* u = x     *)

--- a/theories/H10/Dio/dio_elem.v
+++ b/theories/H10/Dio/dio_elem.v
@@ -292,7 +292,7 @@ Section diophantine_system.
     + exists 0, (x-y); omega.
   Qed.
 
-  (** x = i <~~> s = 0 /\ exists s p q u v w, s = p+q /\ u = p+v /\ u = q+w /\ v = x /\ w = i *)
+  (** x = i <~~> s = 0 /\ exists p q u v w, s = p+q /\ u = p+v /\ u = q+w /\ v = x /\ w = i *)
 
   Lemma dio_repr_at_cst x i a : dio_repr_at (fun ν => ν x = i) a 6 5.
   Proof.
@@ -312,6 +312,31 @@ Section diophantine_system.
     + intros v; split.
       * intros H.
         exists (g0 a 0 0 (v x) (v x) i 0 0 0); 
+          repeat constructor; simpl; rew g0; auto.
+      * intros (phi & H); revert H.
+        repeat rewrite Forall_cons_inv; simpl; omega.
+  Defined.
+
+  (** x = y <~~> s = 0 /\ exists p q u v w, s = p+q /\ u = p+v /\ u = q+w /\ v = x /\ w = y *)
+
+  Lemma dio_repr_at_eq x y a : dio_repr_at (fun ν => ν x = ν y) a 6 5.
+  Proof.
+    exists ( (a+5,dee_add (a+0) (a+1))     (* s = p + q *)
+           ::(a+2,dee_add (a+0) (a+3))     (* u = p + v *)
+           ::(a+2,dee_add (a+1) (a+4))     (* u = q + w *)
+           ::(a+3,dee_par x)               (* v = x     *)
+           ::(a+4,dee_par y)               (* w = y     *)
+           ::nil)
+           (a+5); simpl; auto; try omega.
+    + intros j c.
+      repeat (intros [ <- | H ]; [ simpl; try omega | revert H ]); try tauto.
+    + intros v.
+      destruct (complete_lemma (v x) (v y)) as (p & q & H).
+      exists (g0 a p q (p+v x) (v x) (v y) (p+q) 0 0); 
+        repeat constructor; simpl; rew g0; auto.
+    + intros v; split.
+      * intros H.
+        exists (g0 a 0 0 (v x) (v x) (v y) 0 0 0); 
           repeat constructor; simpl; rew g0; auto.
       * intros (phi & H); revert H.
         repeat rewrite Forall_cons_inv; simpl; omega.
@@ -495,6 +520,7 @@ Section diophantine_system.
   Fixpoint df_weight_1 f :=
     match f with
       | df_cst _ _     => 6
+      | df_eq _ _      => 6
       | df_op _ _ _ _  => 8
       | df_bin _ f g   => 1 + df_weight_1 f + df_weight_1 g  
       | df_exst f      => 1 + df_weight_1 f
@@ -506,6 +532,7 @@ Section diophantine_system.
   Fixpoint df_weight_2 f :=
     match f with
       | df_cst _ _     => 5
+      | df_eq _ _      => 5
       | df_op _ _ _ _  => 7
       | df_bin _ f g   => 1 + df_weight_2 f + df_weight_2 g  
       | df_exst f      => df_weight_2 f
@@ -517,8 +544,9 @@ Section diophantine_system.
   Lemma dio_repr_at_form n f : dio_repr_at (df_pred f) n (df_weight_1 f) (df_weight_2 f).
   Proof.
     revert n;
-    induction f as [ x i | o x y z | o f IHf g IHg | f IHf ]; intros n; simpl df_pred; simpl df_weight_1; simpl df_weight_2.
+    induction f as [ x i | x y | o x y z | o f IHf g IHg | f IHf ]; intros n; simpl df_pred; simpl df_weight_1; simpl df_weight_2.
     + apply dio_repr_at_cst; auto.
+    + apply dio_repr_at_eq; auto.
     + apply dio_repr_at_op; auto.
     + apply dio_repr_at_bin with (n1 := df_weight_1 f) (a2 := n+df_weight_1 f) (n2 := df_weight_1 g); auto; omega.
     + apply dio_repr_at_exst with (n := df_weight_1 f); auto; omega.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -32,6 +32,12 @@ Local Notation expo := (mscal mult 1).
     from the new Diophantine shapes that include Diophantine
     functions. *)
 
+Local Notation "x ≐ n" := (df_cst x n) (at level 49, no associativity, format "x  ≐  n").
+Local Notation "x ≐ y ⨢ z" := (df_add x y z) 
+      (at level 49, no associativity, y at next level, format "x  ≐  y  ⨢  z").
+Local Notation "x ≐ y ⨰ z" := (df_mul x y z) 
+      (at level 49, no associativity, y at next level, format "x  ≐  y  ⨰  z").
+
 Theorem dio_rel_alpha a b c : 𝔻F a -> 𝔻F b -> 𝔻F c
                            -> 𝔻R (fun ν => 3 < b ν /\ a ν = alpha_nat (b ν) (c ν)).
 Proof.
@@ -43,9 +49,9 @@ Hint Resolve dio_rel_alpha : dio_rel_db.
 Local Fact dio_rel_alpha_example : 𝔻R (fun ν => 3 < ν 1 /\ ν 0 = alpha_nat (ν 1) (ν 2)).
 Proof. dio auto. Defined.
 
-(* Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example). *)
+(* Eval compute in proj1_sig dio_rel_alpha_example. *)
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 6562%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 2794%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -62,11 +68,11 @@ Hint Resolve dio_fun_expo : dio_fun_db.
 Local Fact dio_fun_expo_example : 𝔻F (fun ν => expo (ν 0) (ν 1)).
 Proof. dio auto. Defined.
 
-(* Eval compute in df_size_Z (proj1_sig dio_expr_expo_example). *)
+(* Eval compute in (proj1_sig dio_fun_expo_example). *)
 
 (* The new Diophantine shapes builds at bit bigger formulas ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 22878%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 9606%Z.
 Proof. reflexivity. Qed.
 
 Section dio_rel_is_digit.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -33,33 +33,34 @@ Theorem dio_rel_alpha a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
 Proof.
   intros.
   apply dio_rel_equiv with (1 := fun v => alpha_diophantine (a v) (b v) (c v)).
-  unfold alpha_conditions. 
-  dio_rel_auto.
+  unfold alpha_conditions; dio auto.
 Defined.
 
 Hint Resolve dio_rel_alpha : dio_rel_db.
 
 Local Fact dio_rel_alpha_example : 𝔻R (fun ν => 3 < ν 1 /\ ν 0 = alpha_nat (ν 1) (ν 2)).
-Proof. apply dio_rel_alpha; dio_rel_auto. Defined.
+Proof. dio auto. Defined.
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 5338%Z.
+(* Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example). *)
+
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 6562%Z.
 Proof. reflexivity. Qed.
 
 Theorem dio_expr_expo q r : 𝔻P q -> 𝔻P r -> 𝔻P (fun ν => expo (r ν) (q ν)).
 Proof.
   intros.
   apply dio_rel_equiv with (1 := fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
-  unfold expo_conditions. 
-  dio_rel_auto.
-  all: apply dio_rel_eq; dio_rel_auto.
+  unfold expo_conditions; dio auto. 
 Defined.
 
-Hint Resolve dio_expr_expo : dio_rel_db.
+Hint Resolve dio_expr_expo : dio_expr_db.
 
 Local Fact dio_expr_expo_example : 𝔻P (fun ν => expo (ν 0) (ν 1)).
-Proof. dio_rel_auto. Defined.
+Proof. dio auto. Defined.
 
-Fact dio_expr_expo_size : df_size_Z (proj1_sig dio_expr_expo_example) = 18546%Z.
+(* Eval compute in df_size_Z (proj1_sig dio_expr_expo_example). *)
+
+Fact dio_expr_expo_size : df_size_Z (proj1_sig dio_expr_expo_example) = 22878%Z.
 Proof. reflexivity. Qed.
 
 Section df_digit.
@@ -81,9 +82,7 @@ Section df_digit.
   Proof.
     intros H1 H2 H3 H4.
     apply dio_rel_equiv with (1 := fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
-    dio_rel_auto.
-    apply dio_rel_eq; dio_rel_auto.
-    apply dio_expr_plus; dio_rel_auto.
+    dio auto.
   Defined.
 
 End df_digit.
@@ -91,7 +90,7 @@ End df_digit.
 Hint Resolve dio_rel_is_digit : dio_rel_db.
 
 Local Fact dio_rel_is_digit_example : 𝔻R (fun ν => is_digit (ν 0) (ν 1) (ν 2) (ν 3)).
-Proof. apply dio_rel_is_digit; dio_rel_auto. Defined.
+Proof. dio auto. Defined.
 
 Check dio_rel_is_digit_example.
 Eval compute in df_size_Z (proj1_sig dio_rel_is_digit_example).
@@ -178,15 +177,15 @@ Section df_binomial.
   Proof.
     intros H2 H3.
     apply dio_rel_equiv with (1 := fun ν => is_binomial_eq (ν 0) (n ν↓) (k ν↓)).
-    dio_rel_auto; apply dio_expr_plus; auto.
+    dio auto.
   Defined.
 
 End df_binomial.
 
-Hint Resolve dio_expr_binomial : dio_rel_db.
+Hint Resolve dio_expr_binomial : dio_expr_db.
 
 Local Fact dio_expr_binomial_example : 𝔻P (fun ν => binomial (ν 0) (ν 1)).
-Proof. apply dio_expr_binomial; dio_rel_auto. Defined.
+Proof. dio auto. Defined.
 
 Check dio_expr_binomial_example.
 Eval compute in df_size_Z (proj1_sig dio_expr_binomial_example).

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -25,9 +25,6 @@ Set Implicit Arguments.
 Local Notation power := (mscal mult 1).
 Local Notation expo := (mscal mult 1).
 
-Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
-Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
-
 (** Here one can witness how workable is automation of recognition
     of Diophantine shapes.
 
@@ -57,7 +54,7 @@ Proof. reflexivity. Qed.
 
 Theorem dio_fun_expo q r : 𝔻F q -> 𝔻F r -> 𝔻F (fun ν => expo (r ν) (q ν)).
 Proof.
-  dio by lemma (fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
+  dio by lemma (fun v => expo_diophantine (v 0) (q v⭳) (r v⭳)).
 Defined.
 
 Hint Resolve dio_fun_expo : dio_fun_db.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -38,9 +38,7 @@ Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓"
 Theorem dio_rel_alpha a b c : 𝔻F a -> 𝔻F b -> 𝔻F c
                            -> 𝔻R (fun ν => 3 < b ν /\ a ν = alpha_nat (b ν) (c ν)).
 Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => alpha_diophantine (a v) (b v) (c v)).
-  unfold alpha_conditions; dio auto.
+  dio by lemma (fun v => alpha_diophantine (a v) (b v) (c v)).
 Defined.
 
 Hint Resolve dio_rel_alpha : dio_rel_db.
@@ -59,9 +57,7 @@ Proof. reflexivity. Qed.
 
 Theorem dio_fun_expo q r : 𝔻F q -> 𝔻F r -> 𝔻F (fun ν => expo (r ν) (q ν)).
 Proof.
-  intros.
-  apply dio_rel_equiv with (1 := fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
-  unfold expo_conditions; dio auto. 
+  dio by lemma (fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
 Defined.
 
 Hint Resolve dio_fun_expo : dio_fun_db.
@@ -96,9 +92,7 @@ Section dio_rel_is_digit.
   Lemma dio_rel_is_digit c q i y : 𝔻F c -> 𝔻F q -> 𝔻F i -> 𝔻F y
                                 -> 𝔻R (fun ν => is_digit (c ν) (q ν) (i ν) (y ν)).
   Proof.
-    intros H1 H2 H3 H4.
-    apply dio_rel_equiv with (1 := fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
-    dio auto.
+    dio by lemma (fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
   Defined.
 
 End dio_rel_is_digit.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -52,9 +52,9 @@ Hint Resolve dio_rel_alpha : dio_rel_db.
 Local Fact dio_rel_alpha_example : 𝔻R (fun ν => 3 < ν 1 /\ ν 0 = alpha_nat (ν 1) (ν 2)).
 Proof. dio auto. Defined.
 
-(* Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example). *)
+Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example).
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1605%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1525%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -71,11 +71,11 @@ Hint Resolve dio_fun_expo : dio_fun_db.
 Local Fact dio_fun_expo_example : 𝔻F (fun ν => expo (ν 0) (ν 1)).
 Proof. dio auto. Defined.
 
-(* Eval compute in df_size_Z (proj1_sig dio_fun_expo_example). *)
+Eval compute in df_size_Z (proj1_sig dio_fun_expo_example).
 
 (* The new Diophantine shapes builds at bit bigger formulas ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5589%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5319%Z.
 Proof. reflexivity. Qed.
 
 Section dio_rel_is_digit.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -12,7 +12,7 @@
 Require Import Arith Nat Omega List.
 
 From Undecidability.Shared.Libs.DLW.Utils 
-  Require Import utils_tac sums rel_iter binomial gcd.
+  Require Import utils_tac sums rel_iter gcd.
 
 From Undecidability.H10.Matija 
   Require Import alpha expo_diophantine.
@@ -28,7 +28,14 @@ Local Notation expo := (mscal mult 1).
 Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
 Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
-Theorem dio_rel_alpha a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
+(** Here one can witness how workable is automation of recognition
+    of Diophantine shapes.
+
+    Notice that alpha_conditions below could probably be optimized
+    from the new Diophantine shapes that include Diophantine
+    functions. *)
+
+Theorem dio_rel_alpha a b c : 𝔻F a -> 𝔻F b -> 𝔻F c
                            -> 𝔻R (fun ν => 3 < b ν /\ a ν = alpha_nat (b ν) (c ν)).
 Proof.
   intros.
@@ -46,24 +53,33 @@ Proof. dio auto. Defined.
 Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 6562%Z.
 Proof. reflexivity. Qed.
 
-Theorem dio_expr_expo q r : 𝔻P q -> 𝔻P r -> 𝔻P (fun ν => expo (r ν) (q ν)).
+(** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
+    
+    Notice that expo_conditions below could also probably be optimized *)
+
+Theorem dio_fun_expo q r : 𝔻F q -> 𝔻F r -> 𝔻F (fun ν => expo (r ν) (q ν)).
 Proof.
   intros.
   apply dio_rel_equiv with (1 := fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
   unfold expo_conditions; dio auto. 
 Defined.
 
-Hint Resolve dio_expr_expo : dio_expr_db.
+Hint Resolve dio_fun_expo : dio_fun_db.
 
-Local Fact dio_expr_expo_example : 𝔻P (fun ν => expo (ν 0) (ν 1)).
+Local Fact dio_fun_expo_example : 𝔻F (fun ν => expo (ν 0) (ν 1)).
 Proof. dio auto. Defined.
 
 (* Eval compute in df_size_Z (proj1_sig dio_expr_expo_example). *)
 
-Fact dio_expr_expo_size : df_size_Z (proj1_sig dio_expr_expo_example) = 22878%Z.
+(* The new Diophantine shapes builds at bit bigger formulas ... *)
+
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 22878%Z.
 Proof. reflexivity. Qed.
 
-Section df_digit.
+Section dio_rel_is_digit.
+
+  (* The is_digit c q i y relation stating that 
+     "y is the i-th digit of c is base q" *)
 
   Let is_digit_eq c q i y : is_digit c q i y 
                         <-> y < q
@@ -77,7 +93,7 @@ Section df_digit.
       split; auto; exists a, b; subst; auto.
   Qed.
 
-  Lemma dio_rel_is_digit c q i y : 𝔻P c -> 𝔻P q -> 𝔻P i -> 𝔻P y
+  Lemma dio_rel_is_digit c q i y : 𝔻F c -> 𝔻F q -> 𝔻F i -> 𝔻F y
                                 -> 𝔻R (fun ν => is_digit (c ν) (q ν) (i ν) (y ν)).
   Proof.
     intros H1 H2 H3 H4.
@@ -85,7 +101,7 @@ Section df_digit.
     dio auto.
   Defined.
 
-End df_digit.
+End dio_rel_is_digit.
 
 Hint Resolve dio_rel_is_digit : dio_rel_db.
 
@@ -94,98 +110,3 @@ Proof. dio auto. Defined.
 
 Check dio_rel_is_digit_example.
 Eval compute in df_size_Z (proj1_sig dio_rel_is_digit_example).
-
-Section df_binomial.
-
-  Notation "∑" := (msum plus 0).
-
-  Let plus_cancel_l : forall a b c, a + b = a + c -> b = c.
-  Proof. intros; omega. Qed.
-
-  Hint Resolve Nat.mul_add_distr_r.
-
-  Let is_binomial_eq b n k :  b = binomial n k
-                          <-> exists q c, q = power (1+n) 2
-                                       /\ c = power n (1+q) 
-                                       /\ is_digit c q k b.
-  Proof.
-    split.
-    + intros ?; subst.
-      set (q := power (1+n) 2).
-      assert (Hq : q <> 0).
-      { unfold q; generalize (@power_ge_1 (S n) 2); intros; simpl; omega. }
-      set (c := power n (1+q)).
-      exists q, c; split; auto.
-      split; auto.
-      split. 
-      * apply binomial_lt_power.
-      * destruct (le_lt_dec k n) as [ Hk | Hk ].
-        - exists (∑ (n-k) (fun i => binomial n (S k+i) * power i q)),
-                 (∑ k (fun i => binomial n i * power i q)); split; auto.
-          2: { apply sum_power_lt; auto; intros; apply binomial_lt_power. }
-          rewrite Nat.mul_add_distr_r, <- mult_assoc, <- power_S.
-          rewrite <- sum_0n_distr_r with (1 := Nat_plus_monoid) (3 := Nat_mult_monoid); auto.
-          rewrite <- plus_assoc, (plus_comm _ (∑ _ _)).
-          rewrite <- msum_plus1 with (f := fun i => binomial n i * power i q); auto.
-          rewrite plus_comm.
-          unfold c.
-          rewrite Newton_nat_S.
-          replace (S n) with (S k + (n-k)) by omega.
-          rewrite msum_plus; auto; f_equal; apply msum_ext.
-          intros; rewrite power_plus; ring.
-        - exists 0, c.
-          rewrite binomial_gt; auto.
-          rewrite Nat.mul_0_l; split; auto.
-          unfold c.
-          apply lt_le_trans with (power (S n) q).
-          ++ rewrite Newton_nat_S.
-             apply sum_power_lt; auto.
-             intros; apply binomial_lt_power.
-          ++ apply power_mono; omega.
-    + intros (q & c & H1 & H2 & H3).
-      assert (Hq : q <> 0).
-      { rewrite H1; generalize (@power_ge_1 (S n) 2); intros; simpl; omega. }
-      rewrite Newton_nat_S in H2.
-      apply is_digit_fun with (1 := H3).
-      destruct (le_lt_dec k n) as [ Hk | Hk ].
-      * red; split.
-        - subst; apply binomial_lt_power.
-        - exists (∑ (n-k) (fun i => binomial n (S k+i) * power i q)),
-                 (∑ k (fun i => binomial n i * power i q)); split.
-          2: {  apply sum_power_lt; auto; intros; subst; apply binomial_lt_power. }
-          rewrite Nat.mul_add_distr_r, <- mult_assoc, <- power_S.
-          rewrite <- sum_0n_distr_r with (1 := Nat_plus_monoid) (3 := Nat_mult_monoid); auto.
-          rewrite <- plus_assoc, (plus_comm _ (∑ _ _)).
-          rewrite <- msum_plus1 with (f := fun i => binomial n i * power i q); auto.
-          rewrite plus_comm, H2.
-          replace (S n) with (S k + (n-k)) by omega.
-          rewrite msum_plus; auto; f_equal.
-          apply msum_ext.
-          intros; rewrite power_plus; ring.
-      * rewrite binomial_gt; auto.
-        split; try omega. 
-        exists 0, c.
-        rewrite Nat.mul_0_l; split; auto.
-        rewrite H2.
-        apply lt_le_trans with (power (S n) q).
-        - apply sum_power_lt; auto.
-          subst; intros; apply binomial_lt_power.
-        - apply power_mono; omega.
-  Qed.
-
-  Lemma dio_expr_binomial n k : 𝔻P n -> 𝔻P k -> 𝔻P (fun ν => binomial (n ν) (k ν)).
-  Proof.
-    intros H2 H3.
-    apply dio_rel_equiv with (1 := fun ν => is_binomial_eq (ν 0) (n ν↓) (k ν↓)).
-    dio auto.
-  Defined.
-
-End df_binomial.
-
-Hint Resolve dio_expr_binomial : dio_expr_db.
-
-Local Fact dio_expr_binomial_example : 𝔻P (fun ν => binomial (ν 0) (ν 1)).
-Proof. dio auto. Defined.
-
-Check dio_expr_binomial_example.
-Eval compute in df_size_Z (proj1_sig dio_expr_binomial_example).

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -54,7 +54,7 @@ Proof. dio auto. Defined.
 
 Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example).
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1525%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1520%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -75,7 +75,7 @@ Eval compute in df_size_Z (proj1_sig dio_fun_expo_example).
 
 (* The new Diophantine shapes builds at bit bigger formulas ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5319%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5304%Z.
 Proof. reflexivity. Qed.
 
 Section dio_rel_is_digit.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -10,14 +10,23 @@
 (** ** Object-level encoding of exponential *)
 
 Require Import Arith Nat Omega List.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac sums rel_iter binomial. 
-From Undecidability.H10.Matija Require Import alpha expo_diophantine.
-From Undecidability.H10.Dio Require Import dio_logic.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac sums rel_iter binomial gcd.
+
+From Undecidability.H10.Matija 
+  Require Import alpha expo_diophantine.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic.
 
 Set Implicit Arguments.
 
 Local Notation power := (mscal mult 1).
 Local Notation expo := (mscal mult 1).
+
+Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
+Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
 Theorem dio_rel_alpha a b c : 𝔻P a -> 𝔻P b -> 𝔻P c
                            -> 𝔻R (fun ν => 3 < b ν /\ a ν = alpha_nat (b ν) (c ν)).
@@ -28,25 +37,29 @@ Proof.
   dio_rel_auto.
 Defined.
 
-Hint Resolve dio_rel_alpha.
+Hint Resolve dio_rel_alpha : dio_rel_db.
 
-Fact dio_rel_alpha_size : df_size (proj1_sig (dio_rel_alpha (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2))) = 490.
+Local Fact dio_rel_alpha_example : 𝔻R (fun ν => 3 < ν 1 /\ ν 0 = alpha_nat (ν 1) (ν 2)).
+Proof. apply dio_rel_alpha; dio_rel_auto. Defined.
+
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 5338%Z.
 Proof. reflexivity. Qed.
 
-Theorem dio_rel_expo p q r : 𝔻P p -> 𝔻P q -> 𝔻P r -> 𝔻R (fun ν => p ν = expo (r ν) (q ν)).
+Theorem dio_expr_expo q r : 𝔻P q -> 𝔻P r -> 𝔻P (fun ν => expo (r ν) (q ν)).
 Proof.
   intros.
-  apply dio_rel_equiv with (1 := fun v => expo_diophantine (p v) (q v) (r v)).
+  apply dio_rel_equiv with (1 := fun v => expo_diophantine (v 0) (q v↓) (r v↓)).
   unfold expo_conditions. 
   dio_rel_auto.
+  all: apply dio_rel_eq; dio_rel_auto.
 Defined.
 
-Hint Resolve dio_rel_expo.
- 
-Check dio_rel_expo.
-Print Assumptions dio_rel_expo.
+Hint Resolve dio_expr_expo : dio_rel_db.
 
-Fact dio_rel_expo_size : df_size (proj1_sig (dio_rel_expo (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2))) = 1689.
+Local Fact dio_expr_expo_example : 𝔻P (fun ν => expo (ν 0) (ν 1)).
+Proof. dio_rel_auto. Defined.
+
+Fact dio_expr_expo_size : df_size_Z (proj1_sig dio_expr_expo_example) = 18546%Z.
 Proof. reflexivity. Qed.
 
 Section df_digit.
@@ -68,15 +81,20 @@ Section df_digit.
   Proof.
     intros H1 H2 H3 H4.
     apply dio_rel_equiv with (1 := fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
-    dio_rel_auto; apply dio_expr_plus; auto.
+    dio_rel_auto.
+    apply dio_rel_eq; dio_rel_auto.
+    apply dio_expr_plus; dio_rel_auto.
   Defined.
 
 End df_digit.
 
-Hint Resolve dio_rel_is_digit.
+Hint Resolve dio_rel_is_digit : dio_rel_db.
 
-Check dio_rel_is_digit.
-Eval compute in df_size (proj1_sig (dio_rel_is_digit (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2) (dio_expr_var 3))).
+Local Fact dio_rel_is_digit_example : 𝔻R (fun ν => is_digit (ν 0) (ν 1) (ν 2) (ν 3)).
+Proof. apply dio_rel_is_digit; dio_rel_auto. Defined.
+
+Check dio_rel_is_digit_example.
+Eval compute in df_size_Z (proj1_sig dio_rel_is_digit_example).
 
 Section df_binomial.
 
@@ -156,15 +174,19 @@ Section df_binomial.
         - apply power_mono; omega.
   Qed.
 
-  Lemma dio_rel_binomial b n k : 𝔻P b -> 𝔻P n -> 𝔻P k
-                              -> 𝔻R (fun ν => b ν = binomial (n ν) (k ν)).
+  Lemma dio_expr_binomial n k : 𝔻P n -> 𝔻P k -> 𝔻P (fun ν => binomial (n ν) (k ν)).
   Proof.
-    intros H1 H2 H3.
-    apply dio_rel_equiv with (1 := fun ν => is_binomial_eq (b ν) (n ν) (k ν)).
+    intros H2 H3.
+    apply dio_rel_equiv with (1 := fun ν => is_binomial_eq (ν 0) (n ν↓) (k ν↓)).
     dio_rel_auto; apply dio_expr_plus; auto.
   Defined.
 
 End df_binomial.
 
-Check dio_rel_binomial.
-Eval compute in df_size (proj1_sig (dio_rel_binomial (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2))).
+Hint Resolve dio_expr_binomial : dio_rel_db.
+
+Local Fact dio_expr_binomial_example : 𝔻P (fun ν => binomial (ν 0) (ν 1)).
+Proof. apply dio_expr_binomial; dio_rel_auto. Defined.
+
+Check dio_expr_binomial_example.
+Eval compute in df_size_Z (proj1_sig dio_expr_binomial_example).

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -54,7 +54,7 @@ Proof. dio auto. Defined.
 
 Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example).
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1440%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1445%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -73,35 +73,37 @@ Proof. dio auto. Defined.
 
 Eval compute in df_size_Z (proj1_sig dio_fun_expo_example).
 
-(* The new Diophantine shapes builds at bit bigger formulas ... *)
+(* The new Diophantine shapes (w/o build-in polynimoals) 
+   build formulas that are a bit bigger ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 4960%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 4903%Z.
 Proof. reflexivity. Qed.
 
-Section dio_rel_is_digit.
+(** We use the exponantial to characterize digits *)
 
-  (* The is_digit c q i y relation stating that 
-     "y is the i-th digit of c is base q" *)
+(** The is_digit c q i y relation stating that 
+     
+       "y is the i-th digit of c is base q" 
+ *)
 
-  Let is_digit_eq c q i y : is_digit c q i y 
-                        <-> y < q
-                        /\ exists a b p, c = (a*q+y)*p+b 
-                                      /\ b < p
-                                      /\ p = power i q.
-  Proof.
-    split; intros (H1 & a & b & H2).
-    + split; auto; exists a, b, (power i q); repeat split; tauto.
-    + destruct H2 as (p & H2 & H3 & H4).
-      split; auto; exists a, b; subst; auto.
-  Qed.
+Local Fact is_digit_eq c q i y : 
+            is_digit c q i y 
+        <-> y < q
+         /\ exists a b p, c = (a*q+y)*p+b 
+                       /\ b < p
+                       /\ p = power i q.
+Proof.
+  split; intros (H1 & a & b & H2).
+  + split; auto; exists a, b, (power i q); repeat split; tauto.
+  + destruct H2 as (p & H2 & H3 & H4).
+    split; auto; exists a, b; subst; auto.
+Qed.
 
-  Lemma dio_rel_is_digit c q i y : 𝔻F c -> 𝔻F q -> 𝔻F i -> 𝔻F y
-                                -> 𝔻R (fun ν => is_digit (c ν) (q ν) (i ν) (y ν)).
-  Proof.
-    dio by lemma (fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
-  Defined.
-
-End dio_rel_is_digit.
+Lemma dio_rel_is_digit c q i y : 𝔻F c -> 𝔻F q -> 𝔻F i -> 𝔻F y
+                              -> 𝔻R (fun ν => is_digit (c ν) (q ν) (i ν) (y ν)).
+Proof.
+  dio by lemma (fun ν => is_digit_eq (c ν) (q ν) (i ν) (y ν)).
+Defined.
 
 Hint Resolve dio_rel_is_digit : dio_rel_db.
 

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -54,7 +54,7 @@ Proof. dio auto. Defined.
 
 Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example).
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1520%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1440%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -75,7 +75,7 @@ Eval compute in df_size_Z (proj1_sig dio_fun_expo_example).
 
 (* The new Diophantine shapes builds at bit bigger formulas ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5304%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 4960%Z.
 Proof. reflexivity. Qed.
 
 Section dio_rel_is_digit.

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -32,7 +32,8 @@ Local Notation expo := (mscal mult 1).
     from the new Diophantine shapes that include Diophantine
     functions. *)
 
-Local Notation "x ≐ n" := (df_cst x n) (at level 49, no associativity, format "x  ≐  n").
+Local Notation "x ≐ n" := (df_cst x n) 
+      (at level 49, no associativity, format "x  ≐  n").
 Local Notation "x ≐ y ⨢ z" := (df_add x y z) 
       (at level 49, no associativity, y at next level, format "x  ≐  y  ⨢  z").
 Local Notation "x ≐ y ⨰ z" := (df_mul x y z) 

--- a/theories/H10/Dio/dio_expo.v
+++ b/theories/H10/Dio/dio_expo.v
@@ -32,8 +32,10 @@ Local Notation expo := (mscal mult 1).
     from the new Diophantine shapes that include Diophantine
     functions. *)
 
-Local Notation "x ≐ n" := (df_cst x n) 
-      (at level 49, no associativity, format "x  ≐  n").
+Local Notation "x ≐ ⌞ n ⌟" := (df_cst x n) 
+      (at level 49, no associativity, format "x  ≐  ⌞ n ⌟").
+Local Notation "x ≐ y" := (df_eq x y) 
+      (at level 49, no associativity, format "x  ≐  y").
 Local Notation "x ≐ y ⨢ z" := (df_add x y z) 
       (at level 49, no associativity, y at next level, format "x  ≐  y  ⨢  z").
 Local Notation "x ≐ y ⨰ z" := (df_mul x y z) 
@@ -50,9 +52,9 @@ Hint Resolve dio_rel_alpha : dio_rel_db.
 Local Fact dio_rel_alpha_example : 𝔻R (fun ν => 3 < ν 1 /\ ν 0 = alpha_nat (ν 1) (ν 2)).
 Proof. dio auto. Defined.
 
-(* Eval compute in proj1_sig dio_rel_alpha_example. *)
+(* Eval compute in df_size_Z (proj1_sig dio_rel_alpha_example). *)
 
-Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 2794%Z.
+Fact dio_rel_alpha_size : df_size_Z (proj1_sig dio_rel_alpha_example) = 1605%Z.
 Proof. reflexivity. Qed.
 
 (** This is Matiyasevich theorem stating that q^r is a Diophantine function. 
@@ -69,11 +71,11 @@ Hint Resolve dio_fun_expo : dio_fun_db.
 Local Fact dio_fun_expo_example : 𝔻F (fun ν => expo (ν 0) (ν 1)).
 Proof. dio auto. Defined.
 
-(* Eval compute in (proj1_sig dio_fun_expo_example). *)
+(* Eval compute in df_size_Z (proj1_sig dio_fun_expo_example). *)
 
 (* The new Diophantine shapes builds at bit bigger formulas ... *)
 
-Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 9606%Z.
+Local Fact dio_fun_expo_example_size : df_size_Z (proj1_sig dio_fun_expo_example) = 5589%Z.
 Proof. reflexivity. Qed.
 
 Section dio_rel_is_digit.

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -21,8 +21,8 @@ Fixpoint env_lift {X} (φ : nat -> X) k n { struct n } :=
     | S n => φ n
   end.
 
-Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
-Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
+Local Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
+Local Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
 Inductive dio_op := do_add | do_mul.
 
@@ -137,14 +137,10 @@ Section diophantine_logic.
     end.
 
   Fact df_ren_size ρ f : df_size (df_ren ρ f) = df_size f.
-  Proof.
-    revert ρ; induction f; intros; simpl; auto; do 2 f_equal; auto.
-  Qed.
+  Proof. revert ρ; induction f; intros; simpl; auto; do 2 f_equal; auto. Qed.
 
   Fact df_ren_size_Z ρ f : df_size_Z (df_ren ρ f) = df_size_Z f.
-  Proof.
-    do 2 rewrite df_size_Z_spec; f_equal; apply df_ren_size.
-  Qed.
+  Proof. do 2 rewrite df_size_Z_spec; f_equal; apply df_ren_size. Qed.
 
   Fact df_pred_ren f ν ρ : df_pred (df_ren ρ f) ν <-> df_pred f (fun x => ν (ρ x)).
   Proof.
@@ -172,53 +168,43 @@ Section dio_rel.
   Implicit Types R S : (nat -> nat) -> Prop.
 
   Fact dio_rel_cst x n : 𝔻R (fun ν => ν x = n).
-  Proof.
-    exists (df_cst x n); intro; simpl; tauto.
-  Defined.
+  Proof. exists (df_cst x n); abstract (intro; simpl; tauto). Defined.
 
   Fact dio_rel_add x y z : 𝔻R (fun ν => ν x = ν y + ν z).
-  Proof.
-    exists (df_add x y z); intro; simpl; tauto.
-  Defined.
+  Proof. exists (df_add x y z); abstract (intro; simpl; tauto). Defined.
 
   Fact dio_rel_mul x y z : 𝔻R (fun ν => ν x = ν y * ν z).
-  Proof.
-    exists (df_mul x y z); intro; simpl; tauto.
-  Defined.
+  Proof. exists (df_mul x y z); abstract (intro; simpl; tauto). Defined.
  
   Fact dio_rel_conj R S : 𝔻R R -> 𝔻R S -> 𝔻R (fun ν => R ν /\ S ν).
   Proof.
-    intros (fR & H1) (fS & H2).
-    exists (df_conj fR fS); intros v.
-    rewrite df_pred_conj, H1, H2; tauto.
+    intros (fR & H1) (fS & H2); exists (df_conj fR fS).
+    abstract (intros v; rewrite df_pred_conj, H1, H2; tauto).
   Defined.
 
   Fact dio_rel_disj R S : 𝔻R R -> 𝔻R S -> 𝔻R (fun ν => R ν \/ S ν).
   Proof.
-    intros (fR & H1) (fS & H2).
-    exists (df_disj fR fS); intros v.
-    rewrite df_pred_disj, H1, H2; tauto.
+    intros (fR & H1) (fS & H2); exists (df_disj fR fS).
+    abstract (intros v; rewrite df_pred_disj, H1, H2; tauto).
   Defined.
 
   Fact dio_rel_exst (K : nat -> (nat -> nat) -> Prop) : 
                  𝔻R (fun ν => K (ν 0) ν↓) -> 𝔻R (fun ν => exists x, K x ν).
   Proof.
-    intros (f & Hf).
-    exists (df_exst f); intros v.
-    rewrite df_pred_exst.
-    split; intros (n & Hn); exists n; revert Hn; rewrite Hf; simpl; auto.
+    intros (f & Hf); exists (df_exst f). 
+    abstract (intros v; rewrite df_pred_exst;
+      split; intros (n & Hn); exists n; revert Hn; rewrite Hf; simpl; auto).
   Defined.
 
   Lemma dio_rel_equiv R S : (forall ν, S ν <-> R ν) -> 𝔻R R -> 𝔻R S.
   Proof. 
-    intros H (f & Hf); exists f; intro; rewrite Hf, H; tauto.
+    intros H (f & Hf); exists f; abstract (intro; rewrite Hf, H; tauto).
   Defined.
 
   Lemma dio_rel_ren R f : 𝔻R R -> 𝔻R (fun ν => R (fun n => ν (f n))).
   Proof.
-    intros (r & HR).
-    exists (df_ren f r).
-    intros; rewrite df_pred_ren, HR; tauto.
+    intros (r & HR); exists (df_ren f r).
+    abstract (intros; rewrite df_pred_ren, HR; tauto).
   Defined.
 
 End dio_rel.
@@ -227,9 +213,10 @@ Create HintDb dio_rel_db.
 
 Hint Resolve dio_rel_cst dio_rel_add dio_rel_mul : dio_rel_db.
 
-Ltac dio_rel_auto := repeat (apply dio_rel_exst 
+Ltac dio_rel_auto := auto with dio_rel_db;
+                     repeat ((apply dio_rel_exst 
                            || apply dio_rel_conj 
-                           || apply dio_rel_disj); auto with dio_rel_db.
+                           || apply dio_rel_disj || idtac); auto with dio_rel_db).
 
 Tactic Notation "by" "dio" "equiv" uconstr(f) :=
   apply dio_rel_equiv with (R := f); [ | dio_rel_auto ].
@@ -243,18 +230,22 @@ Defined.
 Fact dio_rel_False : 𝔻R (fun _ => False).
 Proof.
   by dio equiv (fun _ => exists x, x = 1 /\ x = x + x).
-  split; try tauto; intros (? & ? & ?); abstract omega.
+  abstract (split; try tauto; intros (? & ? & ?); omega).
 Defined.
 
 Fact dio_rel_eq_var x y : 𝔻R (fun ν => ν x = ν y).
 Proof.
   by dio equiv (fun ν => exists k, k = 0 /\ ν x = ν y + k).
-  intros v; split.
-  + intros ->; exists 0; auto.
-  + intros (? & -> & H); abstract omega.
-Qed.
+  abstract( intros v; split;
+   [ intros ->; exists 0; auto
+   | intros (? & -> & H); omega ]).
+Defined.
 
-Hint Resolve dio_rel_True dio_rel_False dio_rel_eq_var : dio_rel_db. 
+Hint Resolve dio_rel_True dio_rel_False dio_rel_eq_var : dio_rel_db.
+
+Local Fact example_1 : 𝔻R (fun ν => ν 0 = ν 0).
+Proof. dio_rel_auto. Defined.
+Eval compute in df_size_Z (proj1_sig example_1).
 
 Definition dio_expr t := 𝔻R (fun ν => ν 0 = t ν↓).
 
@@ -270,13 +261,13 @@ Fact dio_rel_eq r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν = t ν).
 Proof.
   intros H1 H2; red in H1, H2.
   by dio equiv (fun ν => exists x, x = r ν /\ x = t ν).
-  intros v; split.
-  + intros ->; exists (t v); auto.
-  + intros (? & -> & ?); auto.
+  abstract (intros v; split;
+   [ intros ->; exists (t v); auto 
+   | intros (? & -> & ?); auto ]).
 Defined.
 
 Fact dio_expr_ren t f : 𝔻P t -> 𝔻P (fun ν => t (fun n => ν (f n))).
-Proof. apply dio_rel_ren with (f := der_lift f). Qed.
+Proof. apply dio_rel_ren with (f := der_lift f). Defined.
 
 Hint Resolve dio_expr_var dio_expr_cst dio_rel_eq dio_expr_ren : dio_rel_db.
 
@@ -284,18 +275,18 @@ Fact dio_expr_plus r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν + t ν).
 Proof.
   intros H1 H2.
   by dio equiv (fun ν => exists b c, ν 0 = b + c /\ b = r ν↓ /\ c = t ν↓).
-  intros v; split.
-  + exists (r v↓), (t v↓); auto.
-  + intros (? & ? & -> & -> & ->); auto.
+  abstract (intros v; split;
+   [ exists (r v↓), (t v↓); auto
+   | intros (? & ? & -> & -> & ->); auto ]).
 Defined.
 
 Fact dio_expr_mult r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν * t ν).
 Proof.
   intros H1 H2.
   by dio equiv (fun ν => exists b c, ν 0 = b * c /\ b = r ν↓ /\ c = t ν↓).
-  intros v; split.
-  + exists (r v↓), (t v↓); auto.
-  + intros (? & ? & -> & -> & ->); auto.
+  abstract (intros v; split;
+   [ exists (r v↓), (t v↓); auto
+   | intros (? & ? & -> & -> & ->); auto ]).
 Defined.
 
 Hint Resolve dio_expr_plus dio_expr_mult : dio_rel_db.
@@ -304,18 +295,18 @@ Fact dio_rel_le r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν <= t ν).
 Proof.
   intros H1 H2.
   by dio equiv (fun ν => exists a, t ν = a + r ν).
-  intros v; split.
-  + intros H; exists (t v - r v); abstract omega.
-  + intros (? & ->); abstract omega.
+  abstract (intros v; split;
+   [ intros H; exists (t v - r v); omega
+   | intros (? & ->); omega ]).
 Defined.
 
 Fact dio_rel_lt r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν < t ν).
 Proof.
   intros H1 H2.
   by dio equiv (fun ν => exists a, t ν = (1+a) + r ν).
-  intros v; split.
-  + intros H; exists (t v - S (r v)); abstract omega.
-  + intros (? & ->); abstract omega.
+  abstract(intros v; split;
+   [ intros H; exists (t v - S (r v)); omega
+   | intros (? & ->); omega ]).
 Defined.
 
 Hint Resolve dio_rel_le dio_rel_lt : dio_rel_db.
@@ -331,10 +322,16 @@ Fact dio_rel_div r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => divides (r ν) (t 
 Proof.
   intros.
   by dio equiv (fun ν => exists x, t ν = x * r ν).
-  intros; unfold divides; tauto.
+  abstract (intros; unfold divides; tauto).
 Defined.
 
 Hint Resolve dio_rel_neq dio_rel_div : dio_rel_db.
+
+Local Fact example_2 : 𝔻R (fun ν => ν 0 <> ν 1).
+Proof. dio_rel_auto. Defined.
+
+Check example_2.
+Eval compute in df_size_Z (proj1_sig example_2). 
 
 Section more_examples.
 
@@ -369,7 +366,7 @@ Section more_examples.
 
   Fact dio_rel_congruence x y p : 𝔻P x -> 𝔻P y -> 𝔻P p  
                                 -> 𝔻R (fun ν => rem (x ν) (p ν) = rem (y ν) (p ν)).
-  Proof. intros; dio_rel_auto. Qed.
+  Proof. intros; dio_rel_auto. Defined.
 
   Hint Resolve dio_rel_congruence : dio_rel_deb.
 
@@ -421,24 +418,44 @@ Section more_examples.
 
 End more_examples.
 
-Hint Resolve dio_expr_rem dio_rel_not_divides : dio_rel_deb.
+Hint Resolve dio_expr_rem dio_rel_not_divides : dio_rel_db.
+
+Local Fact example_3 : 𝔻R (fun ν => rem (ν 0) (ν 1) = ν 2 * ν 3).
+Proof. dio_rel_auto. Defined.
+
+Check example_3.
+Eval compute in df_size (proj1_sig example_3). 
 
 Section dio_rel_compose.
 
   Variable (f : (nat -> nat) -> nat) (R : nat -> (nat -> nat) -> Prop).
-  Hypothesis (Hf : 𝔻R (fun ν => ν 0 = f (fun x => ν (S x)))) 
-             (HR : 𝔻R (fun ν => R (ν 0) (fun x => ν (S x)))).
+  Hypothesis (Hf : 𝔻R (fun ν => ν 0 = f ν↓)) 
+             (HR : 𝔻R (fun ν => R (ν 0) ν↓)).
 
   Lemma dio_rel_compose : 𝔻R (fun ν => R (f ν) ν).
   Proof.
-    apply dio_rel_equiv with (R := fun v => exists y, y = f v /\ R y v).
-    + intros v; split.
-      * exists (f v); auto.
-      * intros (? & -> & ?); auto.
-    + dio_rel_auto.
+    by dio equiv (fun v => exists y, y = f v /\ R y v).
+    abstract(intros v; split;
+     [ exists (f v); auto
+     | intros (? & -> & ?); auto ]).
   Defined.
 
 End dio_rel_compose.
+
+Section dio_expr_compose.
+
+  Variable (f : (nat -> nat) -> nat) (Hf : 𝔻P f)
+           (g : nat -> nat) (Hg : 𝔻P (fun ν => g (ν 0))).
+
+  Lemma dio_expr_compose : 𝔻P (fun ν => g (f ν)).
+  Proof.
+    by dio equiv (fun v => exists y, y = f v↓ /\ v 0 = g y).
+    abstract(intros; split;
+     [ exists (f ν↓); auto
+     | intros (? & -> & ?); auto ]).
+  Defined.
+
+End dio_expr_compose.
 
 Section multiple_exists.
 

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -489,7 +489,13 @@ Proof.
     | intros (? & ? & ? & -> & -> & ->); omega ]).
 Defined.
 
-Hint Resolve dio_rel_le_im dio_rel_lt_im : dio_rel_im_db.
+Fact dio_rel_div_im x y : 𝔻R (fun ν => divides (ν x) (ν y)).
+Proof.
+  by dio equiv (fun ν => exists a, ν y = a * ν x).
+  unfold divides; tauto.
+Defined.
+
+Hint Resolve dio_rel_le_im dio_rel_lt_im  dio_rel_div_im : dio_rel_im_db.
 
 Fact dio_rel_le r t : 𝔻F r -> 𝔻F t -> 𝔻R (fun ν => r ν <= t ν).
 Proof.
@@ -514,7 +520,7 @@ Hint Resolve dio_rel_lt dio_rel_le : dio_rel_db.
 Fact dio_rel_neq r t : 𝔻F r -> 𝔻F t -> 𝔻R (fun ν => r ν <> t ν).
 Proof.
   intros H1 H2.
-  by dio equiv (fun ν => exists a b, (a < b \/ b < a) /\ a = r ν /\ b = t ν).
+  by dio equiv (fun v => exists a b, (a < b \/ b < a) /\ a = r v /\ b = t v).
   abstract (intros v; split;
     [ exists (r v), (t v)
     | intros (? & ? & ?) ]; omega).
@@ -523,8 +529,10 @@ Defined.
 Fact dio_rel_div r t : 𝔻F r -> 𝔻F t -> 𝔻R (fun ν => divides (r ν) (t ν)).
 Proof.
   intros H1 H2.
-  by dio equiv (fun ν => exists x, t ν = x * r ν).
-  abstract (intros; unfold divides; tauto).
+  by dio equiv (fun v => exists a b, divides a b /\ a = r v /\ b = t v).
+  abstract (intros v; split;
+    [ exists (r v), (t v)
+    | intros (? & ? & ? & -> & ->) ]; auto).
 Defined.
 
 Hint Resolve dio_rel_neq dio_rel_div : dio_rel_db.
@@ -537,11 +545,17 @@ Proof. dio auto. Defined.
 Check example_le.
 Eval compute in (proj1_sig example_le). 
 
-Local Fact example_2 : 𝔻R (fun ν => ν 0 < ν 1).
+Local Fact example_lt : 𝔻R (fun ν => ν 0 < ν 1).
 Proof. dio auto. Defined.
 
-Check example_2.
-Eval compute in (proj1_sig example_2). 
+Check example_lt.
+Eval compute in (proj1_sig example_lt). 
+
+Local Fact example_div : 𝔻R (fun ν => divides (ν 0) (ν 1)).
+Proof. dio auto. Defined.
+
+Check example_div.
+Eval compute in (proj1_sig example_div). 
 
 Section dio_fun_rem.
 
@@ -621,11 +635,11 @@ End dio_rel_not_divides.
 
 Hint Resolve dio_rel_not_divides : dio_rel_db.
 
-Local Fact example_3 : 𝔻R (fun ν => rem (ν 0) (ν 1) = ν 2 * ν 3).
+Local Fact example_rem : 𝔻R (fun ν => rem (ν 0) (ν 1) = ν 2 * ν 3).
 Proof. dio auto. Defined.
 
-Check example_3.
-Eval compute in df_size_Z (proj1_sig example_3).
+Check example_rem.
+Eval compute in (proj1_sig example_rem).
 
 (** We do not automate the remaining closure props here because
     they are used only once or twice elsewhere *) 

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -15,165 +15,68 @@ From Undecidability.Shared.Libs.DLW.Utils Require Import gcd.
 
 Set Implicit Arguments.
 
-Section diophantine_expressions.
+Fixpoint env_lift {X} (φ : nat -> X) k n { struct n } :=
+  match n with
+    | 0   => k
+    | S n => φ n
+  end.
 
-  Inductive dio_op := do_add | do_mul.
+Notation "phi ↑ k" := (env_lift phi k) (at level 1, format "phi ↑ k", left associativity).
+Notation "phi ↓"   := (fun n => phi (S n)) (at level 1, format "phi ↓", no associativity).
 
-  Definition do_eval o :=
-    match o with
-      | do_add => plus
-      | do_mul => mult
-    end.
+Inductive dio_op := do_add | do_mul.
 
-  Inductive dio_expression : Set :=
-    | de_cst  : nat -> dio_expression
-    | de_var  : nat -> dio_expression
-    | de_comp : dio_op -> dio_expression -> dio_expression -> dio_expression.
+Definition de_op_sem (o : dio_op) :=
+  match o with
+    | do_add => plus
+    | do_mul => mult
+  end.
 
-  Definition de_add := de_comp do_add.
-  Definition de_mul := de_comp do_mul.
+Definition df_op_sem (o : dio_op) :=
+  match o with
+    | do_add => or
+    | do_mul => and
+  end.
 
-  Fixpoint de_size e :=
-    match e with
-      | de_cst n => 1
-      | de_var x => 1
-      | de_comp _ p q => 1 + de_size p + de_size q
-    end.
+(** De Bruin syntax for diophantine formulas of the form
 
-  Fixpoint de_size_Z e :=
-    (match e with
-      | de_cst n => 1
-      | de_var x => 1
-      | de_comp _ p q => 1 + de_size_Z p + de_size_Z q
-    end)%Z.
+         A,B ::= x = n | x = y o z | A /\ B | A \/ B | ∃x.A with o in {+,*}     
+*)
 
-  Fact de_size_Z_spec e : de_size_Z e = Z.of_nat (de_size e).
-  Proof.
-    induction e as [ | | o f Hf g Hg ]; auto.
-    simpl de_size; unfold de_size_Z; fold de_size_Z.
-    rewrite Nat2Z.inj_succ, Nat2Z.inj_add; omega.
-  Qed.
+Inductive dio_formula : Set :=
+  | df_cst  : forall (x : nat) (n : nat), dio_formula
+  | df_op   : forall (o : dio_op) (x y z : nat), dio_formula 
+  | df_bin  : forall (o : dio_op) (_ _ : dio_formula), dio_formula
+  | df_exst : dio_formula -> dio_formula.
 
-  Fixpoint de_eval ν e  :=
-    match e with
-      | de_cst n => n
-      | de_var x => ν x
-      | de_comp o p q => do_eval o (de_eval ν p) (de_eval ν q)
-    end.
-
-  Fact de_eval_ext e ν ω : (forall x, ν x = ω x) -> de_eval ν e = de_eval ω e.
-  Proof.
-    intros H; induction e as [ | | [] ]; simpl; auto.
-  Qed.
-
-  (* ρ σ ν *)
-
-  Fixpoint de_subst σ e :=
-    match e with
-      | de_cst n => de_cst n
-      | de_var x => σ x
-      | de_comp o p q => de_comp o (de_subst σ p) (de_subst σ q)
-    end.
-
-  Fact de_eval_subst σ ν e : de_eval ν (de_subst σ e) = de_eval (fun x => de_eval ν (σ x)) e.
-  Proof. induction e as [ | | [] ]; simpl; auto. Qed.
-
-  Fact de_subst_subst σ1 σ2 e : de_subst σ1 (de_subst σ2 e) = de_subst (fun x => de_subst σ1 (σ2 x)) e.
-  Proof. induction e as [ | | [] ]; simpl; f_equal; auto. Qed.
-
-  Definition de_ren ρ := de_subst (fun x => de_var (ρ x)).
-
-  Fact de_ren_size ρ e : de_size (de_ren ρ e) = de_size e.
-  Proof.
-    revert ρ; induction e as [ | | o e He f Hf ]; intros rho; auto.
-    unfold de_ren; simpl de_subst; unfold de_size; fold de_size. 
-    f_equal; [ f_equal | ].
-    * apply He.
-    * apply Hf.
-  Qed.
-
-  Fact de_ren_size_Z ρ e : de_size_Z (de_ren ρ e) = de_size_Z e.
-  Proof. do 2 rewrite de_size_Z_spec; f_equal; apply de_ren_size. Qed.
-
-  Fact de_eval_ren ρ ν e : de_eval ν (de_ren ρ e)  = de_eval (fun x => ν (ρ x)) e.
-  Proof. apply de_eval_subst. Qed.
-
-  Definition de_lift := de_ren S.
-
-  Fact de_eval_lift ν e : de_eval ν (de_lift e) = de_eval (fun x => ν (S x)) e.
-  Proof. apply de_eval_ren. Qed.
-
-End diophantine_expressions.
-
-Definition dio_expr t := { e | forall ν, de_eval ν e = t ν }.
-
-Notation 𝔻P := dio_expr.
-
-Section dio_expr.
-
-  (* How to analyse meta-level diophantine expressions *)
-
-  Implicit Types r t : (nat -> nat) -> nat.
-
-  Fact dio_expr_var i : 𝔻P (fun v => v i).
-  Proof. exists (de_var i); simpl; auto. Defined.
-
-  Fact dio_expr_cst c : 𝔻P (fun _ => c).
-  Proof. exists (de_cst c); simpl; auto. Defined.
-
-  Fact dio_expr_plus r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν + t ν).
-  Proof. intros (e1 & H1) (e2 & H2); exists (de_add e1 e2); simpl; auto. Defined.
-  
-  Fact dio_expr_mult r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν * t ν).
-  Proof. intros (e1 & H1) (e2 & H2); exists (de_mul e1 e2); simpl; auto. Defined.
-
-  Fact dio_expr_ren t ρ : 𝔻P t -> 𝔻P (fun ν => t (fun i => ν (ρ i))).
-  Proof. intros (e & He); exists (de_ren ρ e); intros; rewrite de_eval_ren, He; tauto. Defined.
-
-  Fact dio_expr_subst t σ : 𝔻P t -> 𝔻P (fun ν => t (fun i => de_eval ν (σ i))).
-  Proof. intros (e & He); exists (de_subst σ e); intros; rewrite de_eval_subst, He; tauto. Defined.
-
-End dio_expr.
-
-Hint Resolve dio_expr_var dio_expr_cst dio_expr_plus dio_expr_mult dio_expr_ren.
+Notation df_add := (df_op do_add).
+Notation df_mul := (df_op do_mul).
+Notation df_conj := (df_bin do_mul).
+Notation df_disj := (df_bin do_add).
 
 Section diophantine_logic.
 
-  (* De Bruin syntax for diophantine formulas of the form
-
-         A,B ::= e1 = e2 | A /\ B | A \/ B | ∃x.A
-
-   *)
-
-  Inductive dio_formula : Set :=
-    | df_atm  : dio_expression -> dio_expression -> dio_formula   (* a = b *)
-    | df_conj : dio_formula -> dio_formula -> dio_formula 
-    | df_disj : dio_formula -> dio_formula -> dio_formula
-    | df_exst : dio_formula -> dio_formula.
-
   Fixpoint df_size f :=
     match f with
-      | df_atm a b  => 1 + de_size a + de_size b
-      | df_conj f g => 1 + df_size f + df_size g  
-      | df_disj f g => 1 + df_size f + df_size g  
-      | df_exst f   => 1 + df_size f
+      | df_cst _ _    => 3
+      | df_op _ _ _ _ => 5
+      | df_bin _ f g  => 1 + df_size f + df_size g   
+      | df_exst f     => 1 + df_size f
     end.
 
   Fixpoint df_size_Z f :=
     (match f with
-      | df_atm a b  => 1 + de_size_Z a + de_size_Z b
-      | df_conj f g => 1 + df_size_Z f + df_size_Z g  
-      | df_disj f g => 1 + df_size_Z f + df_size_Z g  
-      | df_exst f   => 1 + df_size_Z f
+      | df_cst _ _    => 3
+      | df_op _ _ _ _ => 5
+      | df_bin _ f g  => 1 + df_size_Z f + df_size_Z g   
+      | df_exst f     => 1 + df_size_Z f
     end)%Z.
 
   Fact df_size_Z_spec f : df_size_Z f = Z.of_nat (df_size f).
   Proof.
-    induction f as [ a b | f Hf g Hg | f Hf g Hg | f Hf ]; simpl df_size;
+    induction f as [ | | ? f Hf g Hg | f Hf ]; simpl df_size;
       rewrite Nat2Z.inj_succ; try rewrite Nat2Z.inj_add; unfold df_size_Z; fold df_size_Z; auto; try omega.
-    do 2 rewrite de_size_Z_spec; omega.
   Qed.
-
 
   (* dv_lift : lifting of a diophantive valuation *)
 
@@ -183,33 +86,41 @@ Section diophantine_logic.
        | S n => ν n 
      end.
 
+  Reserved Notation "'⟦' t '⟧'" (at level 1, format "⟦ t ⟧").
+
   Fixpoint df_pred f ν :=
     match f with
-      | df_atm a b  => de_eval ν a  = de_eval ν b
-      | df_conj f g => df_pred f ν /\ df_pred g ν
-      | df_disj f g => df_pred f ν \/ df_pred g ν
-      | df_exst f   => exists n, df_pred f (dv_lift ν n)
-    end.
+      | df_cst x n     => ν x = n
+      | df_op  o x y z => ν x = de_op_sem o (ν y) (ν z)
+      | df_bin o f g   => df_op_sem o (⟦f⟧ ν) (⟦g⟧ ν)
+      | df_exst f      => exists n, ⟦f⟧ ν↑n
+    end
+  where "⟦ f ⟧" := (df_pred f).
 
-  Fact df_pred_atm a b ν : df_pred (df_atm a b) ν = (de_eval ν a = de_eval ν b).
-  Proof. auto. Qed.
+  Fact df_pred_cst x n ν : ⟦df_cst x n⟧ ν = (ν x = n).
+  Proof. reflexivity. Qed.
+
+  Fact df_pred_add x y z ν : ⟦df_add x y z⟧ ν = (ν x = ν y + ν z).
+  Proof. reflexivity. Qed.
+
+  Fact df_pred_mul x y z ν : ⟦df_mul x y z⟧ ν = (ν x = ν y * ν z).
+  Proof. reflexivity. Qed.
   
-  Fact df_pred_conj f g ν : df_pred (df_conj f g) ν = (df_pred f ν /\ df_pred g ν).
-  Proof. auto. Qed.
+  Fact df_pred_conj f g ν : ⟦df_conj f g⟧ ν = (⟦f⟧ ν /\ ⟦g⟧ ν).
+  Proof. reflexivity. Qed.
 
-  Fact df_pred_disj f g ν : df_pred (df_disj f g) ν = (df_pred f ν \/ df_pred g ν).
-  Proof. auto. Qed.
+  Fact df_pred_disj f g ν : ⟦df_disj f g⟧ ν = (⟦f⟧ ν \/ ⟦g⟧ ν).
+  Proof. reflexivity. Qed.
 
-  Fact df_pred_exst f ν : df_pred (df_exst f) ν = exists n, df_pred f (dv_lift ν n).
-  Proof. auto. Qed.
+  Fact df_pred_exst f ν : ⟦df_exst f⟧ ν = exists n, ⟦f⟧ ν↑n.
+  Proof. reflexivity. Qed.
 
-  Fact df_pred_ext f ν ω : (forall x, ν x = ω x) -> df_pred f ν <-> df_pred f ω.
+  Fact df_pred_ext f ν ω : (forall x, ν x = ω x) -> ⟦f⟧ ν <-> ⟦f⟧ ω.
   Proof.
-    revert ν ω; induction f as [ a b | f Hf g Hg | f Hf g Hg | f Hf ]; intros ν ω H; simpl.
-    + do 2 rewrite de_eval_ext with (1 := H); tauto.
-    + rewrite Hf, Hg; auto; tauto.
-    + rewrite Hf, Hg; auto; tauto.
-    + split; intros (n & Hn); exists n; revert Hn; apply Hf;
+    revert ν ω; induction f as [ | [] | [] f Hf g Hg | f Hf ]; intros ν ω H; simpl.
+    1-3: rewrite !H; tauto.
+    1-2: rewrite Hf, Hg; auto; tauto.
+    split; intros (n & Hn); exists n; revert Hn; apply Hf;
         intros []; simpl; auto.
   Qed.
 
@@ -219,16 +130,15 @@ Section diophantine_logic.
 
   Fixpoint df_ren ρ f :=
     match f with
-      | df_atm a b  => let σ := fun x => de_var (ρ x) in df_atm (de_subst σ a) (de_subst σ b)
-      | df_conj f g => df_conj (df_ren ρ f) (df_ren ρ g)
-      | df_disj f g => df_disj (df_ren ρ f) (df_ren ρ g)
-      | df_exst f   => df_exst (df_ren (der_lift ρ) f)
+      | df_cst x n    => df_cst (ρ x) n
+      | df_op o x y z => df_op o (ρ x) (ρ y) (ρ z)
+      | df_bin o f g  => df_bin o (df_ren ρ f) (df_ren ρ g)
+      | df_exst f     => df_exst (df_ren (der_lift ρ) f)
     end.
 
   Fact df_ren_size ρ f : df_size (df_ren ρ f) = df_size f.
   Proof.
     revert ρ; induction f; intros; simpl; auto; do 2 f_equal; auto.
-    all: apply de_ren_size.
   Qed.
 
   Fact df_ren_size_Z ρ f : df_size_Z (df_ren ρ f) = df_size_Z f.
@@ -238,110 +148,18 @@ Section diophantine_logic.
 
   Fact df_pred_ren f ν ρ : df_pred (df_ren ρ f) ν <-> df_pred f (fun x => ν (ρ x)).
   Proof.
-    revert ν ρ; induction f as [ a b | f Hf g Hg | f Hf g Hg | f Hf ]; intros ν ρ; simpl.
-    + repeat rewrite de_eval_subst; simpl; tauto.
-    + rewrite Hf, Hg; tauto.
-    + rewrite Hf, Hg; tauto.
-    + split; intros (n & Hn); exists n; revert Hn; rewrite Hf;
+    revert ν ρ; induction f as [ | [] | [] f Hf g Hg | f Hf ]; intros ν ρ; simpl; try tauto.
+    1-2: rewrite Hf, Hg; tauto.
+    split; intros (n & Hn); exists n; revert Hn; rewrite Hf;
         apply df_pred_ext; intros []; simpl; auto.
-  Qed.
-
-  (* Lifting of a diophantine expression substitutions *)
-
-  Definition des_lift σ x := match x with 0 => de_var 0 | S x => de_ren S (σ x) end. 
-     
-  Fixpoint df_subst σ f := 
-    match f with
-      | df_atm a b  => df_atm (de_subst σ a) (de_subst σ b)
-      | df_conj f g => df_conj (df_subst σ f) (df_subst σ g)
-      | df_disj f g => df_disj (df_subst σ f) (df_subst σ g)
-      | df_exst f   => df_exst (df_subst (des_lift σ) f)
-    end.
-
-  Fact df_pred_subst f ν σ : df_pred (df_subst σ f) ν <-> df_pred f (fun x => de_eval ν (σ x)).
-  Proof.
-    revert ν σ; induction f as [ a b | f Hf g Hg | f Hf g Hg | f Hf ]; intros ν σ; simpl.
-    + repeat rewrite de_eval_subst; simpl; tauto.
-    + rewrite Hf, Hg; tauto.
-    + rewrite Hf, Hg; tauto.
-    + split; intros (n & Hn); exists n; revert Hn; rewrite Hf;
-        apply df_pred_ext; intros []; simpl; auto;
-        rewrite de_eval_ren; apply de_eval_ext; auto.
   Qed.
 
   Definition df_lift := df_ren S.
 
-  Fact df_pred_lift f ν : df_pred (df_lift f) ν <-> df_pred f (fun x => ν (S x)).
+  Fact df_pred_lift f ν : df_pred (df_lift f) ν <-> df_pred f ν↓.
   Proof. apply df_pred_ren. Qed. 
 
 End diophantine_logic.
-
-Section examples.
-
-  Variable ν : nat -> nat.
-
-  Definition df_true := df_atm (de_cst 0) (de_cst 0).
-  Definition df_false := df_atm (de_cst 0) (de_cst 1).
-
-  Fact df_true_spec : df_pred df_true ν <-> True.
-  Proof. simpl; split; auto. Qed.
-
-  Fact df_false_spec : df_pred df_false ν <-> False.
-  Proof. simpl; split; try discriminate; tauto. Qed.
-
-  Notation "'⟦' x '⟧'" := (de_eval ν x).
-
-  Definition df_le x y := df_exst (df_atm (de_add (de_var 0) (de_lift x)) (de_lift y)).
-
-  Fact df_le_spec x y : df_pred (df_le x y) ν <-> ⟦x⟧ <= ⟦y⟧.
-  Proof.
-    simpl.
-    split.
-    + intros (n & Hn); revert Hn; do 2 rewrite de_eval_lift; simpl.
-      change (fun x => ν x) with ν; intros; omega.
-    + exists (de_eval ν y - de_eval ν x); simpl.
-      repeat rewrite de_eval_lift; simpl.
-      change (fun x => ν x) with ν; omega.
-  Qed.
-
-  Definition df_lt x y := df_exst (df_atm (de_add (de_cst 1) (de_add (de_var 0) (de_lift x))) (de_lift y)).
-
-  Fact df_lt_spec x y : df_pred (df_lt x y) ν <-> ⟦x⟧ < ⟦y⟧.
-  Proof.
-    simpl.
-    split.
-    + intros (? & Hn); revert Hn; simpl.
-      do 2 rewrite de_eval_lift; simpl.
-      change (fun x => ν x) with ν; intros; omega.
-    + exists (de_eval ν y - de_eval ν x - 1); simpl.
-      repeat rewrite de_eval_lift; simpl.
-      change (fun x => ν x) with ν; omega.
-  Qed.
-
-  Definition df_eq x y := df_atm x y.
-
-  Fact df_eq_spec x y : df_pred (df_eq x y) ν <-> ⟦x⟧ = ⟦y⟧.
-  Proof. simpl; tauto. Qed.
-
-  Definition df_neq x y := df_disj (df_lt x y) (df_lt y x).
-
-  Fact df_neq_spec x y : df_pred (df_neq x y) ν <-> ⟦x⟧ <> ⟦y⟧.
-  Proof.
-    unfold df_neq.
-    rewrite df_pred_disj, df_lt_spec, df_lt_spec.
-    omega.
-  Qed.
-
-  Definition df_div x y := df_exst (df_atm (de_lift y) (de_mul (de_var 0) (de_lift x))).
-
-  Fact df_div_spec x y : df_pred (df_div x y) ν <-> divides ⟦x⟧ ⟦y⟧.
-  Proof. 
-    simpl; unfold divides.
-    split; intros (n & H); exists n; revert H; repeat rewrite de_eval_lift;
-      simpl; change (fun x => ν x) with ν; auto.
-  Qed.
-
-End examples.
 
 Definition dio_rel R := { f | forall ν, df_pred f ν <-> R ν }.
 Notation 𝔻R := dio_rel.
@@ -353,48 +171,21 @@ Section dio_rel.
   
   Implicit Types R S : (nat -> nat) -> Prop.
 
-  Fact dio_rel_True : 𝔻R (fun _ => True).
+  Fact dio_rel_cst x n : 𝔻R (fun ν => ν x = n).
   Proof.
-    exists df_true.
-    intros; rewrite df_true_spec; tauto.
+    exists (df_cst x n); intro; simpl; tauto.
   Defined.
 
-  Fact dio_rel_False : 𝔻R (fun _ => False).
+  Fact dio_rel_add x y z : 𝔻R (fun ν => ν x = ν y + ν z).
   Proof.
-    exists df_false.
-    intros; rewrite df_false_spec; tauto.
+    exists (df_add x y z); intro; simpl; tauto.
   Defined.
 
-  Fact dio_rel_eq r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν = t ν).
+  Fact dio_rel_mul x y z : 𝔻R (fun ν => ν x = ν y * ν z).
   Proof.
-    intros (e1 & H1) (e2 & H2); exists (df_atm e1 e2).
-    intros; rewrite df_pred_atm, H1, H2; tauto.
+    exists (df_mul x y z); intro; simpl; tauto.
   Defined.
-
-  Fact dio_rel_le r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν <= t ν).
-  Proof. 
-    intros (e1 & H1) (e2 & H2); exists (df_le e1 e2).
-    intro; rewrite df_le_spec, H1, H2; tauto.
-  Defined.
-
-  Fact dio_rel_lt r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν < t ν).
-  Proof. 
-    intros (e1 & H1) (e2 & H2); exists (df_lt e1 e2).
-    intro; rewrite df_lt_spec, H1, H2; tauto.
-  Defined.
-
-  Fact dio_rel_neq r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν <> t ν).
-  Proof.
-    intros (e1 & H1) (e2 & H2); exists (df_neq e1 e2).
-    intros; rewrite df_neq_spec, H1, H2; tauto.
-  Defined.
-
-  Fact dio_rel_div r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => divides (r ν) (t ν)).
-  Proof.
-    intros (e1 & H1) (e2 & H2); exists (df_div e1 e2).
-    intros; rewrite df_div_spec, H1, H2; tauto.
-  Defined.
-
+ 
   Fact dio_rel_conj R S : 𝔻R R -> 𝔻R S -> 𝔻R (fun ν => R ν /\ S ν).
   Proof.
     intros (fR & H1) (fS & H2).
@@ -410,8 +201,7 @@ Section dio_rel.
   Defined.
 
   Fact dio_rel_exst (K : nat -> (nat -> nat) -> Prop) : 
-                   𝔻R (fun v => K (v 0) (fun n => v (S n))) 
-      -> 𝔻R (fun ν => exists x, K x ν).
+                 𝔻R (fun ν => K (ν 0) ν↓) -> 𝔻R (fun ν => exists x, K x ν).
   Proof.
     intros (f & Hf).
     exists (df_exst f); intros v.
@@ -424,33 +214,168 @@ Section dio_rel.
     intros H (f & Hf); exists f; intro; rewrite Hf, H; tauto.
   Defined.
 
-  Lemma dio_rel_ren R f : 𝔻R R -> 𝔻R (fun v => R (fun n => v (f n))).
+  Lemma dio_rel_ren R f : 𝔻R R -> 𝔻R (fun ν => R (fun n => ν (f n))).
   Proof.
     intros (r & HR).
     exists (df_ren f r).
     intros; rewrite df_pred_ren, HR; tauto.
   Defined.
 
-  Lemma dio_rel_subst R f : 𝔻R R -> 𝔻R (fun v => R (fun n => de_eval v (f n))).
-  Proof.
-    intros (r & HR).
-    exists (df_subst f r).
-    intros; rewrite df_pred_subst, HR; tauto.
-  Defined.
-
 End dio_rel.
 
-Hint Resolve dio_rel_True dio_rel_False dio_rel_eq dio_rel_neq 
-             dio_rel_le dio_rel_lt dio_rel_div 
-             dio_rel_conj 
-             dio_rel_disj 
-             dio_rel_exst.
+Create HintDb dio_rel_db.
 
-Ltac dio_rel_auto := repeat ((apply dio_rel_exst || apply dio_rel_conj || apply dio_rel_disj || apply dio_rel_eq); auto).
+Hint Resolve dio_rel_cst dio_rel_add dio_rel_mul : dio_rel_db.
+
+Ltac dio_rel_auto := repeat (apply dio_rel_exst 
+                           || apply dio_rel_conj 
+                           || apply dio_rel_disj); auto with dio_rel_db.
+
+Tactic Notation "by" "dio" "equiv" uconstr(f) :=
+  apply dio_rel_equiv with (R := f); [ | dio_rel_auto ].
+
+Fact dio_rel_True : 𝔻R (fun _ => True).
+Proof.
+  by dio equiv (fun _ => exists x, x = 0).
+  split; try tauto; exists 0; auto.
+Defined.
+
+Fact dio_rel_False : 𝔻R (fun _ => False).
+Proof.
+  by dio equiv (fun _ => exists x, x = 1 /\ x = x + x).
+  split; try tauto; intros (? & ? & ?); abstract omega.
+Defined.
+
+Fact dio_rel_eq_var x y : 𝔻R (fun ν => ν x = ν y).
+Proof.
+  by dio equiv (fun ν => exists k, k = 0 /\ ν x = ν y + k).
+  intros v; split.
+  + intros ->; exists 0; auto.
+  + intros (? & -> & H); abstract omega.
+Qed.
+
+Hint Resolve dio_rel_True dio_rel_False dio_rel_eq_var : dio_rel_db. 
+
+Definition dio_expr t := 𝔻R (fun ν => ν 0 = t ν↓).
+
+Notation 𝔻P := dio_expr.
+
+Fact dio_expr_var i : 𝔻P (fun ν => ν i).
+Proof. red; dio_rel_auto. Defined.
+
+Fact dio_expr_cst c : 𝔻P (fun _ => c).
+Proof. red; dio_rel_auto. Defined.
+
+Fact dio_rel_eq r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν = t ν).
+Proof.
+  intros H1 H2; red in H1, H2.
+  by dio equiv (fun ν => exists x, x = r ν /\ x = t ν).
+  intros v; split.
+  + intros ->; exists (t v); auto.
+  + intros (? & -> & ?); auto.
+Defined.
+
+Fact dio_expr_ren t f : 𝔻P t -> 𝔻P (fun ν => t (fun n => ν (f n))).
+Proof. apply dio_rel_ren with (f := der_lift f). Qed.
+
+Hint Resolve dio_expr_var dio_expr_cst dio_rel_eq dio_expr_ren : dio_rel_db.
+
+Fact dio_expr_plus r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν + t ν).
+Proof.
+  intros H1 H2.
+  by dio equiv (fun ν => exists b c, ν 0 = b + c /\ b = r ν↓ /\ c = t ν↓).
+  intros v; split.
+  + exists (r v↓), (t v↓); auto.
+  + intros (? & ? & -> & -> & ->); auto.
+Defined.
+
+Fact dio_expr_mult r t : 𝔻P r -> 𝔻P t -> 𝔻P (fun ν => r ν * t ν).
+Proof.
+  intros H1 H2.
+  by dio equiv (fun ν => exists b c, ν 0 = b * c /\ b = r ν↓ /\ c = t ν↓).
+  intros v; split.
+  + exists (r v↓), (t v↓); auto.
+  + intros (? & ? & -> & -> & ->); auto.
+Defined.
+
+Hint Resolve dio_expr_plus dio_expr_mult : dio_rel_db.
+
+Fact dio_rel_le r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν <= t ν).
+Proof.
+  intros H1 H2.
+  by dio equiv (fun ν => exists a, t ν = a + r ν).
+  intros v; split.
+  + intros H; exists (t v - r v); abstract omega.
+  + intros (? & ->); abstract omega.
+Defined.
+
+Fact dio_rel_lt r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν < t ν).
+Proof.
+  intros H1 H2.
+  by dio equiv (fun ν => exists a, t ν = (1+a) + r ν).
+  intros v; split.
+  + intros H; exists (t v - S (r v)); abstract omega.
+  + intros (? & ->); abstract omega.
+Defined.
+
+Hint Resolve dio_rel_le dio_rel_lt : dio_rel_db.
+
+Fact dio_rel_neq r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => r ν <> t ν).
+Proof.
+  intros.
+  by dio equiv (fun ν => r ν < t ν \/ t ν < r ν).
+  abstract (intros; omega).
+Defined.
+
+Fact dio_rel_div r t : 𝔻P r -> 𝔻P t -> 𝔻R (fun ν => divides (r ν) (t ν)).
+Proof.
+  intros.
+  by dio equiv (fun ν => exists x, t ν = x * r ν).
+  intros; unfold divides; tauto.
+Defined.
+
+Hint Resolve dio_rel_neq dio_rel_div : dio_rel_db.
 
 Section more_examples.
 
-  Fact ndivides_eq x y : ~ (divides x y) <-> x = 0 /\ y <> 0 \/ exists a b, y = a*x+b /\ 0 < b < x.
+  Let rem_equiv p x r : r = rem x p <-> (p = 0 /\ x = r)
+                                      \/ (p <> 0 /\ r < p /\ exists n, x = n*p + r).
+  Proof.
+    split.
+    + intro; subst.
+      destruct (eq_nat_dec p 0) as [ Hp | Hp ].
+      * left; split; auto; subst; rewrite rem_0; auto.
+      * right; split; auto; split.
+        - apply div_rem_spec2; auto.
+        - exists (div x p);apply div_rem_spec1.
+    + intros [ (H1 & H2) | (H1 & H2 & n & H3) ].
+      * subst; rewrite rem_0; auto.
+      * symmetry; apply rem_prop with n; auto.
+  Qed.
+ 
+  Fact dio_expr_rem p x : 𝔻P p -> 𝔻P x -> 𝔻P (fun ν => rem (x ν) (p ν)).
+  Proof.
+    intros.
+    apply dio_rel_equiv with (1 := fun v => rem_equiv (p v↓) (x v↓) (v 0)).
+    dio_rel_auto.
+  Defined.
+  
+  Hint Resolve dio_expr_rem : dio_rel_db.
+
+  Fact dio_rel_remainder p x r : 𝔻P p -> 𝔻P x -> 𝔻P r -> 𝔻R (fun ν => r ν = rem (x ν) (p ν)).
+  Proof. intros; dio_rel_auto. Defined.
+ 
+  Hint Resolve dio_rel_remainder : dio_rel_db.
+
+  Fact dio_rel_congruence x y p : 𝔻P x -> 𝔻P y -> 𝔻P p  
+                                -> 𝔻R (fun ν => rem (x ν) (p ν) = rem (y ν) (p ν)).
+  Proof. intros; dio_rel_auto. Qed.
+
+  Hint Resolve dio_rel_congruence : dio_rel_deb.
+
+  (** The way it is done in the FSCD paper *)
+
+  Let ndivides_eq x y : ~ (divides x y) <-> x = 0 /\ y <> 0 \/ exists a b, y = a*x+b /\ 0 < b < x.
   Proof.
     split.
     + intros H.
@@ -468,60 +393,18 @@ Section more_examples.
         apply div_rem_spec2; omega.
   Qed.
   
-  Lemma dio_rel_ndivides x y : 𝔻P x -> 𝔻P y -> 𝔻R (fun ν => ~ divides (x ν) (y ν)).
+  Fact dio_rel_ndivides x y : 𝔻P x -> 𝔻P y -> 𝔻R (fun ν => ~ divides (x ν) (y ν)).
   Proof.
     intros.
     apply dio_rel_equiv with (1 := fun v => ndivides_eq (x v) (y v)).
     dio_rel_auto.
-  Qed.
-
-  Hint Resolve dio_rel_ndivides.
-
-  Fact rem_equiv p x r : r = rem x p <-> (p = 0 /\ x = r)
-                                      \/ (p <> 0 /\ r < p /\ exists n, x = n*p + r).
-  Proof.
-    split.
-    + intro; subst.
-      destruct (eq_nat_dec p 0) as [ Hp | Hp ].
-      * left; split; auto; subst; rewrite rem_0; auto.
-      * right; split; auto; split.
-        - apply div_rem_spec2; auto.
-        - exists (div x p);apply div_rem_spec1.
-    + intros [ (H1 & H2) | (H1 & H2 & n & H3) ].
-      * subst; rewrite rem_0; auto.
-      * symmetry; apply rem_prop with n; auto.
-  Qed.
- 
-  Lemma dio_rel_remainder p x r : 𝔻P p -> 𝔻P x -> 𝔻P r  
-                               -> 𝔻R (fun ν => r ν = rem (x ν) (p ν)).
-  Proof.
-    intros.
-    apply dio_rel_equiv with (1 := fun v => rem_equiv (p v) (x v) (r v)).
-    dio_rel_auto.
   Defined.
 
-  (* Eval compute in proj1_sig (dio_rel_remainder (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2)). *)
+  Hint Resolve dio_rel_ndivides : dio_rel_db.
 
-  Hint Resolve dio_rel_remainder.
+  (** A shorter way *)
 
-  Fact congr_equiv x y p : rem x p = rem y p <-> (exists r, r = rem x p /\ r = rem y p).
-  Proof.
-    split.
-    + intros H; exists (rem x p); auto.
-    + intros (? & ? & ?); subst; auto.
-  Qed.
-
-  Lemma dio_rel_congruence x y p : 𝔻P x -> 𝔻P y -> 𝔻P p  
-                                -> 𝔻R (fun ν => rem (x ν) (p ν) = rem (y ν) (p ν)).
-  Proof.
-    intros.
-    apply dio_rel_equiv with (1 := fun v => congr_equiv (x v) (y v) (p v)).
-    dio_rel_auto.
-  Defined.
-
-  Hint Resolve dio_rel_congruence.
-
-  Fact not_divides_eq p x : ~ divides p x <-> exists r, r = rem x p /\ r <> 0.
+  Let not_divides_eq p x : ~ divides p x <-> exists r, r = rem x p /\ r <> 0.
   Proof.
     rewrite divides_rem_eq.
     split.
@@ -538,14 +421,7 @@ Section more_examples.
 
 End more_examples.
 
-Hint Resolve dio_rel_congruence dio_rel_not_divides.
-
-(* Even computation in Coq works well
-
-Eval compute in proj1_sig (dio_rel_congruence (dio_expr_var 0) (dio_expr_var 1) (dio_expr_var 2)).
-Eval compute in proj1_sig (dio_rel_not_divides (dio_expr_var 0) (dio_expr_var 1)).
-
-*)
+Hint Resolve dio_expr_rem dio_rel_not_divides : dio_rel_deb.
 
 Section dio_rel_compose.
 
@@ -590,26 +466,28 @@ Section multiple_exists.
        <-> exists π, df_pred f (fun i => if le_lt_dec n i then ν (i-n) else π i).
   Proof.
     revert f ν; induction n as [ | n IHn ]; intros f v.
-    + simpl; split; [ intros H; exists (fun _ => 0) | intros (_ & H) ]; revert H; 
+    + simpl; split; [ intros H; exists (fun _ => 0) | intros (? & H) ]; revert H; 
         apply df_pred_ext; intros; f_equal; omega.
     + simpl df_mexists; rewrite IHn; split; intros (pi & Hpi).
       * revert Hpi; rewrite df_pred_exst.
         intros (u & Hu).
         exists (fun i => match i with 0 => u | S i => pi i end).
         revert Hu; apply df_pred_ext.
-        intros [ | i ].
-        - replace (0-S n) with 0 by omega; simpl; auto.
-        - replace (S i - S n) with (i-n) by omega.
-          simpl dv_lift. 
-          destruct (le_lt_dec (S n) (S i)); destruct (le_lt_dec n i); auto; omega.
+        Opaque le_lt_dec.
+        simpl; intros [ | i ].
+        - replace (0-S n) with 0 by omega; auto.
+        - replace (S i - S n) with (i-n) by omega. 
+          simpl; destruct (le_lt_dec (S n) (S i)); 
+            destruct (le_lt_dec n i); auto; omega.
       * exists (fun i => pi (S i)).
         rewrite df_pred_exst; exists (pi 0).
         revert Hpi; apply df_pred_ext.
         intros [ | i ].
         - replace (0-S n) with 0 by omega; simpl; auto.
         - replace (S i - S n) with (i-n) by omega.
-          simpl dv_lift. 
-          destruct (le_lt_dec (S n) (S i)); destruct (le_lt_dec n i); auto; omega.
+          Opaque le_lt_dec.
+          simpl; destruct (le_lt_dec (S n) (S i)); 
+            destruct (le_lt_dec n i); auto; omega.
   Qed.
 
 End multiple_exists.

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -15,7 +15,7 @@
 Require Import Arith Nat Omega.
 
 From Undecidability.Shared.Libs.DLW.Utils 
-  Require Import gcd.
+  Require Import utils_tac gcd.
 
 Set Implicit Arguments.
 
@@ -442,11 +442,11 @@ Defined.
 
 Hint Resolve dio_fun_plus dio_fun_mult : dio_fun_db.
 
-Local Fact example_1 : 𝔻R (fun ν => ν 0 = ν 0).
+Local Fact example_eq : 𝔻R (fun ν => ν 0 = ν 0).
 Proof. dio auto. Defined.
 
-Check example_1.
-Eval compute in (proj1_sig example_1).
+Check example_eq.
+Eval compute in (proj1_sig example_eq).
 
 (** Now you can start witnessing the magic of 
     Diophantine shapes recognition *)
@@ -559,19 +559,22 @@ Eval compute in (proj1_sig example_div).
 
 Section dio_fun_rem.
 
-  (** The remainder function is Diophantine *)
+  (** The remainder function is Diophantine 
+      Beware avoiding the duplication of x & p *)
 
-  Let rem_equiv p x r : r = rem x p <-> (p = 0 /\ x = r)
-                                      \/ (p <> 0 /\ r < p /\ exists n, x = n*p + r).
+  Let rem_equiv p x r : r = rem x p 
+                    <-> exists x' p', x' = x /\ p' = p /\
+                                 (   (p' = 0  /\ x' = r)
+                                  \/ (p' <> 0 /\ r < p' /\ exists n, x' = n*p' + r) ).
   Proof.
     split.
-    + intro; subst.
+    + intro; exists x, p; subst; msplit 2; auto.
       destruct (eq_nat_dec p 0) as [ Hp | Hp ].
       * left; split; auto; subst; rewrite rem_0; auto.
       * right; split; auto; split.
         - apply div_rem_spec2; auto.
         - exists (div x p);apply div_rem_spec1.
-    + intros [ (H1 & H2) | (H1 & H2 & n & H3) ].
+    + intros (? &  ? & -> & -> & [ (H1 & H2) | (H1 & H2 & n & H3) ]).
       * subst; rewrite rem_0; auto.
       * symmetry; apply rem_prop with n; auto.
   Qed.

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -142,7 +142,7 @@ Section diophantine_logic.
   Fact df_ren_size_Z ρ f : df_size_Z (df_ren ρ f) = df_size_Z f.
   Proof. do 2 rewrite df_size_Z_spec; f_equal; apply df_ren_size. Qed.
 
-  Fact df_pred_ren f ν ρ : df_pred (df_ren ρ f) ν <-> df_pred f (fun x => ν (ρ x)).
+  Fact df_pred_ren f ν ρ : ⟦df_ren ρ f⟧ ν <-> ⟦f⟧ (fun x => ν (ρ x)).
   Proof.
     revert ν ρ; induction f as [ | [] | [] f Hf g Hg | f Hf ]; intros ν ρ; simpl; try tauto.
     1-2: rewrite Hf, Hg; tauto.
@@ -152,14 +152,14 @@ Section diophantine_logic.
 
   Definition df_lift := df_ren S.
 
-  Fact df_pred_lift f ν : df_pred (df_lift f) ν <-> df_pred f ν↓.
+  Fact df_pred_lift f ν : ⟦df_lift f⟧ ν <-> ⟦f⟧ ν↓.
   Proof. apply df_pred_ren. Qed. 
 
 End diophantine_logic.
 
 Local Notation "⟦ f ⟧" := (df_pred f).
 
-Definition dio_rel R := { f | forall ν, df_pred f ν <-> R ν }.
+Definition dio_rel R := { f | forall ν, ⟦f⟧ ν <-> R ν }.
 Notation 𝔻R := dio_rel.
 
 Definition dio_expr t := 𝔻R (fun ν => ν 0 = t ν↓).

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -32,25 +32,12 @@ Section df_seq.
   Proof.
     intros H1 H2 H3.
     unfold is_seq.
-    apply dio_rel_fall_lt; dio_rel_auto; auto.
+    apply dio_rel_fall_lt; dio_rel_auto.
   Defined.
 
 End df_seq.
 
-Hint Resolve dio_rel_is_seq.
-
-(*
-Fact dio_rel_compose (R T : nat -> nat -> (nat -> nat) -> Prop) :
-     dio_rel (fun ν => R (ν 0) (ν 1) (fun n => ν (S (S n))))
-  -> dio_rel (fun ν => T (ν 0) (ν 1) (fun n => ν (S (S n))))
-  -> dio_rel (fun ν => exists x, R (ν 0) x (fun n => ν (S (S n))) /\ T x (ν 1) (fun n => ν (S (S n)))).
-Proof.
-  intros H1 H2.
-  apply dio_rel_exst, dio_rel_conj.
-  + revert H1; apply dio_rel_ren with (f := fun n => match n with 0 => 1 | 1 => 0 | S (S n) => S (S (S n)) end).
-  + revert H2; apply dio_rel_ren with (f := fun n => match n with 0 => 0 | 1 => 2 | S (S n) => S (S (S n)) end).
-Defined.
-*)
+Hint Resolve dio_rel_is_seq : dio_rel_db.
 
 Fact dio_rel_power_subst a b (R : nat -> (nat -> nat) -> Prop) : 
                   𝔻P a -> 𝔻P b
@@ -58,10 +45,8 @@ Fact dio_rel_power_subst a b (R : nat -> (nat -> nat) -> Prop) :
       -> 𝔻R (fun ν => R (power (a ν) (b ν)) ν).
 Proof.
   intros Ha Hb HR.
-  apply dio_rel_equiv with (fun v => exists p, p = power (a v) (b v) /\ R p v).
-  + intros v; split; eauto.
-    intros (? & ? & ?); subst; auto. 
-  + dio_rel_auto.
+  by dio equiv (fun v => exists p, p = power (a v) (b v) /\ R p v).
+  abstract(intros v; split; eauto; intros (? & ? & ?); subst; auto). 
 Defined.
 
 Section df_rel_iter.
@@ -91,4 +76,4 @@ Section df_rel_iter.
 
 End df_rel_iter.
 
-Hint Resolve dio_rel_rel_iter.
+Hint Resolve dio_rel_rel_iter dio_rel_rt : dio_rel_db.

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -11,8 +11,11 @@
 
 Require Import Arith Nat Omega List Bool.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list rel_iter sums.
-From Undecidability.H10.Dio Require Import dio_logic dio_expo dio_bounded.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_list rel_iter sums.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic dio_expo dio_bounded.
 
 Set Implicit Arguments.
 
@@ -27,7 +30,7 @@ Section df_seq.
 
   Variable (R : nat -> nat -> Prop) (HR : 𝔻R (fun ν => R (ν 1) (ν 0))). 
 
-  Theorem dio_rel_is_seq c q n : 𝔻P c -> 𝔻P q -> 𝔻P n
+  Theorem dio_rel_is_seq c q n : 𝔻F c -> 𝔻F q -> 𝔻F n
                               -> 𝔻R (fun ν => is_seq R (c ν) (q ν) (n ν)).
   Proof.
     intros H1 H2 H3.
@@ -40,7 +43,7 @@ End df_seq.
 Hint Resolve dio_rel_is_seq : dio_rel_db.
 
 Fact dio_rel_power_subst a b (R : nat -> (nat -> nat) -> Prop) : 
-                  𝔻P a -> 𝔻P b
+                𝔻F a -> 𝔻F b
       -> 𝔻R (fun ν => R (ν 0) (fun n => ν (S n)))
       -> 𝔻R (fun ν => R (power (a ν) (b ν)) ν).
 Proof.
@@ -49,7 +52,7 @@ Proof.
   abstract(intros v; split; eauto; intros (? & ? & ?); subst; auto). 
 Defined.
 
-Section df_rel_iter.
+Section df_rel_iter_rt.
 
   (** we show that for a diophantine binary relation R,
       the iterator fun n x y => rel_iter R n x y is also diophantine
@@ -57,10 +60,10 @@ Section df_rel_iter.
 
         rel_iter R n x y <-> exists q c, is_seq R c q n /\ is_digit c q 0 x /\ is_digit c q n y. *)
 
-  Variable (R : nat -> nat -> Prop) (HR : dio_rel (fun ν => R (ν 1) (ν 0))).
+  Variable (R : nat -> nat -> Prop) (HR : 𝔻R (fun ν => R (ν 1) (ν 0))).
 
   Lemma dio_rel_rel_iter n x y : 
-                  𝔻P n -> 𝔻P x -> 𝔻P y
+                 𝔻F n -> 𝔻F x -> 𝔻F y
       -> 𝔻R (fun ν => rel_iter R (n ν) (x ν) (y ν)).
   Proof.
     intros Hn Hx Hy.
@@ -70,10 +73,10 @@ Section df_rel_iter.
 
   Hint Resolve dio_rel_rel_iter.
 
-  Corollary dio_rel_rt x y : 𝔻P x -> 𝔻P y -> 
+  Corollary dio_rel_rt x y : 𝔻F x -> 𝔻F y -> 
                                     𝔻R (fun ν => exists i, rel_iter R i (x ν) (y ν)).
   Proof. intros; dio auto. Qed.
 
-End df_rel_iter.
+End df_rel_iter_rt.
 
 Hint Resolve dio_rel_rel_iter dio_rel_rt : dio_rel_db.

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -49,7 +49,7 @@ Fact dio_rel_power_subst a b (R : nat -> (nat -> nat) -> Prop) :
 Proof.
   intros Ha Hb HR.
   by dio equiv (fun v => exists p, p = power (a v) (b v) /\ R p v).
-  abstract(intros v; split; eauto; intros (? & ? & ?); subst; auto). 
+  abstract(intros v; split; eauto; intros (? & ? & ?); subst; auto).
 Defined.
 
 Section df_rel_iter_rt.
@@ -66,9 +66,7 @@ Section df_rel_iter_rt.
                  𝔻F n -> 𝔻F x -> 𝔻F y
       -> 𝔻R (fun ν => rel_iter R (n ν) (x ν) (y ν)).
   Proof.
-    intros Hn Hx Hy.
-    apply dio_rel_equiv with (1 := fun v => rel_iter_seq_equiv R (n v) (x v) (y v)).
-    dio auto.
+    dio by lemma (fun v => rel_iter_seq_equiv R (n v) (x v) (y v)).
   Defined.
 
   Hint Resolve dio_rel_rel_iter.

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -32,7 +32,7 @@ Section df_seq.
   Proof.
     intros H1 H2 H3.
     unfold is_seq.
-    apply dio_rel_fall_lt; dio_rel_auto.
+    apply dio_rel_fall_lt; dio auto.
   Defined.
 
 End df_seq.
@@ -65,14 +65,14 @@ Section df_rel_iter.
   Proof.
     intros Hn Hx Hy.
     apply dio_rel_equiv with (1 := fun v => rel_iter_seq_equiv R (n v) (x v) (y v)).
-    dio_rel_auto.
+    dio auto.
   Defined.
 
   Hint Resolve dio_rel_rel_iter.
 
   Corollary dio_rel_rt x y : 𝔻P x -> 𝔻P y -> 
                                     𝔻R (fun ν => exists i, rel_iter R i (x ν) (y ν)).
-  Proof. intros; dio_rel_auto. Qed.
+  Proof. intros; dio auto. Qed.
 
 End df_rel_iter.
 

--- a/theories/H10/FRACTRAN_DIO.v
+++ b/theories/H10/FRACTRAN_DIO.v
@@ -21,96 +21,71 @@ From Undecidability.H10 Require Import MM_FRACTRAN.
 
 Set Implicit Arguments.
 
+Fact reduction_dependent X Y (P : X -> Prop) (Q : Y -> Prop) :
+        P ⪯ Q <-> inhabited (forall x, { y | P x <-> Q y }).
+Proof.
+  split.
+  + intros (f & Hf); exists.
+    intros x; exists (f x); auto.
+  + intros [f].
+    exists (fun x => proj1_sig (f x)).
+    intros; apply (proj2_sig (f x)).
+Qed.
+
 (** A diophantine logic satisfiability question is given
     a diophantine logic formula f and a valuation for the
     parameters. Is the formula valid ? *)
 
-Definition DIO_LOGIC_PROBLEM := (dio_formula * (nat -> nat))%type.
+Definition DIO_LOGIC_PROBLEM := 
+  (dio_formula * (nat -> nat))%type.
 
-Definition DIO_LOGIC_SAT : DIO_LOGIC_PROBLEM -> Prop. 
+Definition DIO_LOGIC_SAT (p : DIO_LOGIC_PROBLEM) :=
+  let (f,ν) := p in df_pred f ν. 
+
+Theorem FRACTRAN_HALTING_DIO_LOGIC_SAT : FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT.
 Proof.
-  intros (A,v).
-  exact (df_pred A v).
-Defined.
-
-Section FRACTRAN_HALTING_DIO_LOGIC_SAT.
-
-  Let f : FRACTRAN_PROBLEM -> DIO_LOGIC_PROBLEM.
-  Proof.
-    intros (l & x).
-    destruct FRACTRAN_HALTING_on_diophantine with (ll := l) (x := fun _ : nat -> nat => x)
-      as (A & HA).
-    + auto.
-    + exact (A, fun _ => 0).
-  Defined.
-
-  Opaque FRACTRAN_HALTING_on_diophantine.
-
-  Theorem FRACTRAN_HALTING_DIO_LOGIC_SAT : FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT.
-  Proof.
-    exists f.
-    intros (l & x); simpl.
-    destruct FRACTRAN_HALTING_on_diophantine with (ll := l) as (A & HA); simpl.
-    unfold DIO_LOGIC_SAT; rewrite HA; tauto.
-  Qed.
-
-End FRACTRAN_HALTING_DIO_LOGIC_SAT.
+  apply reduction_dependent; exists.
+  intros (l & x).
+  destruct FRACTRAN_HALTING_on_diophantine 
+    with (ll := l) (x := fun _ : nat -> nat => x) as (f & Hf); simpl.
+  + dio_rel_auto.
+  + exists (f, fun _ => x); unfold DIO_LOGIC_SAT; rewrite Hf; tauto.
+Qed.
 
 (** An elementary diophantine problem is a list of elementary diophantine
     constraints and a valuation for the parameters. The question is whether
     there exists a valuation for the variables that satisfies all the constraints
     simultaneously *)
 
-Definition DIO_ELEM_PROBLEM := (list dio_constraint * (nat -> nat))%type.
+Definition DIO_ELEM_PROBLEM := 
+  (list dio_constraint * (nat -> nat))%type.
 
-Definition DIO_ELEM_SAT : DIO_ELEM_PROBLEM -> Prop. 
+Definition DIO_ELEM_SAT (p : DIO_ELEM_PROBLEM) :=
+  let (l,v) := p in exists φ, Forall (dc_eval φ v) l.
+
+Theorem DIO_LOGIC_ELEM_SAT : DIO_LOGIC_SAT ⪯  DIO_ELEM_SAT.
 Proof.
+  apply reduction_dependent; exists.
+  intros (A,v).
+  destruct (dio_formula_elem A) as (l & _ & _ & Hl).
+  exists (l,v); apply Hl.
+Qed.
+
+Definition DIO_SINGLE_PROBLEM := 
+  (dio_single nat nat * (nat -> nat))%type.
+
+Definition DIO_SINGLE_SAT (p : DIO_SINGLE_PROBLEM) :=
+  let (E,φ) := p in dio_single_pred E φ.
+
+Theorem DIO_ELEM_SINGLE_SAT : DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT.
+Proof.
+  apply reduction_dependent; exists.
   intros (l,v).
-  exact (exists φ, Forall (dc_eval φ v) l).
-Defined.
+  destruct (dio_elem_equation l) as (E & _ & HE).
+  exists (E,v).
+  unfold DIO_ELEM_SAT, DIO_SINGLE_SAT.
+  rewrite <- HE; tauto.
+Qed.
 
-Section DIO_LOGIC_ELEM_SAT.
-
-  Let f : DIO_LOGIC_PROBLEM -> DIO_ELEM_PROBLEM.
-  Proof.
-    intros (A,v).
-    destruct (dio_formula_elem A) as (l & _ & _ & H3).
-    exact (l,v).
-  Defined.
-
-  Theorem DIO_LOGIC_ELEM_SAT : DIO_LOGIC_SAT ⪯  DIO_ELEM_SAT.
-  Proof.
-    exists f; intros (A,v); unfold DIO_LOGIC_SAT, DIO_ELEM_SAT, f.
-    destruct (dio_formula_elem A) as (l & _ & _ & H3); simpl; auto.
-  Qed.
-
-End DIO_LOGIC_ELEM_SAT.
-
-Definition DIO_SINGLE_PROBLEM := (dio_single nat nat * (nat -> nat))%type.
-
-Definition DIO_SINGLE_SAT : DIO_SINGLE_PROBLEM -> Prop.
-Proof.
-  intros (e,v).
-  apply (dio_single_pred e v).
-Defined.
-
-Section DIO_ELEM_SINGLE_SAT.
-
-  Let f : DIO_ELEM_PROBLEM -> DIO_SINGLE_PROBLEM.
-  Proof.
-    intros (l,v).
-    destruct (dio_elem_equation l) as (e & _ & H1).
-    exact (e,v).
-  Defined.
-
-  Theorem DIO_ELEM_SINGLE_SAT : DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT.
-  Proof.
-    exists f; intros (l,v).
-    unfold DIO_ELEM_SAT, DIO_SINGLE_SAT, f.
-    destruct (dio_elem_equation l) as (e & _ & H1).
-    rewrite H1; tauto.
-  Qed.
-
-End DIO_ELEM_SINGLE_SAT.
 
 

--- a/theories/H10/Fractran/fractran_dio.v
+++ b/theories/H10/Fractran/fractran_dio.v
@@ -33,14 +33,13 @@ Section fractran_dio.
 
   (* Fractran step is a diophantine relation, by induction on l *)
 
-  Lemma dio_rel_fractran_step l x y : 𝔻P x -> 𝔻P y -> 𝔻R (fun ν => l /F/ x ν → y ν).
+  Lemma dio_rel_fractran_step l x y : 𝔻F x -> 𝔻F y -> 𝔻R (fun ν => l /F/ x ν → y ν).
   Proof.
     intros Hx Hy.
     induction l as [ | (p,q) l IHl ].
     + by dio equiv (fun _ => False).
       abstract (intros v; rewrite fractran_step_nil_inv; split; tauto).
-    + apply dio_rel_equiv with (1 := fun v => fractran_step_cons_inv p q l (x v) (y v)).
-      dio auto.
+    + dio by lemma (fun v => fractran_step_cons_inv p q l (x v) (y v)).
   Defined.
 
   Hint Resolve dio_rel_fractran_step : dio_rel_db.
@@ -48,19 +47,18 @@ Section fractran_dio.
   (* Hence Fractan step* (refl. trans. closure) is diophantine *)
 
   Corollary dio_rel_fractran_rt l x y : 
-                     𝔻P x -> 𝔻P y -> 𝔻R (fun ν => fractran_compute l (x ν) (y ν)).
+                     𝔻F x -> 𝔻F y -> 𝔻R (fun ν => fractran_compute l (x ν) (y ν)).
   Proof. intros; apply dio_rel_rt; dio auto. Defined.
 
   (* Fractran stop is a diophantine relation *)
 
-  Lemma dio_rel_fractran_stop l x : 𝔻P x -> 𝔻R (fun ν => fractran_stop l (x ν)).
+  Lemma dio_rel_fractran_stop l x : 𝔻F x -> 𝔻R (fun ν => fractran_stop l (x ν)).
   Proof.
     intros Hx.
     induction l as [ | (p,q) l IHl ].
     + by dio equiv (fun _ => True).
       abstract(intro v; split; auto; intros _ ?; rewrite fractran_step_nil_inv; auto).
-    + apply dio_rel_equiv with (1 := fun v => fractan_stop_cons_inv p q l (x v)).
-      dio auto.
+    + dio by lemma (fun v => fractan_stop_cons_inv p q l (x v)).
   Defined.
 
   Hint Resolve dio_rel_fractran_rt dio_rel_fractran_stop : dio_rel_db.
@@ -71,7 +69,7 @@ Section fractran_dio.
   (* Hence Halting from the value x is diophantine *)
 
   Theorem FRACTRAN_HALTING_on_diophantine ll x :
-                      𝔻P x -> 𝔻R (fun ν => FRACTRAN_HALTING (ll,x ν)).
+                      𝔻F x -> 𝔻R (fun ν => FRACTRAN_HALTING (ll,x ν)).
   Proof. intros; dio auto. Defined.
 
 End fractran_dio.
@@ -95,7 +93,7 @@ Section exp_diophantine.
 
   (* for fixed n i j, the function v => exp i <v(j),...,v(n-1+j)> has a diophantine representation *)
 
-  Let exp_dio n i j : 𝔻P (fun v => exp i (fun2vec j n v)).
+  Let exp_dio n i j : 𝔻F (fun v => exp i (fun2vec j n v)).
   Proof.
     revert j i; induction n as [ | n IHn ]; intros j i.
     + simpl; dio auto.
@@ -109,12 +107,12 @@ Section exp_diophantine.
 
      has a diophantine representation *)
 
-  Fact fractran_exp_diophantine n : 𝔻P (fun ν => ps 1 * exp 1 (fun2vec 0 n ν)).
+  Fact fractran_exp_diophantine n : 𝔻F (fun ν => ps 1 * exp 1 (fun2vec 0 n ν)).
   Proof. dio auto. Defined.
 
 End exp_diophantine.
 
-Hint Resolve fractran_exp_diophantine : dio_expr_db.
+Hint Resolve fractran_exp_diophantine : dio_fun_db.
 
 Theorem FRACTRAN_HALTING_on_exp_diophantine n l :  
                      𝔻R (fun ν => l /F/ ps 1 * exp 1 (fun2vec 0 n ν) ↓).

--- a/theories/H10/H10.v
+++ b/theories/H10/H10.v
@@ -9,13 +9,26 @@
 
 (** ** Hilbert's tenth problem is undecidable *)
 
-From Undecidability.ILL Require Import Definitions UNDEC.
-From Undecidability.PCP Require Import singleTM.
-From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac.
-From Undecidability.ILL.Mm   Require Import mm_defs.
-From Undecidability.H10 Require Import FRACTRAN_DIO HALT_MM MM_FRACTRAN Fractran.fractran_defs.
-From Undecidability.H10.Dio Require Import dio_logic dio_elem dio_single.
+From Undecidability.ILL 
+  Require Import Definitions UNDEC.
+
+From Undecidability.PCP 
+  Require Import singleTM.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
+
+From Undecidability.ILL.Mm
+  Require Import mm_defs.
+
+From Undecidability.H10 
+  Require Import FRACTRAN_DIO HALT_MM MM_FRACTRAN Fractran.fractran_defs.
+
+From Undecidability.H10.Dio 
+  Require Import dio_logic dio_elem dio_single.
 
 Set Implicit Arguments.
 
@@ -31,32 +44,22 @@ Proof.
   apply (dio_single_pred (p,q)), (fun _ => 0).
 Defined.
 
-Section DIO_SINGLE_SAT_H10.
-
-  Let f : DIO_SINGLE_PROBLEM -> H10_PROBLEM.
-  Proof.
-    intros (E,v).
-    destruct (dio_poly_eq_pos E) as (n & p & q & H2).
-    exists n.
-    exact (dp_inst_par v p, dp_inst_par v q).
-  Defined.
-
-  Theorem DIO_SINGLE_SAT_H10 : DIO_SINGLE_SAT ⪯ H10.
-  Proof.
-    exists f; intros (E,v).
-    unfold DIO_SINGLE_SAT, H10, f.
-    destruct (dio_poly_eq_pos E) as (n & p & q & H2).
-    rewrite H2; unfold dio_single_pred.
-    simpl.
-    split; intros (phi & H); exists phi; revert H; 
-      repeat rewrite dp_inst_par_eval; auto.
-  Qed.
-
-End DIO_SINGLE_SAT_H10.
+Theorem DIO_SINGLE_SAT_H10 : DIO_SINGLE_SAT ⪯ H10.
+Proof.
+  apply reduction_dependent; exists.
+  intros (E,v).
+  destruct (dio_poly_eq_pos E) as (n & p & q & H).
+  exists (existT _ n (dp_inst_par v p, dp_inst_par v q)).
+  unfold DIO_SINGLE_SAT, H10.
+  rewrite H.
+  unfold dio_single_pred.
+  split; intros (phi & H1); exists phi; revert H1;
+    rewrite !dp_inst_par_eval; auto.
+Qed.
 
 Theorem Fractran_UNDEC : Halt ⪯ FRACTRAN_HALTING.
 Proof.
-  eapply reduces_transitive. exact MM_HALTING_undec.
+  apply reduces_transitive with (1 := MM_HALTING_undec).
   exact MM_FRACTRAN_HALTING.
 Qed.
 

--- a/theories/H10/Matija/alpha.v
+++ b/theories/H10/Matija/alpha.v
@@ -1352,11 +1352,14 @@ Section diophantine_necessity.
 End diophantine_necessity.
 
 Theorem alpha_diophantine a b c : 3 < b /\ a = alpha_nat b c 
-                              <-> exists u t r s v w x y, alpha_conditions a b c u t r s v w x y.
+                              <-> exists a' b' c', a' = a /\ b' = b /\ c' = c
+                               /\ exists u t r s v w x y, 
+                                    alpha_conditions a' b' c' u t r s v w x y.
 Proof.
   split.
-  + apply alpha_necessity.
-  + intros (u & t & r & s & v & w & x & y & H); revert H.
+  + exists a, b, c; msplit 3; auto; apply alpha_necessity; auto.
+  + intros (? & ? & ? & -> & -> & -> & H); revert H.
+    intros (u & t & r & s & v & w & x & y & H); revert H.
     apply alpha_sufficiency.
 Qed.
 

--- a/theories/Shared/Libs/DLW/Utils/gcd.v
+++ b/theories/Shared/Libs/DLW/Utils/gcd.v
@@ -706,6 +706,13 @@ Section division.
   Fact rem_idem q p : q < p -> rem q p = q.
   Proof. apply rem_prop with 0; auto. Qed.
 
+  Fact rem_rem x m : rem (rem x m) m = rem x m.
+  Proof.
+    destruct (eq_nat_dec m 0).
+    + subst; rewrite !rem_0; auto.
+    + apply rem_idem, div_rem_spec2; auto.
+  Qed.
+
   Fact is_gcd_rem p n a : is_gcd p n a <-> is_gcd p (rem n p) a.
   Proof.
     rewrite (div_rem_spec1 n p) at 1; apply is_gcd_mult.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -122,6 +122,8 @@ H10/Fractran/mm_fractran.v
 H10/ArithLibs/Zp.v
 H10/ArithLibs/matrix.v
 H10/ArithLibs/luca.v
+H10/ArithLibs/lagrange.v
+
 H10/Matija/alpha.v
 H10/Matija/expo_diophantine.v
 H10/Matija/cipher.v


### PR DESCRIPTION
Hi Yannick,

This is in preparation for the journal paper.

* I did reimplement `dio_form` so that atoms are just `x ≐ ⌞n⌟`, `x ≐ y`, `x ≐ y ⨢ z` and `x ≐ y ⨰ z` which allows for a much smoother reduction to `dio_elem`, both in the code which is now much nicer, and most importantly in the explanation part that is going to be included in the journal paper. 

* Also, I did strengthen the notion of Diophantine polynomial to that of _Diophantine function_ encoded as `dio_fun` and denoted `𝔻F`. Now we can work with arbitrary functions in Diophantine shapes, provided there is a Diophantine encoding of their graph. This allows for less cumbersome definitions.

* Finally a **major** cleanup of automation that is now very satisfactory ... basically, the new `dio auto` tactic fails nearly _nowhere_. 

* I added a proof of the full statement of _Luca's theorem_ and a proof of _Lagrange's theorem_ (stating positive integers are sums of four squares).

* And yes, I tested _forking_.