### PR TITLE
new version of the DPRM which shows all availalable equivalences

### DIFF
--- a/theories/H10/DPRM.v
+++ b/theories/H10/DPRM.v
@@ -183,7 +183,37 @@ Section Various_definitions_of_recursive_enum_1.
         forall x, P x <-> exists w, ⟦p⟧ (vec_pos w) (fun _ => x) 
                                   = ⟦q⟧ (vec_pos w) (fun _ => x) } } }.
 
-  (** 5 = ps 1 could be chosen as 2 and 7 = qs 1 as 3 *)
+  (** Reworking ps and qs to avoid the first primes, may be 2, 3 and 5
+      and show be possible to replace with
+
+            FRACTRAN_RECO := { l | forall x, P x <-> l /F/ 2^(1+x) ↓ }
+
+      Let use assume l does not use 2, 3, 5 and P x <-> l /F/ 7.11^x ↓
+
+      then let us define l' = [ 5*11/3*2; 3/5; 3/2; 7/3 ] ++ l
+
+      then l' /F/ 2^(1+x) ~~> 3.2^x
+           l' /F/ 3.2^0  ~~> 7.11^0
+           l' /F/ 3.11^y.2^(1+x) ~~> 5.11^(1+y).2^x ~~> 3.11^(1+y).2^x
+      hence l' /F/ 3.2^x ~~> 3.11^x ~~> 7.11^x 
+
+      and after that the first fractions of l' cannot be used
+      because neither 2, 3 or 5 will ever be a factor of the 
+      current state.
+
+      So l' /F/ 2^(1+x) ↓ <-> l /F/ 7.11^x <-> P x
+
+      One the other hand, with P x <-> l /F/ x ↓ it is not possible
+      to represent arbitrary RE predicates 
+
+      Indeed for any l, on can show forall x, l /F/ x ↓ -> l /F/ 1 ↓  
+      because for l to terminate on x, it cannot contain any p/q being
+      a nat, hence in that case, the computation from 1 cannot start
+
+      So the predicate l /F/ x ↓ cannot serve as a generic RE predicate
+      because it cannot simulate P x := x = 2.
+
+     *)
 
   Definition fractran_recognisable := { l | forall x, P x <-> l /F/ 5*7^x ↓ }.
 

--- a/theories/H10/DPRM.v
+++ b/theories/H10/DPRM.v
@@ -17,61 +17,147 @@ From Undecidability.ILL.Code Require Import sss.
 From Undecidability.ILL.Mm   Require Import mm_defs.
 From Undecidability.H10.Fractran Require Import fractran_defs fractran_dio mm_fractran prime_seq.
 From Undecidability.H10.Dio Require Import dio_logic dio_elem dio_single.
+From Undecidability.MuRec Require Import recalg ra_utils recomp ra_recomp ra_dio_poly ra_mm ra_simul.
 
 Set Implicit Arguments.
 
 Local Notation "P /MM/ s ↓" := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity).
 Local Notation "l '/F/' x ↓" := (fractran_terminates l x) (at level 70, no associativity).
 Local Notation "'⟦' p '⟧'" := (fun φ ν => dp_eval φ ν p).
+Local Notation "f ⇓ v" := (ex (@ra_rel _ f v)) (at level 70, no associativity).
 
 (** Definitions of n-ary recursive enumerable predicates *)
 
-Definition mm_recognisable_n n (R : vec nat n -> Prop) := 
-  { m & { M : list (mm_instr (pos (n+m))) | forall v, R v <-> (1,M) /MM/ (1,vec_app v vec_zero) ↓ } }.
+Section Various_definitions_of_recursive_enum.
 
