### PR TITLE
Mu to lambda

### DIFF
--- a/theories/L/Computability/MuRec.v
+++ b/theories/L/Computability/MuRec.v
@@ -103,8 +103,14 @@ Proof.
      *assumption.
 Qed.
 
+Lemma mu_spec : converges (mu P) <-> exists n : nat, P (ext n) == ext true.
+Proof.
+  split.
+  - intros (? & ? & ?). eapply mu_sound in H as (? & ? & ? & ?); eauto.
+  - intros []. eapply mu_complete in H as []. exists (ext x0). split. eauto. eapply proc_ext.
+Qed.
+
 End MuRecursor.
 
 Hint Resolve mu'_proc : LProc.
 Hint Resolve mu_proc : LProc.
-

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -56,7 +56,7 @@ Section L_enum_rec.
       + rewrite <- H0. symmetry. cbn. Lsimpl.
       + subst. eapply H_f. exists n.
         assert ((λ y, !! (ext test) !! (enc x) y) !!(ext n) == ext (test x n)).
-        cbn. Lsimpl. rewrite H2 in *.
+        cbn. Lsimpl. cbn in *. rewrite H2 in *.
         eapply unique_normal_forms in H3; try Lproc.
         eapply inj_enc in H3.
         unfold test in H3. destruct (f n); inv H3.

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -14,6 +14,9 @@ Definition L_enumerable {X} `{registered X} (p : X -> Prop) :=
   exists f : nat -> option X, is_computable f /\ (enumerates f p).
 
 Definition L_recognisable {X} `{registered X} (p : X -> Prop) :=
+  exists f : X -> nat -> bool, is_computable f /\ forall x, p x <-> exists n, f x n = true.
+
+Definition L_recognisable' {X} `{registered X} (p : X -> Prop) :=
   exists s : term, forall x, p x <-> converges (s (enc x)).
 
 Section L_enum_rec.
@@ -39,7 +42,7 @@ Section L_enum_rec.
   Qed.
     
   Lemma L_enumerable_recognisable :
-    L_recognisable p.
+    L_recognisable' p.
   Proof.
     exists (λ x, !!mu (λ y, !!(ext test) x y)).
     intros. split; intros.
@@ -156,3 +159,24 @@ Proof.
   - now exists (fun x0 => x (enc x0)). 
 Qed.  
 
