### PR TITLE
Unified definition of first-order logic syntax

### DIFF
--- a/theories/FOLP/Input.v
+++ b/theories/FOLP/Input.v
@@ -177,13 +177,13 @@ Module minimal.
   Coercion V := @bVar min.
 
   Definition phi1 :==: ∀ x, !P x x.
-  Print phi1.
+  (* Print phi1. *)
 
   Definition phi2 :==: free y z, ∀ x, !P x y --> !P z x.
-  Print phi2.
+  (* Print phi2. *)
       
   Definition phi3 :==: ∀ x y, !P ($f1 $e) y --> (∀ z, !P x z) --> !Q.
-  Print phi3.
+  (* Print phi3. *)
 End minimal.
   
 Notation "£ f" := (bEmbed f List.nil) (at level 2). 
@@ -199,15 +199,15 @@ Module PA.
   Coercion V' := @bVar PA.
   
   Definition PA_inj :==: ∀ x y, !Eq ($S x) ($S y) --> !Eq x y.
-  Print PA_inj.
+  (* Print PA_inj. *)
     
   Definition PA_ind (Phi : form) :==: ∀ x, £Phi $O --> (∀ x, £Phi x --> £Phi ($S x)) --> ∀ x, £Phi x.
-  Print PA_ind.
+  (* Print PA_ind. *)
   
   Definition functional (phi : form) :==: ∀ x y y', £phi x y --> £phi x y' --> !Eq y y'.
-  Print functional.
+  (* Print functional. *)
 
   Definition replacement (Phi : form) :==: £(functional Phi) --> ∀ x, !Eq $O x.
-  Print replacement.
+  (* Print replacement. *)
  
 End PA.

--- a/theories/FOLP/NewFOL.v
+++ b/theories/FOLP/NewFOL.v
@@ -1,0 +1,128 @@
+Require Import Vector.
+
+(** * Proposed new definition of First Order Logic in Coq *)
+
+(**
+
+Renaming table w.r.t. the three existing developments
+
+new name     | TRAKH name     | completeness name
+--------------------------------------------------
+syms         | syms           | Funcs
+ar_syms      | ar_syms        | fun_ar
+var          | in_var         | var_term
+func         | in_fot         | Func
+preds        | rels           | Preds
+ar_preds     | ar_rels        | pred_ar
+binop        | fol_bop        | -
+quantop      | fol_qop        | -
+fal          | fol_false      | Fal
+atom         | fol_atom       | Pred
+bin          | fol_bin        | Impl / ...
+quant        | fol_quant      | All / ...
+
+*)
+
+(** Some preliminary definitions for substitions  *)
+Definition scons {X: Type} (x : X) (xi : nat -> X) :=
+  fun n => match n with
+          |0 => x
+          |S n => xi n
+          end.
+
+Definition funcomp {X Y Z} (g : Y -> Z) (f : X -> Y)  :=
+  fun x => g (f x).
+
+(** Signatures are a record to allow for easier definitions of general transformations on signatures *)
+Record signature :=
+  Mk_signature {
+      symbols : Type ;
+      arity : symbols -> nat;
+    }.
+
+(** Make two aliases of signatures type classes so they can become proper implicits *)
+Definition funcs_signature := signature.
+Existing Class funcs_signature.
+
+Definition preds_signature := signature.
+Existing Class preds_signature.
+
+Section fix_signature.
+
+  Context {Σ_funcs : funcs_signature}.
+
+  Notation syms := (symbols Σ_funcs).
+  Notation ar_syms := (arity Σ_funcs).
+
+  (** We use the stdlib definition of vectors to be maximally compatible  *)
+  Inductive term  : Type :=
+  | var : nat -> term
+  | func : forall (f : syms), Vector.t term (ar_syms f) -> term.
+
+  Fixpoint subst_term   (σ : nat -> term) (t : term) : term :=
+    match t with
+    | var t => σ t
+    | func f v => func f (Vector.map (subst_term σ) v)
+    end.
+
+  Context {Σ_preds : preds_signature}.
+
+  Notation preds := (symbols Σ_preds).
+  Notation ar_preds := (arity Σ_preds).
+
+  (** Syntax is parametrised in binary operators and quantifiers.
+      Most developments will fix these types in the beginning and never change them.
+   *)
+  Definition binops := Type.
+  Existing Class binops.
+
+  Definition quantops := Type.
+  Existing Class quantops.
+
+  Context {binop : binops}.
+  Context {quantop : quantops}.
+
+  (** Formulas have falsity as fixed constant -- we could parametrise against this in principle *)
+  Inductive form  : Type :=
+  | fal : form
+  | atom : forall (P : preds), Vector.t term (ar_preds P) -> form
+  | bin : binop -> form  -> form  -> form
+  | quant : quantop -> form  -> form.
+
+  Definition up (σ : nat -> term) := scons (var 0) (funcomp (subst_term (funcomp σ S)) σ).
+
+  Fixpoint subst_form (σ : nat -> term) (phi : form) : form :=
+    match phi with
+    | fal => fal
+    | atom P v => atom P (Vector.map (subst_term σ) v)
+    | bin op phi1 phi2 => bin op (subst_form σ phi1) (subst_form σ phi2)
+    | quant op phi => quant op (subst_form (up σ) phi)
+    end.
+
+End fix_signature.
+
+(** Setting implicit arguments is crucial  *)
+(** We can write term both with and without arguments, but printing is without. *)
+Arguments term _, {_}.
+Compute (term _).
+Compute term.
+
+Arguments var _ _, {_} _.
+Arguments func _ _ _, {_} _ _.
+Compute (var 0).
+Compute (var _ 0).
+Compute (func _ _).
+
+Arguments subst_term {_} _ _.
+
+(** Formulas can be written with the signatures explicit or not.
+    If the operations are explicit, the signatures are too.
+ *)
+Arguments form  _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments fal   _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments atom  _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments bin   _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments quant _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+
+Arguments up         _, {_}.
+Arguments subst_form _ _ _ _, _ _ {_ _}, {_ _ _ _}.

