### PR TITLE
Informative lift of the definition of reduces, i.e. ⪯

### DIFF
--- a/theories/FOL/Reductions.v
+++ b/theories/FOL/Reductions.v
@@ -5,13 +5,15 @@ From Undecidability Require Export Problems.Reduction DecidableEnumerable.
 Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> decidable q -> decidable p.
 Proof.
-  intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0.
+  intros [f Hf] [d Hd]. 
+  exists (fun x => d (f x)). 
+  intros x; rewrite <- Hd; apply Hf.
 Qed.
 
 Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y).
 Proof.
-  intros [f]. exists f. intros x. now rewrite H.
+  intros [f Hf]. exists f. intros x. now rewrite Hf.
 Qed.
 
 Section enum_red.
@@ -61,10 +63,10 @@ Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
   p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) ->
   ~ decidable q /\ ~ decidable (compl q).
 Proof.
-  intros. split; intros ?.
-  - eapply H1. eapply dec_red in H2; eauto.
-    eapply dec_compl in H2. eapply dec_count_enum; eauto.
-  - eapply H1. eapply dec_red in H2; eauto.
+  intros H1 H2 H3; split; intros H4.
+  - eapply H3. eapply dec_red in H4; eauto.
+    eapply dec_compl in H4. eapply dec_count_enum; eauto.
+  - eapply H3. eapply dec_red in H4; eauto.
     eapply dec_count_enum; eauto. now eapply red_comp.
 Qed.
 
@@ -72,7 +74,9 @@ Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) :
   p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) -> discrete Y ->
   ~ enumerable (compl q).
 Proof.
-  intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto.
+  intros H1 H2 H3 H4 H5. 
+  eapply H3. 
+  eapply enumerable_red in H5; eauto.
   now eapply red_comp.
 Qed.
 

--- a/theories/H10/H10.v
+++ b/theories/H10/H10.v
@@ -60,15 +60,15 @@ Proof.
   exact MM_FRACTRAN_HALTING.
 Qed.
 
-Theorem Hilberts_Tenth : Halt ⪯ PCP
-                      /\ PCP ⪯ MM_HALTING
-                      /\ MM_HALTING ⪯ FRACTRAN_HALTING
-                      /\ FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT
-                      /\ DIO_LOGIC_SAT ⪯ DIO_ELEM_SAT
-                      /\ DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT
-                      /\ DIO_SINGLE_SAT ⪯ H10.
+Theorem Hilberts_Tenth : ((Halt ⪯ PCP)
+                      * (PCP ⪯ MM_HALTING)
+                      * (MM_HALTING ⪯ FRACTRAN_HALTING)
+                      * (FRACTRAN_HALTING ⪯ DIO_LOGIC_SAT)
+                      * (DIO_LOGIC_SAT ⪯ DIO_ELEM_SAT)
+                      * (DIO_ELEM_SAT ⪯ DIO_SINGLE_SAT)
+                      * (DIO_SINGLE_SAT ⪯ H10))%type.
 Proof.
-  msplit 6.
+  repeat split.
   + apply Halt_PCP.
   + apply PCP_MM_HALTING.
   + apply MM_FRACTRAN_HALTING.

--- a/theories/ILL/BPCP_iBPCP.v
+++ b/theories/ILL/BPCP_iBPCP.v
@@ -1,4 +1,5 @@
 From Undecidability Require Import ILL.Definitions.
+Require Import Undecidability.Shared.Prelim.
 
 (** ** BPCP reduces to iBPCP *)
 

--- a/theories/ILL/Ll/eill.v
+++ b/theories/ILL/Ll/eill.v
@@ -314,9 +314,9 @@ Section g_eill_complete.
   Proof. apply nat_sort_eq. Qed.
 
   Let n := length vv.
-  Let w : vec ll_vars n := proj1_sig (list_vec vv).
+  Let w : vec ll_vars n := proj1_sig (list_vec_full vv).
   Let Hw : vec_list w = vv.
-  Proof. apply (proj2_sig (list_vec vv)). Qed.
+  Proof. apply (proj2_sig (list_vec_full vv)). Qed.
 
   Let w_surj : forall u, In u vars -> exists p, u = vec_pos w p.
   Proof.

--- a/theories/ILL/PCP_BPCP.v
+++ b/theories/ILL/PCP_BPCP.v
@@ -1,4 +1,5 @@
-From Undecidability Require Import ILL.Definitions.
+Require Import Undecidability.Shared.Prelim.
+From Undecidability.Problems Require Import Reduction PCP.
 
 (** ** PCP reduces to BPCP *)
 

--- a/theories/ILL/iBPCP_BSM.v
+++ b/theories/ILL/iBPCP_BSM.v
@@ -9,6 +9,7 @@
 
 Require Import List Arith Omega.
 
+Require Import Undecidability.Shared.Prelim.
 From Undecidability Require Import ILL.Definitions.
 
 From Undecidability.Shared.Libs.DLW Require Import Utils.utils Vec.pos Vec.vec. 

--- a/theories/L/Reductions/H10_to_L.v
+++ b/theories/L/Reductions/H10_to_L.v
@@ -161,13 +161,13 @@ Proof.
   extract.
 Qed.
   