+Lemma L_recognisable'_recognisable {X} `{registered X} (p : X -> Prop) :
+  L_recognisable p -> L_recognisable' p.
+Proof.
+  intros (f & [c_f] & H_f).
+  exists (lam (mu (lam (ext f 1 0)))).
+  intros. 
+  assert (((lam (mu (lam ((ext f 1) 0)))) (enc x)) >* mu (lam (ext f (enc x) 0))) by Lsimpl.
+  rewrite H0. rewrite mu_spec.
+  - rewrite H_f. split; intros [n]; exists n.
+    Lsimpl. now rewrite H1.
+    eapply enc_extinj.
+    now assert ((lam (((ext f) (enc x)) 0)) (ext n) == enc (f x n)) as <- by Lsimpl.
+  - Lproc.
+  - intros. exists (f x n). Lsimpl.
+Qed.    
+
+Lemma L_recognisable_halt {X} `{registered X} (p : X -> Prop) :
+  L_recognisable p -> p ⪯ converges.
+Proof.
+  intros. eapply L_recognisable'_recognisable in H0 as  (f & H_f). now exists (fun x0 => f (enc x0)). 
+Qed.

--- a/theories/L/Datatypes/LSum.v
+++ b/theories/L/Datatypes/LSum.v
@@ -1,0 +1,30 @@
+From Undecidability.L Require Export L Tactics.LTactics.
+
+From Undecidability.L.Datatypes Require Import LNat.
+
+(** ** Encoding of sums *)
+
+Section Fix_XY.
+
+  Variable X Y:Type.
+  
+  Variable intX : registered X.
+  Variable intY : registered Y.
+
+  Run TemplateProgram (tmGenEncode "sum_enc" (X + Y)).
+  Hint Resolve sum_enc_correct : Lrewrite.
+  
+  (* now we must register the constructors*)
+  Global Instance term_inl : computable inl.
+  Proof.
+    extract constructor.
+  Qed.
+
+  Global Instance term_inr : computable inr.
+  Proof.
+    extract constructor.
+  Qed.
+  
+End Fix_XY.
+
+Hint Resolve sum_enc_correct : Lrewrite.

--- a/theories/L/Functions/Ackermann.v
+++ b/theories/L/Functions/Ackermann.v
@@ -27,22 +27,22 @@ Local Lemma Ack_pos n m : 0 < ackermann n m.
   all:eauto.
 Qed.
 
-Lemma termT_ackermann :
-  computableTime ackermann
-                 (fun x _ =>
-                    (14,
-                     fun y _ =>
-                       (cnst("f",x,y),tt))).
-Proof.
-  extract.
-  Import Ring Arith.
-  cbn. fold ackermann. 
-  repeat (cbn ;intros;intuition idtac;try destruct _;try ring_simplify;try lia).
-  all:repeat change (fix ackermann_Sn (m : nat) : nat :=
-    match m with
-    | 0 => fun _ => ackermann x0 1
-    | S m0 => fun _  => ackermann x0 (ackermann_Sn m0)
-    end true) with (ackermann (S x0)). all: refine ( _:(_ >= _)).
-  (* Todo: find an f satisfying the 3 equations in the goal *)
-Abort.
+(* Lemma termT_ackermann : *)
+(*   computableTime ackermann *)
+(*                  (fun x _ => *)
+(*                     (14, *)
+(*                      fun y _ => *)
+(*                        (cnst("f",x,y),tt))). *)
+(* Proof. *)
+(*   extract. *)
+(*   Import Ring Arith. *)
+(*   cbn. fold ackermann.  *)
+(*   repeat (cbn ;intros;intuition idtac;try destruct _;try ring_simplify;try lia). *)
+(*   all:repeat change (fix ackermann_Sn (m : nat) : nat := *)
+(*     match m with *)
+(*     | 0 => fun _ => ackermann x0 1 *)
+(*     | S m0 => fun _  => ackermann x0 (ackermann_Sn m0) *)
+(*     end true) with (ackermann (S x0)). all: refine ( _:(_ >= _)). *)
+(*   (* Todo: find an f satisfying the 3 equations in the goal *) *)
+(* Abort. *)
   

--- a/theories/L/Reductions/MuRec.v
+++ b/theories/L/Reductions/MuRec.v
@@ -1,0 +1,444 @@
+From Undecidability.H10 Require Import H10 dio_single dio_logic.
+From Undecidability.L.Datatypes Require Import LNat Lists LOptions LSum.
+From Undecidability.L Require Import Tactics.LTactics Computability.MuRec Computability.Synthetic Tactics.GenEncode.
+
+
+
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+From Undecidability.Shared Require Import DLW.Vec.vec DLW.Vec.pos.
+From Undecidability.MuRec Require Import recalg.
+
+Set Implicit Arguments.
+
+Reserved Notation "  '[' f ';' v ']' '~~>' x " (at level 70).
+
+(* Bigstep semantics for recursive algorithms *)
+   
+Inductive ra_bs : forall k, recalg k -> vec nat k -> nat -> Prop :=
+    | in_ra_bs_cst  : forall n v,             [ra_cst n;        v] ~~> n
+    | in_ra_bs_zero : forall v,               [ra_zero;         v] ~~> 0
+    | in_ra_bs_succ : forall v,               [ra_succ;         v] ~~> S (vec_head v)
+    | in_ra_bs_proj : forall k v j,           [@ra_proj k j;    v] ~~> vec_pos v j
+    
+    | in_ra_bs_comp : forall k i f (gj : vec (recalg i) k) v w x,
+                                   (forall j, [vec_pos gj j;    v] ~~> vec_pos w j)
+                               ->             [f;               w] ~~> x
+                               ->             [ra_comp f gj;    v] ~~> x
+
+    | in_ra_bs_rec_0 : forall k f (g : recalg (S (S k))) v x,
+                                              [f;               v] ~~> x
+                               ->             [ra_rec f g;   0##v] ~~> x
+
+    | in_ra_bs_rec_S : forall k f (g : recalg (S (S k))) v n x y,
+                                              [ra_rec f g;   n##v] ~~> x
+                               ->             [g;         n##x##v] ~~> y
+                               ->             [ra_rec f g; S n##v] ~~> y
+                               
+    | in_ra_bs_min : forall k (f : recalg (S k)) v x w ,
+                           (forall j : pos x, [f;    pos2nat j##v] ~~> S (vec_pos w j))
+                               ->             [f;            x##v] ~~> 0
+                               ->             [ra_min f;        v] ~~> x
+where " [ f ; v ] ~~> x " := (@ra_bs _ f v x).
+
+
+Reserved Notation "  '[' f ';' v ';' c ']' '~~>' x " (at level 70).
+
+(* Bigstep semantics for recursive algorithms *)
+   
+Inductive ra_bs_c : nat -> forall k, recalg k -> vec nat k -> nat -> Prop := 
+    | in_ra_bs_c_cst  : forall c n v,             [ra_cst n;        v; S c] ~~> n
+    | in_ra_bs_c_zero : forall c v,               [ra_zero;         v; S c] ~~> 0
+    | in_ra_bs_c_succ : forall c v,               [ra_succ;         v; S c] ~~> S (vec_head v)
+    | in_ra_bs_c_proj : forall c k v j,           [@ra_proj k j;    v; S c] ~~> vec_pos v j 
+    
+    | in_ra_bs_c_comp : forall c k i f (gj : vec (recalg i) k) v w x,
+                                         (forall j, [vec_pos gj j;    v; c + pos2nat j] ~~> vec_pos w j)
+                                 ->             [f;               w; c] ~~> x
+                                 ->             [ra_comp f gj;    v; c + k] ~~> x
+
+    | in_ra_bs_c_rec_0 : forall c k f (g : recalg (S (S k))) v x,    
+                                               [f;               v; c] ~~> x 
+                                 ->             [ra_rec f g;   0##v; S c] ~~> x
+
+    | in_ra_bs_c_rec_S : forall c k f (g : recalg (S (S k))) v n x y,          
+                                              [ra_rec f g;   n##v; c] ~~> x
+                               ->             [g;         n##x##v; c] ~~> y
+                               ->             [ra_rec f g; S n##v; S c] ~~> y
+                               
+    | in_ra_bs_c_min : forall c k (f : recalg (S k)) v x w , 
+                           (forall j : pos x, [f;    pos2nat j##v; c + pos2nat j] ~~> S (vec_pos w j)) 
+                               ->             [f;            x##v; c] ~~> 0
+                               ->             [ra_min f;        v; c + x] ~~> x
+where " [ f ; v ; c ] ~~> x " := (@ra_bs_c c _ f v x).
+
+
+Lemma ra_bs_mono k (f : recalg k) v c1 x :
+  [f ; v ; c1 ] ~~> x -> forall c2, c1 <= c2 -> [f ; v ; c2] ~~> x. 
+Proof.
+  induction 1; intros; try (destruct c2;[ omega | ]).
+  - econstructor.
+  - econstructor.
+  - econstructor.
+  - econstructor.
+  - assert (c2 = (c2 - k) + k) as -> by omega.
+    econstructor.
+    + intros. eapply H0. omega.
+    + eapply IHra_bs_c. omega.
+  - econstructor. eapply IHra_bs_c. omega.
+  - econstructor.
+    + eapply IHra_bs_c1. omega.
+    + eapply IHra_bs_c2. omega.
+  - assert (c2 = (c2 - x) + x) as -> by omega.
+    econstructor.
+    + intros. eapply H0. omega.
+    + eapply IHra_bs_c. omega.
+Qed.
+
+Require Import Equations.Prop.DepElim.
+
+Lemma vec_sum_le:
+  forall (k : nat) (cst : vec nat k) (j : pos k), vec_pos cst j <= vec_sum cst.
+Proof.
+  intros k cst j.
+  induction cst; cbn.
+  - inversion j.
+  - depelim j. omega. specialize (IHcst j). omega.
+Qed.
+
+Lemma ra_bs_to_c k (f : recalg k) v x :
+  [ f; v ] ~~> x -> exists c, [f ; v ; c ] ~~> x.
+Proof.
+  induction 1.
+  - exists 1. econstructor.
+  - exists 1. econstructor.
+  - exists 1. econstructor.
+  - exists 1. econstructor.
+  - destruct IHra_bs as [c].
+    eapply vec_reif in H0 as [cst].
+    exists (c + vec_sum cst + k).
+    econstructor.
+    + intros. eapply ra_bs_mono. eauto.
+      enough (vec_pos cst j <= vec_sum cst) by omega.
+      eapply vec_sum_le.
+    + eapply ra_bs_mono. eauto. omega.
+  - destruct IHra_bs as [c]. exists (S c). now econstructor.
+  - destruct IHra_bs1 as [c1].
+    destruct IHra_bs2 as [c2].
+    exists (1 + c1 + c2).
+    cbn. econstructor.
+    + eapply ra_bs_mono. eauto. omega.
+    + eapply ra_bs_mono. eauto. omega.
+  - destruct IHra_bs as [c].
+    eapply vec_reif in H0 as [cst].
+    exists (c + vec_sum cst + x).
+    econstructor.
+    + intros. eapply ra_bs_mono. eauto.
+      enough (vec_pos cst j <= vec_sum cst) by omega.
+      eapply vec_sum_le.
+    + eapply ra_bs_mono. eauto. omega.
+Qed.
+
+Inductive reccode :=
+| rc_cst (n : nat)
+| rc_zero
+| rc_succ
+| rc_proj (n : nat)
+| rc_comp (f : reccode) (g : reccode)
+| rc_cons (f : reccode) (g : reccode)
+| rc_nil
+| rc_rec (f : reccode) (g : reccode)
+| rc_min (f : reccode).
+
+Run TemplateProgram (tmGenEncode "enc_reccode" reccode).
+Hint Resolve enc_reccode_correct : Lrewrite.
+
+Instance term_rc_comp: computable rc_comp. extract constructor. Qed.
+Instance term_rc_cons : computable rc_cons.  extract constructor. Qed.
+Instance term_rc_rec : computable rc_rec.  extract constructor. Qed.
+Instance term_rc_min : computable rc_min.  extract constructor. Qed.
+
+Fixpoint eval (fuel : nat) (min : nat) (c : reccode) (v : list nat) : option (nat + list nat) :=
+  match fuel with
+  | 0 => None
+  | S fuel =>
+    match c with
+    | rc_cst n => Some (inl n)
+    | rc_zero => Some (inl 0)
+    | rc_succ => match v with
+                | x :: _ => Some (inl (S x))
+                | _ => None
+                end
+    | rc_proj n => match nth_error v n with Some r => Some (inl r) | None => None end
+    | rc_comp f g => match eval fuel min g v
+                    with
+                    | Some (inr g) => match eval fuel min f g with Some (inl f) => Some (inl f) | _ => None end
+                    | _ => None
+                    end
+    | rc_cons f g => match eval fuel min f v, eval fuel min g v with
+                    | Some (inl f), Some (inr g) => Some (inr (f :: g))
+                    | _, _ => None
+                    end
+    | rc_nil => Some (inr nil)
+    | rc_rec f g => match v with
+                   | 0 :: v => match eval fuel min f v with Some (inl r) => Some (inl r) | _ => None end
+                   | S n :: v => match eval fuel min (rc_rec f g) (n :: v) with
+                               | Some (inl y) => match eval fuel min g (n :: y :: v) with Some (inl r) => Some (inl r) | _ => None end
+                               | _ => None
+                               end
+                   | _ => None
+                   end
+    | rc_min f => match eval fuel 0 f (min :: v) with
+                 | Some (inl 0) => Some (inl min)
+                 | Some (inl _) => match eval fuel (S min) (rc_min f) v with Some (inl r) => Some (inl r) | _ => None end
+                 | _ => None
+                 end
+    end
+  end.
+
+(* Lemma eval_mono_S fuel min c v r : *)
+(*   eval fuel min c v = Some r -> eval (S fuel) min c v = Some r. *)
+(* Proof. *)
+(*   intros. induction fuel in H, c, min, r, v |- *. *)
+(*   - inv H. *)
+(*   - cbn in H. destruct c; eauto. *)
+(*     + assert (IH2 := IHfuel min c2 v). *)
+(*       destruct (eval fuel min c2 v); try congruence. *)
+(*       destruct s; try congruence. *)
+(*       assert (IH1 := IHfuel min c1 l). *)
+(*       destruct (eval fuel min c1 l); try congruence. *)
+(*       specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). *)
+(*       remember (S fuel) as n. cbn. *)
+(*       rewrite IH2, IH1. eassumption. *)
+(*     + assert (IH1 := IHfuel min c1 v). *)
+(*       destruct (eval fuel min c1 v); try congruence. *)
+(*       destruct s; try congruence. *)
+(*       assert (IH2 := IHfuel min c2 v). *)
+(*       destruct (eval fuel min c2 v); try congruence. *)
+(*       destruct s; try congruence. inv H.       *)
+(*       specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). *)
+(*       remember (S fuel) as k. cbn. *)
+(*       now rewrite IH2, IH1.  *)
+(*     + *)
+(* Admitted. *)
+
+(* Lemma eval_mono fuel1 fuel2 min c v r : *)
+(*   eval fuel1 min c v = Some r -> fuel1 <= fuel2 -> eval fuel2 min c v = Some r. *)
+(* Proof. *)
+(*   intros. induction H0. *)
+(*   - eauto. *)
+(*   - eapply eval_mono_S. eauto. *)
+(* Qed. *)
+
+(* Inductive bigstep (min : nat) : reccode -> list nat -> nat -> Prop := *)
+(* | sem_cst v n : bigstep min (rc_cst n) v n *)
+(* | sem_zero v : bigstep min (rc_zero) v 0 *)
+(* | sem_succ x v : bigstep min (rc_succ) (x :: v) (S x) *)
+(* | sem_proj n v r : nth_error v n = Some r -> bigstep min (rc_proj n) v r *)
+(* | sem_comp f g G v r : bigstep_list min g v G -> bigstep min f G r -> bigstep min (rc_comp f g) v r *)
+(* | sem_rec1 f g v r : bigstep min f v r -> bigstep min (rc_rec f g) (0 :: v) r *)
+(* | sem_rec2 f g n v y x : bigstep min (rc_rec f g) (n :: v) y -> bigstep min g (n :: y :: v) x -> bigstep min (rc_rec f g) (S n :: v) x *)
+(* | sem_min f x v w : min <= x -> |w| >= x -> bigstep 0 f (x :: v) 0 -> (forall p n, min <= p < x -> nth_error w p = Some n -> bigstep 0 f (p :: v) (S n)) -> bigstep min (rc_min f) v x *)
+(* with bigstep_list (min : nat) : reccode -> list nat -> list nat -> Prop := *)
+(* | sem_cons f g v r G : bigstep min f v r -> bigstep_list min g v G -> bigstep_list min (rc_cons f g) v (r :: G) *)
+(* | sem_nil v : bigstep_list min (rc_nil) v nil. *)
+
+Inductive bigstep (min : nat) : nat -> reccode -> list nat -> nat -> Prop :=
+| sem_cst c v n : bigstep min (S c) (rc_cst n) v n
+| sem_zero c v : bigstep min (S c) (rc_zero) v 0
+| sem_succ c x v : bigstep min (S c) (rc_succ) (x :: v) (S x)
+| sem_proj c n v r : nth_error v n = Some r -> bigstep min (S c) (rc_proj n) v r
+| sem_comp c f g G v r : bigstep_list min c g v G -> bigstep min c f G r -> bigstep min (S c) (rc_comp f g) v r
+| sem_rec1 c f g v r : bigstep min c f v r -> bigstep min (S c) (rc_rec f g) (0 :: v) r
+| sem_rec2 c f g n v y x : bigstep min c (rc_rec f g) (n :: v) y -> bigstep min c g (n :: y :: v) x -> bigstep min (S c) (rc_rec f g) (S n :: v) x
+| sem_min c f x v w : min <= x -> |w| >= x -> bigstep 0 c f (x :: v) 0 -> (forall p n, min <= p < x -> nth_error w p = Some n -> bigstep 0 (c + x - p) f (p :: v) (S n)) -> bigstep min (c + x - min) (rc_min f) v x
+with bigstep_list (min : nat) : nat -> reccode -> list nat -> list nat -> Prop :=
+| sem_cons c f g v r G : bigstep min c f v r -> bigstep_list min c g v G -> bigstep_list min (S c) (rc_cons f g) v (r :: G)
+| sem_nil c v : bigstep_list min c (rc_nil) v nil.
+
+Notation "'rec_erase' erase" := (fix rec k v := match v with vec_nil => rc_nil | vec_cons _ x v => rc_cons (erase _ x) (rec _ v) end) (at level 10).
+
+Fixpoint erase k (f : recalg k) : reccode :=
+  match f with
+  | ra_cst n => rc_cst n
+  | ra_zero => rc_zero
+  | ra_succ => rc_succ
+  | ra_proj _ p => rc_proj (pos2nat p)
+  | ra_comp _ _ f g => rc_comp (erase f) (rec_erase erase _ g)
+  | ra_rec _ f g => rc_rec (erase f) (erase g)
+  | ra_min _ f => rc_min (erase f)
+  end.
+
+Lemma vec_list_nth:
+  forall (k : nat) (p : pos k) (v : vec nat k), nth_error (vec_list v) (pos2nat p) = Some (vec_pos v p).
+Proof.
+  intros k p v.
+  induction v.
+  - cbn. inversion p.
+  - cbn. depelim p.
+    + reflexivity.
+    + eapply IHv.
+Qed.
+
+Lemma erase_correct k (f : recalg k) v n c :
+  ra_bs_c c f v n <-> bigstep 0 c (erase f) (vec_list v) n.
+Proof.
+  revert k f v n.
+  pattern c. eapply lt_wf_ind. intros.
+  destruct f.
+  - split; inversion 1; econstructor.
+  - split; inversion 1; econstructor.
+  - split.
+    + intros. inversion H0. subst.
+      eapply EqDec.inj_right_pair in H2. subst.
+      depelim v. econstructor.
+    + intros. inversion H0. subst.
+      depelim v. cbn in H2. inv H2. econstructor.
+  - split.
+    + intros. inversion H0. subst.
+      eapply EqDec.inj_right_pair in H4. subst.
+      eapply EqDec.inj_right_pair in H5. subst.
+      econstructor. clear. eapply vec_list_nth.              
+    + intros. inversion H0. subst.
+      
+
+  - split; inversion 1; econstructor.
+
+  - 
+
+  split.
+  - intros. induction H.
+    + econstructor.
+    + econstructor.
+    + depelim v. depelim v. cbn. econstructor.
+    + econstructor.      
+      depind v; cbn.
+      * depelim j.
+      * depelim j.
+        -- rewrite pos2nat_fst. reflexivity.
+        -- rewrite pos2nat_nxt. cbn. eauto.
+    + admit.
+    + econstructor. eauto.
+    + econstructor. eauto. eauto.
+    + eapply sem_min with (w := vec_list w).
+      * omega.
+      * rewrite vec_list_length. omega.
+      * eauto. 
+      * intros. admit.
+  - 
+
+
+Import ListNotations.
+
+Fixpoint update X (l : list X) n x :=
+  match n, l with
+  | 0, _ :: l => x :: l
+  | S n, y :: l => y :: update l n x
+  | _, [] => []
+  end.
+
+Lemma eval_bigstep fuel min c v r :
+  eval fuel min c v = Some r ->
+  match r with
+  | inl n => bigstep min fuel c v n
+  | inr L => bigstep_list min fuel c v L
+  end.
+Proof.
+  revert min c v r. induction fuel; cbn; intros; try destruct c; try congruence.
+  all: try now (inv H; econstructor).
+  - destruct v; inv H. econstructor.
+  - destruct (nth_error v n) eqn:E; inv H. now econstructor.
+  - assert (IH2 := IHfuel min c2 v).
+    destruct (eval fuel min c2 v). destruct s. all:try congruence.
+    assert (IH1 := IHfuel min c1 l).
+    destruct (eval fuel min c1 l). destruct s. all:try congruence.
+    specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). inv H. cbn in *.
+    econstructor. eauto. eauto.
+  - assert (IH1 := IHfuel min c1 v).
+    destruct (eval fuel min c1 v). destruct s. all:try congruence.
+    assert (IH2 := IHfuel min c2 v).
+    destruct (eval fuel min c2 v). destruct s. all:try congruence.
+    specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). inv H. cbn in *.
+    econstructor. eauto. eauto.
+  - destruct v; try congruence.
+    destruct n.
+    + assert (IH1 := IHfuel min c1 v).
+      destruct (eval fuel min c1 v). destruct s. all:try congruence. inv H.
+      specialize (IH1 _ eq_refl). cbn in *.
+      econstructor. eauto.
+    + assert (IH2 := IHfuel min (rc_rec c1 c2) (n :: v)).
+      destruct (eval fuel min (rc_rec c1 c2) (n :: v)). destruct s. all:try congruence.
+      specialize (IH2 _ eq_refl).
+      assert (IH3 := IHfuel min c2 (n :: n0 :: v)).
+      destruct (eval fuel min c2 (n :: n0 :: v)). destruct s. all:try congruence. 
+      specialize (IH3 _ eq_refl). cbn in *. inv H.
+      econstructor. eauto. eauto.
+  - assert (IH1 := IHfuel 0 c (min :: v)).
+    destruct (eval fuel 0 c (min :: v)); try congruence.
+    destruct s; try congruence.
+    specialize (IH1 _ eq_refl).
+    destruct n.
+    + inv H. cbn in *. eapply sem_min with (w := repeat min min). eauto. eauto.
+      rewrite repeat_length. omega. eauto.
+      intros. omega. 
+    + assert (IH2 := IHfuel (S min) (rc_min c) v).
+      destruct (eval fuel (S min) (rc_min c) v); try congruence.
+      destruct s; inv H.
+      specialize (IH2 _ eq_refl). cbn in *. inversion IH2. subst.
+      eapply sem_min with (w := update w min n).
+      omega. admit. eauto. intros.
+      decide (min = p).
+      * subst. admit.
+      * eapply H3. omega. admit.
+Admitted.
+
+Scheme bigstep1_ind := Induction for bigstep Sort Prop
+  with bigstep2_ind := Induction for bigstep_list Sort Prop.
+Combined Scheme bigstepInd from bigstep1_ind, bigstep2_ind.
+
+Lemma bigstep_eval min  :
+  (forall c v n, bigstep min c v n -> exists fuel, eval fuel min c v = Some (inl n)) /\
+  (forall c v L, bigstep_list min c v L -> exists fuel, eval fuel min c v = Some (inr L)).
+Proof.
+  apply bigstepInd with (P := fun min c v n _ => exists fuel : nat, eval fuel min c v = Some (inl n)) (P0 := fun min c v L _ => exists fuel : nat, eval fuel min c v = Some (inr L)).
+  all: cbn; intros.
+  all: try now exists 1; eauto.
+  - exists 1. cbn. now rewrite e. 
+  - destruct H, H0.
+    exists (1 + x + x0). 
+    cbn. erewrite eval_mono; eauto.
+    cbn. erewrite eval_mono; eauto.
+    eauto. omega. omega.
+  - destruct H.
+    exists (1 + x). 
+    cbn. erewrite eval_mono; eauto.
+    eauto.
+  - destruct H, H0.
+    exists (1 + x0 + x1). 
+    cbn. erewrite eval_mono; eauto.
+    cbn. erewrite eval_mono; eauto.
+    eauto. omega. omega.
+  - destruct H.
+    exists (1 + x0). 
+    cbn. decide (min0 = x).
+    + subst. now rewrite H.
+    + assert (min0 <= min0 < x). omega. eapply H0 in H1 as [].
+      admit. admit.
+  - destruct H, H0.
+    exists (1 + x0 + x). 
+    cbn. erewrite eval_mono; eauto.
+    cbn. erewrite eval_mono; eauto.
+    eauto. omega. omega.
+Admitted.
+
+Instance term_eval : computable eval.
+Proof.
+  extract.
+Qed.

--- a/theories/L/Reductions/MuRec.v
+++ b/theories/L/Reductions/MuRec.v
@@ -1,94 +1,48 @@
 From Undecidability.H10 Require Import H10 dio_single dio_logic.
 From Undecidability.L.Datatypes Require Import LNat Lists LOptions LSum.
 From Undecidability.L Require Import Tactics.LTactics Computability.MuRec Computability.Synthetic Tactics.GenEncode.
-
-
-
-(**************************************************************)
-(*   Copyright Dominique Larchey-Wendling [*]                 *)
-(*                                                            *)
-(*                             [*] Affiliation LORIA -- CNRS  *)
-(**************************************************************)
-(*      This file is distributed under the terms of the       *)
-(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
-(**************************************************************)
-
 From Undecidability.Shared Require Import DLW.Vec.vec DLW.Vec.pos.
-From Undecidability.MuRec Require Import recalg.
+From Undecidability.MuRec Require Import recalg ra_bs ra_sem_eq.
 
-Set Implicit Arguments.
-
-Reserved Notation "  '[' f ';' v ']' '~~>' x " (at level 70).
+Reserved Notation "  '[' f ';' v ';' min ';' c ']' '~~>' x " (at level 70).
 
 (* Bigstep semantics for recursive algorithms *)
    
-Inductive ra_bs : forall k, recalg k -> vec nat k -> nat -> Prop :=
-    | in_ra_bs_cst  : forall n v,             [ra_cst n;        v] ~~> n
-    | in_ra_bs_zero : forall v,               [ra_zero;         v] ~~> 0
-    | in_ra_bs_succ : forall v,               [ra_succ;         v] ~~> S (vec_head v)
-    | in_ra_bs_proj : forall k v j,           [@ra_proj k j;    v] ~~> vec_pos v j
+Inductive ra_bs_c : nat -> nat -> forall k, recalg k -> vec nat k -> nat -> Prop := 
+    | in_ra_bs_c_cst  : forall min c n v,             [ra_cst n;        v; min; S c] ~~> n
+    | in_ra_bs_c_zero : forall min c v,               [ra_zero;         v; min; S c] ~~> 0
+    | in_ra_bs_c_succ : forall min c v,               [ra_succ;         v; min; S c] ~~> S (vec_head v)
+    | in_ra_bs_c_proj : forall min c k v j,           [@ra_proj k j;    v; min; S c] ~~> vec_pos v j 
     
-    | in_ra_bs_comp : forall k i f (gj : vec (recalg i) k) v w x,
-                                   (forall j, [vec_pos gj j;    v] ~~> vec_pos w j)
-                               ->             [f;               w] ~~> x
-                               ->             [ra_comp f gj;    v] ~~> x
+    | in_ra_bs_c_comp : forall min c k i f (gj : vec (recalg i) k) v w x,
+                                         (forall j, [vec_pos gj j;    v; min; c - pos2nat j] ~~> vec_pos w j)
+                                 ->             [f;               w; min; S c] ~~> x
+                                 ->             [ra_comp f gj;    v; min; S (S c)] ~~> x
 
-    | in_ra_bs_rec_0 : forall k f (g : recalg (S (S k))) v x,
-                                              [f;               v] ~~> x
-                               ->             [ra_rec f g;   0##v] ~~> x
+    | in_ra_bs_c_rec_0 : forall min c k f (g : recalg (S (S k))) v x,    
+                                               [f;               v; min; c] ~~> x 
+                                 ->             [ra_rec f g;   0##v; min; S c] ~~> x
 
-    | in_ra_bs_rec_S : forall k f (g : recalg (S (S k))) v n x y,
-                                              [ra_rec f g;   n##v] ~~> x
-                               ->             [g;         n##x##v] ~~> y
-                               ->             [ra_rec f g; S n##v] ~~> y
+    | in_ra_bs_c_rec_S : forall min c k f (g : recalg (S (S k))) v n x y,          
+                                             [ra_rec f g;   n##v; min; c] ~~> x
+                               ->             [g;         n##x##v; min; c] ~~> y
+                               ->             [ra_rec f g; S n##v; min; S c] ~~> y
                                
-    | in_ra_bs_min : forall k (f : recalg (S k)) v x w ,
-                           (forall j : pos x, [f;    pos2nat j##v] ~~> S (vec_pos w j))
-                               ->             [f;            x##v] ~~> 0
-                               ->             [ra_min f;        v] ~~> x
-where " [ f ; v ] ~~> x " := (@ra_bs _ f v x).
+    | in_ra_bs_c_min : forall min c k (f : recalg (S k)) v x w , x >= min ->
+                           (forall j : pos x, pos2nat j >= min -> [f;    pos2nat j##v; 0; c - (pos2nat j - min)] ~~> S (vec_pos w j)) 
+                                             ->             [f;            x##v; 0; c - (x - min)] ~~> 0
+                                             ->             [ra_min f;        v; min; S c] ~~> x
+where " [ f ; v ; min ; c ] ~~> x " := (@ra_bs_c min c _ f v x).
 
-
-Reserved Notation "  '[' f ';' v ';' c ']' '~~>' x " (at level 70).
-
-(* Bigstep semantics for recursive algorithms *)
-   
-Inductive ra_bs_c : nat -> forall k, recalg k -> vec nat k -> nat -> Prop := 
-    | in_ra_bs_c_cst  : forall c n v,             [ra_cst n;        v; S c] ~~> n
-    | in_ra_bs_c_zero : forall c v,               [ra_zero;         v; S c] ~~> 0
-    | in_ra_bs_c_succ : forall c v,               [ra_succ;         v; S c] ~~> S (vec_head v)
-    | in_ra_bs_c_proj : forall c k v j,           [@ra_proj k j;    v; S c] ~~> vec_pos v j 
-    
-    | in_ra_bs_c_comp : forall c k i f (gj : vec (recalg i) k) v w x,
-                                         (forall j, [vec_pos gj j;    v; c + k - pos2nat j] ~~> vec_pos w j)
-                                 ->             [f;               w; c] ~~> x
-                                 ->             [ra_comp f gj;    v; S c + 1 + k] ~~> x
-
-    | in_ra_bs_c_rec_0 : forall c k f (g : recalg (S (S k))) v x,    
-                                               [f;               v; c] ~~> x 
-                                 ->             [ra_rec f g;   0##v; S c] ~~> x
-
-    | in_ra_bs_c_rec_S : forall c k f (g : recalg (S (S k))) v n x y,          
-                                              [ra_rec f g;   n##v; c] ~~> x
-                               ->             [g;         n##x##v; c] ~~> y
-                               ->             [ra_rec f g; S n##v; S c] ~~> y
-                               
-    | in_ra_bs_c_min : forall c k (f : recalg (S k)) v x w , 
-                           (forall j : pos x, [f;    pos2nat j##v; c - pos2nat j] ~~> S (vec_pos w j)) 
-                               ->             [f;            x##v; c] ~~> 0
-                               ->             [ra_min f;        v; S c] ~~> x
-where " [ f ; v ; c ] ~~> x " := (@ra_bs_c c _ f v x).
-
-Lemma ra_bs_mono k (f : recalg k) v c1 x :
-  [f ; v ; c1 ] ~~> x -> forall c2, c1 <= c2 -> [f ; v ; c2] ~~> x. 
+Lemma ra_bs_mono min k (f : recalg k) v c1 x :
+  [f ; v ; min ; c1 ] ~~> x -> forall c2, c1 <= c2 -> [f ; v ; min; c2] ~~> x. 
 Proof.
   induction 1; intros; try (destruct c2;[ omega | ]).
   - econstructor.
   - econstructor.
   - econstructor.
   - econstructor.
-  - assert (S c2 = S (c2 - k - 1) + 1 + k ) as -> by omega.
-    econstructor.
+  - destruct c2; try omega. econstructor.
     + intros. eapply H0. omega.
     + eapply IHra_bs_c. omega.
   - econstructor. eapply IHra_bs_c. omega.
@@ -96,7 +50,8 @@ Proof.
     + eapply IHra_bs_c1. omega.
     + eapply IHra_bs_c2. omega.
   - econstructor.
-    + intros. eapply H0. omega.
+    + omega.
+    + intros. eapply H1. omega. omega.
     + eapply IHra_bs_c. omega.
 Qed.
 
@@ -111,8 +66,18 @@ Proof.
   - depelim j. omega. specialize (IHcst j). omega.
 Qed.
 
+Lemma ra_bs_from_c k (f : recalg k) c v x :
+ [f ; v ; 0 ; c] ~~> x -> [ f; v ] ~~> x.
+Proof.
+  remember 0 as min.
+  induction 1; subst; eauto using ra_bs.
+
+  econstructor. intros. eapply H1; omega.
+  eauto.
+Qed.
+
 Lemma ra_bs_to_c k (f : recalg k) v x :
-  [ f; v ] ~~> x -> exists c, [f ; v ; c ] ~~> x.
+  [ f; v ] ~~> x -> exists c, [f ; v ; 0 ; c] ~~> x.
 Proof.
   induction 1.
   - exists 1. econstructor.
@@ -121,7 +86,7 @@ Proof.
   - exists 1. econstructor.
   - destruct IHra_bs as [c].
     eapply vec_reif in H0 as [cst].
-    exists (1 + c + vec_sum cst + 1 + k). cbn.
+    exists (2 + c + vec_sum cst + k). cbn.
     econstructor.
     + intros. eapply ra_bs_mono. eauto.
       rewrite <- Nat.add_sub_assoc.
@@ -139,7 +104,7 @@ Proof.
   - destruct IHra_bs as [c].
     eapply vec_reif in H0 as [cst].
     exists (1 + c + vec_sum cst + x). cbn.
-    econstructor. 
+    econstructor. omega. 
     + intros. eapply ra_bs_mono. eauto.
       rewrite <- Nat.add_sub_assoc.
       2: pose (pos2nat_prop j); omega.
@@ -158,14 +123,6 @@ Inductive reccode :=
 | rc_nil
 | rc_rec (f : reccode) (g : reccode)
 | rc_min (f : reccode).
-
-Run TemplateProgram (tmGenEncode "enc_reccode" reccode).
-Hint Resolve enc_reccode_correct : Lrewrite.
-
-Instance term_rc_comp: computable rc_comp. extract constructor. Qed.
-Instance term_rc_cons : computable rc_cons.  extract constructor. Qed.
-Instance term_rc_rec : computable rc_rec.  extract constructor. Qed.
-Instance term_rc_min : computable rc_min.  extract constructor. Qed.
 
 Fixpoint eval (fuel : nat) (min : nat) (c : reccode) (v : list nat) : option (nat + list nat) :=
   match fuel with
@@ -205,66 +162,6 @@ Fixpoint eval (fuel : nat) (min : nat) (c : reccode) (v : list nat) : option (na
     end
   end.
 
-(* Lemma eval_mono_S fuel min c v r : *)
-(*   eval fuel min c v = Some r -> eval (S fuel) min c v = Some r. *)
-(* Proof. *)
-(*   intros. induction fuel in H, c, min, r, v |- *. *)
-(*   - inv H. *)
-(*   - cbn in H. destruct c; eauto. *)
-(*     + assert (IH2 := IHfuel min c2 v). *)
-(*       destruct (eval fuel min c2 v); try congruence. *)
-(*       destruct s; try congruence. *)
-(*       assert (IH1 := IHfuel min c1 l). *)
-(*       destruct (eval fuel min c1 l); try congruence. *)
-(*       specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). *)
-(*       remember (S fuel) as n. cbn. *)
-(*       rewrite IH2, IH1. eassumption. *)
-(*     + assert (IH1 := IHfuel min c1 v). *)
-(*       destruct (eval fuel min c1 v); try congruence. *)
-(*       destruct s; try congruence. *)
-(*       assert (IH2 := IHfuel min c2 v). *)
-(*       destruct (eval fuel min c2 v); try congruence. *)
-(*       destruct s; try congruence. inv H. *)
-(*       specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). *)
-(*       remember (S fuel) as k. cbn. *)
-(*       now rewrite IH2, IH1. *)
-(*     + *)
-(* Admitted. *)
-
-(* Lemma eval_mono fuel1 fuel2 min c v r : *)
-(*   eval fuel1 min c v = Some r -> fuel1 <= fuel2 -> eval fuel2 min c v = Some r. *)
-(* Proof. *)
-(*   intros. induction H0. *)
-(*   - eauto. *)
-(*   - eapply eval_mono_S. eauto. *)
-(* Qed. *)
-
-(* Inductive bigstep (min : nat) : reccode -> list nat -> nat -> Prop := *)
-(* | sem_cst v n : bigstep min (rc_cst n) v n *)
-(* | sem_zero v : bigstep min (rc_zero) v 0 *)
-(* | sem_succ x v : bigstep min (rc_succ) (x :: v) (S x) *)
-(* | sem_proj n v r : nth_error v n = Some r -> bigstep min (rc_proj n) v r *)
-(* | sem_comp f g G v r : bigstep_list min g v G -> bigstep min f G r -> bigstep min (rc_comp f g) v r *)
-(* | sem_rec1 f g v r : bigstep min f v r -> bigstep min (rc_rec f g) (0 :: v) r *)
-(* | sem_rec2 f g n v y x : bigstep min (rc_rec f g) (n :: v) y -> bigstep min g (n :: y :: v) x -> bigstep min (rc_rec f g) (S n :: v) x *)
-(* | sem_min f x v w : min <= x -> |w| >= x -> bigstep 0 f (x :: v) 0 -> (forall p n, min <= p < x -> nth_error w p = Some n -> bigstep 0 f (p :: v) (S n)) -> bigstep min (rc_min f) v x *)
-(* with bigstep_list (min : nat) : reccode -> list nat -> list nat -> Prop := *)
-(* | sem_cons f g v r G : bigstep min f v r -> bigstep_list min g v G -> bigstep_list min (rc_cons f g) v (r :: G) *)
-(* | sem_nil v : bigstep_list min (rc_nil) v nil. *)
-
-Inductive bigstep (min : nat) : nat -> reccode -> list nat -> nat -> Prop :=
-| sem_cst c v n : bigstep min (S c) (rc_cst n) v n
-| sem_zero c v : bigstep min (S c) (rc_zero) v 0
-| sem_succ c x v : bigstep min (S c) (rc_succ) (x :: v) (S x)
-| sem_proj c n v r : nth_error v n = Some r -> bigstep min (S c) (rc_proj n) v r
-| sem_comp c f g G v r : bigstep_list min c g v G -> bigstep min c f G r -> bigstep min (S c) (rc_comp f g) v r
-| sem_rec1 c f g v r : bigstep min c f v r -> bigstep min (S c) (rc_rec f g) (0 :: v) r
-| sem_rec2 c f g n v y x : bigstep min c (rc_rec f g) (n :: v) y -> bigstep min c g (n :: y :: v) x -> bigstep min (S c) (rc_rec f g) (S n :: v) x
-| sem_min c f x v w : min <= x -> |w| >= x -> bigstep 0 c f (x :: v) 0 -> (forall p n, min <= p < x -> nth_error w p = Some n -> bigstep 0 (c + x - p) f (p :: v) (S n)) -> bigstep min (c + x - min) (rc_min f) v x
-with bigstep_list (min : nat) : nat -> reccode -> list nat -> list nat -> Prop :=
-| sem_cons c f g v r G : bigstep min c f v r -> bigstep_list min c g v G -> bigstep_list min (S c) (rc_cons f g) v (r :: G)
-| sem_nil c v : bigstep_list min c (rc_nil) v nil.
-
 Definition rec_erase i (erase : forall i, recalg i -> reccode) := (fix rec k (v : vec (recalg i) k) := match v with vec_nil => rc_nil | vec_cons _ x v => rc_cons (erase _ x) (rec _ v) end).
 
 Fixpoint erase k (f : recalg k) : reccode :=
@@ -289,13 +186,65 @@ Proof.
     + eapply IHv.
 Qed.
 
-Lemma erase_correct k (f : recalg k) v n c  :
-  (ra_bs_c c f v n <-> eval c 0 (erase f) (vec_list v) = Some (inl n)).
-  (* (forall i (g : vec (recalg i) k) w v', (forall j : pos k, [vec_pos g j; v'; c - pos2nat j ] ~~> vec_pos w j) <-> eval c 0 (rec_erase erase g) (vec_list v') = Some (inr (vec_list w))). *)
+Lemma eval_inv n min i k (v : vec (recalg i) k) a l :
+  eval n min (rec_erase erase v) a = Some (inr l) ->
+  exists x, vec_list x = l /\
+  (forall j : pos k, eval (n -S (pos2nat j)) min (erase (vec_pos v j)) a = Some (inl (vec_pos x j))).
+Proof.
+  induction v in n,l |- *.
+  - destruct n; cbn. firstorder congruence. exact vec_nil. intros [=]. subst. exists vec_nil. split. reflexivity. intros. depelim j.
+  - destruct n. inversion 1.
+    intros ?. cbn in H.
+    destruct (eval n) eqn:E1; try congruence.
+    destruct s; try congruence.
+    destruct (eval n min (rec_erase erase v) a) eqn:E2; try congruence.
+    destruct s; try congruence. inv H. 
+    edestruct IHv as (? & ? & ?). eauto.
+    exists (vec_cons n1 x0). split. cbn. firstorder congruence.
+    intros j. depelim j.
+    + rewrite pos2nat_fst in *. assert (S n - 1 = n) by omega. rewrite H1 in *.
+      cbn -[eval].  eassumption.
+    + rewrite pos2nat_nxt.
+      specialize (H0 j). 
+      assert (S n - S (S (pos2nat j)) = n - S (pos2nat j)) by omega. rewrite H1 in *.
+      rewrite H0. reflexivity.
+Qed.
+
+Lemma le_ind2 m (P : nat -> Prop) :
+  P m -> (forall n, P (S n) -> S n <= m -> P n) -> forall n, n <= m -> P n.
+Proof.
+  intros. induction H1.
+  - eauto.
+  - eauto.
+Qed. 
+
+Lemma vec_pos_gt n X (w : vec X n) j k n1:
+  pos2nat k < pos2nat j ->
+  vec_pos w j = vec_pos (vec_change w k n1) j.
+Proof.
+  intros.
+  induction w.
+  - cbn. depelim j.
+  - cbn. depelim j.
+    + depelim k.
+      * cbn. omega.
+      * cbn. reflexivity.
+    + depelim k.
+      * cbn. reflexivity.
+      * cbn. eapply IHw. rewrite !pos2nat_nxt in *. omega.
+Qed.
+
+Lemma erase_correct k min (f : recalg k) v n c  :
+  (ra_bs_c min c f v n <-> eval c min (erase f) (vec_list v) = Some (inl n)).
 Proof.
   revert all except c.
   pattern c. eapply lt_wf_ind. intros.
   destruct f; cbn. 
+  - split.
+    + inversion 1. subst.
+      eapply EqDec.inj_right_pair in H4. subst.
+      reflexivity.
+    + destruct n; inversion 1. subst. econstructor.
   - split.
     + inversion 1. subst.
       eapply EqDec.inj_right_pair in H3. subst.
@@ -303,235 +252,186 @@ Proof.
     + destruct n; inversion 1. subst. econstructor.
   - split.
     + inversion 1. subst.
-      eapply EqDec.inj_right_pair in H2. subst.
-      reflexivity.
-    + destruct n; inversion 1. subst. econstructor.
-  - split.
-    + inversion 1. subst.
-      eapply EqDec.inj_right_pair in H2. subst.
+      eapply EqDec.inj_right_pair in H3. subst.
       cbn. depelim v. cbn. reflexivity.
     + destruct n; inversion 1. depelim v. subst. cbn in H2. inv H2. econstructor.
   - split.
     + inversion 1. subst.
-      eapply EqDec.inj_right_pair in H4. subst.
       eapply EqDec.inj_right_pair in H5. subst.
+      eapply EqDec.inj_right_pair in H6. subst.
       cbn. rewrite vec_list_nth. reflexivity.
     + destruct n; inversion 1. rewrite vec_list_nth in H2. inv H2. econstructor.
   - split.
     + inversion 1. subst.
       eapply EqDec.inj_right_pair in H2. subst.
       eapply EqDec.inj_right_pair in H7. subst.
-      eapply EqDec.inj_right_pair in H6. subst.
-      eapply EqDec.inj_right_pair in H6. subst.
-      assert (forall j : pos k, eval (c0 + k - pos2nat j) 0 (erase (vec_pos v0 j)) (vec_list v) = Some (inl (vec_pos w j))).
+      eapply EqDec.inj_right_pair in H7. subst.
+      eapply EqDec.inj_right_pair in H8. subst.
+      assert (forall j : pos k, eval (c0 - pos2nat j) min (erase (vec_pos v0 j)) (vec_list v) = Some (inl (vec_pos w j))).
       intros. eapply H. omega.
                                       
-      cbn. eapply H in H9. 2:omega. eauto.
-      eapply H in H9. 2:omega. cbn.
+      cbn. eapply H. omega. eapply H. omega. specialize (H9 j).
+      eapply H in H9. 2:omega. eapply H. omega. eauto.
+      remember (S c0) as c'. cbn.
 
-      assert (eval (c0 + 1 + k) 0 (rec_erase erase v0) (vec_list v) = Some (inr (vec_list w))).
-      { clear - H1. induction v0.
-        - cbn. assert (c0 + 1 + 0 = S c0) as -> by omega. cbn. depelim w. reflexivity.
-        - cbn. assert (c0 + 1 + S n = S c0 + 1 + n) as -> by omega.
-          cbn. pose proof (H1 pos_fst). cbn in H. rewrite pos2nat_fst in H.
-          assert (c0 + S n - 0 = c0 + 1 + n) by omega. rewrite H0 in *. clear H0.
-          rewrite H. depelim w. erewrite IHv0.  reflexivity.
+      assert (eval c' min (rec_erase erase v0) (vec_list v) = Some (inr (vec_list w))).
+      { subst. clear - H1. revert c0 H1. induction v0; intros.
+        - cbn. depelim w. reflexivity.
+        - cbn. pose proof (H1 pos_fst). cbn in H. rewrite pos2nat_fst in H.
+          replace (c0 - 0) with c0 in H by omega. rewrite H.
+          depelim w. destruct c0. cbn in H. inv H. erewrite IHv0.
+          reflexivity.
           intros. specialize (H1 (pos_nxt j)). rewrite pos2nat_nxt in H1.
-          assert (c0 + n - pos2nat j = c0 + S n - S (pos2nat j)) as -> by omega.
-          rewrite H1. reflexivity.
+          eassumption.
       }
-      rewrite H2. admit.
-    + 
-
-
-      edestruct H with (m := c0) as [_ ]. omega.
-      eapply H1 in H8. clear H1. rewrite H8, H9. reflexivity.
+      rewrite H2. subst. eapply H in H10. rewrite H10. reflexivity. omega.
     + destruct n; inversion 1.
-      destruct (eval n 0 (rec_erase erase v0) (vec_list v)) eqn:E; try congruence.
+      destruct (eval n min (rec_erase erase v0) (vec_list v)) eqn:E; try congruence.
       destruct s; try congruence.
-      destruct (eval n 0 (erase f) l) eqn:E2; try congruence.
-      destruct s; try congruence.
-      inv H2.
-      destruct (list_vec l). rewrite <- e in *. clear e.
-      econstructor.
-      * edestruct H with (m := n) as [_ ].
-        omega.
-        specialize (H1 i v0 x).
+      destruct (eval n min (erase f) l) eqn:E2; try congruence.
+      destruct s; try congruence. inv H2.
+      destruct n; try now inv E2.
 
-      * eapply H. omega. 
+      destruct (list_vec l). 
+      destruct (eval_inv E) as (w & ? & ?). subst.
 
-
-Lemma erase_correct k (f : recalg k) v n c :
-  ra_bs_c c f v n <-> bigstep 0 c (erase f) (vec_list v) n.
-Proof.
-  revert k f v n.
-  pattern c. eapply lt_wf_ind. intros.
-  destruct f.
-  - split; inversion 1; econstructor.
-  - split; inversion 1; econstructor.
-  - split.
-    + intros. inversion H0. subst.
-      eapply EqDec.inj_right_pair in H2. subst.
-      depelim v. econstructor.
-    + intros. inversion H0. subst.
-      depelim v. cbn in H2. inv H2. econstructor.
-  - split.
-    + intros. inversion H0. subst.
-      eapply EqDec.inj_right_pair in H4. subst.
+      eapply in_ra_bs_c_comp with (w := w).
+      * intros. eapply H. omega. specialize (H2 j). assert (S n - S (pos2nat j) = n - pos2nat j) by omega. rewrite H1 in *.
+        eauto.
+      * eapply H. omega. eassumption.
+  - split. inversion 1.
+    + eapply EqDec.inj_right_pair in H4. subst.
+      eapply EqDec.inj_right_pair in H6. subst.
+      eapply EqDec.inj_right_pair in H7. subst.
+      cbn.
+      eapply H in H8. 2:omega. rewrite H8. reflexivity.
+    + eapply EqDec.inj_right_pair in H2. subst.
       eapply EqDec.inj_right_pair in H5. subst.
-      econstructor. clear. eapply vec_list_nth.              
-    + intros. inversion H0. subst.
-      rewrite vec_list_nth in H3. inv H3. econstructor.
+      eapply EqDec.inj_right_pair in H6. subst.
+      eapply H in H7.
+      cbn. 2:omega. rewrite H7.
+      eapply H in H9. 2:omega. rewrite H9. reflexivity.
+    + intros. destruct n; inv H0.
+      depelim v. cbn in H2. destruct n1.
+      * destruct (eval n min (erase f1) (vec_list v)) eqn:E.
+        destruct s; inv H2.
+        -- econstructor. eapply H. omega. eauto.
+        -- econstructor. congruence.
+      * destruct eval eqn:E2; try congruence.
+        destruct s; try congruence.
+        destruct (eval n min (erase f2)) eqn:E3.
+        destruct s; inv H2.
+        -- econstructor. eapply H. omega. eauto. eapply H. omega. eauto.
+        -- congruence.
   - split.
-    + intros. cbn.
-      admit.
-    + admit.
-  - split.
-    + intros. inversion H0. subst.
-      * eapply EqDec.inj_right_pair in H3. subst.
-        eapply EqDec.inj_right_pair in H5. subst.
-        eapply EqDec.inj_right_pair in H6. subst.
-        cbn. econstructor. eapply H. omega. eauto.
-      * eapply EqDec.inj_right_pair in H2. subst.
-        eapply EqDec.inj_right_pair in H5. subst.
-        eapply EqDec.inj_right_pair in H4. subst.
-        cbn. econstructor.
-        -- eapply H with (f := ra_rec f1 f2) (v := vec_cons n1 v0). omega. eauto. 
-        -- eapply H with (v := vec_cons n1 (vec_cons x v0)). omega. eauto. 
-    + intros. inversion H0; subst.
-      * depelim v. inv H5. econstructor. eapply H. omega. eauto.
-      * depelim v. inv H4. econstructor. eapply H. omega. eauto.
-        eapply H. omega. eauto.
-  - split.
-    + 
+    + inversion 1. subst.
+      eapply EqDec.inj_right_pair in H1. subst.
+      eapply EqDec.inj_right_pair in H2. subst.
+      clear H0. unfold ge in *.
+      revert c0 H w H7 H8. pattern n0. revert min H3.
+      eapply le_ind2; intros.
+      * cbn in *. eapply H in H8. 2:omega.
+        assert (c0 - (n0 - n0) = c0) by lia. rewrite H0 in *.
+        rewrite H8. reflexivity.
+      * destruct n0; try omega.
+        assert (n < S n0) by omega.
+        assert (H10 := H7).
+        specialize (H7 (nat2pos H2)). rewrite pos2nat_nat2pos in H7.
+        assert (n <= n) by omega. eapply H7 in H3.
+        eapply H1 in H3. 2: omega. cbn.
+        assert (c0 - (n - n) = c0) by omega. rewrite H4 in *. rewrite H3.
 
+        assert (eval c0 (S n) (rc_min (erase f)) (vec_list v) = Some (inl (S n0))).
+        eapply H1 with (f := ra_min f). omega.
 
-  split.
-  - intros. induction H.
-    + econstructor.
-    + econstructor.
-    + depelim v. depelim v. cbn. econstructor.
-    + econstructor.      
-      depind v; cbn.
-      * depelim j.
-      * depelim j.
-        -- rewrite pos2nat_fst. reflexivity.
-        -- rewrite pos2nat_nxt. cbn. eauto.
-    + admit.
-    + econstructor. eauto.
-    + econstructor. eauto. eauto.
-    + eapply sem_min with (w := vec_list w).
-      * omega.
-      * rewrite vec_list_length. omega.
-      * eauto. 
-      * intros. admit.
-  - 
+        destruct c0. inv H3.
+        econstructor. omega.
+           
+        intros ? ?. specialize (H10 j).
+        assert (S c0 - (pos2nat j - n) = c0 - (pos2nat j - S n)) by omega.
+        rewrite H6 in *.  eapply H10. omega.
+        assert (S c0 - (S n0 - n) = c0 - (S n0 - S n)) by lia. rewrite H5 in *.
+        eassumption.
+        now rewrite H5.
+    + intros.
+      destruct n; try now inv H0. cbn in H0.
+      destruct (eval n) eqn:E1; try now inv H0.
+      destruct s; try congruence.
+      destruct n1; inv H0.
+      * econstructor. omega. intros. pose proof (pos2nat_prop j). omega.
+        eapply H. omega. assert (n - (n0 - n0) = n) as -> by omega. eassumption.
+      * destruct (eval n (S min)) eqn:E2; try now inv H2.
+        destruct s; inv H2.
+        eapply H with (f := ra_min f) in E2. 2:omega.
+        eapply H with (v := vec_cons min v) in E1. 2:omega.
+        inversion E2; subst.
+        eapply EqDec.inj_right_pair in H0. subst.
+        eapply EqDec.inj_right_pair in H1. subst.
+        assert (min < n0) by omega.
+        eapply in_ra_bs_c_min with (w := vec_change w (nat2pos H0) n1).
+        -- omega.
+        -- intros. inversion H1.
+           ++ subst.
+              rewrite nat2pos_pos2nat.
+              rewrite vec_change_eq. 2:reflexivity.
+              assert (S c0 - (pos2nat j - pos2nat j) = S c0) as -> by omega.
+              eassumption.
+           ++ specialize (H6 j).
+              assert (S c0 - (S m - min) = c0 - (pos2nat j - S min)) by lia. rewrite H5 in *.
+              enough (vec_pos w j = vec_pos (vec_change w (nat2pos H0) n1) j).
+              rewrite H8 in H6. rewrite H3. eapply H6. omega.
+              assert (pos2nat j > min) by omega.
+              eapply vec_pos_gt.
+              rewrite pos2nat_nat2pos. omega.
+        -- assert (S c0 - (n0 - min) = c0 - (n0 - S min)) by omega. rewrite H1. eassumption.
+           Grab Existential Variables. exact vec_zero.
+Qed.
 
+Run TemplateProgram (tmGenEncode "enc_reccode" reccode).
+Hint Resolve enc_reccode_correct : Lrewrite.
 
-Import ListNotations.
-
-Fixpoint update X (l : list X) n x :=
-  match n, l with
-  | 0, _ :: l => x :: l
-  | S n, y :: l => y :: update l n x
-  | _, [] => []
-  end.
-
-Lemma eval_bigstep fuel min c v r :
-  eval fuel min c v = Some r ->
-  match r with
-  | inl n => bigstep min fuel c v n
-  | inr L => bigstep_list min fuel c v L
-  end.
-Proof.
-  revert min c v r. induction fuel; cbn; intros; try destruct c; try congruence.
-  all: try now (inv H; econstructor).
-  - destruct v; inv H. econstructor.
-  - destruct (nth_error v n) eqn:E; inv H. now econstructor.
-  - assert (IH2 := IHfuel min c2 v).
-    destruct (eval fuel min c2 v). destruct s. all:try congruence.
-    assert (IH1 := IHfuel min c1 l).
-    destruct (eval fuel min c1 l). destruct s. all:try congruence.
-    specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). inv H. cbn in *.
-    econstructor. eauto. eauto.
-  - assert (IH1 := IHfuel min c1 v).
-    destruct (eval fuel min c1 v). destruct s. all:try congruence.
-    assert (IH2 := IHfuel min c2 v).
-    destruct (eval fuel min c2 v). destruct s. all:try congruence.
-    specialize (IH1 _ eq_refl). specialize (IH2 _ eq_refl). inv H. cbn in *.
-    econstructor. eauto. eauto.
-  - destruct v; try congruence.
-    destruct n.
-    + assert (IH1 := IHfuel min c1 v).
-      destruct (eval fuel min c1 v). destruct s. all:try congruence. inv H.
-      specialize (IH1 _ eq_refl). cbn in *.
-      econstructor. eauto.
-    + assert (IH2 := IHfuel min (rc_rec c1 c2) (n :: v)).
-      destruct (eval fuel min (rc_rec c1 c2) (n :: v)). destruct s. all:try congruence.
-      specialize (IH2 _ eq_refl).
-      assert (IH3 := IHfuel min c2 (n :: n0 :: v)).
-      destruct (eval fuel min c2 (n :: n0 :: v)). destruct s. all:try congruence. 
-      specialize (IH3 _ eq_refl). cbn in *. inv H.
-      econstructor. eauto. eauto.
-  - assert (IH1 := IHfuel 0 c (min :: v)).
-    destruct (eval fuel 0 c (min :: v)); try congruence.
-    destruct s; try congruence.
-    specialize (IH1 _ eq_refl).
-    destruct n.
-    + inv H. cbn in *. eapply sem_min with (w := repeat min min). eauto. eauto.
-      rewrite repeat_length. omega. eauto.
-      intros. omega. 
-    + assert (IH2 := IHfuel (S min) (rc_min c) v).
-      destruct (eval fuel (S min) (rc_min c) v); try congruence.
-      destruct s; inv H.
-      specialize (IH2 _ eq_refl). cbn in *. inversion IH2. subst.
-      eapply sem_min with (w := update w min n).
-      omega. admit. eauto. intros.
-      decide (min = p).
-      * subst. admit.
-      * eapply H3. omega. admit.
-Admitted.
-
-Scheme bigstep1_ind := Induction for bigstep Sort Prop
-  with bigstep2_ind := Induction for bigstep_list Sort Prop.
-Combined Scheme bigstepInd from bigstep1_ind, bigstep2_ind.
-
-Lemma bigstep_eval min  :
-  (forall c v n, bigstep min c v n -> exists fuel, eval fuel min c v = Some (inl n)) /\
-  (forall c v L, bigstep_list min c v L -> exists fuel, eval fuel min c v = Some (inr L)).
-Proof.
-  apply bigstepInd with (P := fun min c v n _ => exists fuel : nat, eval fuel min c v = Some (inl n)) (P0 := fun min c v L _ => exists fuel : nat, eval fuel min c v = Some (inr L)).
-  all: cbn; intros.
-  all: try now exists 1; eauto.
-  - exists 1. cbn. now rewrite e. 
-  - destruct H, H0.
-    exists (1 + x + x0). 
-    cbn. erewrite eval_mono; eauto.
-    cbn. erewrite eval_mono; eauto.
-    eauto. omega. omega.
-  - destruct H.
-    exists (1 + x). 
-    cbn. erewrite eval_mono; eauto.
-    eauto.
-  - destruct H, H0.
-    exists (1 + x0 + x1). 
-    cbn. erewrite eval_mono; eauto.
-    cbn. erewrite eval_mono; eauto.
-    eauto. omega. omega.
-  - destruct H.
-    exists (1 + x0). 
-    cbn. decide (min0 = x).
-    + subst. now rewrite H.
-    + assert (min0 <= min0 < x). omega. eapply H0 in H1 as [].
-      admit. admit.
-  - destruct H, H0.
-    exists (1 + x0 + x). 
-    cbn. erewrite eval_mono; eauto.
-    cbn. erewrite eval_mono; eauto.
-    eauto. omega. omega.
-Admitted.
+Instance term_rc_comp: computable rc_comp. extract constructor. Qed.
+Instance term_rc_cons : computable rc_cons.  extract constructor. Qed.
+Instance term_rc_rec : computable rc_rec.  extract constructor. Qed.
+Instance term_rc_min : computable rc_min.  extract constructor. Qed.
 
 Instance term_eval : computable eval.
 Proof.
   extract.
 Qed.
+
+Definition evalfun fuel c v := match eval fuel 0 c v with Some (inl x) => Some x | _ => None end.
+
+Definition UMUREC_HALTING c := exists fuel, evalfun fuel c nil <> None.
+
+From Undecidability.Problems Require Import Reduction.
+
+Lemma MUREC_red : MUREC_HALTING ⪯ UMUREC_HALTING.
+Proof.
+  unshelve eexists.
+  - intros f. exact (erase f).
+  - unfold UMUREC_HALTING, MUREC_HALTING. 
+    intros f.
+    split; intros [].
+    + rewrite ra_bs_correct in H. eapply ra_bs_to_c in H as [].
+      exists x0. eapply erase_correct in H. unfold evalfun. rewrite H. congruence.
+    + unfold evalfun in H. destruct eval eqn:E; try congruence.
+      destruct s; try congruence.
+      eapply erase_correct with (v := vec_nil) in E.
+      exists n. eapply ra_bs_correct. now eapply ra_bs_from_c.
+Qed.
+
+Local Definition r := (fun c n => match eval n 0 c [] with Some (inl n) => true | _ => false end).
+
+Lemma MUREC_WCBV : MUREC_HALTING ⪯ converges.
+Proof.
+  eapply reduces_transitive. eapply MUREC_red.
+  eapply L_recognisable_halt.
+  exists (fun c n => match eval n 0 c [] with Some (inl n) => true | _ => false end).
+  split.
+  - econstructor. extract.
+  - firstorder.
+    + unfold evalfun in *. exists x0. destruct eval; try destruct s; try congruence.
+    + exists x0. unfold evalfun in *. destruct eval; try destruct s; try congruence.
+Qed.
+Print Assumptions MUREC_WCBV.

--- a/theories/MuRec/minimizer.v
+++ b/theories/MuRec/minimizer.v
@@ -1,0 +1,196 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Omega.
+
+Set Implicit Arguments.
+
+Section nat_rev_ind.
+
+  (** A reverse recursion principle *)
+
+  Variables (P : nat -> Prop)
+            (HP : forall n, P (S n) -> P n).
+
+  Theorem nat_rev_ind x y : x <= y -> P y -> P x.
+  Proof. induction 1; auto. Qed.
+
+End nat_rev_ind.
+
+Section nat_rev_ind'.
+
+  (** A reverse recursion principle *)
+
+  Variables (P : nat -> Prop) (k : nat)
+            (HP : forall n, n < k -> P (S n) -> P n).
+
+  Theorem nat_rev_ind' x y : x <= y <= k -> P y -> P x.
+  Proof.
+    intros H1 H2. 
+    set (Q n := n <= k /\ P n).
+    assert (forall x y, x <= y -> Q y -> Q x) as H.
+      apply nat_rev_ind.
+      intros n (H3 & H4); split.
+      omega.
+      revert H4; apply HP, H3.
+    apply (H x y).
+    omega.
+    split; auto; omega.
+  Qed.
+
+End nat_rev_ind'.
+
+Section minimizer_pred.
+
+  Variable (P : nat -> Prop)
+           (HP : forall p: { n | P n \/ ~ P n }, { P (proj1_sig p) } + { ~ P (proj1_sig p) }).
+
+  Definition minimizer n := P n /\ forall i, i < n -> ~ P i.
+
+  Inductive bar n : Prop :=
+    | in_bar_0 : P n -> bar n
+    | in_bar_1 : ~ P n -> bar (S n) -> bar n.
+
+  Let bar_ex n : bar n -> P n \/ ~ P n.
+  Proof. induction 1; auto. Qed.
+
+  Let loop : forall n, bar n -> { k | P k /\ forall i, n <= i < k -> ~ P i }.
+  Proof.
+    refine (fix loop n Hn { struct Hn } := match HP (exist _ n (bar_ex Hn)) with
+      | left H => exist _ n _
+      | right H => match loop (S n) _ with 
+        | exist _ k Hk => exist _ k _
+      end 
+    end).
+    * split; auto; intros; omega.
+    * destruct Hn; [ destruct H | ]; assumption.
+    * destruct Hk as (H1 & H2).
+      split; trivial; intros i Hi.
+      destruct (eq_nat_dec i n).
+      - subst; trivial.
+      - apply H2; omega.
+  Qed.
+
+  Hypothesis Hmin : ex minimizer.
+
+  Let bar_0 : bar 0.
+  Proof.
+    destruct Hmin as (k & H1 & H2).
+    apply in_bar_0 in H1.
+    clear HP.
+    revert H1.
+    apply nat_rev_ind' with (k := k).
+    intros i H3.
+    apply in_bar_1, H2; trivial.
+    omega.
+  Qed.
+
+  Definition minimizer_pred : sig minimizer.
+  Proof.
+    destruct (loop bar_0) as (k & H1 & H2).
+    exists k; split; auto.
+    intros; apply H2; omega.
+  Defined.
+
+End minimizer_pred.
+
+(* Check minimizer_pred. *)
+(* Print Assumptions minimizer_pred. *)
+
+(* (** Let P be a computable predicate: *)
+(*       - whenever P n has a value (P n or not P n) then that value can be computed *)
+(*     Then minimizer P is computable as well: *)
+(*       - whenever minimizer P holds for some n, then such an n can be computed *)
+(*  *) *)
+      
+
+(* Corollary minimizer_alt (P : nat -> Prop) : *)
+(*     (forall n, P n \/ ~ P n -> { P n } + { ~ P n }) -> ex (minimizer P) -> sig (minimizer P). *)
+(* Proof. *)
+(*   intro H; apply minimizer_pred. *)
+(*   intros (n & Hn); apply H, Hn. *)
+(* Defined. *)
+
+(* Check minimizer_alt. *)
+(* Print Assumptions minimizer_alt. *)
+
+(* Section minimizer. *)
+
+(*   Variable (R : nat -> nat -> Prop) *)
+(*            (Rfun : forall n u v, R n u -> R n v -> u = v) *)
+(*            (HR : forall n, ex (R n) -> sig (R n)). *)
+
+(*   Definition minimizer' n := R n 0 /\ forall i, i < n -> exists u, R i (S u). *)
+
+(*   Fact minimizer_fun n m : minimizer' n -> minimizer' m -> n = m. *)
+(*   Proof. *)
+(*     intros (H1 & H2) (H3 & H4). *)
+(*     destruct (lt_eq_lt_dec n m) as [ [ H | ] | H ]; auto;  *)
+(*       [ apply H4 in H | apply H2 in H ]; destruct H as (u & Hu); *)
+(*       [ generalize (Rfun H1 Hu) | generalize (Rfun H3 Hu) ]; discriminate. *)
+(*   Qed.  *)
+
+(*   Inductive bar n : Prop := *)
+(*     | in_bar_0 : R n 0 -> bar n *)
+(*     | in_bar_1 : (exists u, R n (S u)) -> bar (S n) -> bar n. *)
+
+(*   Let bar_ex n : bar n -> ex (R n). *)
+(*   Proof. *)
+(*     induction 1 as [ n Hn | n (k & Hk) _ _ ]. *)
+(*     exists 0; auto. *)
+(*     exists (S k); trivial. *)
+(*   Qed. *)
+
+(*   Let loop : forall n, bar n -> { k | R k 0 /\ forall i, n <= i < k -> exists u, R i (S u) }. *)
+(*   Proof. *)
+(*     refine (fix loop n Hn { struct Hn } := match HR (bar_ex Hn) with *)
+(*         | exist _ u Hu => match u as m return R _ m -> _ with *)
+(*             | 0   => fun H => exist _ n _ *)
+(*             | S v => fun H => match loop (S n) _ with *)
+(*                 | exist _ k Hk => exist _ k _ *)
+(*               end *)
+(*           end Hu *)
+(*       end). *)
+(*     * split; auto; intros; omega. *)
+(*     * destruct Hn as [ Hn | ]; trivial; exfalso; generalize (Rfun H Hn); discriminate. *)
+(*     * destruct Hk as (H1 & H2); split; trivial; intros i Hi. *)
+(*       destruct (eq_nat_dec i n). *)
+(*       - subst; exists v; trivial. *)
+(*       - apply H2; omega. *)
+(*   Qed. *)
+
+(*   Hypothesis Hmin : ex minimizer. *)
+
+(*   Let bar_0 : bar 0. *)
+(*   Proof. *)
+(*     destruct Hmin as (k & H1 & H2). *)
+(*     apply in_bar_0 in H1. *)
+(*     clear Hmin HR. *)
+(*     revert H1. *)
+(*     apply nat_rev_ind' with (k := k). *)
+(*     intros i H3. *)
+(*     apply in_bar_1, H2; trivial. *)
+(*     omega. *)
+(*   Qed. *)
+
+(*   Definition minimizer_coq : sig minimizer. *)
+(*   Proof. *)
+(*     destruct (loop bar_0) as (k & H1 & H2). *)
+(*     exists k; split; auto. *)
+(*     intros; apply H2; omega. *)
+(*   Defined. *)
+
+(* End minimizer. *)
+
+(* Check minimizer_coq. *)
+(* Print Assumptions minimizer_coq. *)
+
+(* Extraction "minimizer.ml" minimizer_coq. *)
+
+     

--- a/theories/MuRec/ra_bs.v
+++ b/theories/MuRec/ra_bs.v
@@ -1,0 +1,43 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+From Undecidability.Shared Require Import DLW.Vec.vec DLW.Vec.pos.
+From Undecidability.MuRec Require Import recalg.
+
+Set Implicit Arguments.
+
+Reserved Notation "  '[' f ';' v ']' '~~>' x " (at level 70).
+
+(* Bigstep semantics for recursive algorithms *)
+   
+Inductive ra_bs : forall k, recalg k -> vec nat k -> nat -> Prop :=
+    | in_ra_bs_cst  : forall n v,             [ra_cst n;        v] ~~> n
+    | in_ra_bs_zero : forall v,               [ra_zero;         v] ~~> 0
+    | in_ra_bs_succ : forall v,               [ra_succ;         v] ~~> S (vec_head v)
+    | in_ra_bs_proj : forall k v j,           [@ra_proj k j;    v] ~~> vec_pos v j
+    
+    | in_ra_bs_comp : forall k i f (gj : vec (recalg i) k) v w x,
+                                   (forall j, [vec_pos gj j;    v] ~~> vec_pos w j)
+                               ->             [f;               w] ~~> x
+                               ->             [ra_comp f gj;    v] ~~> x
+
+    | in_ra_bs_rec_0 : forall k f (g : recalg (S (S k))) v x,
+                                              [f;               v] ~~> x
+                               ->             [ra_rec f g;   0##v] ~~> x
+
+    | in_ra_bs_rec_S : forall k f (g : recalg (S (S k))) v n x y,
+                                              [ra_rec f g;   n##v] ~~> x
+                               ->             [g;         n##x##v] ~~> y
+                               ->             [ra_rec f g; S n##v] ~~> y
+                               
+    | in_ra_bs_min : forall k (f : recalg (S k)) v x w ,
+                           (forall j : pos x, [f;    pos2nat j##v] ~~> S (vec_pos w j))
+                               ->             [f;            x##v] ~~> 0
+                               ->             [ra_min f;        v] ~~> x
+where " [ f ; v ] ~~> x " := (@ra_bs _ f v x).

--- a/theories/MuRec/ra_ca.v
+++ b/theories/MuRec/ra_ca.v
@@ -1,0 +1,254 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Eqdep_dec.
+
+From Undecidability.Shared Require Import DLW.Utils.utils DLW.Vec.vec DLW.Vec.pos.
+From Undecidability.MuRec Require Import recalg.
+
+Set Implicit Arguments.
+
+Reserved Notation "  '[' f ';' v ']' '-[' n '>>' x " (at level 70).
+
+(** The intuitive meaning of [f;v] -[n>> x is
+   
+      There is a computation of f(v) which costs n and results in x
+    
+    We define it in such a way that 
+      1/ the cost is never 0, 
+      2/ the cost of compound computation is greater than
+         the sum of the costs of its sub-computations
+      3/ the cost and the result are unique (if they exist) 
+      
+ **)
+   
+Inductive ra_ca : forall k, recalg k -> vec nat k -> nat -> nat -> Prop := 
+    | in_ra_ca_cst  : forall n v,             [ra_cst n;        v] -[ 1           >> n
+    | in_ra_ca_zero : forall v,               [ra_zero;         v] -[ 1           >> 0
+    | in_ra_ca_succ : forall v,               [ra_succ;         v] -[ 1           >> S (vec_head v)
+    | in_ra_ca_proj : forall k v j,           [@ra_proj k j;    v] -[ 1           >> vec_pos v j 
+    
+    | in_ra_ca_comp : forall k i f (gj : vec (recalg i) k) v q w p x,
+                                   (forall j, [vec_pos gj j;    v] -[ vec_pos q j >> vec_pos w j)
+                               ->             [f;               w] -[ p           >> x
+                               ->             [ra_comp f gj;    v] -[1+p+vec_sum q>> x
+
+    | in_ra_ca_rec_0 : forall k f (g : recalg (S (S k))) v n x,    
+                                              [f;               v] -[ n           >> x 
+                               ->             [ra_rec f g;   0##v] -[ S n         >> x
+
+    | in_ra_ca_rec_S : forall k f (g : recalg (S (S k))) v n p x q y,          
+                                              [ra_rec f g;   n##v] -[ p           >> x
+                               ->             [g;         n##x##v] -[ q           >> y
+                               ->             [ra_rec f g; S n##v] -[ 1+p+q       >> y
+                               
+    | in_ra_ca_min : forall k (f : recalg (S k)) v x p w q , 
+                           (forall j : pos x, [f;    pos2nat j##v] -[ vec_pos q j >> S (vec_pos w j)) 
+                               ->             [f;            x##v] -[ p           >> 0
+                               ->             [ra_min f;        v] -[1+p+vec_sum q>> x
+where " [ f ; v ] -[ n >> x " := (@ra_ca _ f v n x).
+
+Section inversion_lemmas.
+
+  (** The inversion tactic won't work for the dependent predicate ra_ca so
+      we build the inversion lemma by hand.
+
+      Notice the presence of type-castings (eq_rect ...) which disappear
+      when we instanciate that lemma on the individual cases 
+      (the lemmas ra_ca_*_inv below)
+
+      The statement of the lemma is complicated but the proof is trivial !!
+  *)
+
+  Lemma ra_ca_inv k (f : recalg k) v n x : 
+    [f;v] -[n>> x -> (n = 1 /\ exists (H : k = 0), eq_rect _ _ f _ H = ra_cst x)
+                  \/ (n = 1 /\ x = 0 /\ exists (H : k = 1), eq_rect _ _ f _ H = ra_zero)
+                  \/ (n = 1 /\ exists (H : k = 1), x = S (vec_head (eq_rect _ _ v _ H)) /\ eq_rect _ _ f _ H = ra_succ)
+                  \/ (n = 1 /\ exists p, x = vec_pos v p /\ f = ra_proj p)
+                  \/ (exists i (h : recalg i) gj w q m, n = 1+q+vec_sum m /\ [h;w] -[q>> x 
+                              /\ (forall p, [vec_pos gj p;v] -[vec_pos m p>> vec_pos w p)
+                              /\ f = ra_comp h gj) 
+                  \/ (exists k' (H : k = S k') (h : recalg k') g m, 
+                                 n = S m 
+                              /\ vec_head (eq_rect _ _ v _ H) = 0
+                              /\ [h;vec_tail (eq_rect _ _ v _ H)] -[m>> x 
+                              /\ eq_rect _ _ f _ H = ra_rec h g) 
+                  \/ (exists k' (H : k = S k') m y (h : recalg k') g p q, 
+                                 vec_head (eq_rect _ _ v _ H) = S m
+                              /\ n = 1+p+q
+                              /\ [ra_rec h g; m##vec_tail (eq_rect _ _ v _ H)] -[p>> y                             
+                              /\ [g; m##y##vec_tail (eq_rect _ _ v _ H)] -[q>> x  
+                              /\ eq_rect _ _ f _ H = ra_rec h g) 
+                  \/ (exists (g : recalg (S k)) (m w : vec _ x) q,
+                                 n = 1+q+vec_sum m
+                              /\ (forall p, [g; pos2nat p##v] -[vec_pos m p>> S (vec_pos w p))  
+                              /\ [g; x##v] -[q>> 0
+                              /\ f = ra_min g)  
+                 .
+  Proof.
+    induction 1 as [ | | 
+                   | k v j 
+                   | k i f gj v q w p x 
+                   | k f g v n x 
+                   | k f g v n p x q y
+                   | k f v x p w q
+                   ].
+    do 0 right; left; split; auto; exists eq_refl; auto.
+    do 1 right; left; do 2 (split; auto); exists eq_refl; auto.
+    do 2 right; left; split; auto; exists eq_refl; split; simpl; auto.
+    do 3 right; left; split; auto; exists j; auto.
+    do 4 right; left; exists k, f, gj, w, p, q; auto.
+    do 5 right; left; exists k, eq_refl, f, g, n; auto.
+    do 6 right; left; exists k, eq_refl, n, x, f, g, p, q; auto.
+    do 7 right; exists f, q, w, p; auto.
+  Qed.
+
+  (* The next proofs by hand are long but not complicated ... we simply have to
+     discard all the unnecessary cases generated by the general
+     inversion lemma using the discriminate tactic *)
+
+  (* Automation is our friend here *)
+
+  (* This is to destruct the inversion lemma 
+
+     This lemma creates variables which are partly hard coded ...
+     this is not ideal and could be improved
+   *)
+     
+  Local Ltac myinv := 
+    let H := fresh in
+    intros H;
+    apply ra_ca_inv in H;   
+    destruct H as   [ (? & ? & ?) 
+                  | [ (? & ? & ? & ?)
+                  | [ (? & ? & ? & ?)
+                  | [ (? & ? & ? & ?)
+                  | [ (? & ? & ? & w' & q' & m' & ? & ? & ? & ?) 
+                  | [ (? & ? & ? & ? & m' & ? & ? & ? & ?)
+                  | [ (? & ? & ? & y' & ? & ? & p' & q' & ? & ? & ? & ? & ?) 
+                    | (? & m' & w' & q' & ? & ? & ? & ?) 
+                    ] ] ] ] ] ] ].
+
+  Ltac injc H := injection H; clear H;
+                 repeat match goal with 
+                          |- _ = _ -> _ => 
+                          intro; subst end.
+
+  Ltac eqgoal := 
+    match goal with 
+      |- ?a -> ?b => replace a with b; auto 
+    end.
+  
+  Ltac inst H :=
+    let K := fresh in
+    match goal with 
+    | [ G : ?x -> _ |- _ ] => 
+      match G with 
+        H => assert (x) as K; [ clear H | specialize (H K); clear K ]
+      end 
+    end.
+
+  Fact eq_gen { X } (P : X -> Type) x : (forall y, y = x -> P y) -> P x.
+  Proof. intros H; apply H, eq_refl. Qed.
+  
+  Ltac gen_eq t := apply eq_gen with (x := t).
+
+  Fact eq_nat_pirr (n m : nat) (H1 H2 : n = m) : H1 = H2.
+  Proof. apply UIP_dec, eq_nat_dec. Qed.
+
+  (* Remove identities of the form H : n = n :> nat and eliminates H 
+   by replacing it with eq_refl *)
+
+  Ltac natid :=
+    repeat
+      match goal with 
+      |  [ H: ?x = ?x :> nat |- _ ]  => let G := fresh 
+                                    in generalize (@eq_nat_pirr _ _ H eq_refl); 
+                                       intros G; subst H 
+      end;
+    simpl eq_rect in * |- *.
+
+  Local Ltac natSimpl :=
+    repeat match goal with [ H : S _ = S _ |- _ ] => let G := fresh in injection H; intro G; subst; natid end.
+    
+  Local Ltac mydiscr :=     
+     repeat match goal with 
+            | H : _ = _ :> nat      |- _  => discriminate H; fail
+            | H : _ = _ :> recalg _ |- _  => discriminate H; fail
+            end.  
+
+  Local Ltac myauto := myinv; subst; natid; natSimpl; mydiscr; auto.
+  
+  Lemma ra_ca_cst_inv i v n x : [ra_cst i;v] -[n>> x -> n = 1 /\ x = i.
+  Proof. inversion_clear 1; auto. Qed.
+
+  Lemma ra_ca_zero_inv v n x : [ra_zero;v] -[n>> x -> n = 1 /\ x = 0.
+  Proof. inversion_clear 1; auto. Qed.
+
+  Lemma ra_ca_succ_inv v n x : [ra_succ;v] -[n>> x -> n = 1 /\ x = S (vec_head v).
+  Proof. myauto. Qed.
+  
+  Local Ltac ra_inj := 
+    match goal with 
+       | H : ra_proj _   = ra_proj _   |- _ => apply ra_proj_inj in H
+       | H : ra_comp _ _ = ra_comp _ _ |- _ => apply ra_comp_inj in H; destruct H as (? & ? & ?) 
+       | H : ra_rec _ _  = ra_rec _ _  |- _ => apply ra_rec_inj in H; destruct H
+       | H : ra_min _    = ra_min _    |- _ => apply ra_min_inj in H
+    end; subst; simpl in * |- *.
+
+  Lemma ra_ca_proj_inv k (p : pos k) v n x : [ra_proj p;v] -[n>> x -> n = 1 /\ x = vec_pos v p.
+  Proof.
+    myauto; ra_inj; auto.
+  Qed.
+  
+  (* These 4 proofs use variable names which are hard coded
+     in the tactic myinv ... they should not conflict with
+     other variables names but be warned that this is not 
+     an ideal situation for the stability of those proofs
+   *)
+
+  Lemma ra_ca_comp_inv k i f (gj : vec (recalg i) k) v n x : 
+     [ra_comp f gj;v] -[n>> x -> exists p w q,
+                                   n = 1+p+vec_sum q 
+                                /\ (forall j, [vec_pos gj j;v] -[vec_pos q j>> vec_pos w j)
+                                /\ [f;w] -[p>> x.
+  Proof.
+    myauto; ra_inj. 
+    exists q', w', m'; auto.
+  Qed.
+  
+  Lemma ra_ca_rec_0_inv k f g v n x : 
+    [@ra_rec k f g; 0##v] -[n>> x -> exists m, n = S m /\ [f;v] -[m>> x.
+  Proof.
+    myauto; ra_inj.
+    exists m'; auto.
+  Qed.
+
+  Lemma ra_ca_rec_S_inv k f g v i n x : 
+     [@ra_rec k f g; S i##v] -[n>> x -> exists y p q, 
+                                          n = 1+q+p
+                                       /\ [ra_rec f g; i##v] -[q>> y
+                                       /\ [g; i##y##v] -[p>> x.
+  Proof.
+    myauto; ra_inj; natSimpl.
+    exists y', q', p'; auto.
+  Qed.
+
+  Lemma ra_ca_min_inv k f v n x : 
+     [@ra_min k f;v] -[n>> x -> exists p w q,
+                                 n = 1+p+vec_sum q
+                              /\ [f;x##v] -[p>> 0
+                              /\ forall j, [f;pos2nat j##v] -[vec_pos q j>> S (@vec_pos _ x w j). 
+  Proof.
+    myauto; ra_inj.
+    exists q', w', m'; auto.
+  Qed.
+
+End inversion_lemmas.
+

--- a/theories/MuRec/ra_sem_eq.v
+++ b/theories/MuRec/ra_sem_eq.v
@@ -1,0 +1,121 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Omega.
+
+From Undecidability.Shared Require Import DLW.Utils.utils DLW.Vec.vec DLW.Vec.pos.
+From Undecidability.MuRec Require Import recalg ra_bs recursor minimizer ra_ca.
+
+Set Implicit Arguments.
+
+Notation "[| f |]" := (@ra_rel _ f) (at level 0).
+
+Section soundness_and_completeness.
+
+  (* By induction on the ra_ca predicate *)
+
+  Lemma ra_ca_inc_bs k (f : recalg k) v x : (exists n, [f;v] -[n>> x) -> [f;v] ~~> x.
+  Proof.
+    intros (n & H); revert H.
+    induction 1 as [ n v | v | v
+                   | k v p 
+                   | k i f gj v n w q x H1 IH1 H2 IH2 
+                   | k f g v n x H1 IH2 
+                   | k f g v n p x q y H1 IH1 H2 IH2
+                   | k f v p n w q H1 IH1 H2 IH2 ]; try (constructor; auto; fail).
+    apply in_ra_bs_comp with w; auto.
+    apply in_ra_bs_rec_S with x; auto.
+    apply in_ra_bs_min with w; auto.
+  Qed.
+
+  (* By induction on the ra_bs predicate *)
+
+  Lemma ra_bs_inc_rel k (f : recalg k) v x : [f;v] ~~> x -> [|f|] v x.
+  Proof.
+    induction 1 as [ n v | v | v
+                   | k v p 
+                   | k i f gj v w x H1 IH1 H2 IH2 
+                   | k f g v n x H1 IH2 
+                   | k f g v n x y H1 IH1 H2 IH2
+                   | k f v n w H1 IH1 H2 IH2 ]; try reflexivity.
+    exists w; split; auto; intros; rewrite vec_pos_set; auto.
+    red; unfold s_rec; simpl; auto.
+    rewrite ra_rel_fix_rec in IH1 |- *; unfold s_rec in IH1 |- *.
+    simpl in IH1 |- *; exists x; auto.
+    rewrite ra_rel_fix_min; unfold s_min; split; auto.    
+    intros y Hy.
+  Admitted.
+  (*   exists (vec_get w _ Hy). *)
+  (*   generalize (IH1 (nat2pos Hy)). *)
+  (*   rewrite pos2nat_nat2pos. *)
+  (*   eqgoal; do 2 f_equal. *)
+  (*   apply vec_get_pos_eq. *)
+  (*   rewrite pos2nat_nat2pos; auto. *)
+  (* Qed. *)
+  
+  (* By induction on f *)
+  
+  Lemma ra_rel_inc_ca k (f : recalg k) v x : [|f|] v x -> exists n, [f;v] -[n>> x.
+  Proof.
+    revert v x; induction f as [ k n | | | k p | k i f gj Hf Hgj 
+                               | k f g Hf Hg 
+                               | ]; intros v x.
+    rewrite ra_rel_fix_cst; unfold s_cst; intros []; exists 1; constructor.
+    rewrite ra_rel_fix_zero; unfold s_zero; intro; subst; exists 1; constructor.
+    rewrite ra_rel_fix_succ; unfold s_succ; intro; subst; exists 1; constructor.
+    rewrite ra_rel_fix_proj; unfold s_proj; intros []; exists 1; constructor.
+    
+    rewrite ra_rel_fix_comp; unfold s_comp; intros (w & H1 & H2).
+    apply Hf in H1; destruct H1 as (n & H1).
+    assert (forall p, exists n, [vec_pos gj p;v] -[n>> vec_pos w p) as H3.
+      intros p; specialize (H2 p); rewrite vec_pos_map in H2; auto.
+    apply vec_reif in H3.
+    destruct H3 as (m & Hm).
+    exists (1+n+vec_sum m).
+    apply in_ra_ca_comp with (2 := H1); auto.
+    
+    rewrite ra_rel_fix_rec; unfold s_rec.
+    rewrite (vec_head_tail v); simpl; generalize (vec_head v) (vec_tail v).
+    clear v; intros i v.
+    revert x; induction i as [ | i IHi ]; intros x; simpl.
+    intros H; apply Hf in H; destruct H as (n & Hn); exists (S n); constructor; auto.
+    intros (y & H1 & H2).
+    apply IHi in H1; destruct H1 as (n & Hn).
+    apply Hg in H2; destruct H2 as (m & Hm).
+    exists (1+n+m); apply in_ra_ca_rec_S with (1 := Hn); auto.
+    
+    rewrite ra_rel_fix_min; unfold s_min; intros (H1 & H2).
+    assert (forall (p : pos x), exists r, [|f|] (pos2nat p##v) (S r)) as H3.
+      intros p; apply (H2 _ (pos2nat_prop p)).
+    apply vec_reif in H3.
+    destruct H3 as (w & Hw).
+    assert (forall p, exists n, [f;pos2nat p##v] -[n>> S (vec_pos w p)) as H3.
+      intros p; apply IHf, Hw.
+    apply vec_reif in H3.
+    destruct H3 as (m & Hm).
+    apply IHf in H1.
+    destruct H1 as (n & Hn).
+    exists (1+n+vec_sum m).
+    apply in_ra_ca_min with (1 := Hm); auto.
+  Qed.
+  
+  (** Hence, there is a correspondance between the relational semantics
+      and the bigstep semantics of recalg.
+   **)
+
+  Hint Resolve ra_ca_inc_bs ra_bs_inc_rel ra_rel_inc_ca.
+  
+  Theorem ra_bs_correct k (f : recalg k) v x : [|f|] v x <-> [f;v] ~~> x.
+  Proof. split; auto. Qed.
+
+  Theorem ra_ca_correct k (f : recalg k) v x : [|f|] v x <-> exists n, [f;v] -[n>> x.
+  Proof. split; auto. Qed.
+
+End soundness_and_completeness.
+

--- a/theories/MuRec/recursor.v
+++ b/theories/MuRec/recursor.v
@@ -1,0 +1,55 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import Arith Omega.
+From Undecidability.Shared Require Import DLW.Utils.utils.
+
+Set Implicit Arguments.
+
+Section recursor.
+
+  Variables (F : nat -> Prop) 
+            (Ffun : forall n m, F n -> F m -> n = m) 
+            (HF : ex F -> sig F)
+            (G : nat -> nat -> nat -> Prop) 
+            (Gfun : forall x y n m, G x y n -> G x y m -> n = m)
+            (HG : forall x y, ex (G x y) -> sig (G x y)).
+  
+  Fixpoint recursor n x := 
+    match n with
+      | 0   => F x
+      | S n => exists y, recursor n y /\ G n y x
+      end.
+
+  Fact recursor_fun n x y : recursor n x -> recursor n y -> x = y.
+  Proof.
+    revert x y; induction n as [ | n IHn ]; simpl; auto.
+    intros x y (a & H1 & H2) (b & H3 & H4).
+    specialize (IHn _ _ H1 H3); subst b.
+    revert H2 H4; apply Gfun.
+  Qed.
+
+  Fixpoint recursor_coq n (Hn : ex (recursor n)) : sig (recursor n).
+  Proof.
+    destruct n as [ | n ].
+    apply HF, Hn.
+    refine (match recursor_coq n _ with
+        | exist _ xn Hxn => match @HG n xn _ with 
+          | exist _ xSn HxSn => exist _ xSn _
+        end
+      end).
+    * destruct Hn as (_ & y & ? & _); exists y; auto.
+    * destruct Hn as (x & y & H1 & H2).
+      exists x; revert H2; eqgoal; do 2 f_equal.
+      revert H1 Hxn. eapply recursor_fun.
+    * exists xn; auto.
+  Defined.
+
+End recursor.
+

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -113,6 +113,11 @@ MuRec/ra_dio_poly.v
 MuRec/ra_mm_env.v
 MuRec/ra_mm.v
 MuRec/ra_comp.v
+MuRec/ra_bs.v
+MuRec/minimizer.v
+MuRec/recursor.v
+MuRec/ra_sem_eq.v
+MuRec/ra_ca.v
 
 H10/Fractran/mm_no_self.v
 H10/Fractran/prime_seq.v
@@ -294,6 +299,7 @@ L/Reductions/SR_MPCP_computable.v
 L/Reductions/MPCP_PCP_computable.v
 L/Reductions/PCP_CFG_computable.v
 L/Reductions/H10_to_L.v
+L/Reductions/MuRec.v
 
 L/Complexity/ResourceMeasures.v
 L/Complexity/SpaceBoundsTime.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -270,6 +270,7 @@ L/Datatypes/Lists.v
 L/Datatypes/LNat.v
 L/Datatypes/LOptions.v
 L/Datatypes/LProd.v
+L/Datatypes/LSum.v
 L/Datatypes/LBinNums.v
 L/Datatypes/LTerm.v
 


### PR DESCRIPTION
I've finished the reduction from mu-halting to lambda-halting.

Trickier than expected, because mu recursive functions are defined as a dependent type (not supported by L extraction) and there was no "simple" step-indexed evaluator. I've written one now and it extracts perfectly well to L, it's probably the most complicated example we ever tried the extraction on (that's also why it's slow).

There's one gap in `ra_ca.v` where I admitted something, otherwise I was able to port code easily from the ITP '17 repo of mu recursive functions.