-Definition diophantine_n n (R : vec nat n -> Prop) :=
-  { m : nat &
-  { p : dio_polynomial (pos m) (pos n) &
-  { q : dio_polynomial (pos m) (pos n) |
-        forall v, R v <-> exists w, ⟦p⟧ (vec_pos w) (vec_pos v) 
+  (* P is a predicate over n-tuples of nat *)
+
+  Variable (n : nat) (P : vec nat n -> Prop).
+
+  (* There is a Minsky machine that recognises P *)
+
+  Definition mm_recognisable_n :=
+    { m & { M : list (mm_instr (pos (n+m))) | forall v, P v <-> (1,M) /MM/ (1,vec_app v vec_zero) ↓ } }.
+
+  (* There is a µ-recursive function of which P is the domain *)
+
+  Definition µ_recursive_n := { f | forall v, P v <-> f ⇓ v }.
+
+  Notation vec2val := (fun v => vec2fun v 0).
+
+  (* There is a Diophantine logic formula satisfied exactly on P *)
+
+  Definition dio_rec_form_n := 
+    { A | forall v, P v <-> df_pred A (vec2val v) }.
+
+  (* There is a list of elementary Diophantine constraints simultaneously
+     satisfiable exactly on P *)
+
+  Definition dio_rec_elem_n :=
+    { l | forall v, P v <-> exists φ, Forall (dc_eval φ (vec2val v)) l }.
+
+  (* There is a single Diophantine equations solvable exactly when
+     its n-tuple of parameters belong to P *)
+
+  Definition dio_rec_single_n :=
+    { m : nat &
+    { p : dio_polynomial (pos m) (pos n) &
+    { q : dio_polynomial (pos m) (pos n) |
+        forall v, P v <-> exists w, ⟦p⟧ (vec_pos w) (vec_pos v) 
                                   = ⟦q⟧ (vec_pos w) (vec_pos v) } } }.
 
-Section DPRM_n.
-
-  Variable (n : nat) (R : vec nat n -> Prop) (HR : mm_recognisable_n R).
-
-  (* There is a FRACTRAN program simulating R *)
-
-  Let FRACTRAN : { l | forall v, R v <-> l /F/ ps 1 * exp 1 v ↓ }.
+  Local Theorem dio_rec_form_elem : dio_rec_form_n -> dio_rec_elem_n.
   Proof.
-    destruct HR as (m & Q & HQ).
-    destruct mm_fractran_n with (P := Q) as (l & _ & Hl).
-    exists l. 
-    intros x; rewrite HQ, Hl.
-    rewrite exp_app, exp_zero, Nat.mul_1_r; tauto.
+    intros (A & HA).
+    destruct (dio_formula_elem A) as (l & _ & _ & Hl).
+    exists l; intros v.
+    rewrite HA, Hl; tauto.
+  Qed. 
+
+  Local Theorem dio_rec_elem_single : dio_rec_elem_n -> dio_rec_single_n.
+  Proof.
+    intros (l & Hl).
+    destruct (dio_elem_equation l) as (e & _ & H2).
+    destruct (dio_poly_eq_pos e) as (m & p & q & H3).
+    set (p' := dp_proj_par n p).
+    set (q' := dp_proj_par n q).
+    exists m, p', q'; intros v.
+    rewrite Hl, <- H2, H3.
+    unfold dio_single_pred, p', q'; simpl; split.
+    + intros (phi & H).
+      exists (vec_set_pos phi).
+      rewrite !dp_proj_par_eval.
+      eq goal H; f_equal; apply dp_eval_ext; auto.
+      all: intros; rewrite vec_pos_set; auto.
+    + intros (w & H).
+      exists (vec_pos w).
+      rewrite !dp_proj_par_eval in H; auto.
   Qed.
 
-  (* Then R is diophantine_n *)
-
-  Theorem DPRM_n : diophantine_n R.
+  Local Theorem dio_rec_single_µ_rec : dio_rec_single_n -> µ_recursive_n.
   Proof.
-    destruct FRACTRAN as (l & Hl).
-    clear FRACTRAN HR.
-    destruct FRACTRAN_HALTING_on_exp_diophantine with n l as (f & Hf); auto.
-    destruct (dio_formula_elem f) as (ll & _ & _ & G3).
-    destruct (dio_elem_equation ll) as (c & _ & G4).
-    destruct (dio_poly_eq_pos c) as (m & p & q & Hpq).
-    exists m, (dp_proj_par n p), (dp_proj_par n q); intros phi.
-    rewrite <- (fun2vec_vec2fun phi) with (x := 0) at 1.
-    rewrite Hl, <- Hf, G3, <- G4, Hpq, dio_poly_eq_pos_equiv.
-    split; intros (w & Hw); exists w; eq goal Hw; f_equal;
-      rewrite dp_proj_par_eval; apply dp_eval_ext; auto.
+    intros (m & p & q & H).
+    exists (ra_dio_poly_find p q).
+    intros v; rewrite H, ra_dio_poly_find_spec; tauto.
   Qed.
 
-End DPRM_n.
+  Local Theorem µ_rec_mm_reco : µ_recursive_n -> mm_recognisable_n.
+  Proof.
+    intros (f & Hf).
+    destruct (ra_mm_simulator f) as (m & M & H).
+    exists (S m), M; intro.
+    rewrite Hf, H; tauto.
+  Qed.
 
-Print mm_recognisable_n.
-Print diophantine_n.
+  (** For n = 1 one could add FRACTRAN as well. The Gödel encoding
+      of tuple make the definition of FRACTRAN recognisability for
+      n > 1 a bit weird *)
+
+  Section mm_reco_dio_form.
+
+    Variable (HP : mm_recognisable_n).
+
+    (* There is a FRACTRAN program simulating R *)
+
+    Let FRACTRAN : { l | forall v, P v <-> l /F/ ps 1 * exp 1 v ↓ }.
+    Proof.
+      destruct HP as (m & Q & HQ).
+      destruct mm_fractran_n with (P := Q) as (l & _ & Hl).
+      exists l. 
+      intros x; rewrite HQ, Hl.
+      rewrite exp_app, exp_zero, Nat.mul_1_r; tauto.
+    Qed.
+
+    Local Theorem mm_reco_dio_form : dio_rec_form_n.
+    Proof.
+      destruct FRACTRAN as (Q & HQ).
+      clear FRACTRAN HP.
+      destruct FRACTRAN_HALTING_on_exp_diophantine with n Q as (A & HA); auto.
+      exists A; intros v.
+      rewrite HQ, HA, fun2vec_vec2fun; tauto.
+    Qed.
+
+  End mm_reco_dio_form.
+
+End Various_definitions_of_recursive_enum.
+
+Local Hint Resolve dio_rec_form_elem  dio_rec_elem_single
+                   dio_rec_single_µ_rec  µ_rec_mm_reco
+                   mm_reco_dio_form : core.
+
+Local Ltac lsplit n := 
+  match n with 
+    | 0    => idtac 
+    | S ?n => split; [ lsplit n | ]
+   end.
+
+Theorem DPRM_n n (R : vec nat n -> Prop) : 
+         (mm_recognisable_n R  -> dio_rec_form_n R)
+       * (dio_rec_form_n R     -> dio_rec_elem_n R)
+       * (dio_rec_elem_n R     -> dio_rec_single_n R)
+       * (dio_rec_single_n R   -> µ_recursive_n R)
+       * (µ_recursive_n R      -> mm_recognisable_n R).
+Proof. lsplit 4; auto. Qed. 
 
 Check DPRM_n.
 Print Assumptions DPRM_n.

--- a/theories/Shared/Libs/DLW/Utils/utils_tac.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_tac.v
@@ -49,6 +49,15 @@ Ltac msplit n :=
     | S ?n => split; [ | msplit n ]
    end.
 
+Ltac lsplit n := 
+  match n with 
+    | 0    => idtac 
+    | S ?n => split; [ lsplit n | ]
+   end.
+
+Fact equal_equiv (P Q : Prop) : P = Q -> P <-> Q.
+Proof. intros []; tauto. Qed.
+
 Section forall_equiv.
 
   Variable (X : Type) (A P Q : X -> Prop) (HPQ : forall n, A n -> P n <-> Q n).


### PR DESCRIPTION
Hi Yannick,

I did update `DPRM.v` and the theorem `DPRM_n` so that it contains all the available equivalences: MM -> DIO_FORM -> DIO_ELEM -> DIO_SINGLE -> µ-rec -> MM at the level of _recognisable predicates_, not just undecidability. Hence we have provable equivalence of all these models.

FRACTRAN could be added but when recognising n-tuples (with n>1), you need a Gödel coding so even though it is a hidden intermediate step, it does not appear in the  `DPRM_n` theorem.