### PR TITLE
Remove more warnings in L and TM part

### DIFF
--- a/CeCILL_LICENSE.txt
+++ b/CeCILL_LICENSE.txt
@@ -1,5 +1,7 @@
 
-CeCILL FREE SOFTWARE LICENSE AGREEMENT
+  CeCILL FREE SOFTWARE LICENSE AGREEMENT
+
+Version 2.1 dated 2013-06-21
 
 
     Notice
@@ -8,27 +10,27 @@ This Agreement is a Free Software license agreement that is the result
 of discussions between its authors in order to ensure compliance with
 the two main principles guiding its drafting:
 
-    * firstly, compliance with the principles governing the distribution
-      of Free Software: access to source code, broad rights granted to
-      users,
-    * secondly, the election of a governing law, French law, with which
-      it is conformant, both as regards the law of torts and
-      intellectual property law, and the protection that it offers to
-      both authors and holders of the economic rights over software.
+  * firstly, compliance with the principles governing the distribution
+    of Free Software: access to source code, broad rights granted to users,
+  * secondly, the election of a governing law, French law, with which it
+    is conformant, both as regards the law of torts and intellectual
+    property law, and the protection that it offers to both authors and
+    holders of the economic rights over software.
 
-The authors of the CeCILL (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
-license are:
+The authors of the CeCILL (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) 
+license are: 
 
-Commissariat à l'Energie Atomique - CEA, a public scientific, technical
-and industrial research establishment, having its principal place of
-business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+Commissariat à l'énergie atomique et aux énergies alternatives - CEA, a
+public scientific, technical and industrial research establishment,
+having its principal place of business at 25 rue Leblanc, immeuble Le
+Ponant D, 75015 Paris, France.
 
 Centre National de la Recherche Scientifique - CNRS, a public scientific
 and technological establishment, having its principal place of business
 at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
 
 Institut National de Recherche en Informatique et en Automatique -
-INRIA, a public scientific and technological establishment, having its
+Inria, a public scientific and technological establishment, having its
 principal place of business at Domaine de Voluceau, Rocquencourt, BP
 105, 78153 Le Chesnay cedex, France.
 
@@ -39,8 +41,8 @@ The purpose of this Free Software license agreement is to grant users
 the right to modify and redistribute the software governed by this
 license within the framework of an open source distribution model.
 
-The exercising of these rights is conditional upon certain obligations
-for users so as to preserve this status for all subsequent redistributions.
+The exercising of this right is conditional upon certain obligations for
+users so as to preserve this status for all subsequent redistributions.
 
 In consideration of access to the source code and the rights to copy,
 modify and redistribute granted by the license, users are provided only
@@ -62,6 +64,10 @@ removed herefrom.
 
 This Agreement may apply to any or all software for which the holder of
 the economic rights decides to submit the use thereof to its provisions.
+
+Frequently asked questions can be found on the official website of the
+CeCILL licenses family (http://www.cecill.info/index.en.html) for any 
+necessary clarification.
 
 
     Article 1 - DEFINITIONS
@@ -117,6 +123,12 @@ that they both execute in the same address space.
 GNU GPL: means the GNU General Public License version 2 or any
 subsequent version, as published by the Free Software Foundation Inc.
 
+GNU Affero GPL: means the GNU Affero General Public License version 3 or
+any subsequent version, as published by the Free Software Foundation Inc.
+
+EUPL: means the European Union Public License version 1.1 or any
+subsequent version, as published by the European Commission.
+
 Parties: mean both the Licensee and the Licensor.
 
 These expressions may be used both in singular and plural form.
@@ -126,8 +138,8 @@ These expressions may be used both in singular and plural form.
 
 The purpose of the Agreement is the grant by the Licensor to the
 Licensee of a non-exclusive, transferable and worldwide license for the
-Software as set forth in Article 5 hereinafter for the whole term of the
-protection granted by the rights over said Software. 
+Software as set forth in Article 5 <#scope> hereinafter for the whole
+term of the protection granted by the rights over said Software.
 
 
     Article 3 - ACCEPTANCE
@@ -136,18 +148,17 @@ protection granted by the rights over said Software.
 conditions of this Agreement upon the occurrence of the first of the
 following events:
 
-    * (i) loading the Software by any or all means, notably, by
-      downloading from a remote server, or by loading from a physical
-      medium;
-    * (ii) the first time the Licensee exercises any of the rights
-      granted hereunder.
+  * (i) loading the Software by any or all means, notably, by
+    downloading from a remote server, or by loading from a physical medium;
+  * (ii) the first time the Licensee exercises any of the rights granted
+    hereunder.
 
 3.2 One copy of the Agreement, containing a notice relating to the
 characteristics of the Software, to the limited warranty, and to the
 fact that its use is restricted to experienced users has been provided
 to the Licensee prior to its acceptance as set forth in Article 3.1
-hereinabove, and the Licensee hereby acknowledges that it has read and
-understood it.
+<#accepting> hereinabove, and the Licensee hereby acknowledges that it
+has read and understood it.
 
 
     Article 4 - EFFECTIVE DATE AND TERM
@@ -156,7 +167,7 @@ understood it.
       4.1 EFFECTIVE DATE
 
 The Agreement shall become effective on the date when it is accepted by
-the Licensee as set forth in Article 3.1.
+the Licensee as set forth in Article 3.1 <#accepting>.
 
 
       4.2 TERM
@@ -186,18 +197,18 @@ The Licensee is authorized to use the Software, without any limitation
 as to its fields of application, with it being hereinafter specified
 that this comprises:
 
-   1. permanent or temporary reproduction of all or part of the Software
-      by any or all means and in any or all form.
+ 1. permanent or temporary reproduction of all or part of the Software
+    by any or all means and in any or all form.
 
-   2. loading, displaying, running, or storing the Software on any or
-      all medium.
+ 2. loading, displaying, running, or storing the Software on any or all
+    medium.
 
-   3. entitlement to observe, study or test its operation so as to
-      determine the ideas and principles behind any or all constituent
-      elements of said Software. This shall apply when the Licensee
-      carries out any or all loading, displaying, running, transmission
-      or storage operation as regards the Software, that it is entitled
-      to carry out hereunder.
+ 3. entitlement to observe, study or test its operation so as to
+    determine the ideas and principles behind any or all constituent
+    elements of said Software. This shall apply when the Licensee
+    carries out any or all loading, displaying, running, transmission or
+    storage operation as regards the Software, that it is entitled to
+    carry out hereunder.
 
 
       5.2 ENTITLEMENT TO MAKE CONTRIBUTIONS
@@ -230,16 +241,17 @@ The Licensee is authorized to distribute true copies of the Software in
 Source Code or Object Code form, provided that said distribution
 complies with all the provisions of the Agreement and is accompanied by:
 
-   1. a copy of the Agreement,
+ 1. a copy of the Agreement,
 
-   2. a notice relating to the limitation of both the Licensor's
-      warranty and liability as set forth in Articles 8 and 9,
+ 2. a notice relating to the limitation of both the Licensor's warranty
+    and liability as set forth in Articles 8 and 9,
 
 and that, in the event that only the Object Code of the Software is
-redistributed, the Licensee allows future Licensees unhindered access to
-the full Source Code of the Software by indicating how to access it, it
-being understood that the additional cost of acquiring the Source Code
-shall not exceed the cost of transferring the data.
+redistributed, the Licensee allows effective access to the full Source
+Code of the Software for a period of at least three years from the
+distribution of the Software, it being understood that the additional
+acquisition cost of the Source Code shall not exceed the cost of the
+data transfer.
 
 
         5.3.2 DISTRIBUTION OF MODIFIED SOFTWARE
@@ -252,17 +264,19 @@ The Licensee is authorized to distribute the Modified Software, in
 source code or object code form, provided that said distribution
 complies with all the provisions of the Agreement and is accompanied by:
 
-   1. a copy of the Agreement,
+ 1. a copy of the Agreement,
 
-   2. a notice relating to the limitation of both the Licensor's
-      warranty and liability as set forth in Articles 8 and 9,
+ 2. a notice relating to the limitation of both the Licensor's warranty
+    and liability as set forth in Articles 8 and 9,
 
-and that, in the event that only the object code of the Modified
-Software is redistributed, the Licensee allows future Licensees
-unhindered access to the full source code of the Modified Software by
-indicating how to access it, it being understood that the additional
-cost of acquiring the source code shall not exceed the cost of
-transferring the data.
+and, in the event that only the object code of the Modified Software is
+redistributed,
+
+ 3. a note stating the conditions of effective access to the full source
+    code of the Modified Software for a period of at least three years
+    from the distribution of the Modified Software, it being understood
+    that the additional acquisition cost of the source code shall not
+    exceed the cost of the data transfer.
 
 
         5.3.3 DISTRIBUTION OF EXTERNAL MODULES
@@ -272,17 +286,17 @@ conditions of this Agreement do not apply to said External Module, that
 may be distributed under a separate license agreement.
 
 
-        5.3.4 COMPATIBILITY WITH THE GNU GPL
+        5.3.4 COMPATIBILITY WITH OTHER LICENSES
 
 The Licensee can include a code that is subject to the provisions of one
-of the versions of the GNU GPL in the Modified or unmodified Software,
-and distribute that entire code under the terms of the same version of
-the GNU GPL.
+of the versions of the GNU GPL, GNU Affero GPL and/or EUPL in the
+Modified or unmodified Software, and distribute that entire code under
+the terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
 
 The Licensee can include the Modified or unmodified Software in a code
 that is subject to the provisions of one of the versions of the GNU GPL,
-and distribute that entire code under the terms of the same version of
-the GNU GPL.
+GNU Affero GPL and/or EUPL and distribute that entire code under the
+terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
 
 
     Article 6 - INTELLECTUAL PROPERTY
@@ -297,7 +311,7 @@ and no one shall be entitled to modify the terms and conditions for the
 distribution of said Initial Software.
 
 The Holder undertakes that the Initial Software will remain ruled at
-least by this Agreement, for the duration set forth in Article 4.2.
+least by this Agreement, for the duration set forth in Article 4.2 <#term>.
 
 
       6.2 OVER THE CONTRIBUTIONS
@@ -319,17 +333,17 @@ govern its distribution.
 
 The Licensee expressly undertakes:
 
-   1. not to remove, or modify, in any manner, the intellectual property
-      notices attached to the Software;
+ 1. not to remove, or modify, in any manner, the intellectual property
+    notices attached to the Software;
 
-   2. to reproduce said notices, in an identical manner, in the copies
-      of the Software modified or not.
+ 2. to reproduce said notices, in an identical manner, in the copies of
+    the Software modified or not.
 
 The Licensee undertakes not to directly or indirectly infringe the
-intellectual property rights of the Holder and/or Contributors on the
-Software and to take, where applicable, vis-à-vis its staff, any and all
-measures required to ensure respect of said intellectual property rights
-of the Holder and/or Contributors.
+intellectual property rights on the Software of the Holder and/or
+Contributors, and to take, where applicable, vis-à-vis its staff, any
+and all measures required to ensure respect of said intellectual
+property rights of the Holder and/or Contributors.
 
 
     Article 7 - RELATED SERVICES
@@ -390,13 +404,13 @@ or properties.
 
 9.2 The Licensor hereby represents, in good faith, that it is entitled
 to grant all the rights over the Software (including in particular the
-rights set forth in Article 5).
+rights set forth in Article 5 <#scope>).
 
 9.3 The Licensee acknowledges that the Software is supplied "as is" by
 the Licensor without any other express or tacit warranty, other than
-that provided for in Article 9.2 and, in particular, without any warranty 
-as to its commercial value, its secured, safe, innovative or relevant
-nature.
+that provided for in Article 9.2 <#good-faith> and, in particular,
+without any warranty as to its commercial value, its secured, safe,
+innovative or relevant nature.
 
 Specifically, the Licensor does not warrant that the Software is free
 from any error, that it will operate without interruption, that it will
@@ -411,7 +425,7 @@ arising out of any or all proceedings for infringement that may be
 instituted in respect of the use, modification and redistribution of the
 Software. Nevertheless, should such proceedings be instituted against
 the Licensee, the Licensor shall provide it with technical and legal
-assistance for its defense. Such technical and legal assistance shall be
+expertise for its defense. Such technical and legal expertise shall be
 decided on a case-by-case basis between the relevant Licensor and the
 Licensee pursuant to a memorandum of understanding. The Licensor
 disclaims any and all liability as regards the Licensee's use of the
@@ -488,7 +502,8 @@ address new issues encountered by Free Software.
 
 12.3 Any Software distributed under a given version of the Agreement may
 only be subsequently distributed under the same version of the Agreement
-or a subsequent version, subject to the provisions of Article 5.3.4.
+or a subsequent version, subject to the provisions of Article 5.3.4
+<#compatibility>.
 
 
     Article 13 - GOVERNING LAW AND JURISDICTION
@@ -502,5 +517,3 @@ occurrence, and unless emergency proceedings are necessary, the
 disagreements or disputes shall be referred to the Paris Courts having
 jurisdiction, by the more diligent Party.
 
-
-Version 2.0 dated 2006-09-05.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Then the following commands install the library:
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git
-opam install coq-library-undecidability.dev+8.10
+opam install coq-library-undecidability.dev+8.11
 ```
 
 ### Manual installation
 
-You need `Coq 8.10.2` built on OCAML `> 4.02.3`, the [Smpl](https://github.com/uds-psl/smpl) package, the [PSL Base](https://github.com/uds-psl/base-library) library, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
+You need `Coq 8.11` built on OCAML `> 4.02.3`, the [Smpl](https://github.com/uds-psl/smpl) package, the [PSL Base](https://github.com/uds-psl/base-library) library, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
 
 ```
 opam switch create coq-library-undecidability 4.07.1+flambda

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then the following commands install the library:
 
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam repo add opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git
+opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git
 opam install coq-library-undecidability.dev+8.11
 ```
 

--- a/theories/FOL/BPCP_CND.v
+++ b/theories/FOL/BPCP_CND.v
@@ -11,7 +11,7 @@ Definition cprv := @prv class full.
 Instance iUnit P : interp unit (fun _ => tt) :=
   {| i_f _ _ := tt ; i_e := tt ; i_P _ _ := True ; i_Q := P  |}.
 
-Hint Constructors prv.
+Hint Constructors prv : core.
 
 Fixpoint cast {b} (phi : form b) : form full :=
   match phi with

--- a/theories/FOL/BPCP_FOL.v
+++ b/theories/FOL/BPCP_FOL.v
@@ -136,7 +136,7 @@ Section validity.
 
   (** ** Provability *)
 
-  Hint Resolve enc_vars.
+  Hint Resolve enc_vars : core.
 
   Definition ctx_S :=
     F3 :: rev F2 ++ rev F1.
@@ -216,7 +216,7 @@ Proof.
   apply discrete_iff. constructor. apply eq_dec_form.
 Qed.
 
-Hint Resolve stack_enum form_discrete.
+Hint Resolve stack_enum form_discrete : core.
 
 Definition UA :=
   ~ enumerable (compl PCPb).

--- a/theories/FOL/DecidableEnumerable.v
+++ b/theories/FOL/DecidableEnumerable.v
@@ -89,7 +89,7 @@ Qed.
 
 Definition cumulative {X} (L: nat -> list X) :=
   forall n, exists A, L (S n) = L n ++ A.
-Hint Extern 0 (cumulative _) => intros ?; cbn; eauto.
+Hint Extern 0 (cumulative _) => intros ?; cbn; eauto : core.
 
 Lemma cum_ge {X} (L: nat -> list X) n m :
   cumulative L -> m >= n -> exists A, L m = L n ++ A.
@@ -142,13 +142,13 @@ Qed.
 
 Class enumT X :=
   {
-    L_T :> nat -> list X;
+    L_T : nat -> list X;
     cum_T : cumulative L_T ;
     el_T : forall x, exists m, x el L_T m
   }.
 
 Arguments L_T {_ _} _, _ {_} _.
-Hint Immediate cum_T.
+Hint Immediate cum_T : core.
 
 Lemma discrete_bool : discrete bool.
 Proof.

--- a/theories/FOL/Deduction.v
+++ b/theories/FOL/Deduction.v
@@ -248,7 +248,7 @@ Fixpoint L_ded {b} {s : nd} (A : list (form b)) (n : nat) : list (form b) :=
 Opaque in_dec.
 Opaque enumT_nat.
 
-Hint Constructors prv.
+Hint Constructors prv : core.
 
 Lemma enum_prv b s A : enum (@prv s b A) (L_ded A).
 Proof with try (eapply cum_ge'; eauto; omega).

--- a/theories/FOL/Kripke.v
+++ b/theories/FOL/Kripke.v
@@ -172,7 +172,7 @@ Qed.
 
 (** ** Soundness **)
 
-Hint Resolve reach_refl.
+Hint Resolve reach_refl : core.
 
 Definition kcast domain (eta eta' : nat -> domain) (M : kmodel eta) : kmodel eta'.
 Proof.

--- a/theories/FOLP/FOL.v
+++ b/theories/FOLP/FOL.v
@@ -26,7 +26,7 @@ Derive Signature for vector.
 
 Ltac capply H := eapply H; try eassumption.
 Ltac comp := repeat (progress (cbn in *; autounfold in *; asimpl in *)).
-Hint Unfold idsRen.
+Hint Unfold idsRen : core.
 
 Ltac resolve_existT :=
   match goal with
@@ -46,7 +46,7 @@ Section FOL.
   | SImplL phi psi : sf phi (phi --> psi)
   | SImplR phi psi : sf psi (phi --> psi)
   | SAll phi t : sf (phi [t .: ids]) (∀ phi).
-  Hint Constructors sf.
+  Hint Constructors sf : core.
 
   Lemma sf_acc phi rho :
     Acc sf (phi [rho]).
@@ -111,7 +111,7 @@ Section FOL.
   Inductive vec_in (A : Type) (a : A) : forall n, vector A n -> Type :=
   | vec_inB n (v : vector A n) : vec_in a (cons a v)
   | vec_inS a' n (v :vector A n) : vec_in a v -> vec_in a (cons a' v).
-  Hint Constructors vec_in.
+  Hint Constructors vec_in : core.
 
   Lemma strong_term_ind' (p : term -> Type) :
     (forall x, p (var_term x)) -> (forall F v, (Forall p v) -> p (Func F v)) -> forall (t : term), p t.
@@ -321,9 +321,9 @@ Section FOL.
   Infix "⊑" := subset_T (at level 20).
   Infix "∈" := contains (at level 70).
 
-  Hint Unfold contains.
-  Hint Unfold contains_L.
-  Hint Unfold subset_T.
+  Hint Unfold contains : core.
+  Hint Unfold contains_L : core.
+  Hint Unfold subset_T : core.
 
   Global Instance subset_T_trans : Transitive subset_T.
   Proof.
@@ -396,7 +396,7 @@ Proof.
     exists (b :: B). split. 1: auto. intros ? []; subst; auto.
 Qed.
 
-Hint Constructors vec_in.
+Hint Constructors vec_in : core.
 
 Infix "⊏" := contains_L (at level 20).
 Infix "⊑" := subset_T (at level 20).
@@ -584,7 +584,7 @@ End Subterm.
 (* **** Signature extension *)
 
 Section SigExt.
-  Hint Unfold axioms.funcomp.
+  Hint Unfold axioms.funcomp : core.
 
   Definition sig_ext (Sigma : Signature) : Signature :=
     match Sigma with
@@ -629,7 +629,7 @@ Section SigExt.
     match Sigma return @term Sigma -> @term (sig_ext Sigma) with
       B_S Funcs fun_ar Preds pred_ar as S => fun t => sig_lift_term' t
     end.
-  Hint Unfold sig_lift_term.
+  Hint Unfold sig_lift_term : core.
 
   Fixpoint sig_lift' F F_ar P P_ar (phi : @form (B_S F F_ar P P_ar)) :
     (@form (sig_ext (B_S F F_ar P P_ar))) :=
@@ -644,7 +644,7 @@ Section SigExt.
     match Sigma return @form Sigma -> @form (sig_ext Sigma) with
       B_S Funcs fun_ar Preds pred_ar as Sig => fun phi => sig_lift' phi
     end.
-  Hint Unfold sig_lift.
+  Hint Unfold sig_lift : core.
 
   Lemma sig_lift_subst_term {Sigma : Signature} xi t :
     sig_lift_term (subst_term xi t) = subst_term (xi >> sig_lift_term) (sig_lift_term t).
@@ -681,7 +681,7 @@ Section SigExt.
     | inl i => nth_order v i
     | inr (exist _ y _) => var_term (y + m)
     end.
-  Hint Unfold vsubs.
+  Hint Unfold vsubs : core.
 
   Lemma up_term_term_vsubs {Sigma : Signature }n (v : vector term n) i x :
     up_term_term (vsubs i v) x = vsubs (S i) (cons (var_term 0) (map (subst_term (vsubs 1 nil)) v)) x.
@@ -704,7 +704,7 @@ Section SigExt.
     match Sigma return @term (sig_ext Sigma) -> @term Sigma with
       B_S Funcs fun_ar Preds pred_ar as S => sig_drop_term' n
     end.
-  Hint Unfold sig_drop_term.
+  Hint Unfold sig_drop_term : core.
 
   Fixpoint sig_drop' F F_ar P P_ar (n : nat) (phi : @form (sig_ext (B_S F F_ar P P_ar))) :
     @form (B_S F F_ar P P_ar) :=
@@ -719,7 +719,7 @@ Section SigExt.
     match Sigma return @form (sig_ext Sigma) -> @form Sigma with
       B_S Funcs fun_ar Preds pred_ar as Sig => sig_drop' n
     end.
-  Hint Unfold sig_drop.
+  Hint Unfold sig_drop : core.
 
   Lemma nth_order_map X Y (f : X -> Y) n (v : vector X n) i (H : i < n) :
     nth_order (map f v) H = f (nth_order v H).
@@ -768,7 +768,7 @@ Section SigExt.
     end.
   Definition raise {Sigma : Signature} (n : nat) (x : nat) : term := var_term (n + x).
 
-  Hint Unfold ext_c' pref raise.
+  Hint Unfold ext_c' pref raise : core.
 
   Lemma up_term_term_pref_ext_c' f (f_ar : f -> nat) P (P_ar : P -> nat) n x :
     up_term_term (pref n (ext_c' f_ar P_ar)) x = pref (S n) (ext_c' f_ar P_ar) x.

--- a/theories/FOLP/FullFOL.v
+++ b/theories/FOLP/FullFOL.v
@@ -26,7 +26,7 @@ Derive Signature for vector.
 
 Ltac capply H := eapply H; try eassumption.
 Ltac comp := repeat (progress (cbn in *; autounfold in *; asimpl in *)).
-Hint Unfold idsRen.
+Hint Unfold idsRen : core.
 
 Ltac resolve_existT :=
   match goal with
@@ -143,7 +143,7 @@ Section FullFOL.
   Inductive vec_in (A : Type) (a : A) : forall n, vector A n -> Type :=
   | vec_inB n (v : vector A n) : vec_in a (cons a v)
   | vec_inS a' n (v :vector A n) : vec_in a v -> vec_in a (cons a' v).
-  Hint Constructors vec_in.
+  Hint Constructors vec_in : core.
 
   Lemma strong_term_ind' (p : term -> Type) :
     (forall x, p (var_term x)) -> (forall F v, (Forall p v) -> p (Func F v)) -> forall (t : term), p t.
@@ -344,9 +344,9 @@ Section FullFOL.
   Infix "⊑" := subset_T (at level 20).
   Infix "∈" := contains (at level 70).
 
-  Hint Unfold contains.
-  Hint Unfold contains_L.
-  Hint Unfold subset_T.
+  Hint Unfold contains : core.
+  Hint Unfold contains_L : core.
+  Hint Unfold subset_T : core.
 
   Global Instance subset_T_trans : Transitive subset_T.
   Proof.
@@ -419,7 +419,7 @@ Proof.
     exists (b :: B). split. 1: auto. intros ? []; subst; auto.
 Qed.
 
-Hint Constructors vec_in.
+Hint Constructors vec_in : core.
 
 Infix "⊏" := contains_L (at level 20).
 Infix "⊑" := subset_T (at level 20).

--- a/theories/FOLP/FullTarski.v
+++ b/theories/FOLP/FullTarski.v
@@ -96,7 +96,7 @@ Section Tarski.
     Variable D : Type.
     Variable I : interp D.
 
-    Hint Unfold funcomp.
+    Hint Unfold funcomp : core.
 
     Lemma eval_ext rho xi t :
       (forall x, rho x = xi x) -> eval rho t = eval xi t.

--- a/theories/FOLP/Input.v
+++ b/theories/FOLP/Input.v
@@ -149,7 +149,7 @@ Fixpoint conv `{Signature} i (phi : bform) : option (form) :=
 
 Definition convert `{Signature} f := (@conv _ 0 (rmPapps f)).
 
-Notation "=: f" := (ltac:(let y := eval cbv -[subst_form] in (convert f) in match y with Some ?x => exact x | _ => fail 10 end)) (at level 200).
+Notation "=: f" := (ltac:(let y := eval cbv -[subst_form] in (convert f) in match y with Some ?x => exact x | _ => fail 10 end)) (at level 200, only parsing).
 
 (* Notation "=:( x ) f" := (ltac:(let y := eval cbv in (@conv _ x 0 (rmPapps f)) in match y with Some ?x => exact x | _ => fail 10 end)) (at level 5). *)
 

--- a/theories/FOLP/unscoped.v
+++ b/theories/FOLP/unscoped.v
@@ -38,6 +38,8 @@ Class Ren4 (X1 X2 X3 X4 : Type) (Y Z : Type) :=
 Class Ren5 (X1 X2 X3 X4 X5 : Type) (Y Z : Type) :=
   ren5 : X1 -> X2 -> X3 -> X4 -> X5 -> Y -> Z.
 
+Declare Scope subst_scope.
+
 Notation "s ⟨ xi1 ⟩" := (ren1 xi1 s) (at level 7, left associativity, format "s  ⟨ xi1 ⟩") : subst_scope.
 
 Notation "s ⟨ xi1 ; xi2 ⟩" := (ren2 xi1 xi2 s) (at level 7, left associativity, format "s  ⟨ xi1 ; xi2 ⟩") : subst_scope.
@@ -47,6 +49,8 @@ Notation "s ⟨ xi1 ; xi2 ; xi3 ⟩" := (ren3 xi1 xi2 xi3 s) (at level 7, left a
 Notation "s ⟨ xi1 ; xi2 ; xi3 ; xi4 ⟩" := (ren4  xi1 xi2 xi3 xi4 s) (at level 7, left associativity, format "s  ⟨ xi1 ; xi2 ; xi3 ; xi4 ⟩") : subst_scope.
 
 Notation "s ⟨ xi1 ; xi2 ; xi3 ; xi4 ; xi5 ⟩" := (ren5  xi1 xi2 xi3 xi4 xi5 s) (at level 7, left associativity, format "s  ⟨ xi1 ; xi2 ; xi3 ; xi4 ; xi5 ⟩") : subst_scope.
+
+Declare Scope fscope.
 
 Notation "⟨ xi ⟩" := (ren1 xi) (at level 1, left associativity, format "⟨ xi ⟩") : fscope.
 

--- a/theories/H10/ArithLibs/lagrange.v
+++ b/theories/H10/ArithLibs/lagrange.v
@@ -632,6 +632,6 @@ Section lagrange.
 
 End lagrange.
 
-Check lagrange_theorem_Z.
+(* Check lagrange_theorem_Z. *)
 
 

--- a/theories/H10/ArithLibs/luca.v
+++ b/theories/H10/ArithLibs/luca.v
@@ -474,4 +474,4 @@ Section lucas_theorem.
 
 End lucas_theorem.
 
-Check lucas_theorem.
+(* Check lucas_theorem. *)

--- a/theories/L/AbstractMachines/AbstractHeapMachine.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachine.v
@@ -47,7 +47,7 @@ Section Lin.
 
   Definition state := (list clos * list clos *Heap)%type.
 
-  Hint Transparent state.
+  Hint Transparent state : core.
 
   Inductive step : state -> state -> Prop :=
     step_pushVal P P' Q a T V H:
@@ -61,7 +61,7 @@ Section Lin.
       -> step ((varT x::P,a)::T,V,H) ((P,a)::T,g::V,H)
   | step_nil a T V H: step (([],a)::T,V,H) (T,V,H).
 
-  Hint Constructors step.
+  Hint Constructors step : core.
 
   (** *** Unfolding *)
   

--- a/theories/L/AbstractMachines/AbstractHeapMachine.v
+++ b/theories/L/AbstractMachines/AbstractHeapMachine.v
@@ -2,6 +2,8 @@ From Undecidability.L Require Import L AbstractMachines.Programs Complexity.Reso
 
 Require Import Lia.
 
+Import L_Notations.
+
   (** ** Abstract Heap Machine *)
 Section Lin.
 

--- a/theories/L/AbstractMachines/Programs.v
+++ b/theories/L/AbstractMachines/Programs.v
@@ -29,7 +29,7 @@ Definition sizeT t :=
   end.  
 
 Definition sizeP (P:Pro) := sumn (map sizeT P) + 1.
-Hint Unfold sizeP.
+Hint Unfold sizeP : core.
 
 
 Lemma size_geq_1 s: 1<= size s.

--- a/theories/L/Computability/Acceptability.v
+++ b/theories/L/Computability/Acceptability.v
@@ -1,4 +1,5 @@
 From Undecidability.L Require Export Por Decidability Lbeta_nonrefl.
+Import L_Notations.
 
 (** * Definition of L-acceptability *)
 

--- a/theories/L/Computability/Computability.v
+++ b/theories/L/Computability/Computability.v
@@ -31,7 +31,7 @@ Proof.
   destruct (eva n u) as [t|] eqn:Heva.
   -exists (g t). destruct H as [y H]. rewrite <- Heva in H. apply eva_equiv in H.
    assert (lambda t)by now apply eva_lam in Heva. apply eva_equiv in Heva. rewrite Heva in H. erewrite <- Hg. apply equiv_lambda in Heva;try Lproc. rewrite Heva. exact H. apply unique_normal_forms in H;try Lproc. congruence. 
-  -exists (g 0). destruct H as [? H]. inv H.
+  -exists (g #0). destruct H as [? H]. inv H.
   -intros n. destruct (eva n u) eqn:eq.
    +left. destruct H as [n' [y H]]. exists y. apply eva_equiv in H.
     assert (lambda t) by now apply eva_lam in eq. apply eva_equiv in eq. rewrite H in eq. apply unique_normal_forms in eq;[|Lproc..].  congruence.

--- a/theories/L/Computability/Decidability.v
+++ b/theories/L/Computability/Decidability.v
@@ -1,8 +1,9 @@
 From Undecidability.L Require Export Functions.Encoding Datatypes.LBool L.
+Import HOAS_Notations.
 
 (** * Definition of L-decidability *)
 
-Definition decides (u:term) P := forall (s:term), exists b : bool, (u (ext s) == ext b /\ (if b then P s else ~P s)).
+Definition decides (u:term) P := forall (s:term), exists b : bool, (app u (ext s) == ext b /\ (if b then P s else ~P s)).
 
 Definition ldec (P : term -> Prop) := 
   exists u : term, proc u /\ decides u P.
@@ -16,11 +17,11 @@ Definition conj (P : term -> Prop) (Q : term -> Prop) := fun t => P t /\ Q t.
 Definition disj (P : term -> Prop) (Q : term -> Prop) := fun t => P t \/ Q t.
 
 (** * Deciders for complement, conj and disj of ldec predicates *)
-Definition tcompl (u : term) : term := Eval cbn in λ x, (ext negb) (u x).
+Definition tcompl (u : term) : term := Eval cbn in λ x, !!(ext negb) (!!u x).
 
-Definition tconj (u v : term) : term := Eval cbn in λ x, (ext andb) (u x) (v x).
+Definition tconj (u v : term) : term := Eval cbn in λ x, !!(ext andb) (!!u x) (!!v x).
 
-Definition tdisj (u v : term) : term := Eval cbn in λ x, (ext orb) (u x) (v x). 
+Definition tdisj (u v : term) : term := Eval cbn in λ x, !!(ext orb) (!!u x) (!!v x). 
 
 Hint Unfold tcompl tconj tdisj : Lrewrite.
 Hint Unfold tcompl tconj tdisj : LProc.

--- a/theories/L/Computability/Enum.v
+++ b/theories/L/Computability/Enum.v
@@ -1,4 +1,5 @@
 From Undecidability.L Require Import L.
+Import L_Notations.
 
 Notation "A '.[' i  ']'" := (elAt A i) (no associativity, at level 50).
 

--- a/theories/L/Computability/Enum.v
+++ b/theories/L/Computability/Enum.v
@@ -101,7 +101,7 @@ Proof.
     eapply el_elAt in HIn; eauto. destruct HIn. eapply elAt_el in H. eapply el_pos in H. destruct H. rewrite H in *; congruence. 
 Qed.
 
-Hint Unfold left_inverse injective right_inverse surjective.
+Hint Unfold left_inverse injective right_inverse surjective : core.
 
 Lemma disjoint_symm X (A B : list X) : disjoint A B <-> disjoint B A.
 Proof.
@@ -185,7 +185,7 @@ Proof.
     omega.
 Qed.
 
-Hint Unfold left_inverse injective surjective g g_inv.
+Hint Unfold left_inverse injective surjective g g_inv : core.
 
 Lemma g_T : bijective g.
 Proof. 

--- a/theories/L/Computability/Fixpoints.v
+++ b/theories/L/Computability/Fixpoints.v
@@ -1,4 +1,5 @@
 From Undecidability.L Require Export Functions.Encoding Tactics.Lbeta_nonrefl.
+Import L_Notations.
 
 (** * First Fixed Point Theorem *)
 

--- a/theories/L/Computability/MuRec.v
+++ b/theories/L/Computability/MuRec.v
@@ -6,15 +6,20 @@ Variable P : term.
 Hypothesis P_proc : proc P.
 Hint Resolve P_proc : LProc.
 
-Hypothesis dec'_P : forall (n:nat), (exists (b:bool), P (ext n) == ext b ).
+Hypothesis dec'_P : forall (n:nat), (exists (b:bool), app P (ext n) == ext b ).
 
-Lemma dec_P : forall n:nat, {b:bool | P (ext n) == ext b}.
+Lemma dec_P : forall n:nat, {b:bool | app P (ext n) == ext b}.
   intros. eapply lcomp_comp.
   -apply bool_enc_inv_correct.
   -apply dec'_P.
 Qed.
 
-Definition mu' := Eval cbn -[enc] in rho (λ mu P n, (P n) (!!K n) (λ Sn, mu P Sn) (!!(ext S) n)).
+Section hoas.
+  Import HOAS_Notations.
+  Definition mu' := Eval cbn -[enc] in rho (λ mu P n, (P n) (!!K n) (λ Sn, mu P Sn) (!!(ext S) n)).
+End hoas.
+
+Import L_Notations.
 
 Lemma mu'_proc : proc mu'.
   unfold mu'; Lproc. 
@@ -72,7 +77,7 @@ Qed.
 (* the mu combinator:*)
 
 
-Definition mu :term := Eval cbn in λ P, mu' P (ext 0).
+Definition mu :term := lam (mu' #0 (ext 0)).
 
 Lemma mu_proc : proc mu.
   unfold mu. Lproc. 

--- a/theories/L/Computability/Por.v
+++ b/theories/L/Computability/Por.v
@@ -2,7 +2,9 @@ From Undecidability.L.Functions Require Export Eval.
 From Undecidability.L.Tactics Require Import Lbeta_nonrefl.
 (** * Definition of parallel or *)
 
+Section hoas. Import HOAS_Notations.
 Definition Por :term := Eval simpl in (λ s t , (λ n0,  !!(ext doesHaltIn) s n0 ) (!!mu (λ n ,!!(ext orb) (!!(ext doesHaltIn) s n) (!!(ext doesHaltIn) t n)))) .
+End hoas.
 
 Lemma Por_proc : proc Por.
 Proof.
@@ -10,6 +12,8 @@ Proof.
 Qed.
 
 Hint Resolve Por_proc : LProc.
+
+Import L_Notations.
 
 Lemma Por_correct_1a (s t:term) : converges s -> converges (Por (ext s) (ext t)).
 Proof.

--- a/theories/L/Computability/Rice.v
+++ b/theories/L/Computability/Rice.v
@@ -1,5 +1,6 @@
 From Undecidability.L.Computability Require Export Scott Acceptability.
 Import Undecidability.L.Prelim.ARS.ARSNotations.
+Import L_Notations.
 
 (** * The self halting problem is not L-acceptable *)
 

--- a/theories/L/Computability/Scott.v
+++ b/theories/L/Computability/Scott.v
@@ -1,6 +1,6 @@
 From Undecidability.L.Computability Require Export Fixpoints Decidability Seval.
 From Undecidability.L.Functions Require Export Proc Encoding.
-Import ARS.ARSNotations.
+Import ARS.ARSNotations L_Notations.
 (** * Scott's Theorem *)
 
 Theorem Scott (M : term -> Prop) : M <=1 closed ->

--- a/theories/L/Computability/Seval.v
+++ b/theories/L/Computability/Seval.v
@@ -1,12 +1,14 @@
 From Undecidability.L Require Export L.
 Require Import Coq.Logic.ConstructiveEpsilon. 
 
+Import L_Notations.
+
 Lemma eval_converges s t : eval s t -> converges s.
 Proof.
   intros [v [R lv]]. exists t.  rewrite v. subst. split. reflexivity. auto.
 Qed.
 
-Hint Resolve eval_converges.
+Hint Resolve eval_converges : core.
 
 (** * Step indexed evaluation *)
 
@@ -26,7 +28,7 @@ Proof with eauto using star_trans, star_trans_l, star_trans_r.
     transitivity ((lam u) (lam v))... now rewrite stepApp.
 Qed.
 
-Hint Resolve seval_eval.
+Hint Resolve seval_eval : core.
 
 (** Equivalence between step index evaluation and evaluation *)
 

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -19,7 +19,7 @@ Definition L_recognisable {X} `{registered X} (p : X -> Prop) :=
   exists f : X -> nat -> bool, is_computable f /\ forall x, p x <-> exists n, f x n = true.
 
 Definition L_recognisable' {X} `{registered X} (p : X -> Prop) :=
-  exists s : term, forall x, p x <-> converges (s (enc x)).
+  exists s : term, forall x, p x <-> converges (L.app s (enc x)).
 
 Section L_enum_rec.
 
@@ -36,7 +36,9 @@ Section L_enum_rec.
   Proof.
     extract.
   Qed.
-  
+
+  Import HOAS_Notations.
+
   Lemma proc_test (x : X) :
     proc (λ y, !!(ext test) !!(enc x) y).
   Proof.
@@ -158,8 +160,10 @@ Proof.
   edestruct L_enumerable_recognisable with (p := p) (d := fun x y => d (x,y)) (f := f); eauto.
   - extract.
   - intros. specialize (H_d (x,y)). destruct (d (x,y)); intuition.
-  - now exists (fun x0 => x (enc x0)). 
+  - now exists (fun x0 => L.app x (enc x0)). 
 Qed.  
+
+Import L_Notations.
 
 Lemma L_recognisable'_recognisable {X} `{registered X} (p : X -> Prop) :
   L_recognisable p -> L_recognisable' p.

--- a/theories/L/Datatypes/LOptions.v
+++ b/theories/L/Datatypes/LOptions.v
@@ -1,4 +1,5 @@
 From Undecidability.L Require Import Tactics.LTactics Datatypes.LBool Tactics.GenEncode.
+Import L_Notations.
 
 (** ** Encoding of option type *)
 Section Fix_X.

--- a/theories/L/Functions/Eval.v
+++ b/theories/L/Functions/Eval.v
@@ -16,11 +16,13 @@ Proof.
   extract.
 Qed.
 
-Notation "!! u" := (hter u) (at level 0).
-
+Section hoas. Import HOAS_Notations.
 Definition Eval :term := Eval cbn in
       (λ u, !!(ext eva) 
-               (!!mu (λ n, !!(ext doesHaltIn) u n)) u !!I !!I).
+              (!!mu (λ n, !!(ext doesHaltIn) u n)) u !!I !!I).
+End hoas.
+
+Import L_Notations.
 
 Lemma Eval_correct (s v:term) : lambda v -> (Eval (ext s) == v <-> exists (n:nat) (v':term), (ext eva) (ext n) (ext s) == ext (Some v') /\ v = ext v' /\ lambda v').
 Proof.
@@ -71,7 +73,7 @@ Lemma Eval_converges s : converges s <-> converges (Eval (ext s)).
 Proof with eauto.
   split; intros H. 
   - destruct (eval_converges H) as [t Ht].
-    assert (He := eval_Eval Ht). 
+    pose proof (eval_Eval Ht) as He.
     rewrite He. eexists;split;[reflexivity|Lproc].
  - destruct H as [x [H l]]. apply Eval_eval in H;try Lproc. destruct H as [t' [? t]]. exists t'. destruct t. split. now rewrite H0. auto.
 Qed. 

--- a/theories/L/Reductions/TM_to_L.v
+++ b/theories/L/Reductions/TM_to_L.v
@@ -7,7 +7,7 @@ Theorem Halt_eva :
   Halt ⪯ converges.
 Proof.
   eexists (fun '(existT2 (Sigma, n) M tp) =>
-             (mu (@ext _ _ _ (term_test (mk_mconfig (start M) tp))))).
+             (L.app mu (@ext _ _ _ (term_test (mk_mconfig (start M) tp))))).
   intros [ [Sigma n] M tp ]. cbn.  eapply Halt_red.
 Qed.
 

--- a/theories/L/TM/TMEncoding.v
+++ b/theories/L/TM/TMEncoding.v
@@ -6,6 +6,8 @@ Require Import List Init.Nat.
 From Undecidability Require Import TM.TM.
 Require Import PslBase.FiniteTypes.FinTypes.
 
+Import L_Notations.
+
 (** ** Extraction of Turing Machine interpreter  *)
 
 (** *** Encoding finite types *)

--- a/theories/L/Tactics/Computable.v
+++ b/theories/L/Tactics/Computable.v
@@ -41,7 +41,7 @@ Fixpoint computes {A} (tau : TT A) {struct tau}: A -> L.term -> Type :=
     fun f t_f  =>
       proc t_f * forall (a : A) t_a,
         computes tau1 a t_a
-        ->  {v : term & (t_f t_a >* v) * computes tau2 (f a) v}
+        ->  {v : term & (app t_f t_a >* v) * computes tau2 (f a) v}
   end%type.
 
 Lemma computesProc t (ty : TT t) (f : t) fInt:
@@ -94,7 +94,7 @@ Proof.
 Defined.  
 
 Lemma extApp t1 t2 {tt1:TT t1} {tt2 : TT t2} (f: t1 -> t2) (x:t1) (Hf : computable f) (Hx : computable x) :
-  (ext f) (ext x) >* ext (f x).
+  app (ext f) (ext x) >* ext (f x).
 Proof.
   unfold ext, extApp'.
   destruct Hf, Hx.
@@ -120,7 +120,7 @@ Qed.
 
 Lemma computesExpStep t1 t2 (tt1 : TT t1) (tt2 : TT t2) (f : t1 -> t2) (s:term) (fExt : term):
   eval s fExt -> closed s -> 
-  (forall (y : t1) (yExt : term), computes tt1 y yExt -> {v : term & computesExp tt2 (f y) (s yExt) v}%type) ->
+  (forall (y : t1) (yExt : term), computes tt1 y yExt -> {v : term & computesExp tt2 (f y) (app s yExt) v}%type) ->
   computesExp (tt1 ~> tt2) f s fExt.
 Proof.
   intros ? ? H. split. assumption. split. split. now rewrite <-H0. now destruct H0.
@@ -133,7 +133,7 @@ Lemma computesTyArr t1 t2 (tt1 : TT t1) (tt2 : TT t2) f fExt :
   proc fExt
   -> (forall (y : t1) (yExt : term),
         computes tt1 y yExt
-        -> {v : term & eval (fExt yExt) v * (proc v -> computes tt2 (f y) v)}%type)
+        -> {v : term & eval (app fExt yExt) v * (proc v -> computes tt2 (f y) v)}%type)
   -> computes (tt1 ~> tt2) f fExt.
 Proof.
   intros ? H'.

