### PR TITLE
Unify Fin.t / pos and Vector.t / vec

### DIFF
--- a/theories/H10/Fractran/mm_fractran.v
+++ b/theories/H10/Fractran/mm_fractran.v
@@ -146,7 +146,7 @@ Proof with eauto; try omega.
         eapply primestream_divides in H0...
         eapply divides_encode_state in H0... 
       * eapply primestream_divides in H0... subst.
-        eapply (H n p). eauto.
+        eapply (H n t). eauto.
       * eapply divides_encode_state in H0...
       * specialize (IHl (S k)). revert IHl.
         cbn - [subcode]. ring_simplify (S (k + length l)).
@@ -174,13 +174,13 @@ Proof.
     + cbn; rewrite pos2nat_fst, Nat.add_0_r. 
       split.
       * intros [ | ] % divides_mult_inv; eauto.
-        -- destruct x; try omega. cbn in H. 
+        -- destruct h; try omega. cbn in H. 
            apply divides_1_inv in H.
            generalize (str_prime qs j); rewrite H.
            intros [ [] _ ]; auto.
         -- eapply qs_exp_div in H; now eauto.
-      * intros. destruct x. inv H.
-        exists (qs j ^ x * exp (S j) v). cbn. ring.
+      * intros. destruct h. inv H.
+        exists (qs j ^ h * exp (S j) v). cbn. ring.
     + cbn. intros. rewrite <- IHv, pos2nat_nxt.
       rewrite qs_shift with (m := 1).
       simpl.

--- a/theories/H10/Fractran/prime_seq.v
+++ b/theories/H10/Fractran/prime_seq.v
@@ -262,7 +262,7 @@ Qed.
 
 Fact exp_app n m i v w : @exp (n+m) i (vec_app v w) = exp i v * exp (n+i) w.
 Proof.
-  revert i; induction v as [ | n x v IHv ]; intros i.
+  revert i; induction v as [ | x n v IHv ]; intros i.
   + rewrite vec_app_nil, exp_zero; simpl; ring.
   + rewrite vec_app_cons, exp_cons.
     simpl plus; rewrite exp_cons, IHv.
@@ -331,7 +331,7 @@ Qed.
 Lemma qs_shift n m j k (v : vec nat k) :
   divides (qs n) (exp j v) <-> divides (qs (m + n)) (exp (m + j) v).
 Proof.
-  revert m n j; induction v as [ | k x v IHv ]; intros m n j.
+  revert m n j; induction v as [ | x k v IHv ]; intros m n j.
   - cbn; split; intros ? % divides_1_inv % not_qs_1; tauto.
   - cbn. split.
     + intros [ | ] % divides_mult_inv; auto.
@@ -379,7 +379,7 @@ Qed.
 Lemma exp_inj n i v1 v2 :
   @exp n i v1 = exp i v2 -> v1 = v2.
 Proof.
-  revert i v2; induction v1 as [ | n x v1 IH ]; intros i v2.
+  revert i v2; induction v1 as [ | x n v1 IH ]; intros i v2.
   + vec nil v2; auto.
   + vec split v2 with y.
     simpl; intros H.

--- a/theories/L/Reductions/H10_to_L.v
+++ b/theories/L/Reductions/H10_to_L.v
@@ -65,7 +65,7 @@ Defined.
 
 Fixpoint conv n (p : dio_single.dio_polynomial (pos n) (pos 0)) : poly.
 Proof.
-  destruct p.
+  destruct p as [ | p | p | ].
   - exact (poly_cnst n0).
   - exact (poly_var (pos.pos2nat p)).
   - invert pos p.