--- a/theories/FOLP/NewFOL.v
+++ b/theories/FOLP/NewFOL.v
@@ -73,14 +73,8 @@ Section fix_signature.
   (** Syntax is parametrised in binary operators and quantifiers.
       Most developments will fix these types in the beginning and never change them.
    *)
-  Definition binops := Type.
-  Existing Class binops.
-
-  Definition quantops := Type.
-  Existing Class quantops.
-
-  Context {binop : binops}.
-  Context {quantop : quantops}.
+  Class operators := {binop : Type ; quantop : Type}.
+  Context {ops : operators}.
 
   (** Formulas have falsity as fixed constant -- we could parametrise against this in principle *)
   Inductive form  : Type :=
@@ -89,7 +83,7 @@ Section fix_signature.
   | bin : binop -> form  -> form  -> form
   | quant : quantop -> form  -> form.
 
-  Definition up (σ : nat -> term) := scons (var 0) (funcomp (subst_term (funcomp σ S)) σ).
+  Definition up (σ : nat -> term) := scons (var 0) (funcomp (subst_term (funcomp var S)) σ).
 
   Fixpoint subst_form (σ : nat -> term) (phi : form) : form :=
     match phi with
@@ -118,11 +112,11 @@ Arguments subst_term {_} _ _.
 (** Formulas can be written with the signatures explicit or not.
     If the operations are explicit, the signatures are too.
  *)
-Arguments form  _ _ _ _, _ _ {_ _}, {_ _ _ _}.
-Arguments fal   _ _ _ _, _ _ {_ _}, {_ _ _ _}.
-Arguments atom  _ _ _ _, _ _ {_ _}, {_ _ _ _}.
-Arguments bin   _ _ _ _, _ _ {_ _}, {_ _ _ _}.
-Arguments quant _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments form  _ _ _, _ _ {_}, {_ _ _}.
+Arguments fal   _ _ _, _ _ {_}, {_ _ _}.
+Arguments atom  _ _ _, _ _ {_}, {_ _ _}.
+Arguments bin   _ _ _, _ _ {_}, {_ _ _}.
+Arguments quant _ _ _, _ _ {_}, {_ _ _}.
 
 Arguments up         _, {_}.
-Arguments subst_form _ _ _ _, _ _ {_ _}, {_ _ _ _}.
+Arguments subst_form _ _ _, _ _ {_}, {_ _ _}.

--- a/theories/L/AbstractMachines/AbstractSubstMachine.v
+++ b/theories/L/AbstractMachines/AbstractSubstMachine.v
@@ -20,7 +20,7 @@ Inductive step : state -> state -> Prop :=
     -> step ((lamT::P)::T,V) (tc P' T,Q::V)
 | step_beta P Q R T V:
     step ((appT::P)::T,Q::R::V) (substP R 0 (lamT::Q++[retT])::tc P T,V).
-Hint Constructors step.
+Hint Constructors step : core.
 
 Definition init s : state := ([compile s],[]).
 


### PR DESCRIPTION
Here's the promised suggestion which unified syntax of FOL we might use in the future. As discussed in the Zoom meeting I tried to incorporate all the improvements in the different projects.

My idea would be that as a first step we try to base all 3 existing developments on this file (plus a couple of shared files defining the instances for frequent syntax combinations, e.g. FOL with all quantifiers and all binary symbols). For this first step we can keep two lemma bases for substitution: One will be essentially the one of Autosubst to have `asimpl` working (and will likely depend on Fext), another one is the one from the Trakhtenbrot project. Similarly, we can start by having different deduction systems and only unify them in a second step.

I created this as draft PR where we can discuss. It probably makes sense that we first all agree on a new definition of Syntax, port out projects and then go to step 2 and unify other parts (but that plan is also up for discussion).