--- a/theories/L/Tactics/ComputableTactics.v
+++ b/theories/L/Tactics/ComputableTactics.v
@@ -2,6 +2,7 @@ Require Import PslBase.Bijection MetaCoq.Template.All Strings.Ascii.
 From Undecidability.L Require Import Prelim.StringBase.
 From Undecidability.L.Tactics Require Import Lproc Computable ComputableTime Lsimpl mixedTactics Lbeta Lrewrite.
 Require Export Ring Arith Lia.
+Import L_Notations.
 
 (** ** Tactics proving correctness *)
 Module Intern.
@@ -431,16 +432,16 @@ End Intern.
 
 Import Intern.
 
-Ltac register_inj :=   abstract (intros x; induction x; destruct 0;simpl; intros eq; try (injection eq || discriminate eq);intros;f_equal;auto;try apply inj_enc;try easy).
+Ltac register_inj :=   abstract (intros x; induction x; let y := fresh "y" in destruct y;simpl; intros eq; try (injection eq || discriminate eq);intros;f_equal;auto;try apply inj_enc;try easy).
 
 Ltac register_proc :=
-  unfold enc_f;
-  (((induction 0 || intros);
+  unfold enc_f; let x := fresh "x" in
+  (((induction x || intros *);
     cbn; fold_encs;Lproc
                         )).
 
 Ltac register encf :=   refine (@mk_registered _ encf _ _);[
-                          (((induction 0 || intros);(let f := visibleHead encf in unfold f;cbn [f]);
+                          (((let x := fresh "x" in induction x || intros);(let f := visibleHead encf in unfold f;cbn [f]);
                             fold_encs;Lproc
                         )) | try register_inj].
 

--- a/theories/L/Tactics/ComputableTime.v
+++ b/theories/L/Tactics/ComputableTime.v
@@ -20,7 +20,7 @@ Fixpoint computesTime {t} (ty : TT t) :  forall (x:t) (xInt :term) (xTime :timeC
       forall (y : t1) yInt (yTime:timeComplexity t1),
         computesTime y yInt yTime
         -> let fyTime := fTime y yTime in
-          {v : term & (redLe (fst fyTime) (fInt yInt) v) * computesTime (f y) v (snd fyTime)}
+          {v : term & (redLe (fst fyTime) (app fInt yInt) v) * computesTime (f y) v (snd fyTime)}
   end%type.
 
 Arguments computesTime {_} _ _ _ _.
@@ -104,7 +104,7 @@ Proof.
 Defined.
 
 Lemma extTApp t1 t2 {tt1:TT t1} {tt2 : TT t2} (f: t1 -> t2) (x:t1) fT xT (Hf : computableTime f fT) (Hx : computableTime x xT) :
-  (extT f) (extT x) >(<= fst (evalTime f x (evalTime x))) extT (f x).
+  app (extT f) (extT x) >(<= fst (evalTime f x (evalTime x))) extT (f x).
 Proof.
   unfold extT.
   destruct Hf as [fInt [fP fInts]], Hx as [xInt xInts]. cbn.
@@ -125,7 +125,7 @@ Lemma computesTimeTyArr_helper t1 t2 (tt1 : TT t1) (tt2 : TT t2) f fInt time fT:
       (time y yT<= fst (fT y yT)) * 
   forall (yInt : term),
     computesTime tt1 y yInt yT
-    -> {v : term & evalLe (time y yT) (fInt yInt) v * (proc v -> computesTime tt2 (f y) v (snd (fT y yT)))})%type
+    -> {v : term & evalLe (time y yT) (app fInt yInt) v * (proc v -> computesTime tt2 (f y) v (snd (fT y yT)))})%type
 -> computesTime (tt1 ~> tt2) f fInt fT.
 Proof.
   intros H0 H. split. tauto.
@@ -165,7 +165,7 @@ Qed.
 Lemma computesTimeExpStep t1 t2 (tt1 : TT t1) (tt2 : TT t2) (f : t1 -> t2) (s:term) k k' fInt fT:
   k' = k -> evalIn k' s fInt -> closed s -> 
   (forall (y : t1) (yInt : term) yT, computesTime tt1 y yInt yT
-                                -> {v : term & computesTimeExp tt2 (f y) (s yInt) (fst (fT y yT) +k) v (snd (fT y yT))}%type) ->
+                                -> {v : term & computesTimeExp tt2 (f y) (app s yInt) (fst (fT y yT) +k) v (snd (fT y yT))}%type) ->
   computesTimeExp (tt1 ~> tt2) f s k fInt fT.
 
 Proof.

--- a/theories/L/Tactics/Extract.v
+++ b/theories/L/Tactics/Extract.v
@@ -300,7 +300,7 @@ Definition tmEncode (name : ident) (A : Type) :=
 (** *** Generation of constructors *)
 
 Definition gen_constructor args num i  := 
-  it lam args (it lam num (it_i (fun n s => L.app s (n + num)) args (var (num - i - 1)))).
+  it lam args (it lam num (it_i (fun n s => L.app s #(n + num)) args (var (num - i - 1)))).
 
 Definition extract_constr {A} (a : A) (n : ident) (i : nat) (t : Ast.term) (def : option ident) :=
   num <- tmNumConstructors n ;;

--- a/theories/L/Tactics/LClos_Eval.v
+++ b/theories/L/Tactics/LClos_Eval.v
@@ -56,7 +56,7 @@ Proof with repeat (apply validCompApp ||apply validCompClos || eauto || congruen
   -destruct s0...
 Qed.
 
-Hint Resolve CompSeval_validComp.
+Hint Resolve CompSeval_validComp : core.
 
 Lemma CompBeta_sound s t u: CompBeta s t = Some u -> s t >[(1)] u.
 Proof with repeat (auto || congruence || subst || simpl in * || intuition).

--- a/theories/L/Tactics/Lbeta.v
+++ b/theories/L/Tactics/Lbeta.v
@@ -176,10 +176,10 @@ Tactic Notation "standardize" ident(R) constr(n) constr(s) :=
   assert (R : s >(l) t) by simplify_L' n;subst l t;apply pow_star in R.
 
 
-Goal I I >* I.
-Proof. 
-  standardize R 100 ((lam 0) (lam 0)); exact R. 
-Qed.
+(* Goal I I >* I. *)
+(* Proof.  *)
+(*   standardize R 100 ((lam 0) (lam 0)); exact R.  *)
+(* Qed. *)
 
 Ltac standardizeGoal' _n:=
   let R:= fresh "R" in

--- a/theories/L/Tactics/Lbeta_nonrefl.v
+++ b/theories/L/Tactics/Lbeta_nonrefl.v
@@ -1,5 +1,6 @@
 From Undecidability.L Require Import ComputableTactics Lproc mixedTactics Tactics.Computable ComputableTime Lrewrite.
 
+Import L_Notations.
 
 Local Fixpoint subst' (s : term) (k : nat) (u : term) {struct s} : term :=
   match s with

--- a/theories/L/Tactics/Lrewrite.v
+++ b/theories/L/Tactics/Lrewrite.v
@@ -1,4 +1,5 @@
 From Undecidability.L Require Import Tactics.Computable Lproc Lbeta ComputableTime mixedTactics.
+Import L_Notations.
 
 (** *** Lrewrite: simplification with correctness statements*)
 

--- a/theories/L/Tactics/Lsimpl.v
+++ b/theories/L/Tactics/Lsimpl.v
@@ -1,6 +1,7 @@
 From Undecidability.L Require Export L.
 From Undecidability.L.Tactics Require Import Lproc Lbeta Lrewrite Reflection mixedTactics.
 Require Import ListTactics.
+Import L_Notations.
 
 Local Ltac wLsimpl' _n := intros;try reflexivity';try standardizeGoal _n ; try reflexivity'.
 Local Ltac wLsimpl := wLsimpl' 100.

--- a/theories/L/Tactics/Reflection.v
+++ b/theories/L/Tactics/Reflection.v
@@ -21,7 +21,7 @@ Definition denoteTerm (phi : nat -> term) :rTerm->term :=
   fix denoteTerm s :=
     match s with
     | rVar n => var n
-    | rApp s t=> (denoteTerm s) (denoteTerm t)
+    | rApp s t=> app (denoteTerm s) (denoteTerm t)
     | rLam s => lam (denoteTerm s)
     | rConst n => phi n
     | rRho s => rho (denoteTerm s)

--- a/theories/LAM/Prelims.v
+++ b/theories/LAM/Prelims.v
@@ -1,6 +1,6 @@
 Require Export Undecidability.LAM.BaseExtension Coq.Program.Basics PslBase.Base.
 From Undecidability.L Require Export Prelim.ARS L.
-Export ARSNotations.
+Export ARSNotations L_Notations.
 
 Definition evaluatesIn (X : Type) (R : X -> X -> Prop) n (x y : X) := pow R n x y /\ terminal R y.
 

--- a/theories/Shared/Libs/DLW/Utils/binomial.v
+++ b/theories/Shared/Libs/DLW/Utils/binomial.v
@@ -55,7 +55,7 @@ Section binomial.
 
   Infix "<d" := divides (at level 70, no associativity).
 
-  Hint Resolve divides_refl.
+  Hint Resolve divides_refl : core.
 
   Let fact_neq_0 n : fact n <> 0.
   Proof. generalize (fact_gt_0 n); omega. Qed.

--- a/theories/Shared/Libs/DLW/Utils/bool_list.v
+++ b/theories/Shared/Libs/DLW/Utils/bool_list.v
@@ -10,7 +10,9 @@
 (** ** Bitwise operations on nat as list bool *)
 
 Require Import List Omega Bool Setoid.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac.
 
 Set Implicit Arguments.
 
@@ -35,7 +37,7 @@ Set Implicit Arguments.
   Fact leb_strict : ⟘ ⪦ ⟙.
   Proof. exact I. Qed. 
 
-  Hint Resolve leb_refl leb_trans leb_strict.
+  Hint Resolve leb_refl leb_trans leb_strict : core.
 
   (** We develop the Boolean algebra of lists of Booleans *)
 
@@ -88,7 +90,7 @@ Set Implicit Arguments.
         intros [] [] []; simpl; auto.
   Qed.
 
-  Hint Resolve lb_mask_refl lb_mask_trans.
+  Hint Resolve lb_mask_refl lb_mask_trans : core.
 
   Definition lb_mask_equiv l m := l ⪯ m /\ m ⪯ l.
 
@@ -103,7 +105,7 @@ Set Implicit Arguments.
   Fact lb_mask_equiv_trans l m k : l ≂ m -> m ≂ k -> l ≂ k.
   Proof. intros [] []; split; eauto. Qed.
 
-  Hint Resolve in_lb_mask_0 lb_mask_refl lb_mask_equiv_refl.
+  Hint Resolve in_lb_mask_0 lb_mask_refl lb_mask_equiv_refl : core.
 
   Add Parametric Relation: (lb) (lb_mask_equiv)
       reflexivity proved by  lb_mask_equiv_refl
@@ -144,7 +146,7 @@ Set Implicit Arguments.
     | in_lb_ortho_2 : forall x y l m, (x = ⟘ \/ y = ⟘) -> l ⟂ m -> x::l ⟂ y::m
   where "x ⟂ y" := (lb_ortho x y).
 
-  Hint Constructors lb_ortho.
+  Hint Constructors lb_ortho : core.
 
   Fact lb_ortho_cons_inv x y l m : x::l ⟂ y::m -> (x = ⟘ \/ y = ⟘) /\ l ⟂ m.
   Proof. inversion 1; auto. Qed.
@@ -388,7 +390,7 @@ Set Implicit Arguments.
         apply lb_mask_inv_nil in H; constructor; auto.
   Qed.
 
-  Hint Resolve lb_mask_equiv_refl.
+  Hint Resolve lb_mask_equiv_refl : core.
 
   Fact lb_join_inc_left a b : a ⪯  a↑b.
   Proof.
@@ -418,7 +420,7 @@ Set Implicit Arguments.
   Fact lb_meet_dec_right a b : a↓b ⪯  b.
   Proof. rewrite lb_meet_comm; apply lb_meet_dec_left. Qed.
   
-  Hint Resolve lb_join_inc_left lb_join_inc_right lb_meet_dec_left lb_meet_dec_right.
+  Hint Resolve lb_join_inc_left lb_join_inc_right lb_meet_dec_left lb_meet_dec_right : core.
 
   Fact lb_mask_join a b : a ⪯  b <-> a↑b ≂ b.
   Proof.
@@ -525,7 +527,7 @@ Set Implicit Arguments.
           destruct x; destruct y; destruct z; simpl; auto.
   Qed.
 
-  Hint Resolve lb_meet_mono lb_join_mono.
+  Hint Resolve lb_meet_mono lb_join_mono : core.
   
   Fact lb_join_spec a b c : a ⪯  c -> b ⪯  c -> a↑b ⪯  c.
   Proof. intros; rewrite <- (lb_join_idem c); auto. Qed.

--- a/theories/Shared/Libs/DLW/Utils/bool_nat.v
+++ b/theories/Shared/Libs/DLW/Utils/bool_nat.v
@@ -55,7 +55,7 @@ Proof. intros H; apply binary_le_le in H; omega. Qed.
 Fact binary_le_zero n : 0 ≲ n.
 Proof. constructor. Qed.
 
-Hint Resolve binary_le_zero binary_le_refl.
+Hint Resolve binary_le_zero binary_le_refl : core.
 
 Local Notation "⟘" := false.
 Local Notation "⟙" := true.
@@ -92,7 +92,7 @@ Proof. intros [ | [ | ] ] ?; simpl; omega. Qed.
 Fact nat2bool2nat : forall x, nat2bool (bool2nat x) = x.
 Proof. intros []; auto. Qed.
 
-Local Hint Resolve power2_gt_0.
+Local Hint Resolve power2_gt_0 : core.
 
 Local Notation lb := (list bool).
 
@@ -177,7 +177,7 @@ Local Reserved Notation "'⟬' x '⟭'".
 
   Local Notation "⟬ n ⟭" := (nat_lb n).
 
-  Hint Resolve nat_lb_spec.
+  Hint Resolve nat_lb_spec : core.
 
   Fact nat_lb_fix_0 : ⟬ 0⟭ = nil.
   Proof. apply g_nlb_fun with 0; auto; constructor. Qed.
@@ -256,7 +256,7 @@ Local Reserved Notation "'⟬' x '⟭'".
           constructor; auto.
   Qed.
 
-  Hint Resolve lb_mask_binary_le binary_le_lb_mask.
+  Hint Resolve lb_mask_binary_le binary_le_lb_mask : core.
 
   Section lb_mask_nat.
 
@@ -304,7 +304,7 @@ Local Reserved Notation "'⟬' x '⟭'".
     intro; rewrite <- (lb_nat_lb x), <- (lb_nat_lb y); auto.
   Qed.
 
-  Hint Resolve lb_mask_eq_binary_le binary_le_eq_lb_mask.
+  Hint Resolve lb_mask_eq_binary_le binary_le_eq_lb_mask : core.
 
   Fact binary_le_trans x y z : x ≲ y -> y ≲ z -> x ≲ z.
   Proof.
@@ -676,7 +676,7 @@ Local Reserved Notation "'⟬' x '⟭'".
     rewrite lb_mask_nat; auto.
   Qed.
 
-  Hint Resolve nat_meet_left nat_meet_right.
+  Hint Resolve nat_meet_left nat_meet_right : core.
 
   Fact binary_le_nat_meet n m : n ≲ m <-> n⇣m = n.
   Proof.
@@ -778,7 +778,7 @@ Local Reserved Notation "'⟬' x '⟭'".
     rewrite nat_lb_nat, lb_meet_idem; auto.
   Qed.
 
-  Hint Resolve nat_meet_0n nat_meet_n0 nat_meet_idem.
+  Hint Resolve nat_meet_0n nat_meet_n0 nat_meet_idem : core.
 
   Fact nat_meet_assoc n m k : n⇣(m⇣k) = n⇣m⇣k.
   Proof.
@@ -871,7 +871,7 @@ Local Reserved Notation "'⟬' x '⟭'".
     rewrite lb_mask_nat; auto.
   Qed.
 
-  Hint Resolve nat_join_left nat_join_right.
+  Hint Resolve nat_join_left nat_join_right : core.
 
   Fact nat_join_0n n : 0⇡n = n.
   Proof.
@@ -921,12 +921,12 @@ Local Reserved Notation "'⟬' x '⟭'".
     rewrite lb_meet_join_distr; auto.
   Qed.
   
-  Hint Resolve nat_join_0n nat_join_n0 nat_join_assoc.
+  Hint Resolve nat_join_0n nat_join_n0 nat_join_assoc : core.
 
   Lemma nat_join_monoid : monoid_theory nat_join 0.
   Proof. split; auto. Qed.
  
-  Hint Resolve nat_join_monoid nat_join_mono.
+  Hint Resolve nat_join_monoid nat_join_mono : core.
 
   Fact nat_meet_joins_distr_l m n f : m ⇣ msum nat_join 0 n f = msum nat_join 0 n (fun i => m ⇣ f i).
   Proof.
@@ -1316,7 +1316,7 @@ Local Reserved Notation "'⟬' x '⟭'".
       + generalize (Hf j i); intros; omega.
     Qed.
 
-    Hint Resolve sinc_injective.
+    Hint Resolve sinc_injective : core.
 
     Section binary_le_meet_sum_powers.
 
@@ -1472,6 +1472,8 @@ Local Reserved Notation "'⟬' x '⟭'".
     Qed.
 
   End nat_meet_digits.
+
+(* End lb_nat. *)
 
     
         

--- a/theories/Shared/Libs/DLW/Utils/crt.v
+++ b/theories/Shared/Libs/DLW/Utils/crt.v
@@ -12,15 +12,17 @@
 Require Import List Arith Omega Permutation Extraction.
 
 From Undecidability.Shared.Libs.DLW.Utils 
-  Require Import utils_tac utils_list utils_nat gcd
-                 prime binomial.
-From Undecidability.Shared.Libs.DLW.Vec Require Import pos vec.
+  Require Import utils_tac utils_list utils_nat 
+                 gcd prime binomial.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
 
 Set Implicit Arguments.
 
 Section Informative_Chinese_Remainder_theorems.
 
-  Hint Resolve divides_refl divides_mult divides_mult_r.
+  Hint Resolve divides_refl divides_mult divides_mult_r : core.
 
   Section Binary.
 

--- a/theories/Shared/Libs/DLW/Utils/gcd.v
+++ b/theories/Shared/Libs/DLW/Utils/gcd.v
@@ -211,7 +211,7 @@ Section gcd_lcm.
 
   Infix "div" := divides (at level 70, no associativity).
 
-  Hint Resolve divides_0 divides_refl divides_mult divides_1.
+  Hint Resolve divides_0 divides_refl divides_mult divides_1 : core.
 
   Definition is_gcd p q r := r div p /\ r div q /\ forall k, k div p -> k div q -> k div r.
   Definition is_lcm p q r := p div r /\ q div r /\ forall k, p div k -> q div k -> r div k.
@@ -246,7 +246,7 @@ Section gcd_lcm.
   Fact is_gcd_minus p q r : p <= q -> is_gcd p q r -> is_gcd p (q-p) r.
   Proof. intros H1; apply is_gcd_modulus; auto. Qed.
 
-  Hint Resolve divides_plus.
+  Hint Resolve divides_plus : core.
 
   Fact is_gcd_moduplus p q k r : p div k -> is_gcd p q r -> is_gcd p (q+k) r.
   Proof.
@@ -296,7 +296,7 @@ Section bezout.
 
   Infix "div" := divides (at level 70, no associativity).
 
-  Hint Resolve is_gcd_0l is_gcd_0r is_lcm_0l is_lcm_0r divides_refl divides_mult divides_0 is_gcd_minus.
+  Hint Resolve is_gcd_0l is_gcd_0r is_lcm_0l is_lcm_0r divides_refl divides_mult divides_0 is_gcd_minus : core.
 
   Section bezout_rel_prime.
  
@@ -365,7 +365,7 @@ Section bezout.
       exists a, b; auto.
     Qed.
 
-    Hint Resolve divides_1.
+    Hint Resolve divides_1 : core.
 
     Lemma bezout_sc p q a b m : a*p+b*q = 1 + m -> p div m \/ q div m -> is_gcd p q 1.
     Proof.
@@ -422,7 +422,7 @@ Section bezout.
     rewrite mult_comm, H1; auto.
   Qed.
 
-  Hint Resolve divides_1 divides_mult_compat is_gcd_refl.
+  Hint Resolve divides_1 divides_mult_compat is_gcd_refl : core.
 
   Fact is_gcd_0 p q : is_gcd p q 0 -> p = 0 /\ q = 0.
   Proof.
@@ -632,7 +632,7 @@ Section bezout.
           + apply mult_le_compat; auto. }
     Defined.
   
-    Hint Resolve is_gcd_sym is_lcm_sym.
+    Hint Resolve is_gcd_sym is_lcm_sym : core.
 
     Definition bezout_generalized p q : { a : nat 
                                       & { b : nat 
@@ -802,7 +802,7 @@ Section division.
     + apply rem_prop with 0; omega.
   Qed.
 
-  Hint Resolve divides_0_inv.
+  Hint Resolve divides_0_inv : core.
 
   Fact divides_dec q p : { k | q = k*p } + { ~ divides p q }.
   Proof.
@@ -967,5 +967,5 @@ Section rem_2.
 
 End rem_2.
 
-Local Hint Resolve divides_mult divides_mult_r divides_refl.
+Local Hint Resolve divides_mult divides_mult_r divides_refl : core.
 

--- a/theories/Shared/Libs/DLW/Utils/prime.v
+++ b/theories/Shared/Libs/DLW/Utils/prime.v
@@ -11,13 +11,14 @@
 
 Require Import List Arith Omega Bool Permutation.
 
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac utils_list utils_nat gcd sums.
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac utils_list utils_nat gcd sums.
 
 Set Implicit Arguments.
 
 Section prime.
 
-  Hint Resolve divides_0 divides_mult divides_refl divides_0_inv.
+  Hint Resolve divides_0 divides_mult divides_refl divides_0_inv : core.
 
   Infix "<d" := divides (at level 70, no associativity).
 
@@ -317,7 +318,7 @@ Section prime.
         simpl; rewrite <- H2, mult_comm; auto.
   Qed.
 
-  Hint Resolve lprod_ge_1 prime_ge_2.
+  Hint Resolve lprod_ge_1 prime_ge_2 : core.
 
   Fact prime_in_decomp p l : prime p -> Forall prime l -> p <d lprod l -> In p l.
   Proof.

--- a/theories/Shared/Libs/DLW/Utils/quotient.v
+++ b/theories/Shared/Libs/DLW/Utils/quotient.v
@@ -285,11 +285,12 @@ Proof.
   rewrite <- (H1 y); apply H2; auto.
 Qed.
 
+(*
 Print nat_enum_cls.
 Print quotient.
 
 Check enum_quotient.
 Check quotient_is_enum.
-  
+*)
 
 

--- a/theories/Shared/Libs/DLW/Utils/rel_iter.v
+++ b/theories/Shared/Libs/DLW/Utils/rel_iter.v
@@ -10,7 +10,9 @@
 (** ** Iteration of binary relations *)
 
 Require Import Arith Nat Omega.
-From Undecidability.Shared.Libs.DLW.Utils Require Import utils_tac gcd prime binomial sums.
+
+From Undecidability.Shared.Libs.DLW.Utils 
+  Require Import utils_tac gcd prime binomial sums.
 
 Set Implicit Arguments.
 
@@ -187,7 +189,7 @@ Section rel_iter_bound.
     + rewrite <- H2; apply Hc; omega.
   Qed.
 
-  Hint Resolve rel_iter_bound_iter rel_iter_iter_bound.
+  Hint Resolve rel_iter_bound_iter rel_iter_iter_bound : core.
 
   (* A characterization of fun n x y => rel_iter R n x y with a diophantine formula
      (to be proved in dio_expo.v) when the relation R does not grow more that linearly *)
@@ -280,7 +282,7 @@ Section rel_iter_seq.
     + rewrite <- H2; apply Hc; omega.
   Qed.
 
-  Hint Resolve rel_iter_seq_iter rel_iter_iter_seq.
+  Hint Resolve rel_iter_seq_iter rel_iter_iter_seq : core.
 
   (* A characterization of fun n x y => rel_iter R n x y with a diophantine formula *)
 

--- a/theories/Shared/Libs/DLW/Utils/seteq.v
+++ b/theories/Shared/Libs/DLW/Utils/seteq.v
@@ -48,7 +48,7 @@ Section seteq.
     | seteq_trans : forall l m k, l ≡ m -> m ≡ k -> l ≡ k
   where "l ≡ m" := (seteq l m).
 
-  Hint Constructors seteq.
+  Hint Constructors seteq : core.
 
   Fact perm_seteq l m : l ~p m -> l ≡ m.
   Proof. induction 1; eauto. Qed.
@@ -64,7 +64,7 @@ Section seteq.
   Fact incl_cntr (x : X) l : x::x::l ⊆ x::l.
   Proof. intros ? [ -> | [ -> | ] ]; simpl; auto. Qed.
 
-  Hint Resolve incl_refl incl_cons_mono incl_swap incl_cntr incl_tl.
+  Hint Resolve incl_refl incl_cons_mono incl_swap incl_cntr incl_tl : core.
 
   Fact seqeq_incl l m : l ≡ m -> l ⊆ m /\ m ⊆ l.
   Proof.
@@ -120,7 +120,7 @@ Section seteq.
       apply IH; try omega; apply incl_tran with l; auto.
   Qed.
 
-  Hint Resolve seqeq_incl incl_seteq.
+  Hint Resolve seqeq_incl incl_seteq : core.
 
   (** seteq is equivalent to bi-inclusion *)
 
@@ -132,6 +132,8 @@ End seteq.
 Local Infix "≡" := seteq.
 Local Infix "⊆" := incl.
 
+(*
 Print seteq.
 Check seteq_bi_incl.
 Print Assumptions seteq_bi_incl.
+*)

--- a/theories/Shared/Libs/DLW/Utils/sorting.v
+++ b/theories/Shared/Libs/DLW/Utils/sorting.v
@@ -244,7 +244,7 @@ Section sum_bounded_permutation.
        -> (forall k, k <> i -> k <> j -> k < n -> g k = k)
        -> bounded_permut n i j g.
 
-  Hint Resolve swap_spec_i swap_spec_j swap_spec.
+  Hint Resolve swap_spec_i swap_spec_j swap_spec : core.
 
   Fact swap_bounded_permut n i j : i < n -> j < n -> bounded_permut n i j (swap i j).
   Proof. constructor; auto. Qed.

--- a/theories/Shared/Libs/DLW/Utils/sums.v
+++ b/theories/Shared/Libs/DLW/Utils/sums.v
@@ -36,7 +36,7 @@ Fact Zmult_monoid : monoid_theory Zmult 1%Z.
 Proof. exists; intros; ring. Qed.
 
 Hint Resolve Nat_plus_monoid Nat_mult_monoid
-             Zplus_monoid Zmult_monoid.
+             Zplus_monoid Zmult_monoid : core.
 
 Section msum.
 

--- a/theories/Shared/Libs/DLW/Utils/utils_decidable.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_decidable.v
@@ -219,7 +219,9 @@ Section decidable_sinc.
   Proof. exists f; auto. Qed.
 
 End decidable_sinc.
-   
+
+(*
 Check sinc_decidable.
 Check decidable_sinc.
+*)
 

--- a/theories/TM/Code/BinNumbers/PosDefinitions.v
+++ b/theories/TM/Code/BinNumbers/PosDefinitions.v
@@ -4,21 +4,21 @@ From Undecidability Require Export ArithPrelim. (* [nia] etc. *)
 From Undecidability Require Import ArithPrelim. (* [nia] etc. *)
 Require Export BinPos.
 
-Compute 42. (* default number notation is still for [nat] *)
+(* Compute 42. (* default number notation is still for [nat] *) *)
 
 Local Open Scope positive_scope.
 
-Local Set Printing All.
-Compute 42 % positive.
-Compute 42 : positive.
-Local Unset Printing All.
+(* Local Set Printing All. *)
+(* Compute 42 % positive. *)
+(* Compute 42 : positive. *)
+(* Local Unset Printing All. *)
 
 
 (* Big binary numbers are not a problem for Coq *)
-Compute (42 ^ 42) % positive.
+(* Compute (42 ^ 42) % positive. *)
 
 (* Number of bits required to represent this big number *)
-Compute Pos.size_nat (42 ^ 42).
+(* Compute Pos.size_nat (42 ^ 42). *)
 
 
 (** ** General definitions and lemmas on binary numbers *)
@@ -51,7 +51,7 @@ Fixpoint append_bits (x : positive) (bits : list bool) : positive :=
   | b  :: bits' => append_bits (x~~b) bits'
   end.
 
-Compute append_bits 42 [false; true]. (* 42 * 2 * 2 + 1 = 169 *)
+(* Compute append_bits 42 [false; true]. (* 42 * 2 * 2 + 1 = 169 *) *)
 
 Goal encode_pos (append_bits 1234567890 [false;true;true]) = encode_pos 1234567890 ++ map bitToSigPos [false;true;true]. reflexivity. Qed.
 
@@ -79,8 +79,8 @@ Fixpoint bits_to_pos' (bits : list bool) : positive :=
   end.
 Definition bits_to_pos (bits : list bool) := bits_to_pos' (rev bits).
 
-Compute bits_to_pos [false; true; false; true; false]. (* 42 *)
-Compute bits_to_pos [false; true; false; true; true]. (* 43 -> last bit is LSB *)
+(* Compute bits_to_pos [false; true; false; true; false]. (* 42 *) *)
+(* Compute bits_to_pos [false; true; false; true; true]. (* 43 -> last bit is LSB *) *)
 
 
 Lemma bits_to_pos'_cons (bit : bool) (bits : list bool) :
@@ -174,8 +174,8 @@ Fixpoint pushHSB (p : positive) (b : bool) : positive :=
   | 1 => 1 ~~ b
   end.
 
-Compute pushHSB 42 true. (* 42 + 64 = 106 *)
-Compute pushHSB 42 false. (* 42 + 64 - 32 = 74 *)
+(* Compute pushHSB 42 true. (* 42 + 64 = 106 *) *)
+(* Compute pushHSB 42 false. (* 42 + 64 - 32 = 74 *) *)
 
 Lemma encode_pushHSB (p : positive) (b : bool) :
   encode_pos (pushHSB p b) = sigPos_xH :: bitToSigPos b :: tl (encode_pos p).

--- a/theories/TM/Code/BinNumbers/PosMultTM.v
+++ b/theories/TM/Code/BinNumbers/PosMultTM.v
@@ -27,11 +27,11 @@ Fixpoint mult_TR_cont (a : positive) (x y : positive) {struct x} : positive :=
 
 Definition mult_TR (x y : positive) : positive := mult_TR_cont (shift_left y (pos_size x)) x y.
 
-Check eq_refl : let x := 13 in let y := 3 in mult_TR x y = x * y.
-Check eq_refl : let x := 5 in let y := 1 in mult_TR x y = x * y.
-Check eq_refl : let x := 4234 in let y := 2132 in mult_TR x y = x * y.
-Check eq_refl : let x := 43 in let y := 23 in mult_TR x y = x * y.
-Check eq_refl : let x := 43 in let y := 24 in mult_TR x y = x * y.
+(* Check eq_refl : let x := 13 in let y := 3 in mult_TR x y = x * y. *)
+(* Check eq_refl : let x := 5 in let y := 1 in mult_TR x y = x * y. *)
+(* Check eq_refl : let x := 4234 in let y := 2132 in mult_TR x y = x * y. *)
+(* Check eq_refl : let x := 43 in let y := 23 in mult_TR x y = x * y. *)
+(* Check eq_refl : let x := 43 in let y := 24 in mult_TR x y = x * y. *)
 (* All test passed! *)
 
 
@@ -42,8 +42,8 @@ Recursive Extraction mult_TR Pos.mul.
 *)
 
 
-Compute eq_refl: let a := 3 in let x := 4 in let y := 5 in mult_TR_cont (a~0) x (y~0) = (mult_TR_cont a x y)~0.
-Compute eq_refl: let a := 8 in let x := 232 in let y := 123 in mult_TR_cont (a~0) x (y~0) = (mult_TR_cont a x y)~0.
+(* Compute eq_refl: let a := 3 in let x := 4 in let y := 5 in mult_TR_cont (a~0) x (y~0) = (mult_TR_cont a x y)~0. *)
+(* Compute eq_refl: let a := 8 in let x := 232 in let y := 123 in mult_TR_cont (a~0) x (y~0) = (mult_TR_cont a x y)~0. *)
 
 Lemma mult_TR_cont_shift (a x y : positive) :
   mult_TR_cont (a~0) x (y~0) = (mult_TR_cont a x y)~0.

--- a/theories/TM/Code/CaseSum.v
+++ b/theories/TM/Code/CaseSum.v
@@ -137,8 +137,8 @@ Section CaseOption.
   Variable (sigX : finType).
   Hypothesis (codX : codable sigX X).
 
-  Compute encode (None : option nat).
-  Compute encode (Some 42).
+  (* Compute encode (None : option nat). *)
+  (* Compute encode (Some 42). *)
 
   (** ** Deconstructor for Option Types *)
 

--- a/theories/TM/Code/ChangeAlphabet.v
+++ b/theories/TM/Code/ChangeAlphabet.v
@@ -90,8 +90,8 @@ Section MapCode.
   Notation injectTape := (mapTape f').
   Notation surjectTape := (surjectTape g' (inl UNKNOWN)).
 
-  Check injectTape : tape (sig^+) -> tape (tau^+) .
-  Check surjectTape : tape (tau^+) -> tape (sig^+).
+  (* Check injectTape : tape (sig^+) -> tape (tau^+) . *)
+  (* Check surjectTape : tape (tau^+) -> tape (sig^+). *)
 
   (* The other direction does not hold *)
   Lemma surjectTape_injectTape t :

--- a/theories/TM/Code/CodeTM.v
+++ b/theories/TM/Code/CodeTM.v
@@ -79,7 +79,7 @@ Ltac isRight_mono :=
   | [ H : isRight ?t |- isRight ?t ] =>
     apply H
   end.
-Hint Extern 10 => isRight_mono.
+Hint Extern 10 => isRight_mono : core.
 
 
 
@@ -288,7 +288,7 @@ Ltac contains_ext :=
     apply tape_contains_rev_ext with (1 := H); simpl_comp; try reflexivity
   end.
 
-Hint Extern 10 => contains_ext.
+Hint Extern 10 => contains_ext : core.
 
 
 (** Because every machine is defined on an alphabet [Σ^+], the notation adds the discreteness and finiteness constructors, to cast [Σ^+ : finType]. *)

--- a/theories/TM/Code/ListTM.v
+++ b/theories/TM/Code/ListTM.v
@@ -223,8 +223,8 @@ Section Nth'.
   Variable (retr1 : Retract (sigList sigX) sig) (retr2 : Retract sigNat sig).
   Local Instance retr_X_list' : Retract sigX sig := ComposeRetract retr1 (Retract_sigList_X _).
 
-  Check _ : codable sig (list X).
-  Check _ : codable sig nat.
+  (* Check _ : codable sig (list X). *)
+  (* Check _ : codable sig nat. *)
 
   Definition Nth'_Step_size {sigX X : Type} {cX : codable sigX X} (n : nat) (l : list X) : Vector.t (nat -> nat) 3 :=
     match n, l with

--- a/theories/TM/Combinators/Combinators.v
+++ b/theories/TM/Combinators/Combinators.v
@@ -90,14 +90,17 @@ Arguments Return : simpl never.
 
 (** Helper tactics for match *)
 
+Tactic Notation "print" string(e1) := idtac.
+Tactic Notation "print2" ident(e1) string(e2) := idtac.
+
 (** This tactic destructs a variable recursivle and shelves each goal where it couldn't destruct the variable further. The purpose of this tactic is to pre-instantiate functions to relations with holes of the form [Param -> Rel _ _]. We need this for the [Switch] Machine.
 The implementation of this tactic is quiete uggly but works for parameters with up to 9 constructor arguments. This tactic may generates a lot of warnings, which can be ignored. *)
 Ltac destruct_shelve e :=
   cbn in e;
-  idtac "Input:";
+  print "Input:";
   print_type e;
-  idtac "Output:";
-  print_goal_cbn; 
+  print "Output:";
+  print_goal_cbn;
   let x1 := fresh "x" in
   let x2 := fresh "x" in
   let x3 := fresh "x" in
@@ -107,16 +110,16 @@ Ltac destruct_shelve e :=
   let x7 := fresh "x" in
   let x8 := fresh "x" in
   let x9 := fresh "x" in
-  first [ destruct e as [x1|x2|x3|x4|x5|x6|x7|x8|x9]; idtac e "has 9 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7 | try destruct_shelve x8 | try destruct_shelve x9]; shelve
-        | destruct e as [x1|x2|x3|x4|x5|x6|x7|x8]; idtac e "has 8 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7 | try destruct_shelve x8]; shelve
-        | destruct e as [x1|x2|x3|x4|x5|x6|x7]; idtac e "has 7 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7]; shelve
-        | destruct e as [x1|x2|x3|x4|x5|x6]; idtac e "has 6 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6]; shelve
-        | destruct e as [x1|x2|x3|x4|x5]; idtac e "has 5 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5]; shelve
-        | destruct e as [x1|x2|x3|x4]; idtac e "has 4 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4]; shelve
-        | destruct e as [x1|x2|x3]; idtac e "has 3 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3]; shelve
-        | destruct e as [x1|x2]; idtac e "has 2 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2]; shelve
-        | destruct e as [x1]; idtac e "has 1 constructors"; [ try destruct_shelve x1 ]; shelve
-        | destruct e as []; idtac e "has 0 constructors"; shelve
+  first [ destruct e as [x1|x2|x3|x4|x5|x6|x7|x8|x9]; print2 e "has 9 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7 | try destruct_shelve x8 | try destruct_shelve x9]; shelve
+        | destruct e as [x1|x2|x3|x4|x5|x6|x7|x8]; print2 e "has 8 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7 | try destruct_shelve x8]; shelve
+        | destruct e as [x1|x2|x3|x4|x5|x6|x7]; print2 e "has 7 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6 | try destruct_shelve x7]; shelve
+        | destruct e as [x1|x2|x3|x4|x5|x6]; print2 e "has 6 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5 | try destruct_shelve x6]; shelve
+        | destruct e as [x1|x2|x3|x4|x5]; print2 e "has 5 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4 | try destruct_shelve x5]; shelve
+        | destruct e as [x1|x2|x3|x4]; print2 e "has 4 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3 | try destruct_shelve x4]; shelve
+        | destruct e as [x1|x2|x3]; print2 e "has 3 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2 | try destruct_shelve x3]; shelve
+        | destruct e as [x1|x2]; print2 e "has 2 constructors"; [ try destruct_shelve x1 | try destruct_shelve x2]; shelve
+        | destruct e as [x1]; print2 e "has 1 constructors"; [ try destruct_shelve x1 ]; shelve
+        | destruct e as []; print2 e "has 0 constructors"; shelve
         ]
 .
   

--- a/theories/TM/Combinators/Combinators.v
+++ b/theories/TM/Combinators/Combinators.v
@@ -90,16 +90,24 @@ Arguments Return : simpl never.
 
 (** Helper tactics for match *)
 
-Tactic Notation "print" string(e1) := idtac.
-Tactic Notation "print2" ident(e1) string(e2) := idtac.
+Ltac print e := idtac.                                  (* idtac e *)
+Tactic Notation "print_str" string(e1) := idtac. (* idtac e1 *)
+Tactic Notation "print2" ident(e1) string(e2) := idtac. (* idtac e1 e2 *)
+Ltac print_type e := first [ let x := type of e in print x | print_str "Untyped:"; print e ].
+
+Ltac print_goal_cbn :=
+  match goal with
+  | [ |- ?H ] =>
+    let H' := eval cbn in H in print H'
+  end.
 
 (** This tactic destructs a variable recursivle and shelves each goal where it couldn't destruct the variable further. The purpose of this tactic is to pre-instantiate functions to relations with holes of the form [Param -> Rel _ _]. We need this for the [Switch] Machine.
 The implementation of this tactic is quiete uggly but works for parameters with up to 9 constructor arguments. This tactic may generates a lot of warnings, which can be ignored. *)
 Ltac destruct_shelve e :=
   cbn in e;
-  print "Input:";
+  print_str "Input:";
   print_type e;
-  print "Output:";
+  print_str "Output:";
   print_goal_cbn;
   let x1 := fresh "x" in
   let x2 := fresh "x" in
@@ -122,7 +130,6 @@ Ltac destruct_shelve e :=
         | destruct e as []; print2 e "has 0 constructors"; shelve
         ]
 .
-  
 
 (* Eval simpl in ltac:(intros ?e; destruct_shelve e) : (option (bool + (bool + (bool + bool)))) -> Rel _ _. *)
 

--- a/theories/TM/Lifting/LiftTapes.v
+++ b/theories/TM/Lifting/LiftTapes.v
@@ -479,17 +479,17 @@ Ltac simpl_not_in_add_tapes_one :=
 
 Ltac simpl_not_in_add_tapes := repeat simpl_not_in_add_tapes_one.
 
-(* Test *)
-Goal True.
-  assert (forall i : Fin.t 3, not_index (add_tapes _ 2) i -> i = i) by firstorder.
-  simpl_not_in_add_tapes. (* :-) *)
-Abort.
+(* (* Test *) *)
+(* Goal True. *)
+(*   assert (forall i : Fin.t 3, not_index (add_tapes _ 2) i -> i = i) by firstorder. *)
+(*   simpl_not_in_add_tapes. (* :-) *) *)
+(* Abort. *)
 
-Goal True.
-  assert (n : nat) by constructor.
-  assert (forall i : Fin.t (S n), not_index (add_tapes n 1) i -> True) by firstorder.
-  simpl_not_in_add_tapes.
-Abort.
+(* goal True. *)
+(*   assert (n : nat) by constructor. *)
+(*   assert (forall i : Fin.t (S n), not_index (add_tapes n 1) i -> True) by firstorder. *)
+(*   simpl_not_in_add_tapes. *)
+(* Abort. *)
 
 
 (* Support for [app_tapes] *)
@@ -518,13 +518,13 @@ Ltac simpl_not_in_app_tapes_one :=
 
 Ltac simpl_not_in_app_tapes := repeat simpl_not_in_app_tapes_one.
 
-Goal True.
-  assert (forall i : Fin.t 10, not_index (app_tapes 8 _) i -> i = i) as Inj by firstorder.
-  simpl_not_in_app_tapes.
-  Check HIndex_Inj : Fin8 = Fin8.
-  Check HIndex_Inj0 : Fin9 = Fin9.
-  Fail Check HInj.
-Abort.
+(* Goal True. *)
+(*   assert (forall i : Fin.t 10, not_index (app_tapes 8 _) i -> i = i) as Inj by firstorder. *)
+(*   simpl_not_in_app_tapes. *)
+(*   Check HIndex_Inj : Fin8 = Fin8. *)
+(*   Check HIndex_Inj0 : Fin9 = Fin9. *)
+(*   Fail Check HInj. *)
+(* Abort. *)
 
 
 
@@ -537,16 +537,16 @@ Ltac vector_contains a vect :=
   | _ => fail "No vector" vect
   end.
 
-Fail Check ltac:(vector_contains 42 (@Vector.nil nat); idtac "yes!").
-Check ltac:(vector_contains 42 [|4;8;15;16;23;42|]; idtac "yes!").
+(* Fail Check ltac:(vector_contains 42 (@Vector.nil nat); idtac "yes!"). *)
+(* Check ltac:(vector_contains 42 [|4;8;15;16;23;42|]; idtac "yes!"). *)
 
 Ltac vector_doesnt_contain a vect :=
   tryif vector_contains a vect then fail "Vector DOES contain" a else idtac.
 
 
-Check ltac:(vector_doesnt_contain 42 (@Vector.nil nat); idtac "yes!").
-Check ltac:(vector_doesnt_contain 9 [|4;8;15;16;23;42|]; idtac "yes!").
-Fail Check ltac:(vector_doesnt_contain 42 [|4;8;15;16;23;42|]; idtac "yes!").
+(* Check ltac:(vector_doesnt_contain 42 (@Vector.nil nat); idtac "yes!"). *)
+(* Check ltac:(vector_doesnt_contain 9 [|4;8;15;16;23;42|]; idtac "yes!"). *)
+(* Fail Check ltac:(vector_doesnt_contain 42 [|4;8;15;16;23;42|]; idtac "yes!"). *)
 
 
 
@@ -577,19 +577,19 @@ Ltac simpl_not_in_vector_one :=
 Ltac simpl_not_in_vector := repeat simpl_not_in_vector_one.
 
 
-(* Test *)
-Goal True.
-  assert (forall i : Fin.t 10, not_index [|Fin8; Fin1; Fin2; Fin3|] i -> i = i) as HInj by firstorder.
-  simpl_not_in_vector_one.
-  Fail Check HInj.
-  Show Proof.
-  Check (HInj_0 : Fin0 = Fin0).
-  Check (HInj_1 : Fin4 = Fin4).
-  Check (HInj_2 : Fin5 = Fin5).
-  Check (HInj_3 : Fin6 = Fin6).
-  Check (HInj_4 : Fin7 = Fin7).
-  Check (HInj_5 : Fin9 = Fin9).
-Abort.
+(* (* Test *) *)
+(* Goal True. *)
+(*   assert (forall i : Fin.t 10, not_index [|Fin8; Fin1; Fin2; Fin3|] i -> i = i) as HInj by firstorder. *)
+(*   simpl_not_in_vector_one. *)
+(*   Fail Check HInj. *)
+(*   Show Proof. *)
+(*   Check (HInj_0 : Fin0 = Fin0). *)
+(*   Check (HInj_1 : Fin4 = Fin4). *)
+(*   Check (HInj_2 : Fin5 = Fin5). *)
+(*   Check (HInj_3 : Fin6 = Fin6). *)
+(*   Check (HInj_4 : Fin7 = Fin7). *)
+(*   Check (HInj_5 : Fin9 = Fin9). *)
+(* Abort. *)
 
 
 

--- a/theories/TM/PrettyBounds/BaseCode.v
+++ b/theories/TM/PrettyBounds/BaseCode.v
@@ -247,37 +247,37 @@ Section Nth'_nice.
   Lemma Nth'_steps_nice :
     { c | forall (xs : list X) (n : nat), Nth'_steps xs n <=(c) size xs + n + 1 }.
   Proof.
-    pose_nice Nth'_Loop_steps_nice H c.
-    eexists. intros xs n. specialize (H xs n).
-    hnf. unfold Nth'_steps. ring_simplify.
-    (* At this point, ultimate domination would be better, because we would not have to look in the values of [CopyValue_steps] and [Reset_steps], because we already know that they are Θ(size _ xs). Below, [28] has been chosen in dependence of these constants. *)
-    unfold CopyValue_steps, Reset_steps.
-    instantiate (1 := 12 + c + 4 + 4 + _).
-    rewrite !Encode_list_hasSize. rewrite Encode_list_hasSize_skipn.
-    rewrite Encode_nat_hasSize. rewrite H, Encode_list_hasSize.
-    ring_simplify.
-    assert (n - (1 + |xs|) <= n) as H' by omega; rewrite H'; clear H'.
-    (* Encode_list_size cX xs * c + 16 * Encode_list_size cX xs + 4 * n + 48 <=
-       Encode_list_size cX xs * c + Encode_list_size cX xs * ?m + 20 * Encode_list_size cX xs + c * n + c + ?m * n + ?m + 20 * n + 20 *)
-    instantiate (1 := 28).
-    nia.
-  Restart.
-    (* Another proof with more automation *)
-    pose_nice Nth'_Loop_steps_nice H c.
-    eexists. intros xs n. specialize (H xs n).
-    hnf. unfold Nth'_steps.
-    repeat eapply dominatedWith_add.
-    (* Compositional part is more or less automatic *)
-    all: ring_simplify.
-    (* The second tactic can solve more and is faster *)
-    all: domWith_approx.
-    all: try solve [ eauto | apply dominatedWith_const; omega | apply dominatedWith_solve; omega
-                   | eapply dominatedWith_trans; eauto; apply dominatedWith_solve; omega ].
-    (* Specific part for [Nth'] *)
-    1-4: apply dominatedWith_solve; rewrite !Encode_list_hasSize; etransitivity; [ apply (Encode_list_hasSize_skipn _ xs (1+n)) | omega ].
-    1-4: assert (1 <= size xs) by (rewrite Encode_list_hasSize; apply Encode_list_hasSize_ge1);
-      apply dominatedWith_solve; rewrite Encode_nat_hasSize; omega.
-  Restart.
+  (*   pose_nice Nth'_Loop_steps_nice H c. *)
+  (*   eexists. intros xs n. specialize (H xs n). *)
+  (*   hnf. unfold Nth'_steps. ring_simplify. *)
+  (*   (* At this point, ultimate domination would be better, because we would not have to look in the values of [CopyValue_steps] and [Reset_steps], because we already know that they are Θ(size _ xs). Below, [28] has been chosen in dependence of these constants. *) *)
+  (*   unfold CopyValue_steps, Reset_steps. *)
+  (*   instantiate (1 := 12 + c + 4 + 4 + _). *)
+  (*   rewrite !Encode_list_hasSize. rewrite Encode_list_hasSize_skipn. *)
+  (*   rewrite Encode_nat_hasSize. rewrite H, Encode_list_hasSize. *)
+  (*   ring_simplify. *)
+  (*   assert (n - (1 + |xs|) <= n) as H' by omega; rewrite H'; clear H'. *)
+  (*   (* Encode_list_size cX xs * c + 16 * Encode_list_size cX xs + 4 * n + 48 <= *)
+  (*      Encode_list_size cX xs * c + Encode_list_size cX xs * ?m + 20 * Encode_list_size cX xs + c * n + c + ?m * n + ?m + 20 * n + 20 *) *)
+  (*   instantiate (1 := 28). *)
+  (*   nia. *)
+  (* Restart. *)
+  (*   (* Another proof with more automation *) *)
+  (*   pose_nice Nth'_Loop_steps_nice H c. *)
+  (*   eexists. intros xs n. specialize (H xs n). *)
+  (*   hnf. unfold Nth'_steps. *)
+  (*   repeat eapply dominatedWith_add. *)
+  (*   (* Compositional part is more or less automatic *) *)
+  (*   all: ring_simplify. *)
+  (*   (* The second tactic can solve more and is faster *) *)
+  (*   all: domWith_approx. *)
+  (*   all: try solve [ eauto | apply dominatedWith_const; omega | apply dominatedWith_solve; omega *)
+  (*                  | eapply dominatedWith_trans; eauto; apply dominatedWith_solve; omega ]. *)
+  (*   (* Specific part for [Nth'] *) *)
+  (*   1-4: apply dominatedWith_solve; rewrite !Encode_list_hasSize; etransitivity; [ apply (Encode_list_hasSize_skipn _ xs (1+n)) | omega ]. *)
+  (*   1-4: assert (1 <= size xs) by (rewrite Encode_list_hasSize; apply Encode_list_hasSize_ge1); *)
+  (*     apply dominatedWith_solve; rewrite Encode_nat_hasSize; omega. *)
+  (* Restart. *)
     (* Another proof with more automation *)
     pose_nice Nth'_Loop_steps_nice H c.
     eexists. intros xs n. specialize (H xs n).

--- a/theories/TM/Single/EncodeTapes.v
+++ b/theories/TM/Single/EncodeTapes.v
@@ -53,10 +53,10 @@ Instance Encode_tape (sig : Type) : codable (sigTape sig) (tape sig) :=
   |}.
 
 
-Compute encode_tape (niltape nat).
-Compute encode_tape (midtape [3;2;1] 4 [5;6;7]).
-Compute encode_tape (leftof 1 [2;3]).
-Compute encode_tape (rightof 3 [2;1]).
+(* Compute encode_tape (niltape nat). *)
+(* Compute encode_tape (midtape [3;2;1] 4 [5;6;7]). *)
+(* Compute encode_tape (leftof 1 [2;3]). *)
+(* Compute encode_tape (rightof 3 [2;1]). *)
 
 
 (** Moving does not change the number of symbols. *)
@@ -130,7 +130,7 @@ Instance Encode_tapes (sig : Type) (n : nat) : codable (sigList (sigTape sig)) (
   |}.
 
 
-Compute encode_tapes [| niltape nat; midtape [3;2;1] 4 [5;6;7]; leftof 1 [2;3];rightof 3 [2;1] |].
+(* Compute encode_tapes [| niltape nat; midtape [3;2;1] 4 [5;6;7]; leftof 1 [2;3];rightof 3 [2;1] |]. *)
 
 
 Fixpoint split_vector {X : Type} {n : nat} (v : Vector.t X n) (k : nat) : Vector.t X (min k n) * Vector.t X (n-k).
@@ -184,5 +184,5 @@ Proof.
 Qed.
   
 
-Compute split_vector [| 1; 2; 3; 4 |] 1.
-Compute let (x,y) := split_vector [| 1; 2; 3; 4 |] 1 in Vector.append x y.
+(* Compute split_vector [| 1; 2; 3; 4 |] 1. *)
+(* Compute let (x,y) := split_vector [| 1; 2; 3; 4 |] 1 in Vector.append x y. *)

--- a/theories/TM/Single/StepTM.v
+++ b/theories/TM/Single/StepTM.v
@@ -148,9 +148,9 @@ Section Fin.
 
   (* Arguments finMax (n) H : clear implicits. *)
 
-  Compute finMax (ltac:(congruence) : 1 <> 0).
-  Compute finMax (ltac:(congruence) : 10 <> 0).
-  Compute finMax' 99.
+  (* Compute finMax (ltac:(congruence) : 1 <> 0). *)
+  (* Compute finMax (ltac:(congruence) : 10 <> 0). *)
+  (* Compute finMax' 99. *)
 
   Definition finMin (n : nat) : n <> 0 -> Fin.t n.
   Proof.
@@ -200,8 +200,8 @@ Section Fin.
   Definition finSucc' (n : nat) (i : Fin.t (S n)) (H : i <> finMax' n) : Fin.t (S n).
   Proof. unshelve eapply finSucc with (i := i). apply Nat.neq_succ_0. apply H. Defined.
 
-  Compute @finSucc 5 Fin0 _ _.
-  Compute finSucc' (_ : Fin4 <> finMax' 10).
+  (* Compute @finSucc 5 Fin0 _ _. *)
+  (* Compute finSucc' (_ : Fin4 <> finMax' 10). *)
 
 
   Fixpoint finSucc_opt (n : nat) (i : Fin.t n) {struct i} : option (Fin.t n).
@@ -217,13 +217,13 @@ Section Fin.
         * apply None.
   Defined.
 
-  Compute eq_refl : @finSucc_opt 1 Fin0 = None.
-  Compute eq_refl : @finSucc_opt 2 Fin0 = Some Fin1.
-  Compute eq_refl : @finSucc_opt 2 Fin1 = None.
-  Compute eq_refl : @finSucc_opt 3 Fin1 = Some Fin2.
-  Compute eq_refl : @finSucc_opt 3 Fin0 = Some Fin1.
-  Compute eq_refl : @finSucc_opt 8 Fin7 = None.
-  Compute eq_refl : @finSucc_opt 9 Fin7 = Some Fin8.
+  (* Compute eq_refl : @finSucc_opt 1 Fin0 = None. *)
+  (* Compute eq_refl : @finSucc_opt 2 Fin0 = Some Fin1. *)
+  (* Compute eq_refl : @finSucc_opt 2 Fin1 = None. *)
+  (* Compute eq_refl : @finSucc_opt 3 Fin1 = Some Fin2. *)
+  (* Compute eq_refl : @finSucc_opt 3 Fin0 = Some Fin1. *)
+  (* Compute eq_refl : @finSucc_opt 8 Fin7 = None. *)
+  (* Compute eq_refl : @finSucc_opt 9 Fin7 = Some Fin8. *)
 
   Lemma finSucc_opt_Some (n : nat) (i : Fin.t n) :
     S (fin_to_nat i) < n ->

--- a/theories/TM/Univ/StepTM.v
+++ b/theories/TM/Univ/StepTM.v
@@ -355,7 +355,7 @@ Section Univ.
     containsState_size t q s -> containsState t q.
   Proof. firstorder. Qed.
 
-  Hint Resolve containsState_size_containsState.
+  Hint Resolve containsState_size_containsState : core.
 
   (*
   Definition IsFinal_size (M : mTM sigM 1) (q : states M) :=
@@ -478,7 +478,7 @@ Section Univ.
 
   Lemma containsTrans_size_containsTrans t M s : containsTrans_size t M s -> containsTrans t M.
   Proof. intros H. unfold containsTrans, containsTrans_size in *. auto. Qed.
-  Hint Resolve containsTrans_size_containsTrans.
+  Hint Resolve containsTrans_size_containsTrans : core.
 
 
   Local Arguments IsFinal_size : simpl never.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,7 +1,6 @@
 -Q . Undecidability
 
--install none
--arg -w -arg -notation-overridden,-redundant-canonical-projection,-several-object-files,-cannot-define-projection,-records,-unused-intro-pattern,-tactics,-implicit-core-hint-db,-ambiguous-paths
+-arg -w -arg -unused-intro-pattern,-notation-overridden
 COQDOCFLAGS = "--charset utf-8 -s --with-header ../website/resources/header.html --with-footer ../website/resources/footer.html --index indexpage"
 
 Shared/Prelim.v
@@ -514,8 +513,6 @@ TRAKHTENBROT/red_enum.v
 TRAKHTENBROT/red_undec.v
 
 TRAKHTENBROT/summary.v
-
-##############################"
 
 Problems/FOL.v
 Problems/TM.v


### PR DESCRIPTION
4 kinds of warnings left:

- `ambiguous-paths`, stemming from coercions declared in the base library. I have already pushed a fix to the base library, but it's not in the opam package of the base library yet.
- `implicit-core-hint-db`: Only in `Shared/DLW/Libs`. I didn't want to interfere with the open PR extending there, so I'll leave those warnings for @DmxLarchey.
- `notation-overridden`: We are re-defining lots of notations in the `FOL` part of the project. After that's unified I hope that the problem just disappears. For now disabled via `_CoqProject`
- `unused-intro-pattern`: This warning is generated in the `TMcorrect` tactic, but I don't know where. Maybe @mwuttke97 has an idea how to fix this. For now disabled via `_CoqProject`.