-Lemma H10_enumerable : L_enumerable (fun '(p1, p2) => exists L, eval p1 L = eval p2 L).
+Lemma H10_enumerable_t : L_enumerable_t (fun '(p1, p2) => exists L, eval p1 L = eval p2 L).
 Proof.
-  eapply L_enumerable_ext.
-  eapply projection with (Y := list nat).
+  eapply L_enumerable_t_ext.
+  eapply projection_t with (Y := list nat).
   instantiate (1 := fun '( (p1,p2), L) => eval p1 L = eval p2 L).
   2:{ intros []. firstorder. }
-  eapply L_enumerable_enum.
+  eapply L_enumerable_t_enum.
   exists (fix L n := match n with 0 => [] | S n => L n ++ filter test_eq (list_prod (list_prod (L_T poly n) (L_T poly n)) (L_T (list nat) n)) end)%list.
   repeat split.
   - cbn. change (T_list enumT_nat) with (T_list_nat). extract.
@@ -215,11 +215,11 @@ Qed.
 Theorem H10_converges :
   H10 ⪯ converges.
 Proof.
-  eapply reduces_transitive. eapply red.
-  eapply L_enumerable_halt.
-  2: eapply H10_enumerable.
+  eapply reduces_transitive. apply red.
+  eapply L_enumerable_t_halt.
+  2: eapply H10_enumerable_t.
   exists (fun '( (p1, p2), (p1', p2')) => poly_eqb p1 p1' && poly_eqb p2 p2'). split.
-  - econstructor. extract.
+  - extract.
   - intros ( (p1, p2), (p1', p2')).
     destruct (poly_eqb_spec p1 p1'), (poly_eqb_spec p2 p2'); cbn; firstorder congruence.
 Qed.

--- a/theories/MuRec/ra_mm_env.v
+++ b/theories/MuRec/ra_mm_env.v
@@ -10,7 +10,7 @@
 Require Import List Arith Omega.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import utils.
+  Require Import utils finite.
 
 From Undecidability.Shared.Libs.DLW.Vec
   Require Import pos vec.

--- a/theories/MuRec/recalg.v
+++ b/theories/MuRec/recalg.v
@@ -9,8 +9,11 @@
 
 Require Import Arith Eqdep_dec Omega List Bool.
 
-From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils_tac Utils.utils_nat Utils.utils_list Vec.pos Vec.vec.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_nat utils_list finite.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
 
 Set Implicit Arguments.
 

--- a/theories/Problems/Reduction.v
+++ b/theories/Problems/Reduction.v
@@ -1,14 +1,38 @@
-Require Export Undecidability.Shared.Prelim.
+Require Import Undecidability.Shared.Prelim.
 
-Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := exists f : X -> Y, forall x, p x <-> q (f x).
-Notation "p ⪯ q" := (reduces p q) (at level 50).
+(** @DLW: replace with INFORMATIVE reductions
+    We prove informative reductions in here *)
 
-Lemma reduces_reflexive X (p : X -> Prop) : p ⪯ p.
+(* Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := exists f : X -> Y, forall x, p x <-> q (f x).
+Notation "p ⪯ q" := (reduces p q) (at level 50). *)
+
+Definition reduces X Y (P : X -> Prop) (Q : Y -> Prop) :=
+        { f : X -> Y | forall x, P x <-> Q (f x) }.
+
+Infix "⪯" := reduces (at level 70).
+
+Lemma reduces_reflexive X (P : X -> Prop) : P ⪯ P.
 Proof. exists (fun x => x); tauto. Qed.
 
-Lemma reduces_transitive X Y Z (p : X -> Prop) (q : Y -> Prop) (r : Z -> Prop) :
-  p ⪯ q -> q ⪯ r -> p ⪯ r.
+Fact reduces_transitive X P Y Q Z R :
+        @reduces X Y P Q -> @reduces Y Z Q R -> P ⪯ R.
+Proof. 
+  intros (f & Hf) (g & Hg).
+  exists (fun x => g (f x)).
+  intro; rewrite Hf, Hg; tauto.
+Qed.
+
+(** Sometimes the dependent statement is more convenient *)
+
+Fact reduction_dependent X Y (P : X -> Prop) (Q : Y -> Prop) :
+         (P ⪯ Q -> forall x, { y | P x <-> Q y })
+       * ((forall x, { y | P x <-> Q y }) -> P ⪯ Q).
 Proof.
-  intros [f ?] [g ?]. exists (fun x => g (f x)). firstorder.
+  split.
+  + intros (f & Hf).
+    intros x; exists (f x); auto.
+  + intros f.
+    exists (fun x => proj1_sig (f x)).
+    intros; apply (proj2_sig (f x)).
 Qed.
 

--- a/theories/Problems/TM.v
+++ b/theories/Problems/TM.v
@@ -1,4 +1,4 @@
-From Undecidability.TM Require Export TM.
+From Undecidability.TM Require Import TM.
 
 Definition HaltsTM {sig: finType} {n: nat} (M : mTM sig n) (t : tapes sig n) :=
   exists outc k, loopM (initc M t) k = Some outc.

--- a/theories/Reductions/FRACTRAN_to_H10C.v
+++ b/theories/Reductions/FRACTRAN_to_H10C.v
@@ -7,7 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Arith Omega Max.
+Require Import List Arith Omega Max.
 
 From Undecidability Require Import ILL.Definitions.
 

--- a/theories/Reductions/TM_to_BPCP.v
+++ b/theories/Reductions/TM_to_BPCP.v
@@ -1,0 +1,28 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+(** HALT reduces to Binary PCP *)
+
+From Undecidability.ILL Require Import Definitions PCP_BPCP.
+
+From Undecidability.Problems Require Import TM.
+
+From Undecidability.PCP Require Import singleTM TM_SRH SRH_SR SR_MPCP MPCP_PCP.
+
+Set Implicit Arguments.
+
+Corollary HaltTM_BPCP : HaltTM 1 ⪯ BPCP.
+Proof.
+  eapply reduces_transitive. exact singleTM.TM_conv.
+  eapply reduces_transitive. exact TM_SRH.Halt_SRH.
+  eapply reduces_transitive. exact SRH_SR.reduction.
+  eapply reduces_transitive. exact SR_MPCP.reduction.
+  eapply reduces_transitive. exact MPCP_PCP.reduction.
+  exact PCP_BPCP.
+Qed.

--- a/theories/Reductions/mTM_to_TM.v
+++ b/theories/Reductions/mTM_to_TM.v
@@ -1,3 +1,4 @@
+Require Import Undecidability.Shared.Prelim.
 From Undecidability.TM Require Import Single.StepTM Code.CodeTM.
 From Undecidability.Problems Require Import TM Reduction.
 

--- a/theories/Shared/Libs/DLW/Utils/fin_base.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_base.v
@@ -1,0 +1,283 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia Eqdep_dec Bool.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_list utils_nat.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+Set Implicit Arguments.
+
+Section finite.
+
+  Definition finite_t X := { lX | forall x : X, In x lX }.
+  Definition finite X := exists lX, forall x : X, In x lX.
+
+  Fact finite_t_finite X : finite_t X -> finite X.
+  Proof. intros (l & ?); exists l; auto. Qed.
+
+  Definition fin_t X (P : X -> Prop) := { l | forall x, P x <-> In x l }.
+  Definition fin X (P : X -> Prop) := exists l, forall x, P x <-> In x l.
+
+  Fact fin_t_fin X P : @fin_t X P -> fin P.
+  Proof. intros (l & ?); exists l; auto. Qed.
+
+  Fact finite_t_fin_t_eq X : (finite_t X -> fin_t (fun _ : X => True))
+                           * (fin_t (fun _ : X => True) -> finite_t X).
+  Proof.
+    split; intros (l & ?); exists l; firstorder.
+  Qed.
+
+  Fact finite_fin_eq X : finite X <-> fin (fun _ : X => True).
+  Proof.
+    split; intros (l & ?); exists l; firstorder.
+  Qed.
+
+  Fact fin_t_map X Y (f : X -> Y) (P Q : _ -> Prop) : 
+             (forall y, Q y <-> exists x, f x = y /\ P x)
+          -> @fin_t X P
+          -> @fin_t Y Q.
+  Proof.
+    intros H (lP & HP).
+    exists (map f lP).
+    intros x; rewrite in_map_iff, H.
+    firstorder.
+  Qed.
+
+  Fact finite_t_map X Y (f : X -> Y) :
+           (forall y, exists x, f x = y) 
+        -> finite_t X 
+        -> finite_t Y.
+  Proof.
+    intros H (l & Hl).
+    exists (map f l).
+    intros y.
+    destruct (H y) as (x & <-).
+    apply in_map_iff; exists x; auto.
+  Qed.
+
+  Fact Forall_reif_t X l (P : X -> Prop) : Forall P l -> { m : list (sig P) | map (@proj1_sig _ _) m = l }.
+  Proof.
+    induction l as [ | x l IHl ].
+    + exists nil; auto.
+    + intros H; rewrite Forall_cons_inv in H.
+      destruct H as (H1 & H2).
+      destruct (IHl H2) as (m & Hm).
+      exists (exist _ x H1 :: m); simpl; f_equal; auto.
+  Qed.
+
+  Fact fin_t_finite_t X (P : X -> Prop) (Pirr : forall x (H1 H2 : P x), H1 = H2) :
+         fin_t P -> finite_t (sig P).
+  Proof.
+    intros (l & Hl).
+    destruct (@Forall_reif_t _ l P) as (m & Hm).
+    + rewrite Forall_forall; intro; apply Hl.
+    + exists m.
+      intros (x & Hx).
+      generalize Hx; intros H.
+      rewrite Hl, <- Hm, in_map_iff in Hx.
+      destruct Hx as (y & <- & Hy).
+      eq goal Hy; f_equal.
+      destruct y; simpl; f_equal; apply Pirr.
+  Qed.
+
+  Fact fin_t_equiv X (P Q : X -> Prop) : (forall x, P x <-> Q x) -> fin_t P -> fin_t Q.
+  Proof.
+    intros H (l & Hl); exists l.
+    intro; rewrite <- H, Hl; tauto.
+  Qed.
+
+  Fixpoint list_prod X Y (l : list X) (m : list Y) :=
+    match l with
+      | nil  => nil
+      | x::l => map (fun y => (x,y)) m ++ list_prod l m
+    end.
+
+  Fact list_prod_spec X Y l m c : In c (@list_prod X Y l m) <-> In (fst c) l /\ In (snd c) m.
+  Proof.
+    revert c; induction l as [ | x l IHl ]; intros c; simpl; try tauto.
+    rewrite in_app_iff, IHl, in_map_iff; simpl.
+    split.
+    + intros [ (y & <- & ?) | (? & ?) ]; simpl; auto.
+    + intros ([ -> | ] & ? ); destruct c; simpl; firstorder.
+  Qed.
+
+  Fact fin_t_prod X Y (P Q : _ -> Prop) : 
+         @fin_t X P -> @fin_t Y Q -> fin_t (fun c => P (fst c) /\ Q (snd c)).
+  Proof.
+    intros (l & Hl) (m & Hm).
+    exists (list_prod l m); intro; rewrite list_prod_spec, Hl, Hm; tauto.
+  Qed.
+
+  Fact finite_t_prod X Y : finite_t X -> finite_t Y -> finite_t (X*Y).
+  Proof.
+    intros (l & Hl) (m & Hm); exists (list_prod l m).
+    intros []; apply list_prod_spec; auto.
+  Qed.
+
+  Fact finite_prod X Y : finite X -> finite Y -> finite (X*Y).
+  Proof.
+    intros (l & Hl) (m & Hm); exists (list_prod l m).
+    intros []; apply list_prod_spec; auto.
+  Qed.
+
+  Fact fin_t_sum X Y (P Q : _ -> Prop) :
+         @fin_t X P -> @fin_t Y Q -> fin_t (fun z : X + Y => match z with inl x => P x | inr y => Q y end).
+  Proof.
+    intros (l & Hl) (m & Hm).
+    exists (map inl l ++ map inr m).
+    intros z; rewrite in_app_iff, in_map_iff, in_map_iff.
+    destruct z as [ x | y ]; [ rewrite Hl | rewrite Hm ].
+    + split.
+      * left; exists x; auto.
+      * intros [ (z & E & ?) | (z & C & _) ]; try discriminate; inversion E; subst; auto.
+    + split.
+      * right; exists y; auto.
+      * intros [ (z & C & _) | (z & E & ?) ]; try discriminate; inversion E; subst; auto.
+  Qed.
+
+  Fact finite_t_sum X Y : finite_t X -> finite_t Y -> finite_t (X+Y)%type.
+  Proof.
+    intros H1 H2. 
+    apply finite_t_fin_t_eq in H1.
+    apply finite_t_fin_t_eq in H2.
+    apply finite_t_fin_t_eq.
+    generalize (fin_t_sum H1 H2).
+    apply fin_t_equiv.
+    intros []; tauto.
+  Qed.
+
+  Fact finite_sum X Y : finite X -> finite Y -> finite (X+Y)%type.
+  Proof.
+    intros (l & Hl) (r & Hr).
+    exists (map inl l++map inr r).
+    intros []; apply in_app_iff; [ left | right ];
+      apply in_map; auto.
+  Qed.
+
+  Fact finite_t_unit : finite_t unit.
+  Proof. exists (tt::nil); intros []; simpl; auto. Qed.
+
+  Fact finite_unit : finite unit.
+  Proof. apply finite_t_finite, finite_t_unit. Qed.
+
+  Fact finite_t_bool : finite_t bool.
+  Proof. exists (true::false::nil); intros []; simpl; auto. Qed.
+
+  Theorem fin_t_length X n : finite_t X -> fin_t (fun l => @length X l < n).
+  Proof.
+    intros HX.
+    apply finite_t_fin_t_eq in HX.
+    generalize finite_t_unit; intros H1.
+    apply finite_t_fin_t_eq in H1.
+    induction n as [ | n IHn ].
+    + exists nil; intros; split; try lia; intros [].
+    + generalize (fin_t_sum H1 (fin_t_prod HX IHn)).
+      apply fin_t_map with (f := fun c => match c with
+        | inl _     => nil
+        | inr (x,l) => x::l
+      end).
+      intros [ | x l ]; simpl.
+      * split; try lia; exists (inl tt); auto.
+      * split.
+        - intros Hl; exists (inr (x,l)); simpl; msplit 2; auto; lia.
+        - intros ([ [] | (y,m) ] & E & H); try discriminate.
+          simpl in *; inversion E; subst; lia.
+  Qed.
+
+  Theorem finite_t_list X n : finite_t X -> finite_t { l : list X | length l < n }.
+  Proof.
+    intros H; apply (fin_t_length n) in H; revert H; intros (l & Hl).
+    assert (forall x, In x l -> length x < n) as f by (intro; apply Hl).
+    set (g x Hx := exist (fun x => length x < n) x (f x Hx)).
+    exists (list_in_map l g).
+    intros (x & Hx).
+    assert (G : In x l) by (revert Hx; apply Hl).
+    assert (E : Hx = f _ G) by apply lt_pirr.
+    subst Hx; apply In_list_in_map with (f := g).
+  Qed.
+
+  Theorem finite_t_option X : finite_t X -> finite_t (option X).
+  Proof.
+    intros (lX & HX).
+    exists (None :: map Some lX).
+    intros [x|]; simpl; auto.
+    right; apply in_map_iff; exists x; auto.
+  Qed.
+
+  Fact finite_t_pos n : finite_t (pos n).
+  Proof. exists (pos_list n); apply pos_list_prop. Qed.
+
+  Theorem fin_t_vec X P n : @fin_t X P -> fin_t (fun v : vec _ n => forall p, P (vec_pos v p)).
+  Proof.
+    intros HP.
+    induction n as [ | n IHn ].
+    + exists (vec_nil :: nil).
+      intros v; vec nil v; simpl; split; try tauto.
+      intros _ p; invert pos p.
+    + generalize (fin_t_prod HP IHn). 
+      apply fin_t_map with (f := fun c => vec_cons (fst c) (snd c)).
+      intros v; vec split v with x; split.
+      * intros H; exists (x,v); simpl; msplit 2; auto.
+        - apply (H pos0).
+        - intro; apply (H (pos_nxt _)).
+      * intros ((x',v') & H1 & H2 & H3).
+        simpl in H1, H2, H3.
+        apply vec_cons_inv in H1.
+        destruct H1 as (-> & ->).
+        intros p; invert pos p; auto.
+  Qed.
+
+  Theorem finite_t_vec X n : finite_t X -> finite_t (vec X n).
+  Proof.
+    intros HX.
+    apply finite_t_fin_t_eq.
+    apply finite_t_fin_t_eq in HX. 
+    apply fin_t_vec with (n := n) in HX.
+    revert HX; apply fin_t_equiv; tauto.
+  Qed.
+
+  Section filter.
+
+    Variable (X : Type) (P : X -> Prop) (Pdec : forall x, { P x } + { ~ P x }).
+    
+    Theorem fin_t_dec Q : @fin_t X Q -> fin_t (fun x => P x /\ Q x).
+    Proof.
+      intros (l & Hl).
+      exists (filter (fun x => if Pdec x then true else false) l).
+      intros x; rewrite filter_In, <- Hl.
+      destruct (Pdec x); try tauto.
+      split; try tauto.
+      intros []; discriminate.
+    Qed.
+
+  End filter.
+
+  Fact finite_t_fin_t_dec (X : Type) (P : X -> Prop) (Pdec : forall x, { P x } + { ~ P x }) :
+         finite_t X -> fin_t P.
+  Proof. 
+    intros H.
+    apply finite_t_fin_t_eq in H.
+    apply fin_t_dec with (1 := Pdec) in H.
+    revert H; apply fin_t_equiv; tauto.
+  Qed.
+
+End finite.
+
+Lemma finite_t_sig_bool X (P : X -> bool) : finite_t X -> finite_t { x | P x = true }.
+Proof.
+  intros H.
+  apply fin_t_finite_t.
+  + intros; apply UIP_dec, bool_dec.
+  + apply finite_t_fin_t_dec; auto.
+    intro; apply bool_dec.
+Qed.

--- a/theories/Shared/Libs/DLW/Utils/fin_bij.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_bij.v
@@ -1,0 +1,202 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac fin_base fin_choice.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+Set Implicit Arguments.
+
+Definition bij_t (X Y : Type) := { i : X -> Y & { j | (forall x, j (i x) = x) /\ forall y, i (j y) = y } }.
+
+Definition surj_t (X Y : Type) := { s : X -> Y | forall y, exists x, y = s x }.
+
+Fact surj_t_compose X Y Z : surj_t X Y -> surj_t Y Z -> surj_t X Z.
+Proof. 
+  intros (f & Hf) (g & Hg); exists (fun x => g (f x)).
+  intros z.
+  destruct (Hg z) as (y & Hy).
+  destruct (Hf y) as (x & Hx).
+  exists x; subst; auto.
+Qed.
+
+Fact finite_t_surj_t X Y : surj_t X Y -> finite_t X -> finite_t Y.
+Proof.
+  intros [ s E ] (l & Hl).
+  exists (map s l).
+  intros y; rewrite in_map_iff. 
+  destruct (E y) as (x & ?); exists x; auto. 
+Qed.
+
+Fact finite_t_pos_equiv X : (finite_t X -> { n : _ & surj_t (pos n) X })
+                          * ({ n : _ & surj_t (pos n) X } -> finite_t X).
+Proof.
+  split.
+  + intros (l & Hl).
+    exists (length l).
+    destruct (list_vec_full l) as (v & Hv).
+    rewrite <- Hv in Hl.
+    generalize (length l) v Hl.
+    clear l v Hl Hv.
+    intros n v H.
+    exists (vec_pos v).
+    intros x; apply (vec_list_inv _ _ (H x)).
+  + intros (n & Hn).
+    generalize (finite_t_pos n).
+    apply finite_t_surj_t; auto.
+Qed.
+
+Fact NoDup_vec_list X n v : NoDup (@vec_list X n v) -> forall p q, vec_pos v p = vec_pos v q -> p = q.
+Proof.
+  induction v as [ | n x v IHv ]; intros H p q.
+  + invert pos p.
+  + simpl in H; rewrite NoDup_cons_iff in H.
+    destruct H as [ H1 H2 ].
+    invert pos p; invert pos q; intros E; auto.
+    1,2: destruct H1; subst; apply in_vec_list, in_vec_pos.
+    f_equal; apply IHv; auto.
+Qed.
+
+Section list_discr_vec.
+
+  Variable (X : Type) (D : forall x y : X, { x = y } + { x <> y }).
+
+  Fact vec_search n (v : vec X n) x : { p | x = vec_pos v p } + { ~ in_vec x v }.
+  Proof.
+    induction v as [ | n y v [ (p & ->) | H ] ].
+    + right; simpl; auto.
+    + left; exists (pos_nxt p); auto.
+    + destruct (D y x).
+      * left; exists pos0; auto.
+      * right; contradict H; simpl in H; tauto.
+  Qed.
+
+  Variable (ll : list X).
+
+  Let l := nodup D ll.
+  Let Hl1 : NoDup l := NoDup_nodup D ll.
+  Let Hl2 : forall x, In x l <-> In x ll := nodup_In D ll.
+
+  Let v := proj1_sig (list_vec_full l).
+  Let Hv : vec_list v = l := proj2_sig (list_vec_full l).
+
+  Let f x := 
+    match vec_search v x with
+      | inleft (exist _ p Hp) => Some p
+      | inright _             => None
+    end. 
+
+  Fact list_discr_pos_n :
+         { n : nat & 
+         { v : vec X n &
+         { f : X -> option (pos n)  
+         |  (forall x, in_vec x v <-> In x ll)
+         /\ (forall x, In x ll <-> f x <> None) 
+         /\ (forall p, f (vec_pos v p) = Some p)
+         /\ (forall x p, f x = Some p -> vec_pos v p = x) } } }.
+  Proof.
+    exists (length l), v, f; msplit 3.
+    + intro; rewrite in_vec_list, Hv; apply Hl2.
+    + intros x; rewrite <- Hl2.
+      rewrite <- Hv at 1.
+      unfold f.
+      destruct (vec_search v x) as [ (p & ->) | H ].
+      * rewrite <- in_vec_list; split; try discriminate.
+        intros _; apply in_vec_pos.
+      * rewrite <- in_vec_list; tauto.
+    + intros p; unfold f. 
+      destruct (vec_search v (vec_pos v p)) as [ (q & Hq) | H ].
+      * apply NoDup_vec_list in Hq; subst; auto.
+        rewrite Hv; auto.
+      * destruct H; apply in_vec_pos.
+    + intros x p; unfold f.
+      destruct (vec_search v x) as [ (q & ->) | H ].
+      * inversion 1; auto.
+      * discriminate.
+  Qed.
+
+End list_discr_vec.
+
+Fact list_discrete_bij_pos X (l : list X) : 
+        (forall x y : X, { x = y } + { x <> y })
+     -> { n : nat & 
+        { f : forall x, In x l -> pos n &
+        { g : pos n -> X 
+        |  (forall p, In (g p) l) 
+        /\ (forall x Hx, g (f x Hx) = x)
+        /\ (forall p H, f (g p) H = p) } } }.
+Proof. 
+  intros D.
+  generalize (NoDup_nodup D l) (nodup_In D l).
+  set (l' := nodup D l); intros H1 H2.
+  revert H1 H2.
+  generalize l'; clear l'; intros l' H1 H2.
+  exists (length l').
+  destruct (list_vec_full l') as (v & Hv).
+  rewrite <- Hv in H1, H2.
+  generalize (NoDup_vec_list _ H1); intros H3.
+  destruct list_reif_t with (l := l) (R := fun x p => vec_pos v p = x)
+    as (f & Hf).
+  { intros x Hx; apply in_vec_dec_inv; auto.
+    apply in_vec_list, H2; auto. }
+  exists f, (vec_pos v); msplit 2; auto.
+  intro; apply H2, in_vec_list, in_vec_pos.
+Qed.
+
+Fact list_discrete_bij_nat X (l : list X) : 
+        (forall x y : X, { x = y } + { x <> y })
+     -> { n : nat & 
+        { f : X -> nat &
+        { g : nat -> option X 
+        |  (forall x, In x l -> f x < n)
+        /\ (forall x, In x l -> g (f x) = Some x)
+        /\ (forall p, p < n -> exists x, g p = Some x /\ f x = p) } } }.
+Proof.
+  intros D.
+  destruct (list_discrete_bij_pos l D)
+    as (n & f & g & H1 & H2 & H3).
+  exists n.
+  exists (fun x => match in_dec D x l with
+    | left H => pos2nat (f x H)
+    | right _ => 0
+  end).
+  exists (fun k => match le_lt_dec n k with
+    | left _  => None
+    | right H => Some (g (nat2pos H))
+  end).
+  msplit 2.
+  + intros x H; destruct (in_dec D x l); try tauto; apply pos2nat_prop.
+  + intros x H; destruct (in_dec D x l) as [ Hx | Hx ]; try tauto.
+    destruct (le_lt_dec n (pos2nat (f x Hx))) as [ H' | H' ].
+    * generalize (pos2nat_prop (f _ Hx)); lia.
+    * f_equal; rewrite nat2pos_pos2nat; auto.
+  + intros p Hp.
+    exists (g (nat2pos Hp)); split.
+    * destruct (le_lt_dec n p) as [ | ? ]; try (exfalso; lia).
+      do 2 f_equal; apply pos2nat_inj.
+      rewrite !pos2nat_nat2pos; auto.
+    * destruct (in_dec D (g (nat2pos Hp)) l) as [ | [] ]; auto.
+      rewrite H3, pos2nat_nat2pos; auto.
+Qed.
+
+Fact finite_t_discrete_bij_t_pos X : 
+        finite_t X
+     -> (forall x y : X, { x = y } + { x <> y })
+     -> { n : nat & bij_t X (pos n) }.
+Proof. 
+  intros (l & Hl) D.
+  destruct list_discrete_bij_pos with (l := l) (1 := D)
+    as (n & f & g & H1 & H2 & H3).
+  exists n, (fun x => f x (Hl x)), g; split; auto.
+Qed.
+

--- a/theories/Shared/Libs/DLW/Utils/fin_choice.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_choice.v
@@ -1,0 +1,190 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_list utils_nat 
+                 fin_base.
+
+From Undecidability.Shared.Libs.DLW.Vec
+  Require Import pos vec.
+
+Set Implicit Arguments.
+
+(** This files gathers all constructivelly valid choice principles *)
+
+(** This is standart constructive strong choice, no finiteness assumptions here *)
+
+Theorem constructive_choice X (T : X -> Type) (R : forall x, T x -> Prop) :
+          (forall x, sig (R x)) 
+       -> { f : forall x, T x | forall x, R x (f x) }.
+Proof.
+  intros f.
+  exists (fun x => proj1_sig (f x)).
+  intros x; apply (proj2_sig (f x)).
+Qed.
+
+Theorem constructive_choice' X Y (R : X -> Y -> Prop) :
+          (forall x, sig (R x)) 
+       -> { f | forall x, R x (f x) }.
+Proof.
+  apply constructive_choice.
+Qed.
+
+Theorem constructive_dep_choice X Y (P : X -> Prop) (R : X -> Y -> Prop) :
+          (forall x, P x -> sig (R x)) 
+       -> { f : forall x, P x -> Y | forall x Hx, R x (f x Hx) }.
+Proof.
+  intros f.
+  exists (fun x Hx => proj1_sig (f x Hx)).
+  intros x Hx; apply (proj2_sig (f x Hx)).
+Qed.
+
+Fact list_reif_t X Y (R : X -> Y -> Prop) l :
+          (forall x, In x l -> sig (R x)) 
+       -> { f | forall x (Hx : In x l), R x (f x Hx) }.
+Proof. apply constructive_dep_choice. Qed.
+
+Fact pos_reif_t X n (R : pos n -> X -> Prop) : (forall p, { x | R p x }) -> { f | forall p, R p (f p) }.
+Proof. apply constructive_choice. Qed.
+
+Fact vec_reif_t X n (R : pos n -> X -> Prop) : (forall p, sig (R p)) -> { v | forall p, R p (vec_pos v p) }.
+Proof.
+  intros H.
+  apply pos_reif_t in H.
+  destruct H as (f & Hf).
+  exists (vec_set_pos f).
+  intro; rewrite vec_pos_set; trivial.
+Qed.
+
+(** Now weak choice principles that assume some finiteness and discreteness *)
+
+Section finite_discrete_choice.
+
+  Variable (X Y : Type) (R : X -> Y -> Prop) 
+           (X_discrete : forall x y : X, { x = y } + { x <> y }).
+    
+  Theorem list_discrete_choice l :
+            (forall x, In x l -> ex (R x))
+         -> exists f, forall x (Hx : In x l), R x (f x Hx).
+  Proof.
+    induction l as [ | x l IHl ]; intros Hl.
+    + exists (fun x (Hx : @In X x nil) => False_rect Y Hx).
+      intros _ [].
+    + destruct (Hl x) as (y & Hy); simpl; auto.
+      destruct IHl as (f & Hf).
+      * intros; apply Hl; simpl; auto.
+      * assert (forall z, In z (x::l) -> x <> z -> In z l) as H1.
+        { intros z [ -> | ] ?; tauto. }
+        exists (fun z Hz => 
+          match X_discrete x z with
+            | left   _ => y
+            | right  H => f z (H1 _ Hz H)
+          end).
+        intros z Hz.
+        destruct (X_discrete x z); subst; auto.
+  Qed.
+
+  Fact finite_discrete_choice :
+         finite X 
+      -> (forall x, ex (R x)) -> exists f, forall x, R x (f x).
+  Proof.
+    intros (l & Hl) H.
+    destruct list_discrete_choice with (l := l) as (f & Hf); auto.
+    exists (fun x => f x (Hl x)); auto.
+  Qed.
+
+End finite_discrete_choice.
+
+Local Hint Resolve finite_t_pos finite_t_finite.
+ 
+Fact pos_reification X n (R : pos n -> X -> Prop) : (forall p, exists x, R p x) -> exists f, forall p, R p (f p).
+Proof.
+  apply finite_discrete_choice; auto.
+  apply pos_eq_dec.
+Qed.
+
+Notation pos_reif := pos_reification.
+
+Fact vec_reif X n (R : pos n -> X -> Prop) : (forall p, ex (R p)) -> exists v, forall p, R p (vec_pos v p).
+Proof.
+  intros H.
+  apply pos_reification in H.
+  destruct H as (f & Hf).
+  exists (vec_set_pos f).
+  intro; rewrite vec_pos_set; trivial.
+Qed.
+
+Section finite_t_dec_choose_one.
+
+  (** This compares to Constructive Epsilon but here over a finite type
+      instead of nat *) 
+
+  Variable (X : Type) (P Q : X -> Prop) 
+           (HX : finite_t X)
+           (HQ : fin_t Q)
+           (Pdec : forall x, { P x } + { ~ P x }).
+
+  Fact list_dec_choose_one l : (exists x, In x l /\ P x) -> { x | In x l /\ P x }.
+  Proof.
+    clear HX Q HQ.
+    induction l as [ | x l IHl ]; intros H.
+    + exfalso; destruct H as (_ & [] & _).
+    + destruct (Pdec x) as [ H1 | H1 ].
+      * exists x; simpl; auto.
+      * destruct IHl as (y & H2 & H3).
+        - destruct H as (y & [ -> | Hy ] & ?); firstorder.
+        - exists y; simpl; auto.
+  Qed.
+ 
+  Fact fin_t_dec_choose_one : 
+         (exists x, Q x /\ P x) -> { x | Q x /\ P x }.
+  Proof.
+    revert HQ; intros (l & Hl) H.
+    destruct (list_dec_choose_one l) as (x & H1 & H2).
+    + destruct H as (x & ? & ?); exists x; rewrite <- Hl; auto.
+    + exists x; rewrite Hl; auto.
+  Qed.
+
+  Fact finite_t_dec_choose_one : ex P -> sig P. 
+  Proof.
+    clear Q HQ.
+    revert HX; intros (l & Hl) H.
+    destruct (list_dec_choose_one l) as (x & H1 & H2); firstorder.
+  Qed.
+
+End finite_t_dec_choose_one.
+
+(** Reification of a total relation into a function,
+    ie this is relational choice over a finite co-domain
+    with a decidable relation *)
+
+Definition finite_t_dec_choice X Y (R : X -> Y -> Prop) :
+        finite_t Y
+     -> (forall x y, { R x y } + { ~ R x y })
+     -> (forall x, ex (R x))
+     -> { f | forall x, R x (f x) }.
+Proof.
+  intros H2 H1 H3.
+  exists (fun x => proj1_sig (finite_t_dec_choose_one H2 (H1 x) (H3 x))).
+  intros x; apply (proj2_sig (finite_t_dec_choose_one H2 (H1 x) (H3 x))).
+Qed.
+
+Fact pos_dec_reif n (P : pos n -> Prop) (HP : forall p, { P p } + { ~ P p }) : ex P -> sig P.
+Proof. apply finite_t_dec_choose_one; auto. Qed.
+
+(** This is needed to reify a computable binary relation representing a unary function
+    into an actual function *)
+
+Fact pos_dec_rel2fun n (R : pos n -> pos n -> Prop) :
+         (forall a b, { R a b } + { ~ R a b }) 
+      -> (forall p, ex (R p)) -> { f | forall p, R p (f p) }.
+Proof. apply finite_t_dec_choice; auto. Qed.
+

--- a/theories/Shared/Libs/DLW/Utils/fin_dec.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_dec.v
@@ -1,0 +1,77 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import fin_base.
+
+Set Implicit Arguments.
+
+Theorem exists_dec_fin_t X (P Q : X -> Prop) 
+           (Pdec : forall x, { P x } + { ~ P x }) 
+           (HQ : fin_t Q)
+           (HPQ : forall x, P x -> Q x) :
+           { exists x, P x } + { ~ exists x, P x }.
+Proof.
+  generalize (fin_t_dec _ Pdec HQ); intros ([ | x l ] & Hl).
+  + right; intros (x & Hx); apply (Hl x); split; auto.
+  + left; exists x; apply Hl; simpl; auto.
+Qed.
+
+(** On discrete and finite types, one can weakly reify weak decidability 
+    into inhabited strong decidability. But I do not think this could be done with 
+    weak discreteness, weakly decidable equality *)
+
+Definition list_weak_dec X (l : list X) (Q : X -> Prop) : 
+             (forall x y, In x l -> In y l -> { x = y } + { x <> y } ) 
+          -> (forall x, In x l -> Q x \/ ~ Q x)
+          -> inhabited (forall x, In x l -> { Q x } + { ~ Q x }).
+Proof. 
+  induction l as [ | x l IHl ]; intros D H.
+  1: { exists; intros _ []. }
+  destruct IHl as [ f ].
+  + intros; apply D; simpl; auto.
+  + intros; apply H; simpl; auto.
+  + destruct (H x) as [ Hx | Hx ]; simpl; auto. 
+    * exists; intros y Hy.
+      destruct (D x y) as [ H1 | H1 ]; simpl; auto.
+      - left; subst; auto.
+      - apply f; destruct Hy; auto; tauto.
+    * exists; intros y Hy.
+      destruct (D x y) as [ H1 | H1 ]; simpl; auto.
+      - right; subst; auto.
+      - apply f; destruct Hy; auto; tauto.
+Qed.
+
+Fact fin_weak_dec X (P Q : X -> Prop) :
+      (forall x y : X, P x -> P y -> { x = y } + { x <> y } )
+   -> fin P 
+   -> (forall x, P x -> Q x \/ ~ Q x)
+   -> inhabited (forall x, P x -> { Q x } + { ~ Q x }).
+Proof.
+  intros H1 (l & Hl) H2.
+  destruct (list_weak_dec l Q) as [ f ].
+  + intros; apply H1; apply Hl; auto.
+  + intros; apply H2; apply Hl; auto.
+  + exists; intros; apply f, Hl; auto.
+Qed.
+
+Fact finite_weak_dec X (P : X -> Prop) :
+       finite X
+    -> (forall x y : X, { x = y } + { x <> y })
+    -> (forall x, P x \/ ~ P x)
+    -> inhabited (forall x, { P x } + { ~ P x }).
+Proof.
+  intros H1 H2 H3.
+  apply finite_fin_eq in H1.
+  destruct fin_weak_dec with (Q := P) (2 := H1); auto.
+Qed.
+
+

--- a/theories/Shared/Libs/DLW/Utils/fin_quotient.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_quotient.v
@@ -1,0 +1,213 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega Permutation.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_list.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
+
+From Undecidability.Shared.Libs.DLW.Wf 
+  Require Import measure_ind.
+
+Set Implicit Arguments.
+
+Section fp_quotient.
+
+  Variable (X : Type).
+ 
+  Implicit Type (R : X -> X -> Prop).
+
+  Record fp_quotient R := Mk_finite_partial_quotient {
+    fpq_size : nat;
+    fpq_class : X -> option (pos fpq_size);
+    fpq_repr : pos fpq_size -> X;
+    fpq_eq : forall c, fpq_class (fpq_repr c) = Some c;
+    fpq_None : forall x, ~ R x x <-> fpq_class x = None;
+    fpq_Some : forall x y, R x y <-> fpq_class x = fpq_class y /\ fpq_class x <> None;
+  }.
+
+  Let per R := (forall x y, R x y -> R y x) /\ (forall x y z, R x y -> R y z -> R x z).
+  Let dec R := forall x y, { R x y } + { ~ R x y }.
+
+  Let Some_inj K (x y : K) : Some x = Some y -> x = y.
+  Proof. inversion 1; auto. Qed. 
+  
+  Theorem decibable_PER_fp_quotient l R : 
+            (forall x, R x x <-> exists y, In y l /\ R x y) 
+          -> per R -> dec R -> fp_quotient R.
+  Proof.
+    revert R.
+    induction on l as IHl with measure (length l); intros R Hl (H1 & H2) H3.
+    destruct l as [ | x l ].
+    + exists 0 (fun _ => None) (@pos_O_invert _).
+      * intros p; invert pos p.
+      * intros x; rewrite Hl; split; auto.
+        intros _ (? & [] & _).
+      * intros x y; split.
+        - intros H4. 
+          assert (R x x) as C.
+          { apply H2 with y; auto. }
+          apply Hl in C.
+          destruct C as (? & [] & _).
+        - intros (_ & []); auto.
+    + destruct list_discrim with (P := R x) (Q := fun y => ~ R x y) (l := l)
+        as (lx & m & G1 & G2 & G3).
+      { intro; apply H3. }
+      rewrite Forall_forall in G2, G3.
+      set (T u v := ~ R x u /\ R u v).
+      destruct (IHl m) with (R := T) as [ n cl rp Q1 Q2 Q3 ].
+      * apply Permutation_length in G1; rewrite app_length in G1.
+        simpl; omega.
+      * intros u; unfold T; split.
+        - rewrite Hl.
+          intros (F1 & w & [ -> | F2 ] & F3).
+          ++ apply H1 in F3; tauto.
+          ++ exists w; split; auto.
+             apply Permutation_in with (1 := G1), in_app_or in F2.
+             destruct F2; auto.
+             apply G2 in H.
+             contradict F1.
+             apply H2 with w; auto.
+        - intros (v & F1 & F2 & F3); split; auto.
+          apply H2 with v; auto.
+      * split.
+        - intros u v (F1 & F2); split; auto.
+          contradict F1; apply H2 with v; auto.
+        - intros a b c (F1 & F2) (F3 & F4); split; auto.
+          apply H2 with b; auto.
+      * intros u v; unfold T.
+        destruct (H3 x u); destruct (H3 u v); tauto.
+      * destruct (H3 x x) as [ Hx | Hx ].
+        - set (cl' y := match H3 x y with
+               | left Hy  => Some (pos0)
+               | right Hy => match cl y with
+                 | Some p => Some (pos_nxt p)
+                 | None => None
+               end
+             end).
+          set (rp' p := match pos_S_inv p with
+                | inl _  => x
+                | inr (exist _ q _) => rp q
+              end).
+         exists _ cl' rp'.
+         ++ intros p; invert pos p; unfold cl', rp'; simpl.
+            ** destruct (H3 x x) as [ | [] ]; auto.
+            ** rewrite Q1.
+               destruct (H3 x (rp p)) as [ | H ]; auto.
+               unfold T in Q2.
+               specialize (Q1 p).
+               contradict Q1.
+               rewrite (proj1 (Q2 _)); try tauto; discriminate.
+         ++ intros u; unfold cl'; split.
+            ** intros H; destruct (H3 x u) as [ F1 | F1 ].
+               { contradict H; apply H2 with x; auto. }
+               rewrite (proj1 (Q2 _)); auto.
+               intros (? & ?); tauto.
+            ** destruct (H3 x u) as [ F1 | F1 ]; try discriminate.
+               intros F2 F3.
+               destruct (proj1 (Q3 u u)) as (E & ?).
+               red; auto.
+               destruct (cl u); try discriminate; tauto.
+         ++ intros u v; split.
+            ** intros H. 
+               unfold cl'.
+               destruct (H3 x u) as [ F1 | F1 ].
+               { split; try discriminate.
+                 destruct (H3 x v) as [ F2 | F2 ]; auto.
+                 contradict F2; apply H2 with u; auto. }
+               destruct (H3 x v) as [ F2 | F2 ].
+               { contradict F1; apply H2 with v; auto. }
+               destruct (proj1 (Q3 u v)) as (F3 & F4).
+               { red; auto. }
+               rewrite <- F3.
+               destruct (cl u); auto.
+               split; auto; discriminate.
+            ** intros (F1 & F2); revert F1 F2.
+               unfold cl'.
+               { destruct (H3 x u) as [ F1 | F1 ];
+                 destruct (H3 x v) as [ F2 | F2 ].
+                 + intros _ _; apply H2 with x; auto.
+                 + destruct (cl v); discriminate.
+                 + destruct (cl u); discriminate.
+                 + case_eq (cl u).
+                   2: intros _ _ []; auto.
+                   case_eq (cl v); try discriminate.
+                   intros p Hp q Hq E _; apply Q3.
+                   rewrite Hp, Hq; split; try discriminate.
+                   f_equal.
+                   apply Some_inj, pos_nxt_inj in E; subst; auto. }
+        - exists _ cl rp; auto.
+          ++ intros u; split.
+             ** intros H; apply Q2; unfold T; tauto.
+             ** intros H; apply Q2 in H; contradict H; split; auto.
+                contradict Hx; apply H2 with u; auto.
+          ++ intros u v; split.
+             ** intros H; apply Q3.
+                split; auto.
+                contradict Hx; apply H2 with u; auto.
+             ** intros H; apply Q3 in H; destruct H; auto.
+  Qed.
+
+  Record fin_quotient R := Mk_finite_quotient {
+    fq_size : nat;
+    fq_class : X -> pos fq_size;
+    fq_repr : pos fq_size -> X;
+    fq_surj : forall c, fq_class (fq_repr c) = c;
+    fq_equiv : forall x y, R x y <-> fq_class x = fq_class y }.
+
+  (* We do not need the type to be finite, only the number of
+     equivalent classes need be finite *)
+
+  Theorem decidable_EQUIV_fin_quotient l R :
+             (forall x, R x x)
+          -> (forall x y, R x y -> R y x)
+          -> (forall x y z, R x y -> R y z -> R x z)     (* R is an equivalence *)
+          -> (forall x y, { R x y } + { ~ R x y })       (* R is decidable *)
+          -> (forall x : X, exists y, In y l /\ R x y)   (* finitely many classes *)
+          -> fin_quotient R.
+  Proof.
+    intros H1 H2 H3 H4 H5.
+    destruct (@decibable_PER_fp_quotient l R) 
+      as [ n cl rp Q1 Q2 Q3 ]; simpl; auto.
+    + intros x; split; auto; intros _; exists x; auto.
+    + split; auto.
+    + assert (forall x, { y | cl x = Some y }) as H.
+      { intros x; case_eq (cl x).
+        * intros p; exists p; auto.
+        * intros C; exfalso.
+          apply Q2 in C.
+          apply C; auto. }
+      set (cl' x := proj1_sig (H x)).
+      assert (H' : forall x, cl x = Some (cl' x)).
+      { intros x; apply (proj2_sig (H x)). }
+      generalize cl' H'; clear H cl' H'; intros cl' H.
+      exists n cl' rp.
+      * intro x.
+        generalize (Q1 x); rewrite H.
+        injection 1; auto.
+      * intros x y; rewrite Q3.
+        split.
+        - intros (C1 & _).
+          apply Some_inj; rewrite <- H, <- H; auto.
+        - intros E; rewrite H, H, E; split; auto; discriminate.
+  Qed.
+
+End fp_quotient.
+
+Print fp_quotient.
+Check decibable_PER_fp_quotient.
+Print Assumptions decibable_PER_fp_quotient.
+
+Print fin_quotient.
+Check decidable_EQUIV_fin_quotient.
+Print Assumptions decidable_EQUIV_fin_quotient.
+  

--- a/theories/Shared/Libs/DLW/Utils/fin_upto.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_upto.v
@@ -1,0 +1,113 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Nat Lia Relations Bool.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_list fin_base.
+
+Set Implicit Arguments.
+
+Section finite_t_upto.
+
+  Variable (X : Type) (R : X -> X -> Prop).
+
+  Definition fin_t_upto (P : X -> Type) := 
+     { l : _ & (forall x, P x -> exists y, In y l /\ R x y) 
+              *(forall x y, In x l -> R x y -> P y) }%type.
+
+  Definition finite_t_upto := 
+     { l : _ | forall x, exists y, In y l /\ R x y }.
+
+  Fact finite_t_fin_upto : (finite_t_upto -> fin_t_upto (fun _ => True))
+                         * (fin_t_upto (fun _ => True) -> finite_t_upto).
+  Proof.
+    split.
+    + intros (l & Hl); exists l; split; auto.
+    + intros (l & H1 & H2); exists l; firstorder.
+  Qed.
+
+End finite_t_upto.
+
+Arguments finite_t_upto : clear implicits.
+
+Section finite_t_weak_dec_powerset.
+
+  (** We built a list containing all weakly decidable predicates,
+      ie the weakly decidable powerset build as from atoms 
+        x = _ and x <> _  *)
+
+  Variable (X : Type).
+
+  Let wdec (R : X -> Prop) := forall x, R x \/ ~ R x.
+   
+  Let pset_fin_t (l : list X) : { ll | forall R (_ : wdec R), 
+                                        exists T, In T ll 
+                                     /\ forall x, In x l -> R x <-> T x }.
+  Proof.
+    induction l as [ | x l IHl ].
+    + exists ((fun _ => True) :: nil).
+      intros R HR; exists (fun _ => True); simpl; split; tauto.
+    + destruct IHl as (ll & Hll).
+      exists (map (fun T a => x<>a /\ T a) ll ++ map (fun T a => x=a \/ T a) ll).
+      intros R HR.
+      destruct (Hll R) as (T & H1 & H2); auto.
+      destruct (HR x) as [ H0 | H0 ].
+      * exists (fun a => x = a \/ T a); split.
+        - apply in_or_app; right.
+          apply in_map_iff; exists T; auto.
+        - intros y [ <- | H ]; simpl; try tauto.
+          rewrite H2; auto; split; auto.
+          intros [ -> | ]; auto.
+          apply H2; auto.
+      * exists (fun a => x <> a /\ T a); split.
+        - apply in_or_app; left.
+          apply in_map_iff; exists T; auto.
+        - intros y [ <- | H ]; simpl; split; try tauto.
+          ++ rewrite <- H2; auto; split; auto.
+             contradict H0; subst; auto. 
+          ++ rewrite <- H2; tauto.
+  Qed.
+
+  Theorem finite_t_weak_dec_powerset : 
+              finite_t X 
+           -> { l | forall R, wdec R -> exists T, In T l 
+                           /\ forall x, R x <-> T x }.
+  Proof.
+    intros (l & Hl).
+    destruct (pset_fin_t l) as (ll & Hll).
+    exists ll.
+    intros R HR.
+    destruct (Hll _ HR) as (T & H1 & H2).
+    exists T; split; auto.
+  Qed.
+
+End finite_t_weak_dec_powerset.
+
+(** We show that there is a finite_t bound over weakly (hence also strongly) decidable  
+    binary relations upto equivalence. Notice that it is not guaranteed that the list l 
+    below contains only decidable relations *)
+
+Theorem finite_t_weak_dec_rels X :
+            finite_t X -> { l | forall R : X -> X -> Prop, 
+                                  (forall x y, R x y \/ ~ R x y) 
+                                -> exists T, In T l /\ forall x y, R x y <-> T x y }.
+Proof.
+  intros HX.
+  set (Y := (X*X)%type).
+  destruct (@finite_t_weak_dec_powerset Y) as (l & Hl).
+  + unfold Y; apply finite_t_prod; auto.
+  + exists (map (fun P x y => P (x,y)) l).
+    intros R HR.
+    destruct (Hl (fun c => R (fst c) (snd c))) as (T & H1 & H2).
+    * intros []; apply HR.
+    * exists (fun x y => T (x,y)); split.
+      - apply in_map_iff; exists T; auto.
+      - intros x y; apply (H2 (x,y)).
+Qed.

--- a/theories/Shared/Libs/DLW/Utils/finite.v
+++ b/theories/Shared/Libs/DLW/Utils/finite.v
@@ -7,8 +7,10 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-From Undecidability.Shared.Libs.DLW.Utils 
-  Require Export focus utils_tac list_focus 
-                  utils_list utils_nat 
-                  utils_string.
+Require Import List Arith Lia.
 
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Export fin_base 
+                 fin_quotient
+                 fin_dec fin_choice fin_upto
+                 fin_bij.

--- a/theories/Shared/Libs/DLW/Utils/quotient.v
+++ b/theories/Shared/Libs/DLW/Utils/quotient.v
@@ -1,0 +1,295 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Omega Permutation Relations Bool Eqdep_dec.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_nat.
+
+Set Implicit Arguments.
+
+(** Every class of X/~ is enumerated ie there is a surjective partial map
+    from nat to representatives of class *) 
+
+Definition nat_enum_cls X (R : X -> X -> Prop) := 
+  { f : nat -> option X | forall x, exists y n, f n = Some y /\ R y x }. 
+
+Notation dec := ((fun X Y (R : X -> Y -> Prop) => forall x y, { R x y } + { R x y -> False }) _ _).
+
+(** A class function and its inverse, a function that computes representatives
+    with two equations characterizing the quotient *)
+
+Definition quotient X (R : X -> X -> Prop) Y :=
+  { cls : X -> Y & 
+  { rpr : Y -> X |
+         (forall y, cls (rpr y) = y)
+      /\ (forall x1 x2, R x1 x2 <-> cls x1 = cls x2) } }.
+
+Section ep_quotient.
+
+  Variable (X : Type) (R : X -> X -> Prop) (f : nat -> option X) 
+           (Hf : forall x, exists y n, f n = Some y /\ R y x).
+ 
+  Hypothesis HR1 : equiv _ R.
+  Hypothesis HR2 : dec R.
+
+  Let T n m := 
+    match f n, f m with
+      | Some x, Some y => R x y
+      | None  , None   => True
+      | _     , _      => False
+    end.
+
+  Let HT1 : equiv _ T.
+  Proof.
+    msplit 2.
+    + intros x; red; destruct (f x); auto; apply (proj1 HR1).
+    + intros x y z; unfold T.
+      destruct (f x); destruct (f y); destruct (f z); try tauto; apply HR1.
+    + intros x y; unfold T.
+      destruct (f x); destruct (f y); try tauto; apply HR1.
+  Qed.
+
+  Infix "≈" := T (at level 70, no associativity).
+
+  Let is_repr x n := 
+    match f n with
+      | Some r => R r x
+      | None   => False
+    end.
+
+  Let is_repr_trans x1 x2 n : R x1 x2 -> is_repr x1 n -> is_repr x2 n.
+  Proof.
+    intros H1 H2; revert H2 H1.
+    unfold is_repr; destruct (f n); auto.
+    apply HR1.
+  Qed.
+
+  Let is_repr_dec : dec is_repr.
+  Proof. 
+    intros x n.
+    unfold is_repr.
+    destruct (f n).
+    + apply HR2.
+    + tauto.
+  Qed.
+
+  Let is_repr_exists x : ex (is_repr x).
+  Proof.
+    destruct (Hf x) as (y & n & H1 & H2).
+    exists n; red; rewrite H1; auto.
+  Qed.
+
+  Let is_min_repr x n :=
+    is_repr x n /\ forall m, is_repr x m -> n <= m.
+  
+  Let is_min_repr_inj x n1 n2 : is_min_repr x n1 -> is_min_repr x n2 -> n1 = n2.
+  Proof.
+    intros (H1 & H2) (H3 & H4).
+    apply Nat.le_antisymm; auto.
+  Qed.
+
+  Let is_min_repr_involutive x n : is_min_repr x n -> 
+     match f n with 
+       | Some y => is_min_repr y n
+       | None   => False
+     end.
+  Proof.
+    intros (H1 & H2); unfold is_min_repr, is_repr in *.
+    destruct (f n) as [ y | ]; try tauto. 
+    split.
+    + apply (proj1 HR1).
+    + intros m; specialize (H2 m).
+      destruct (f m) as [ k | ]; try tauto.
+      intros H3; apply H2, (proj1 (proj2 HR1)) with (1 := H3); auto.
+  Qed.
+
+  Let find_min_repr x : sig (is_min_repr x).
+  Proof. 
+    destruct min_dec with (P := is_repr x)
+      as (r & H1 & H2).
+    + intro; apply is_repr_dec.
+    + apply is_repr_exists.
+    + exists r; split; auto.
+  Qed.
+
+  Let is_min_repr_dec : dec is_min_repr.
+  Proof.
+    unfold is_min_repr, is_repr.
+    intros x n.
+    destruct (f n) as [ y | ].
+    2: right; tauto.
+    destruct (HR2 y x) as [ H1 | H1 ].
+    2: right; tauto.
+    destruct bounded_search with (m := n) (P := fun m => match f m with Some r => R r x | None => False end)
+      as [ (p & H2 & H3) | H ].
+    + intros m _; destruct (is_repr_dec x m); auto.
+    + case_eq (f p).
+      * intros r Hr.
+        right; intros (G1 & G2).
+        specialize (G2 p).
+        rewrite Hr in G2, H3.
+        specialize (G2 H3); omega.
+      * intros Hr; rewrite Hr in H3; tauto.
+    + left; split; auto.
+      intros m Hm.
+      destruct (le_lt_dec n m) as [ | C ]; auto.
+      exfalso; specialize (H _ C).
+      destruct (f m) as [ z | ]; tauto.
+  Qed.
+
+  Let P n := 
+    match f n with
+      | Some x => if is_min_repr_dec x n then true else false
+      | None   => false
+    end.
+
+  Let P_spec n : P n = true <-> exists x, f n = Some x /\ is_min_repr x n.
+  Proof.
+    unfold P.
+    destruct (f n) as [ x | ].
+    + destruct (is_min_repr_dec x n) as [ | C ]; split; try tauto.
+      * exists x; auto.
+      * discriminate.
+      * intros (y & Hy & ?).
+        destruct C; inversion Hy; auto.
+    + split; try discriminate.
+      intros (? & ? & _); discriminate.
+  Qed.
+
+  Let Y := sig (fun x => P x = true).
+
+  Let pi1_inj : forall x y : Y, proj1_sig x = proj1_sig y -> x = y.
+  Proof.
+    intros (x & H1) (y & H2); simpl; intros; subst; f_equal.
+    apply UIP_dec, bool_dec.
+  Qed.
+
+  Let Y_discrete : dec (@eq Y).
+  Proof.
+    intros (x & Hx) (y & Hy).
+    destruct (eq_nat_dec x y) as [ | H ].
+    + left; apply pi1_inj; simpl; auto.
+    + right; contradict H; inversion H; auto.
+  Qed.
+
+  Let is_min_repr_P n x : is_min_repr x n -> P n = true.
+  Proof.
+    intros H1.
+    apply P_spec; revert H1.
+    unfold is_min_repr, is_repr.
+    case_eq (f n).
+    + intros y Hy (H1 & H2).
+      exists y; msplit 2; auto.
+      * apply (proj1 HR1).
+      * intros m; specialize (H2 m).
+        destruct (f m) as [ z | ]; auto.
+        intros H; apply H2, (proj1 (proj2 HR1) _ y); auto.
+    + intros _ ([] & _).
+  Qed.
+
+  Let cls (x : X) : Y.
+  Proof.
+    destruct (find_min_repr x) as (n & Hn).
+    exists n; apply is_min_repr_P with x; auto.
+  Defined.
+
+  Let P_to_X n : P n = true -> { k | f n = Some k }.
+  Proof.
+    intros H; rewrite P_spec in H.
+    case_eq (f n).
+    + intros k _; exists k; auto.
+    + intros Hn; exfalso; revert Hn.
+      destruct H as (x & -> & _); discriminate.
+  Qed.
+
+  Let rpr (y : Y) := proj1_sig (P_to_X _ (proj2_sig y)).
+
+  Let Hrpr y : f (proj1_sig y) = Some (rpr y).
+  Proof. apply (proj2_sig (P_to_X _ (proj2_sig y))). Qed.
+
+  Let Hcr : forall y, cls (rpr y) = y.
+  Proof.
+    intros (n & Hn); simpl.
+    unfold rpr; simpl.
+    apply pi1_inj; simpl; unfold cls.
+    case (find_min_repr (proj1_sig (P_to_X n Hn))).
+    intros m Hm; simpl.
+    generalize Hn; rewrite P_spec; intros (y & G1 & G2).
+    destruct (P_to_X n Hn) as (z & Hz); simpl in Hm.
+    rewrite Hz in G1; inversion G1; subst z.
+    revert Hm G2; apply is_min_repr_inj.
+  Qed.
+
+  Let Hrc x1 x2 : R x1 x2 <-> cls x1 = cls x2.
+  Proof.
+    split.
+    + intros H; apply pi1_inj.
+      unfold cls.
+      case (find_min_repr x1); intros y1 (G1 & G2); simpl.
+      case (find_min_repr x2); intros y2 (G3 & G4); simpl.
+      apply Nat.le_antisymm.
+      * apply G2; revert G3.
+        apply is_repr_trans, (proj2 (proj2 HR1)); auto.
+      * apply G4; revert G1.
+        apply is_repr_trans; auto.
+    + unfold cls.
+      case (find_min_repr x1); intros y1 G1; simpl.
+      case (find_min_repr x2); intros y2 G2; simpl.
+      intros H; inversion H; subst y2; clear H.
+      apply proj1 in G1; apply proj1 in G2.
+      revert G1 G2; unfold is_repr.
+      destruct (f y1); try tauto; intros H.
+      apply HR1; revert H; apply HR1.
+  Qed.
+
+  Local Fact enum_quotient_rec : 
+        { Y : Type & { _ : dec (@eq Y) & quotient R Y } }.
+  Proof.
+    exists Y, Y_discrete, cls, rpr; split; auto.
+  Qed.
+
+End ep_quotient.
+
+(** Given type X with a decidable equivalence ~ over X
+    such that the classes of X/~ can be enumerated then
+    one can build the quotient X/~ into a discrete type Y
+    and Y is necessarily enumerated, see below
+*) 
+
+Theorem enum_quotient X R : 
+          nat_enum_cls R 
+       -> equiv X R
+       -> dec R
+       -> { Y : Type & { _ : dec (@eq Y) & quotient R Y } }.
+Proof.
+  intros (f & Hf) H1 H2.
+  apply enum_quotient_rec with (1 := Hf) (R := R); auto.
+Qed.
+
+(** A quotient of enumerated classes is automatically enumerated (for equality *)
+
+Fact quotient_is_enum X R Y : nat_enum_cls R -> @quotient X R Y -> nat_enum_cls (@eq Y).
+Proof.
+  intros (f & Hf) (c & r & H1 & H2).
+  exists (fun n => match f n with Some x => Some (c x) | None => None end).
+  intros y.
+  destruct (Hf (r y)) as (z & n & H3 & H4).
+  exists (c z), n; rewrite H3; split; auto.
+  rewrite <- (H1 y); apply H2; auto.
+Qed.
+
+Print nat_enum_cls.
+Print quotient.
+
+Check enum_quotient.
+Check quotient_is_enum.
+  
+
+

--- a/theories/Shared/Libs/DLW/Utils/seteq.v
+++ b/theories/Shared/Libs/DLW/Utils/seteq.v
@@ -1,0 +1,137 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(*                                                            *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+(** A inductive characterization of list bi-inclusion
+    as closure under contraction and permutation
+
+    The proof does not require decidable equality
+    and uses the somehow generalized PHP that
+    states m ⊆ l and |l| <= |m| -> m has dup \/ l ~p m
+
+ *)
+
+Require Import Arith Omega List Permutation.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import php.
+
+From Undecidability.Shared.Libs.DLW.Wf 
+  Require Import measure_ind.
+
+Set Implicit Arguments.
+
+Reserved Notation "x ≡ y" (at level 70, no associativity).
+Reserved Notation "x ⊆ y" (at level 70, no associativity).
+
+Local Infix "~p" := (@Permutation _) (at level 70, no associativity).
+
+Section seteq.
+
+  Variable X : Type.
+
+  (** When viewed as sets, the lists are equivalent,
+      ie closed under perm + contraction + RST *)
+
+  Inductive seteq : list X -> list X -> Prop :=
+    | seteq_nil   : nil ≡ nil
+    | seteq_skip  : forall x l m, l ≡ m -> x::l ≡ x::m
+    | seteq_swap  : forall x y l, x::y::l ≡ y::x::l
+    | seteq_dup   : forall x l, x::x::l ≡ x::l
+    | seteq_sym   : forall l m, l ≡ m -> m ≡ l 
+    | seteq_trans : forall l m k, l ≡ m -> m ≡ k -> l ≡ k
+  where "l ≡ m" := (seteq l m).
+
+  Hint Constructors seteq.
+
+  Fact perm_seteq l m : l ~p m -> l ≡ m.
+  Proof. induction 1; eauto. Qed.
+
+  Notation "l ⊆ m" := (incl l m).
+
+  Fact incl_cons_mono (x : X) l m : l ⊆ m -> x::l ⊆ x::m.
+  Proof. intros ? ? [ -> | ]; simpl; auto. Qed.
+
+  Fact incl_swap (x y : X) l : x::y::l ⊆ y::x::l.
+  Proof. intros ? [ -> | [ -> | ] ]; simpl; auto. Qed.
+
+  Fact incl_cntr (x : X) l : x::x::l ⊆ x::l.
+  Proof. intros ? [ -> | [ -> | ] ]; simpl; auto. Qed.
+
+  Hint Resolve incl_refl incl_cons_mono incl_swap incl_cntr incl_tl.
+
+  Fact seqeq_incl l m : l ≡ m -> l ⊆ m /\ m ⊆ l.
+  Proof.
+    induction 1 as [ | x l m H [] | x y l | x l 
+                   | l m H []
+                   | l m k H1 IH1 H2 IH2 ]; auto.
+    split; apply incl_tran with m; tauto.
+  Qed.
+
+  Lemma list_has_dup_seteq l : list_has_dup l -> exists m, m ≡ l /\ length m < length l.
+  Proof.
+    induction 1 as [ l x H | l x H (m & H1 & H2) ].
+    + induction l as [ | y l IHl ].
+      * exfalso; destruct H.
+      * destruct H as [ -> | H ].
+        - exists (x::l); simpl; split; auto; omega.
+        - destruct (IHl H) as (m & H1 & H2).
+          exists (y::m); simpl in *; split; try omega.
+          apply seteq_trans with (y::x::l); auto.
+    + exists (x::m); simpl; split; auto; omega.
+  Qed.
+
+  (** The proof by induction on |l|+|m| for l ⊆ m and m ⊆ l
+
+      Three cases:
+
+      (1) m has dup    (2) l ~p m      (3) l has dup
+
+      For (2) If l ~p m then it is trivial
+
+      Otherwise (1 or 3), if eg l has dup then l ≡ l' for a shorter l' 
+      we deduce l' ⊆ m and m ⊆ l' by seqeq_incl
+      and apply the induction hypothesis to (l',m)
+
+    *)
+
+  Lemma incl_seteq l m : l ⊆ m -> m ⊆ l -> l ≡ m.
+  Proof.
+    induction on l m as IH with measure (length l + length m).
+    intros H1 H2.
+    destruct (le_lt_dec (length l) (length m)) as [ H3 | H3 ];
+      [ destruct length_le_and_incl_implies_dup_or_perm with (1 := H3)
+        as [ H4 | H4 ]; auto | ].
+    + destruct list_has_dup_seteq with (1 := H4) as (m' & H5 & H6).
+      apply seteq_trans with m'; auto.
+      apply seqeq_incl in H5; destruct H5.
+      apply IH; try omega; apply incl_tran with m; auto.
+    + apply seteq_sym, perm_seteq; auto.
+    + generalize (finite_php_dup H3 H1); intros H4.
+      destruct list_has_dup_seteq with (1 := H4) as (m' & H5 & H6).
+      apply seteq_trans with m'; auto.
+      apply seqeq_incl in H5; destruct H5.
+      apply IH; try omega; apply incl_tran with l; auto.
+  Qed.
+
+  Hint Resolve seqeq_incl incl_seteq.
+
+  (** seteq is equivalent to bi-inclusion *)
+
+  Theorem seteq_bi_incl l m : l ≡ m <-> l ⊆ m /\ m ⊆ l.
+  Proof. split; auto; intros []; auto. Qed.
+
+End seteq.
+
+Local Infix "≡" := seteq.
+Local Infix "⊆" := incl.
+
+Print seteq.
+Check seteq_bi_incl.
+Print Assumptions seteq_bi_incl.

--- a/theories/Shared/Libs/DLW/Utils/sorting.v
+++ b/theories/Shared/Libs/DLW/Utils/sorting.v
@@ -63,7 +63,7 @@ Section php_fun.
 
   Theorem php_fun : exists i j, i < j <= n /\ f i = f j.
   Proof.
-    destruct PHP_rel with (S := fun x y => y = f x) (l := list_an 0 (S n)) (m := list_an 0 n)
+    destruct PHP_rel with (R := fun x y => y = f x) (l := list_an 0 (S n)) (m := list_an 0 n)
       as (a & i & b & j & c & v & H1 & H2 & H3 & H4).
     + intros x; rewrite list_an_spec; simpl; intros [ _ H ].
       exists (f x); split; auto; rewrite list_an_spec; simpl; split; try omega.

--- a/theories/Shared/Libs/DLW/Utils/utils_nat.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_nat.v
@@ -7,11 +7,49 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Max Omega Wellfounded Bool.
+Require Import List Arith Max Omega Wellfounded Bool Eqdep_dec.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import list_focus utils_tac utils_list.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import list_focus utils_tac utils_list.
 
 Set Implicit Arguments.
+
+Section le_lt_pirr.
+
+  (** lt and lt are proof irrelevant *)
+
+  (* a dependent induction principle for le *)
+  
+  Scheme le_indd := Induction for le Sort Prop.
+
+  Theorem le_pirr x y (H1 H2 : x <= y) : H1 = H2.
+  Proof.
+    revert H2.
+    induction H1 as [ | m H1 IH ] using le_indd; intro H2.
+
+    change (le_n x) with (eq_rect _ (fun n' => x <= n') (le_n x) _ eq_refl).
+    generalize (eq_refl x).
+    pattern x at 2 4 6 10, H2. 
+    case H2; [intro E | intros m l E].
+    rewrite UIP_dec with (p1 := E) (p2 := eq_refl); auto.
+    apply eq_nat_dec.
+    contradiction (le_Sn_n m); subst; auto.
+    
+    change (le_S x m H1) with (eq_rect _ (fun n' => x <= n') (le_S x m H1) _ eq_refl).
+    generalize (eq_refl (S m)).
+    pattern (S m) at 1 3 4 6, H2.
+    case H2; [intro E | intros p H3 E].
+    contradiction (le_Sn_n m); subst; auto.
+    injection E; intro; subst.
+    rewrite (IH H3).
+    rewrite UIP_dec with (p1 := E) (p2 := eq_refl); auto.
+    apply eq_nat_dec.
+  Qed.
+
+  Fact lt_pirr x y (H1 H2 : x < y) : H1 = H2.
+  Proof. simpl; intros; apply le_pirr. Qed.
+
+End le_lt_pirr.
 
 Section fin_reif.
 
@@ -133,6 +171,19 @@ Proof.
   induction l as [ | x l IHl ]; simpl; auto; rewrite IHl; omega.
 Qed.
 
+Fact lsum_le x l : In x l -> x <= lsum l.
+Proof.
+  intros H; apply in_split in H.
+  destruct H as (u & v & ->).
+  rewrite lsum_app; simpl; omega.
+Qed.
+
+Fact lmax_prop l x : In x l -> x <= lmax l.
+Proof.
+  specialize (proj1 (lmax_spec l _) (le_refl _)).
+  rewrite Forall_forall; auto.
+Qed.
+
 Section new.
 
   Definition nat_new l := S (lmax l).
@@ -192,6 +243,44 @@ Fixpoint pow2 p :=
     | 0   => 1
     | S p => 2*pow2 p
   end.
+
+Fact pow2_fix0 : pow2 0 = 1.
+Proof. reflexivity. Qed.
+
+Fact pow2_fix1 p : pow2 (S p) = 2*pow2 p.
+Proof. reflexivity. Qed.
+
+Fact pow2_ge1 p : 1 <= pow2 p.
+Proof. induction p; simpl; omega. Qed.
+
+Fact pow2_2n1_dec n : { p : nat & { b | S n = pow2 p*(2*b+1) } }.
+Proof.
+  induction on n as IH with measure n.
+  generalize (div2_spec (S n)).
+  destruct (div2 (S n)) as (d,[]); intros Hn.
+  + exists 0, d; simpl; omega.
+  + destruct d as [ | d ].
+    * simpl in Hn; omega.
+    * destruct (IH d) as (p & b & H).
+      - omega.
+      - exists (S p), b; rewrite pow2_fix1, <- mult_assoc, <- H; auto.
+Qed.
+
+Fact pow2_dec_uniq p a q b : pow2 p*(2*a+1) = pow2 q*(2*b+1) -> p = q /\ a = b.
+Proof.
+  revert q; induction p as [ | p IHp ]; intros [ | q ].
+  + simpl; omega.
+  + rewrite pow2_fix0, pow2_fix1, <- mult_assoc; omega.
+  + rewrite pow2_fix0, pow2_fix1, <- mult_assoc; omega.
+  + rewrite !pow2_fix1, <- !mult_assoc; intros H.
+    destruct (IHp q); omega.
+Qed.
+
+Fact pow2_dec_ge1 p b : 1 <= pow2 p*(2*b+1).
+Proof.
+  change 1 with (1*1) at 1; apply mult_le_compat; 
+    try omega; apply pow2_ge1.
+Qed.
 
 Section pow2_bound.
 

--- a/theories/Shared/Libs/DLW/Utils/utils_tac.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_tac.v
@@ -9,6 +9,7 @@
 
 Require Import Arith List Wellfounded Extraction.
 
+
 Set Implicit Arguments.
 
 Definition eqdec X := forall x y : X, { x = y } + { x <> y }.

--- a/theories/Shared/Libs/DLW/Vec/pos.v
+++ b/theories/Shared/Libs/DLW/Vec/pos.v
@@ -9,7 +9,8 @@
 
 Require Import List Arith Omega.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils.
 
 Set Implicit Arguments.
 
@@ -147,6 +148,17 @@ Tactic Notation "analyse" "pos" hyp(p) := analyse_pos p.
 Definition pos_O_any X : pos 0 -> X.
 Proof. intro p; invert pos p. Qed.
 
+Definition pos_eq_dec n (x y : pos n) : { x = y } + { x <> y }.
+Proof.
+  revert n x y.
+  induction x as [ x | n x IH ]; intros y; invert pos y.
+  1: left; trivial.
+  1,2: right; discriminate.
+  destruct (IH y) as [ | C ].
+  + left; subst; trivial.
+  + right; contradict C; revert C; apply pos_nxt_inj.
+Defined.
+
 Fixpoint pos_left n m (p : pos n) : pos (n+m) :=
   match p with
     | pos_fst   => pos_fst
@@ -242,42 +254,6 @@ Proof.
   induction n; simpl; auto.
   rewrite map_length; f_equal; auto.
 Qed.
- 
-Fact pos_reification X n (R : pos n -> X -> Prop) : (forall p, exists x, R p x) -> exists f, forall p, R p (f p).
-Proof.
-  revert R; induction n as [ | n IHn ]; intros R HR.
-  exists (pos_O_any X); intros p; invert pos p.
-  set (R' q x := R (pos_nxt q) x).
-  destruct (IHn R') as (f & Hf).
-  intros p; apply HR.
-  unfold R' in Hf.
-  destruct (HR pos_fst) as (x & Hx).
-  exists (fun p => match pos_S_inv p with inl _ => x | inr (exist _ q _) => f q end).
-  intros p; invert pos p; auto.
-Qed.
-
-Fact pos_reif_t X n (R : pos n -> X -> Prop) : (forall p, { x | R p x }) -> { f | forall p, R p (f p) }.
-Proof.
-  intros H.
-  exists (fun p => (proj1_sig (H p))).
-  intros; apply (proj2_sig (H p)).
-Qed.
-
-Section pos_eq_dec.
-
-  Definition pos_eq_dec n (x y : pos n) : { x = y } + { x <> y }.
-  Proof.
-    revert n x y.
-    induction x as [ x | n x IH ]; intros y; invert pos y.
-    left; trivial.
-    right; discriminate.
-    right; discriminate.
-    destruct (IH y) as [ | C ].
-    left; subst; trivial.
-    right; contradict C; revert C; apply pos_nxt_inj.
-  Defined.
-
-End pos_eq_dec.
 
 Section pos_map.
 
@@ -457,4 +433,3 @@ Section pos_prod.
   Qed.
   
 End pos_prod.
-

--- a/theories/Shared/Libs/DLW/Vec/vec.v
+++ b/theories/Shared/Libs/DLW/Vec/vec.v
@@ -6,7 +6,7 @@
 (*      This file is distributed under the terms of the       *)
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
-
+ 
 (* Require Import Arith Omega Max List. *)
 
 Require Import Arith Omega List Permutation.

--- a/theories/Shared/Libs/DLW/Wf/acc_irr.v
+++ b/theories/Shared/Libs/DLW/Wf/acc_irr.v
@@ -1,0 +1,52 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Set Implicit Arguments.
+
+Section Acc_irrelevance.
+
+  Variable (X : Type) (R : X -> X -> Prop).
+
+  (* Equivalence of two accessibility proofs kind of hereditary
+     closure under FunExt *)
+
+  Inductive Acc_eq : forall x, Acc R x -> Acc R x -> Prop :=
+    | in_Acc_eq : forall x A1 A2, (forall y H, @Acc_eq y (A1 y H) (A2 y H)) 
+                               -> @Acc_eq x (Acc_intro _ A1) (Acc_intro _ A2). 
+
+  (** All accessibility proofs are equivalent !!
+      But equality between those proofs cannot be proved w/o FunExt 
+      Notice that we use a dependent induction principle here *)
+
+  Fact Acc_eq_total x H1 H2 : @Acc_eq x H1 H2.
+  Proof.
+    revert H2. 
+    induction H1 as [ ? ? IH ] using Acc_inv_dep.
+    intros []; constructor; intros; apply IH.
+  Qed.
+
+  (** This provides a way to show that a dependent function 
+               forall x, Acc R x -> P x 
+      is Acc irrelevant *)
+
+  Variables (P : X -> Type) (f : forall x, Acc R x -> P x)
+            (Hf : forall x H1 H2, (forall y Hy, f (H1 y Hy) =  f (H2 _ Hy)) 
+                               ->  f (Acc_intro x H1) = f (Acc_intro x H2)).
+
+  Theorem Acc_irrelevance x H1 H2 : @f x H1 = f H2.
+  Proof.
+    generalize (Acc_eq_total H1 H2).
+    induction 1 as [ x H1 H2 _ IH ].
+    apply Hf, IH.
+  Qed.
+
+End Acc_irrelevance.
+
+
+

--- a/theories/Shared/Libs/DLW/Wf/measure_ind.v
+++ b/theories/Shared/Libs/DLW/Wf/measure_ind.v
@@ -1,0 +1,181 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Lia Wellfounded List Extraction.
+
+From Undecidability.Shared.Libs.DLW.Wf Require Import acc_irr.
+
+Set Implicit Arguments.
+
+Section measure_rect.
+
+  Variable (X : Type) (m : X -> nat) (P : X -> Type).
+
+  Hypothesis F : forall x, (forall x', m x' < m x -> P x') -> P x.
+
+  Arguments F : clear implicits.
+
+  Let R x y := m x < m y.
+
+  Print Acc.
+
+  (** R is WF when all elements are accessible *)
+
+  Let Rwf : forall x : X, Acc R x.
+  Proof.
+    apply wf_inverse_image with (f := m), lt_wf.
+  Qed.
+
+  (** Structural decrease on the Acc predicate and no 
+      singleton elimination here because the Acc predicated
+      is pattern matched (by destruct) in Prop context *)
+
+  Let Fix_F : forall x : X, Acc R x -> P x.
+  Proof.
+    refine(
+      fix Fix_F x (H : Acc R x) { struct H } := 
+         F x (fun x' (H' : R x' x) => Fix_F x' _)
+    ).
+    destruct H as [ G ].
+    apply G. (* structural decrease here *)
+    trivial. 
+  Defined.
+
+  Print Fix_F.
+
+  (** Acc_inv is precisely implemented by destruct, ie pattern matching *)
+
+  Print Acc_inv.
+
+  (** To evaluate @Fix_F x A, the recursive argument must reduce to a
+      term headed with an inductive constructor *)
+
+  Let Fix_F_fix x A :
+        @Fix_F x A = F x (fun y H => Fix_F (Acc_inv A H)).
+  Proof. destruct A; reflexivity. Qed.
+
+  Definition measure_rect x : P x := Fix_F (Rwf x).
+
+  (** To establish the fixpoint equation for measure_rect, we need
+      to assume that the functional F is extensional because we do not
+      use the FunExt axiom *)
+
+  Hypothesis F_ext : forall x f g, (forall y H, f y H = g y H) -> F x f = F x g.
+
+  (** Another proof method here that in StdLib, using the characterisation
+      of Acc irrelevant functionals *)
+
+  Let Fix_F_Acc_irr : forall x f g, @Fix_F x f = Fix_F g.
+  Proof.
+    apply Acc_irrelevance.
+    intros; apply F_ext; auto.
+  Qed.
+
+  Theorem measure_rect_fix x : 
+          measure_rect x = @F x (fun y _ => measure_rect y).
+  Proof.
+    unfold measure_rect; rewrite Fix_F_fix.
+    apply F_ext.
+    intros; apply Fix_F_Acc_irr.
+  Qed.
+
+End measure_rect.
+
+Tactic Notation "induction" "on" hyp(x) "as" ident(IH) "with" "measure" uconstr(f) :=
+   pattern x; revert x; apply measure_rect with (m := fun x => f); intros x IH.
+
+Extraction Inline measure_rect.
+
+Section measure_double_rect.
+
+  Variable (X Y : Type) (m : X -> Y -> nat) (P : X -> Y -> Type).
+
+  Hypothesis F : (forall x y, (forall x' y', m x' y' < m x y -> P x' y') -> P x y).
+
+  Let m' (c : X * Y) := match c with (x,y) => m x y end.
+
+  Let R c d := m' c < m' d.
+
+  Let Rwf : well_founded R.
+  Proof.
+    apply wf_inverse_image with (f := m'), lt_wf.
+  Qed.
+
+  Section measure_double_rect_paired.
+
+    Let Q c := match c with (x,y) => P x y end.
+
+    Theorem measure_double_rect_paired x y : P x y.
+    Proof.
+      change (Q (x,y)).
+      generalize (x,y); clear x y; intros c.
+
+      induction on c as IH with measure (m' c).
+      destruct c as (x,y); apply F.
+      intros ? ?; apply (IH (_,_)). 
+    Defined.
+
+  End measure_double_rect_paired.
+
+  Section measure_double_rect.
+
+    Let Fix_F_2 : forall x y, Acc R (x,y) -> P x y.
+    Proof.
+      refine (fix Fix_F_2 x y H { struct H } := 
+           @F x y (fun x' y' H' => Fix_F_2 x' y' _)
+      ).
+      destruct H as [ H ]; unfold R in H at 1. 
+      apply H. (* structural decrease here *)
+      apply H'. 
+    Defined.
+
+    Let Fix_F_2_fix x y H :
+        @Fix_F_2 x y H = F (fun x' y' H' => Fix_F_2 (@Acc_inv _ _ _ H (x',y') H')).
+    Proof. destruct H; reflexivity. Qed.
+
+    Definition measure_double_rect x y : P x y := Fix_F_2 (Rwf (_,_)).
+
+    Hypothesis F_ext : forall x y f g, (forall x' y' H, f x' y' H = g x' y' H) 
+                                      -> @F x y f = F g.
+
+    Let Fix_F_2_paired c (A : Acc R c) : P (fst c) (snd c).
+    Proof. destruct c; simpl; apply Fix_F_2; trivial. Defined.
+
+    Let Fix_F_2_paired_Acc_irr : forall c f g, @Fix_F_2_paired c f 
+                                              = Fix_F_2_paired   g.
+    Proof.
+       apply Acc_irrelevance.
+       intros (x,y) f g IH; apply F_ext.
+       intros x' y' ?; apply (@IH (x',y')).
+    Qed.
+
+    Let Fix_F_2_Acc_irr x y f g : @Fix_F_2 x y f = Fix_F_2 g.
+    Proof.
+      intros; apply (@Fix_F_2_paired_Acc_irr (x,y)); trivial.
+    Qed.
+
+    Theorem measure_double_rect_fix x y : 
+             measure_double_rect x y = @F x y (fun x' y' _ => measure_double_rect x' y').
+    Proof.
+      unfold measure_double_rect; rewrite Fix_F_2_fix.
+      apply F_ext.
+      intros; apply Fix_F_2_Acc_irr.
+    Qed.
+
+  End measure_double_rect.
+
+End measure_double_rect.
+
+Tactic Notation "paired" "induction" "on" hyp(x) hyp(y) "as" ident(IH) "with" "measure" uconstr(f) :=
+   pattern x, y; revert x y; apply measure_double_rect_paired with (m := fun x y => f); intros x y IH.
+
+Tactic Notation "induction" "on" hyp(x) hyp(y) "as" ident(IH) "with" "measure" uconstr(f) :=
+   pattern x, y; revert x y; apply measure_double_rect with (m := fun x y => f); intros x y IH.
+
+Extraction Inline measure_double_rect measure_double_rect_paired.

--- a/theories/Shared/Libs/DLW/Wf/wf_chains.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_chains.v
@@ -1,0 +1,159 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith List Lia.
+
+Set Implicit Arguments.
+
+Section wf_chains.
+
+  Variables (X : Type) (R : X -> X -> Prop).
+  
+  Inductive chain : nat -> X -> X -> Prop :=
+    | in_chain_0 : forall x, chain 0 x x
+    | in_chain_1 : forall n x y z, R x y -> chain n y z -> chain (S n) x z.
+
+  Hint Constructors chain.
+
+  Fact chain_inv_0 x y : chain 0 x y -> x = y.
+  Proof. inversion 1; auto. Qed.
+
+  Fact chain_inv_S n x y : chain (S n) x y -> exists z, R x z /\ chain n z y.
+  Proof. inversion 1; exists y0; auto. Qed.
+
+  Fact chain_plus a b x y z : chain a x y -> chain b y z -> chain (a+b) x z.
+  Proof.
+    induction 1 as [ | ? ? y ].
+    + simpl; auto.
+    + intros. simpl. 
+      constructor 2 with y. 
+      * auto.
+      * auto.
+  Qed.
+
+  Corollary chain_snoc n x y z : chain n x y -> R y z -> chain (S n) x z.
+  Proof.
+    intros H1 H2.
+    replace (S n) with (n+1) by lia.
+    apply chain_plus with y; auto.
+    constructor 2 with z; auto.
+  Qed.
+
+  Fact chain_plus_inv a b x z : chain (a+b) x z -> exists y, chain a x y /\ chain b y z.
+  Proof.
+    revert x; induction a as [ | a IHa ]; intros x; simpl.
+    + exists x; split; auto.
+    + intros H.
+      apply chain_inv_S in H.
+      destruct H as (y & H1 & H2).
+      specialize (IHa _ H2).
+      destruct IHa as (k & ? & ?).
+      exists k; split; auto.
+      constructor 2 with y; auto.
+  Qed.
+ 
+  Fact chain_snoc_inv n x z : chain (S n) x z -> exists y, chain n x y /\ R y z.
+  Proof.
+    replace (S n) with (n+1) by lia.
+    intros H; apply chain_plus_inv in H.
+    destruct H as (y & H1 & H2).
+    exists y; split; auto.
+    apply chain_inv_S in H2.
+    destruct H2 as (k & H2 & H3).
+    apply chain_inv_0 in H3; subst; auto.
+  Qed. 
+
+  Inductive chain_list : list X -> X -> X -> Prop :=
+    | in_chain_list_0 : forall x, chain_list nil x x
+    | in_chain_list_1 : forall x l y z, R x y -> chain_list l y z -> chain_list (x::l) x z.
+
+  Fact chain_chain_list n x y : chain n x y -> exists l, chain_list l x y 
+                                                      /\ n = length l.
+  Proof.
+    induction 1 as [ x | n x y z H1 _ (l & H2 & H3) ]; auto.
+    + exists nil; simpl; split; auto; constructor.
+    + exists (x::l); simpl; split; auto; constructor 2 with y; auto.
+  Qed.
+
+  Fact chain_list_chain l x y : chain_list l x y -> chain (length l) x y. 
+  Proof.
+    induction 1 as [ ? | ? ? y ]; simpl; try constructor.
+    constructor 2 with y; auto.
+  Qed.
+
+  Fact chain_list_app l x y m z : chain_list l x y 
+                               -> chain_list m y z 
+                               -> chain_list (l++m) x z.
+  Proof.
+    induction 1 as [ | l x y ]; simpl; auto.
+    constructor 2 with y; auto.
+  Qed.
+
+  Lemma chain_list_inv l x y : 
+         chain_list l x y -> l = nil /\ x = y
+                          \/ exists k l', l = x::l' /\ R x k /\ chain_list l' k y.
+  Proof. intros [|]; firstorder. Qed.
+
+  Corollary chain_list_nil_inv x y : chain_list nil x y -> x = y.
+  Proof.
+    intros H; apply chain_list_inv in H.
+    destruct H as [ (_ & ->) | (? & ? & ? & _) ]; auto; discriminate.
+  Qed.
+
+  Corollary chain_list_cons_inv x l y z : 
+         chain_list (x::l) y z -> x = y /\ exists k, R x k /\ chain_list l k z.
+  Proof.
+    intros H.
+    apply chain_list_inv in H.
+    destruct H as [ (? & _) | (k & l' & H & ? & ?) ]; try discriminate.
+    inversion H; firstorder.
+  Qed.
+
+  Lemma chain_list_app_inv l m x z : 
+         chain_list (l++m) x z -> exists y, chain_list l x y /\ chain_list m y z.
+  Proof.
+    revert x; induction l as [ | a l IHl ]; intros x.
+    + exists x; simpl; split; auto; constructor.
+    + simpl; intros H; apply chain_list_cons_inv in H.
+      destruct H as (-> & b & H1 & H2).
+      apply IHl in H2; destruct H2 as (y & H2 & H3).
+      exists y; split; auto; constructor 2 with b; auto.
+  Qed.
+
+  (* If chains to x have bounded length then x is R-accessible *)
+  
+  Lemma Acc_chains k x : (forall n y, chain n y x -> n <= k) -> Acc R x.
+  Proof.
+    revert x.
+    induction k as [ | k IHk ]; intros x Hx.
+    + constructor 1; intros y Hy.
+      assert (chain 1 y x) as C.
+      { constructor 2 with x.
+        + trivial.
+        + constructor 1. }
+      apply Hx in C; lia.
+    + constructor 1; intros y Hy.
+      apply IHk; intros n z Hn.
+      apply le_S_n. 
+      apply (Hx _ z).
+      apply chain_snoc with y; auto.
+  Qed.
+
+  (* If every x has bounded chains to itself then R is WF *)
+  
+  Hypothesis (HR : forall x, exists k, forall n y, chain n y x -> n <= k). 
+
+  Theorem wf_chains : well_founded R.
+  Proof.
+    intros x.
+    destruct (HR x) as (k & Hk).
+    revert Hk; apply Acc_chains.
+  Qed.
+  
+End wf_chains.

--- a/theories/Shared/Libs/DLW/Wf/wf_finite.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_finite.v
@@ -1,0 +1,111 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith List Lia.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import php.
+
+From Undecidability.Shared.Libs.DLW.Wf 
+  Require Import wf_chains.
+
+Set Implicit Arguments.
+
+Section wf_strict_order_list.
+
+  Variable (X : Type) (R : X -> X -> Prop).
+  Hypothesis (Rirrefl : forall x, ~ R x x)
+             (Rtrans : forall x y z, R x y -> R y z -> R x z).
+
+  Implicit Type l : list X.
+
+  Fact chain_trans n x y : chain R n x y -> n = 0 /\ x = y \/ R x y.
+  Proof.
+    induction 1 as [ x | n x y z H1 H2 IH2 ]; auto.
+    destruct IH2 as [ [] | ]; subst; right; auto.
+    apply Rtrans with (1 := H1); auto.
+  Qed.
+
+  Corollary chain_irrefl n x : n = 0 \/ ~ chain R n x x.
+  Proof.
+    destruct n as [ | n ]; auto; right; intros H.
+    destruct (chain_trans H) as [ (? & _) | H1 ]; try discriminate.
+    revert H1; apply Rirrefl.
+  Qed.
+
+  Variable (m : list X) (Hm : forall x y, R x y -> In x m).
+
+  Fact chain_list_incl l x y : chain_list R l x y -> l = nil \/ incl l m.
+  Proof.
+    induction 1 as [ x | x l y z H1 H2 IH2 ]; simpl; auto; right.
+    apply incl_cons.
+    + apply Hm with (1 := H1); auto.
+    + destruct IH2; auto; subst l; intros _ [].
+  Qed.
+
+  (** Any chain of length above length m contains a duplicated
+      value (by the PHP) hence a non nil sub-chain with identical 
+      endpoints, contradicting chain_irrefl *)
+
+  Lemma chain_bounded n x y : chain R n x y -> n <= length m.
+  Proof.
+    intros H.
+    destruct (le_lt_dec n (length m)) as [ | C ]; auto.
+    destruct chain_chain_list with (1 := H)
+      as (ll & H1 & H2).
+    cut (list_has_dup ll).
+    + intros H3.
+      apply list_has_dup_equiv in H3.
+      destruct H3 as (z & l & u & r & ->).
+      apply chain_list_app_inv in H1.
+      destruct H1 as (a & _ & H1).
+      apply chain_list_cons_inv in H1.
+      destruct H1 as (<- & k & H3 & H1).
+      apply chain_list_app_inv in H1.
+      destruct H1 as (p & H4 & H1).
+      apply chain_list_cons_inv in H1.
+      destruct H1 as (<- & _ & _ & _).
+      apply chain_list_chain in H4.
+      destruct (chain_irrefl (S (length u)) z)
+        as [ | [] ]; try discriminate.
+      constructor 2 with k; auto.
+    + apply chain_list_incl in H1.
+      destruct H1 as [ -> | H1 ].
+      * subst; simpl in C; lia.
+      * apply finite_php_dup with (2 := H1); lia.
+  Qed.
+
+  (** Since chains have bounded length, we get WF *)
+
+  Theorem wf_strict_order_list : well_founded R.
+  Proof.
+    apply wf_chains.
+    intros x; exists (length m). 
+    intros ? ?; apply chain_bounded.
+  Qed.
+
+End wf_strict_order_list.
+
+Section wf_strict_order_finite.
+
+  Variable (X : Type) (HX : exists l, forall x : X, In x l) 
+           (R : X -> X -> Prop)
+           (Rirrefl : forall x, ~ R x x)
+           (Rtrans : forall x y z, R x y -> R y z -> R x z).
+
+  Theorem wf_strict_order_finite : well_founded R.
+  Proof.
+    destruct HX as (m & Hm).
+    apply wf_strict_order_list with (m := m); auto.
+  Qed.
+
+End wf_strict_order_finite.
+
+Check wf_strict_order_finite.
+Print Assumptions wf_strict_order_finite.

--- a/theories/Shared/Libs/DLW/Wf/wf_incl.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_incl.v
@@ -1,0 +1,154 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith List Omega Wellfounded.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import php.
+
+From Undecidability.Shared.Libs.DLW.Wf 
+  Require Import acc_irr measure_ind wf_chains.
+
+Set Implicit Arguments.
+
+(** Results about the well-foundedness of strict (reverse)
+    inclusion between lists 
+
+    These proofs avoid the need of decidable equality
+    and use the finitary Pigeon Hole Principle (PHP) 
+    instead
+*)
+
+Section sincl.
+
+  (** Strict inclusion between lists is a well founded relation *)
+
+  Variable (X : Type).
+
+  Implicit Type (l m : list X).
+    
+  (* sincl l m if incl l m and there is a witness in m \ l *)
+
+  Definition sincl l m := incl l m /\ exists x, ~ In x l /\ In x m.
+
+  (* Any n-chain m ~~> l contains a 
+     duplication-free subset of l of size n 
+     which does not intersect m  *)
+
+  Lemma sincl_chain n m l :   
+       chain sincl n m l -> incl m l 
+                         /\ exists ll, ~ list_has_dup ll 
+                                      /\ length ll = n 
+                                      /\ incl ll l
+                                      /\ forall x, In x m -> In x ll -> False.
+  Proof.
+    induction 1 as [ m | n m l k H1 H2 (H7 & ll & H3 & H4 & H5 & H6) ].
+    + split.
+      * intros ?; auto.
+      * exists nil; simpl; repeat split; auto.
+        - inversion 1.
+        - intros _ [].
+    + split.
+      * intros ? ?; apply H7, H1; auto.
+      * destruct H1 as (G1 & x & G2 & G3).
+        exists (x::ll); simpl; repeat split; auto.
+        - contradict H3.
+          apply list_has_dup_cons_inv in H3.
+          destruct H3 as [ H3 | ]; auto.
+          destruct (H6 x); auto.
+        - apply incl_cons; auto.
+        - intros y F1 [ F2 | F2 ]; subst.
+          ** tauto.
+          ** apply (H6 y); auto.
+  Qed.
+
+  (* Hence, by the PHP, if there is a n-chain to l then n must be less than length l *)
+
+  Corollary sincl_chain_bounded l m n : chain sincl n m l -> n <= length l.
+  Proof.
+    intros H.
+    apply sincl_chain in H.
+    destruct H as (_ & ll & H1 & H2 & H3 & _).
+    destruct (le_lt_dec n (length l)) as [ | C ]; auto.
+    subst; destruct H1.
+    apply finite_php_dup with l; auto.
+  Qed.
+
+  (* Hence sincl is well-founded because n-chains to l have length bounded by length l *)
+   
+  Theorem wf_sincl : well_founded sincl.
+  Proof.
+    apply wf_chains.
+    intros l; exists (length l).
+    intros ? ?; apply sincl_chain_bounded.
+  Qed.
+
+End sincl.
+
+Arguments wf_sincl {X}.
+
+Section rincl_fin.
+
+  (** Strict reverse inclusion between lists is well founded over a finite domain *)
+ 
+  (* M the upper-bound/finiteness of the domain *)
+
+  Variable (X : Type) (M : list X). 
+
+  (* l cap M strictly contains in m cap M *)
+
+  Definition rincl_fin l m := (forall x, In x m -> In x M -> In x l) 
+                            /\ exists x, ~ In x m /\ In x l /\ In x M.
+
+  (* Any n-chain m ~~> l contains a duplication-free subset of M of size n *)
+                            
+  Lemma rincl_fin_chains n m l :   chain rincl_fin n m l 
+                   -> exists ll, ~ list_has_dup ll 
+                                /\ incl ll M 
+                                /\ length ll = n 
+                                /\ incl ll m.
+  Proof.
+    induction 1 as [ x | n m k l H1 H2 (ll & H3 & H4 & H5 & H6) ].
+    + exists nil.
+      repeat split; simpl; auto; inversion 1.
+    + destruct H1 as (H1 & a & G1 & G2 & G3).
+      exists (a::ll).
+      repeat split.
+      * contradict H3.
+        apply list_has_dup_cons_inv in H3.
+        destruct H3 as [ H3 | ]; auto.
+        destruct G1; apply H6; auto.
+      * apply incl_cons; auto.
+      * simpl; f_equal; auto.
+      * apply incl_cons; auto.
+        intros ? ?; auto.
+  Qed.
+
+  (* Hence, by the PHP, if there is a n-chain to l then n is less than length M *)
+
+  Corollary rincl_fin_chain_bounded l m n : chain rincl_fin n m l -> n <= length M.
+  Proof.
+    intros H.
+    apply rincl_fin_chains in H.
+    destruct H as (ll & H1 & H2 & H3 & _).
+    destruct (le_lt_dec n (length M)) as [ | C ]; auto.
+    subst n; destruct H1.
+    apply finite_php_dup with M; auto.
+  Qed.
+
+  Theorem wf_rincl_fin : well_founded rincl_fin.
+  Proof.
+    apply wf_chains.
+    intros l; exists (length M).
+    intros ? ?; apply rincl_fin_chain_bounded.
+  Qed.
+
+End rincl_fin.
+
+Arguments wf_rincl_fin {X}.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -30,10 +30,25 @@ Shared/Libs/DLW/Utils/prime.v
 Shared/Libs/DLW/Utils/power_decomp.v
 Shared/Libs/DLW/Utils/bounded_quantification.v
 Shared/Libs/DLW/Utils/php.v
+Shared/Libs/DLW/Utils/seteq.v
 Shared/Libs/DLW/Utils/rel_iter.v
+Shared/Libs/DLW/Utils/fin_base.v
+Shared/Libs/DLW/Utils/fin_dec.v
+Shared/Libs/DLW/Utils/fin_choice.v
+Shared/Libs/DLW/Utils/fin_bij.v
+Shared/Libs/DLW/Utils/fin_upto.v
+Shared/Libs/DLW/Utils/fin_quotient.v
+Shared/Libs/DLW/Utils/finite.v
+Shared/Libs/DLW/Utils/quotient.v
 
 Shared/Libs/DLW/Vec/pos.v
 Shared/Libs/DLW/Vec/vec.v
+
+Shared/Libs/DLW/Wf/acc_irr.v
+Shared/Libs/DLW/Wf/measure_ind.v
+Shared/Libs/DLW/Wf/wf_chains.v
+Shared/Libs/DLW/Wf/wf_finite.v
+Shared/Libs/DLW/Wf/wf_incl.v
 
 Problems/Reduction.v
 Problems/PCP.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -427,6 +427,7 @@ Reductions/SRH_to_SR.v
 Reductions/SR_to_MPCP.v 
 Reductions/MPCP_to_PCP.v
 Reductions/PCP_to_BPCP.v
+Reductions/TM_to_BPCP.v
 Reductions/BPCP_to_BSM.v
 Reductions/BSM_to_MM.v  
 Reductions/MM_to_ILL.v  


### PR DESCRIPTION
This is a proposed PR for a change in the definition of `reduces` in `Problems/Reduction.v` to make it **informative**. Indeed, the original definition was:

```
 Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := 
    exists f : X -> Y, forall x, p x <-> q (f x).
```

and the proposed new definition is now:

```
Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) :=
    { f : X -> Y | forall x, p x <-> q (f x) }.
```
so just the replacement of non-informative `∃` with informative `∑`.

I acknowledge that this is a **fundamental change** that implied some changes in the code elsewhere, mostly in the `L/*` branch of the library that relied too much on non-informative features, so I had to lift several definitions in `L/Computability/Synthetic.v` to informative as well, i.e. `L_decidable`, `L_enumerable`, `L_recognisable`, `L_enumerable_recognisable`, `L_enum`, `projection`, `L_enumerable_ext`, `L_enumerable_enum`, `L_enumerable_halt`. For each definition/lemma like e.g. `lem`, I did create an informative version named `lem_t` and proved the equivalence 

```
lem_t_eq ... : inhabited(lem_t ...) <-> lem ...
``` 

In the other developments like `ILL` or `H10` or `FOL` ... changes where minimal and proof scripts just worked out of the box. Notice however that some proof scripts do not explicitly name `intros` variables, and names picked up by Coq are not stable when migrating from `Prop` to `Type`. In general, I would advise to **never** use a name which was not introduced explicitly in the proof script.

Overall, the change worked out quite smoothly and this PR proposes a complete migration to informative reduction of the `master` branch. 

The change is motivated by three reasons:
- first informative reductions are needed/helpfull in the developments on decidability of finite FO satisfiability, including the full Trakhtenbrot theorem.
- second, it seems right that a reduction should actually be represented by a type with computational content, hence it can be extracted.
- the third reason is that the informative version allows to use parametrized reductions w/o having to use dependent choice. See below.

Indeed, when you have a _parametrized reduction_ like `∀ t : T, p t ⪯ q t` with `X Y : T -> Prop`, `p : ∀ t : T, X t -> Prop` and `q : ∀ t : T, Y t -> Prop`, one trivially can get a map 
```
{ f : ∀t, X t -> Y t | ∀ t x, p t x <-> q y (f t x) }
``` 
in the informative case but it is not possible to establish 
```
∃ (f : ∀t, X t -> Y t), ∀ t x, p t x <-> q y (f t x)
``` 
in the non-informative case without using dependent choice, more precisely [`DependentFunctionalChoice`](https://coq.inria.fr/library/Coq.Logic.ChoiceFacts.html).

Also the PR proposes some non-destructive add-ons in the `Shared/Libs/DLW/*` libraries.