--- a/theories/L/Reductions/MuRec.v
+++ b/theories/L/Reductions/MuRec.v
@@ -171,7 +171,7 @@ Fixpoint eval (fuel : nat) (min : nat) (c : reccode) (v : list nat) : option (na
     end
   end.
 
-Definition rec_erase i (erase : forall i, recalg i -> reccode) := (fix rec k (v : vec (recalg i) k) := match v with vec_nil => rc_nil | vec_cons _ x v => rc_cons (erase _ x) (rec _ v) end).
+Definition rec_erase i (erase : forall i, recalg i -> reccode) := (fix rec k (v : vec (recalg i) k) := match v with vec_nil => rc_nil | x ## v => rc_cons (erase _ x) (rec _ v) end).
 
 Fixpoint erase k (f : recalg k) : reccode :=
   match f with
@@ -217,7 +217,7 @@ Proof.
     destruct (eval n min (rec_erase erase v) a) eqn:E2; try congruence.
     destruct s; try congruence. inv H. 
     edestruct IHv as (? & ? & ?). eauto.
-    exists (vec_cons n1 x0). split. cbn. firstorder congruence.
+    exists (n1 ## x). split. cbn. firstorder congruence.
     intros j; pos_inv j.
     + rewrite pos2nat_fst in *. assert (S n - 1 = n) by omega. rewrite H1 in *.
       cbn -[eval].  eassumption.
@@ -284,27 +284,27 @@ Proof.
       eapply EqDec.inj_right_pair in H7. subst.
       eapply EqDec.inj_right_pair in H7. subst.
       eapply EqDec.inj_right_pair in H8. subst.
-      assert (forall j : pos k, eval (c0 - pos2nat j) min (erase (vec_pos v0 j)) (vec_list v) = Some (inl (vec_pos w j))).
+      assert (forall j : pos k, eval (c0 - pos2nat j) min (erase (vec_pos t j)) (vec_list v) = Some (inl (vec_pos w j))).
       intros. eapply H. omega.
                                       
       cbn. eapply H. omega. eapply H. omega. specialize (H9 j).
       eapply H in H9. 2:omega. eapply H. omega. eauto.
       remember (S c0) as c'. cbn.
 
-      assert (eval c' min (rec_erase erase v0) (vec_list v) = Some (inr (vec_list w))).
-      { subst. clear - H1. revert c0 H1. induction v0; intros.
+      assert (eval c' min (rec_erase erase t) (vec_list v) = Some (inr (vec_list w))).
+      { subst. clear - H1. revert c0 H1. induction t; intros.
         - cbn; vec nil w; reflexivity.
         - cbn. pose proof (H1 pos_fst). cbn in H. rewrite pos2nat_fst in H.
           replace (c0 - 0) with c0 in H by omega. rewrite H.
           revert H1 H; vec split w with y; intros H1 H.
-          destruct c0. cbn in H. inv H. erewrite IHv0.
+          destruct c0. cbn in H. inv H. erewrite IHt.
           reflexivity.
           intros. specialize (H1 (pos_nxt j)). rewrite pos2nat_nxt in H1.
           eassumption.
       }
       rewrite H2. subst. eapply H in H10. rewrite H10. reflexivity. omega.
     + destruct n; inversion 1.
-      destruct (eval n min (rec_erase erase v0) (vec_list v)) eqn:E; try congruence.
+      destruct (eval n min (rec_erase erase t) (vec_list v)) eqn:E; try congruence.
       destruct s; try congruence.
       destruct (eval n min (erase f) l) eqn:E2; try congruence.
       destruct s; try congruence. inv H2.

--- a/theories/Shared/Libs/DLW/Utils/fin_bij.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_bij.v
@@ -73,7 +73,7 @@ Section list_discr_vec.
 
   Fact vec_search n (v : vec X n) x : { p | x = vec_pos v p } + { ~ in_vec x v }.
   Proof.
-    induction v as [ | n y v [ (p & ->) | H ] ].
+    induction v as [ | y n v [ (p & ->) | H ] ].
     + right; simpl; auto.
     + left; exists (pos_nxt p); auto.
     + destruct (D y x).

--- a/theories/Shared/Libs/DLW/Vec/pos.v
+++ b/theories/Shared/Libs/DLW/Vec/pos.v
@@ -7,19 +7,27 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega.
+Require Import List Arith Omega Fin.
 
 From Undecidability.Shared.Libs.DLW.Utils 
   Require Import utils.
 
 Set Implicit Arguments.
 
+(*
 Inductive pos : nat -> Set :=
   | pos_fst : forall n, pos (S n)
   | pos_nxt : forall n, pos n -> pos (S n).
+*)
 
+Notation pos := Fin.t.
+Notation pos_fst := F1.
+Notation pos_nxt := FS.
+
+(*
 Arguments pos_fst {n}.
 Arguments pos_nxt {n}.
+*)
 
 Notation pos0  := (@pos_fst _).
 Notation pos1  := (pos_nxt pos0).

--- a/theories/Shared/Libs/DLW/Vec/pos.v
+++ b/theories/Shared/Libs/DLW/Vec/pos.v
@@ -7,27 +7,28 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega Fin.
+Require Import List Arith Omega.
+Require Fin.
 
 From Undecidability.Shared.Libs.DLW.Utils 
   Require Import utils.
 
 Set Implicit Arguments.
 
-(*
+(** @DLW: former definition
+
 Inductive pos : nat -> Set :=
   | pos_fst : forall n, pos (S n)
   | pos_nxt : forall n, pos n -> pos (S n).
+
+Arguments pos_fst {n}.
+Arguments pos_nxt {n}.
+
 *)
 
 Notation pos := Fin.t.
-Notation pos_fst := F1.
-Notation pos_nxt := FS.
-
-(*
-Arguments pos_fst {n}.
-Arguments pos_nxt {n}.
-*)
+Notation pos_fst := Fin.F1.
+Notation pos_nxt := Fin.FS.
 
 Notation pos0  := (@pos_fst _).
 Notation pos1  := (pos_nxt pos0).

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -224,12 +224,14 @@ Section Σfull_mon_rem.
       + simpl; tauto.
       + simpl in v; unfold Σfull_mon_rec.
         revert HA; vec split v with t; vec nil v; clear v; simpl vec_head; simpl syms; intros HA.
-        specialize (HA _ (or_introl eq_refl)); simpl in HA.
-        simpl; rewrite (fot_word_var_eq t) at 3.
-        simpl; apply fol_equiv_ext; do 2 f_equal.
-        generalize (fot_word t) (fot_var t); clear t HA; intros w.
-        induction w as [ | s w IHw ]; simpl; auto; intros i.
-        rewrite f_snoc; simpl; do 2 f_equal; auto.
+        specialize (HA _ (or_introl eq_refl)); simpl in HA |- *.
+        replace (fo_term_sem M φ t) 
+        with    (fo_term_sem M φ (fot_word_var (fot_word t) (fot_var t))).
+        * simpl; apply fol_equiv_ext; do 2 f_equal.
+          generalize (fot_word t) (fot_var t); clear t HA; intros w.
+          induction w as [ | s w IHw ]; simpl; auto; intros i.
+          rewrite f_snoc; simpl; do 2 f_equal; auto.
+        * f_equal; symmetry; apply fot_word_var_eq.
       + simpl; apply fol_bin_sem_ext.
         * apply HB; intros ? ?; apply HA, in_app_iff; auto.
         * apply HC; intros ? ?; apply HA, in_app_iff; auto.
@@ -290,14 +292,16 @@ Section Σfull_mon_rem.
         + simpl; tauto.
         + simpl in v; unfold Σfull_mon_rec.
           revert HwA; vec split v with t; vec nil v; clear v; simpl vec_head; simpl syms; intros HwA.
-          specialize (HwA _ (or_introl eq_refl)); simpl in HwA.
-          simpl; rewrite (fot_word_var_eq t) at 3.
-          revert HwA; generalize (fot_word t) (fot_var t); intros w i.
-          rewrite <- (rev_length w), <- Hf. 
-          simpl; generalize (rev w) (φ i); clear w; intros w.
-          induction w as [ | s w IHw ]; simpl; auto; intros Hw x.
-          * rewrite HM2'; tauto.
-          * rewrite HM1', IHw; simpl; try tauto; lia.
+          specialize (HwA _ (or_introl eq_refl)); simpl in HwA |- *.
+          replace (fo_term_sem M φ t) 
+          with    (fo_term_sem M φ (fot_word_var (fot_word t) (fot_var t))).
+          * revert HwA; generalize (fot_word t) (fot_var t); intros w i.
+            rewrite <- (rev_length w), <- Hf. 
+            simpl; generalize (rev w) (φ i); clear w; intros w.
+            induction w as [ | s w IHw ]; simpl; auto; intros Hw x.
+            - rewrite HM2'; tauto.
+            - rewrite HM1', IHw; simpl; try tauto; lia.
+          * f_equal; symmetry; apply fot_word_var_eq.
         + apply fol_bin_sem_ext.
           * apply HB; intros ? ?; apply HwA, in_app_iff; auto.
           * apply HC; intros ? ?; apply HwA, in_app_iff; auto.

--- a/theories/TRAKHTENBROT/Sign_Sig2.v
+++ b/theories/TRAKHTENBROT/Sign_Sig2.v
@@ -90,7 +90,7 @@ Section Sign_Sig2_encoding.
         -> ⟪ A ⟫' φ <-> ⟪Σn_Σ2 d r A⟫ ψ.
   Proof.
     revert d r φ ψ.
-    induction A as [ | [] | b A HA B HB | [] A HA ]; intros l r phi psy H1 H2 H3 H.
+    induction A as [ | [] v | b A HA B HB | [] A HA ]; intros l r phi psy H1 H2 H3 H.
     + simpl; tauto.
     + simpl; red in H3.
       rewrite H3 with (w := vec_map (fun x => psy (Σrel_var x)) v).

--- a/theories/TRAKHTENBROT/fo_logic.v
+++ b/theories/TRAKHTENBROT/fo_logic.v
@@ -489,7 +489,7 @@ Section fol_semantics.
 
   Fact env_vlift_fix1 φ n (v : vec X n) k : env_vlift φ v (k+n) = φ k.
   Proof.
-    revert φ k; induction v as [ | n x v IHv ]; intros phi k; simpl; auto.
+    revert φ k; induction v as [ | x n v IHv ]; intros phi k; simpl; auto.
     replace (k+S n) with (S (k+n)) by lia; simpl; auto.
   Qed.
 
@@ -638,7 +638,7 @@ Section fo_model_simulation.
         -> ⟪A⟫ φ <-> ⟪A⟫' ψ.
   Proof.
     revert φ ψ.
-    induction A as [ | r | b A HA B HB | q A HA ]; intros phi psi Hs1 Hr1 Hp; simpl; try tauto.
+    induction A as [ | r v | b A HA B HB | q A HA ]; intros phi psi Hs1 Hr1 Hp; simpl; try tauto.
     + apply (fos_rels R).
       * apply Hr1; simpl; auto.
       * intros p; do 2 rewrite vec_pos_map.

--- a/theories/TRAKHTENBROT/hfs.v
+++ b/theories/TRAKHTENBROT/hfs.v
@@ -502,7 +502,7 @@ Section hfs.
   Fact hfs_tuple_pow n v t : ∅ ∈ t -> hfs_transitive t -> (forall p, vec_pos v p ∈ t) -> @hfs_tuple n v ∈ iter hfs_pow t (2*n).
   Proof.
     intros Ht1 Ht2.
-    induction v as [ | n x v IHv ]; intros Hv.
+    induction v as [ | x n v IHv ]; intros Hv.
     + simpl; auto.
     + replace (2*S n) with (2*n+2) by lia; rewrite iter_plus.
       simpl hfs_tuple; apply hfs_opair_pow.


### PR DESCRIPTION
This is a PR to unify 

- `Fin.t` (from std lib) with `DLW/Vec/pos.pos`;
- `Vector.t` (from std lib) with `DLW/Vec/vec.vec`.

Not so many changes. For `pos` things went smoothly. For `vec`, it was more complicated because of several reasons:

- `Vector.cons X x n v` = `vec_cons X n x v` ie. arguments are not in the same order, which impacts the `induction` or `destruct` tactics with explicit intro patterns;
- `vec_cons` can no longer be seen as a constructor but the `_ ## _` notation can largely mitigate this;
- proof scripts that use auto-generated names are messed up because `induction v` will now behave as `induction v as [ | x n t ]` and not as `induction v as [ | n x v ]`. 

Might I advice everyone to _always introduce the names they use_ because correcting such migration bugs can become very complicated if the proofs are intricate.