### PR TITLE
New central Synthetic.Definitions file

### DIFF
--- a/theories/CFG/CFG_undec.v
+++ b/theories/CFG/CFG_undec.v
@@ -3,15 +3,14 @@ Require Import Undecidability.CFG.CFG.
 From Undecidability.CFG.Reductions Require 
   CFPP_to_CFP CFPI_to_CFI.
 
-Require Import Undecidability.Problems.TM.
-Require Import Undecidability.Problems.Reduction.
+Require Import Undecidability.Synthetic.Undecidability.
 
 Require Undecidability.CFG.CFP_undec.
 
 (** The Context-free Palindrome Problem is undecidable. *)
-Lemma CFP_undec : HaltTM 1 ⪯ CFP.
+Lemma CFP_undec : undecidable CFP.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact CFP_undec.CFPP_undec.
   exact CFPP_to_CFP.reduction.
 Qed.
@@ -19,9 +18,9 @@ Qed.
 Check CFP_undec.
 
 (** The Context-free Intersection Problem is undecidable. *)
-Lemma CFI_undec : HaltTM 1 ⪯ CFI.
+Lemma CFI_undec : undecidable CFI.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact CFP_undec.CFPI_undec.
   exact CFPI_to_CFI.reduction.
 Qed.

--- a/theories/CFG/CFP_undec.v
+++ b/theories/CFG/CFP_undec.v
@@ -3,23 +3,22 @@ Require Import Undecidability.CFG.CFP.
 From Undecidability.CFG.Reductions Require 
   PCP_to_CFPP PCP_to_CFPI.
 
-Require Import Undecidability.Problems.TM.
-Require Import Undecidability.Problems.Reduction.
+Require Import Undecidability.Synthetic.Undecidability.
 
 Require Undecidability.PCP.PCP_undec.
 
 (** The Context-free Post Grammar Palindrome Problem is undecidable. *)
-Lemma CFPP_undec : HaltTM 1 ⪯ CFPP.
+Lemma CFPP_undec : undecidable CFPP.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact PCP_undec.PCP_undec.
   exact PCP_to_CFPP.reduction.
 Qed.
 
 (** The Context-free Post Grammar Intersection Problem is undecidable. *)
-Lemma CFPI_undec : HaltTM 1 ⪯ CFPI.
+Lemma CFPI_undec : undecidable CFPI.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact PCP_undec.PCP_undec.
   exact PCP_to_CFPI.reduction.
 Qed.

--- a/theories/FOL/DecidableEnumerable.v
+++ b/theories/FOL/DecidableEnumerable.v
@@ -1,477 +1,477 @@
 (** * Decidability and Enumerability *)
 
 From Undecidability Require Export Shared.Prelim.
+From Undecidability.Synthetic Require Export Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts MoreEnumerabilityFacts.
 
+(* (* ** Definitions *) *)
 
-(* ** Definitions *)
+(* Definition compl X p := fun x : X => ~ p x. *)
+(* Definition decidable {X} (p : X -> Prop) := exists f, forall x, p x <-> f x = true. *)
+(* Definition enumerable {X} (p : X -> Prop) := exists f, forall x, p x <-> exists n : nat, f n = Some x. *)
 
-Definition compl X p := fun x : X => ~ p x.
-Definition decidable {X} (p : X -> Prop) := exists f, forall x, p x <-> f x = true.
-Definition enumerable {X} (p : X -> Prop) := exists f, forall x, p x <-> exists n : nat, f n = Some x.
+(* Definition discrete X := decidable (fun '(x,y) => x = y :> X).  *)
+(* Definition enumerable__T X := exists f : nat -> option X, forall x, exists n, f n = Some x. *)
 
-Definition discrete X := decidable (fun '(x,y) => x = y :> X). 
-Definition enumerable__T X := exists f : nat -> option X, forall x, exists n, f n = Some x.
+(* (* *** more practical type-theoretic characterisations *) *)
 
-(* *** more practical type-theoretic characterisations *)
+(* Lemma dec_decidable' X p : *)
+(*   (forall x : X, dec (p x)) -> { f : _ | forall x, p x <-> f x = true}. *)
+(* Proof. *)
+(*   intros d. exists (fun x => if d x then true else false). intros x. destruct (d x); firstorder congruence. *)
+(* Qed. *)
 
-Lemma dec_decidable' X p :
-  (forall x : X, dec (p x)) -> { f : _ | forall x, p x <-> f x = true}.
-Proof.
-  intros d. exists (fun x => if d x then true else false). intros x. destruct (d x); firstorder congruence.
-Qed.
+(* Lemma decidable_iff X p : *)
+(*   decidable p <-> inhabited (forall x : X, dec (p x)). *)
+(* Proof. *)
+(*   split. *)
+(*   - intros [f]. econstructor. intros x. specialize (H x). destruct (f x); firstorder congruence. *)
+(*   - intros [d]. eapply dec_decidable' in d as [f]. now exists f. *)
+(* Qed. *)
 
-Lemma decidable_iff X p :
-  decidable p <-> inhabited (forall x : X, dec (p x)).
-Proof.
-  split.
-  - intros [f]. econstructor. intros x. specialize (H x). destruct (f x); firstorder congruence.
-  - intros [d]. eapply dec_decidable' in d as [f]. now exists f.
-Qed.
+(* Lemma discrete_iff X : *)
+(*   discrete X <-> inhabited (eq_dec X). *)
+(* Proof. *)
+(*   split. *)
+(*   - intros [] % decidable_iff. econstructor. intros x y; destruct (X0 (x,y)); firstorder. *)
+(*   - intros [d]. eapply decidable_iff. econstructor. intros (x,y). eapply d. *)
+(* Qed. *)
 
-Lemma discrete_iff X :
-  discrete X <-> inhabited (eq_dec X).
-Proof.
-  split.
-  - intros [] % decidable_iff. econstructor. intros x y; destruct (X0 (x,y)); firstorder.
-  - intros [d]. eapply decidable_iff. econstructor. intros (x,y). eapply d.
-Qed.
+(* (* ** Facts *) *)
 
-(* ** Facts *)
+(* Lemma dec_compl X p : *)
+(*   decidable p -> decidable (fun x : X => ~ p x). *)
+(* Proof. *)
+(*   intros [f]. exists (fun x => negb (f x)). *)
+(*   intros. rewrite H. destruct (f x); split; cbn; congruence. *)
+(* Qed. *)
 
-Lemma dec_compl X p :
-  decidable p -> decidable (fun x : X => ~ p x).
-Proof.
-  intros [f]. exists (fun x => negb (f x)).
-  intros. rewrite H. destruct (f x); split; cbn; congruence.
-Qed.
+(* Lemma dec_conj X p q : *)
+(*   decidable p -> decidable q -> decidable (fun x : X => p x /\ q x). *)
+(* Proof. *)
+(*   intros [f] [g]. exists (fun x => f x && g x). *)
+(*   intros. rewrite H, H0. destruct (f x), (g x); cbn; firstorder congruence. *)
+(* Qed. *)
 
-Lemma dec_conj X p q :
-  decidable p -> decidable q -> decidable (fun x : X => p x /\ q x).
-Proof.
-  intros [f] [g]. exists (fun x => f x && g x).
-  intros. rewrite H, H0. destruct (f x), (g x); cbn; firstorder congruence.
-Qed.
+(* Lemma dec_disj X p q : *)
+(*   decidable p -> decidable q -> decidable (fun x : X => p x \/ q x). *)
+(* Proof. *)
+(*   intros [f] [g]. exists (fun x => f x || g x). *)
+(*   intros. rewrite H, H0. destruct (f x), (g x); cbn; firstorder congruence. *)
+(* Qed. *)
 
-Lemma dec_disj X p q :
-  decidable p -> decidable q -> decidable (fun x : X => p x \/ q x).
-Proof.
-  intros [f] [g]. exists (fun x => f x || g x).
-  intros. rewrite H, H0. destruct (f x), (g x); cbn; firstorder congruence.
-Qed.
+(* Theorem dec_count_enum X (p : X -> Prop) : *)
+(*   decidable p -> enumerable__T X -> enumerable p. *)
+(* Proof. *)
+(*   intros [d Hd] [c Hc]. *)
+(*   exists (fun n => match c n with Some x => if d x then Some x else None | None => None end). *)
+(*   setoid_rewrite Hd. intros x. split; intros. *)
+(*   - destruct (Hc x) as [n Hn]. exists n. now rewrite Hn, H. *)
+(*   - destruct H as [n H]. destruct (c n) eqn:E. *)
+(*     + destruct (d x0) eqn:E2; now inv H. *)
+(*     + inv H. *)
+(* Qed. *)
 
-Theorem dec_count_enum X (p : X -> Prop) :
-  decidable p -> enumerable__T X -> enumerable p.
-Proof.
-  intros [d Hd] [c Hc].
-  exists (fun n => match c n with Some x => if d x then Some x else None | None => None end).
-  setoid_rewrite Hd. intros x. split; intros.
-  - destruct (Hc x) as [n Hn]. exists n. now rewrite Hn, H.
-  - destruct H as [n H]. destruct (c n) eqn:E.
-    + destruct (d x0) eqn:E2; now inv H.
-    + inv H.
-Qed.
+(* Theorem dec_count_enum' X (p : X -> Prop) : *)
+(*   decidable p -> enumerable__T X -> enumerable (fun x => ~ p x). *)
+(* Proof. *)
+(*   intros ? % dec_compl ?. eapply dec_count_enum; eauto. *)
+(* Qed. *)
 
-Theorem dec_count_enum' X (p : X -> Prop) :
-  decidable p -> enumerable__T X -> enumerable (fun x => ~ p x).
-Proof.
-  intros ? % dec_compl ?. eapply dec_count_enum; eauto.
-Qed.
+(* (** ** Closure of enumerable types *) *)
 
-(** ** Closure of enumerable types *)
+(* Lemma enumerable_enumerable_T X : *)
+(*   enumerable (fun _ : X => True) <-> enumerable__T X. *)
+(* Proof. *)
+(*   split. *)
+(*   - intros [e He]. exists e. intros x. now eapply He. *)
+(*   - intros [c Hc]. exists c. intros x. split; eauto. *)
+(* Qed. *)
 
-Lemma enumerable_enumerable_T X :
-  enumerable (fun _ : X => True) <-> enumerable__T X.
-Proof.
-  split.
-  - intros [e He]. exists e. intros x. now eapply He.
-  - intros [c Hc]. exists c. intros x. split; eauto.
-Qed.
+(* Definition cumulative {X} (L: nat -> list X) := *)
+(*   forall n, exists A, L (S n) = L n ++ A. *)
+(* Hint Extern 0 (cumulative _) => intros ?; cbn; eauto : core. *)
 
-Definition cumulative {X} (L: nat -> list X) :=
-  forall n, exists A, L (S n) = L n ++ A.
-Hint Extern 0 (cumulative _) => intros ?; cbn; eauto : core.
+(* Lemma cum_ge {X} (L: nat -> list X) n m : *)
+(*   cumulative L -> m >= n -> exists A, L m = L n ++ A. *)
+(* Proof. *)
+(*   induction 2 as [|m _ IH]. *)
+(*   - exists nil. now rewrite app_nil_r. *)
+(*   - destruct (H m) as (A&->), IH as [B ->]. *)
+(*     exists (B ++ A). now rewrite app_assoc. *)
+(* Qed. *)
 
-Lemma cum_ge {X} (L: nat -> list X) n m :
-  cumulative L -> m >= n -> exists A, L m = L n ++ A.
-Proof.
-  induction 2 as [|m _ IH].
-  - exists nil. now rewrite app_nil_r.
-  - destruct (H m) as (A&->), IH as [B ->].
-    exists (B ++ A). now rewrite app_assoc.
-Qed.
+(* Lemma cum_ge' {X} (L: nat -> list X) x n m : *)
+(*   cumulative L -> x el L n -> m >= n -> x el L m. *)
+(* Proof. *)
+(*   intros ? H [A ->] % (cum_ge (L := L)). apply in_app_iff. eauto. eauto. *)
+(* Qed. *)
 
-Lemma cum_ge' {X} (L: nat -> list X) x n m :
-  cumulative L -> x el L n -> m >= n -> x el L m.
-Proof.
-  intros ? H [A ->] % (cum_ge (L := L)). apply in_app_iff. eauto. eauto.
-Qed.
+(* Definition enum {X} p (L: nat -> list X) := *)
+(*   cumulative L /\ forall x, p x <-> exists m, x el L m. *)
 
-Definition enum {X} p (L: nat -> list X) :=
-  cumulative L /\ forall x, p x <-> exists m, x el L m.
+(* Section enumerable_enum. *)
 
-Section enumerable_enum.
-
-  Variable X : Type.
-  Variable p : X -> Prop.
-  Variables (e : nat -> option X).
+(*   Variable X : Type. *)
+(*   Variable p : X -> Prop. *)
+(*   Variables (e : nat -> option X). *)
   
-  Definition T_ (n : nat) : list X :=  match e n with Some x => [x] | None => [] end.
+(*   Definition T_ (n : nat) : list X :=  match e n with Some x => [x] | None => [] end. *)
 
-  Lemma count_enum' : exists L : nat -> list X, forall x, (exists n, e n = Some x) <-> (exists n, x el L n).
-  Proof.
-    exists T_. split; intros [n H].
-    - exists n. unfold T_. rewrite H. eauto.
-    - unfold T_ in *. destruct (e n) eqn:E. inv H. eauto. inv H0. inv H.
-  Qed.
+(*   Lemma count_enum' : exists L : nat -> list X, forall x, (exists n, e n = Some x) <-> (exists n, x el L n). *)
+(*   Proof. *)
+(*     exists T_. split; intros [n H]. *)
+(*     - exists n. unfold T_. rewrite H. eauto. *)
+(*     - unfold T_ in *. destruct (e n) eqn:E. inv H. eauto. inv H0. inv H. *)
+(*   Qed. *)
       
-End enumerable_enum.
+(* End enumerable_enum. *)
 
-Lemma enum_to_cumulative X (p : X -> Prop) L :
-  (forall x, p x <-> exists m : nat, x el L m) -> exists L, enum p L.
-Proof.
-  intros H. exists (fix L' n := match n with 0 => [] | S n => L' n ++ L n end).
-  split.
-  - eauto.
-  - intros x. rewrite H. split; intros [m Hm].
-    + exists (S m). eauto.
-    + induction m; try now inv Hm.
-      eapply in_app_iff in Hm as []; eauto.
-Qed.    
+(* Lemma enum_to_cumulative X (p : X -> Prop) L : *)
+(*   (forall x, p x <-> exists m : nat, x el L m) -> exists L, enum p L. *)
+(* Proof. *)
+(*   intros H. exists (fix L' n := match n with 0 => [] | S n => L' n ++ L n end). *)
+(*   split. *)
+(*   - eauto. *)
+(*   - intros x. rewrite H. split; intros [m Hm]. *)
+(*     + exists (S m). eauto. *)
+(*     + induction m; try now inv Hm. *)
+(*       eapply in_app_iff in Hm as []; eauto. *)
+(* Qed.     *)
 
-(** ** Enumerability of pairs of natural numbers *)
+(* (** ** Enumerability of pairs of natural numbers *) *)
 
-Class enumT X :=
-  {
-    L_T : nat -> list X;
-    cum_T : cumulative L_T ;
-    el_T : forall x, exists m, x el L_T m
-  }.
+(* Class enumT X := *)
+(*   { *)
+(*     L_T : nat -> list X; *)
+(*     cum_T : cumulative L_T ; *)
+(*     el_T : forall x, exists m, x el L_T m *)
+(*   }. *)
 
-Arguments L_T {_ _} _, _ {_} _.
-Hint Immediate cum_T : core.
+(* Arguments L_T {_ _} _, _ {_} _. *)
+(* Hint Immediate cum_T : core. *)
 
-Lemma discrete_bool : discrete bool.
-Proof.
-  eapply discrete_iff. econstructor. exact _.
-Qed.
+(* Lemma discrete_bool : discrete bool. *)
+(* Proof. *)
+(*   eapply discrete_iff. econstructor. exact _. *)
+(* Qed. *)
 
-Lemma discrete_nat : discrete nat.
-Proof.
-  eapply discrete_iff. econstructor. exact _.
-Qed.
+(* Lemma discrete_nat : discrete nat. *)
+(* Proof. *)
+(*   eapply discrete_iff. econstructor. exact _. *)
+(* Qed. *)
 
-Lemma discrete_nat_nat : discrete (nat * nat).
-Proof.
-  eapply discrete_iff. econstructor. exact _.
-Qed.
+(* Lemma discrete_nat_nat : discrete (nat * nat). *)
+(* Proof. *)
+(*   eapply discrete_iff. econstructor. exact _. *)
+(* Qed. *)
 
-Instance enum_bool : enumT bool.
-Proof.
-  exists (fun n => [true; false]).
-  - eauto.
-  - intros b; exists 1; destruct b; cbn; eauto.
-Qed.
+(* Instance enum_bool : enumT bool. *)
+(* Proof. *)
+(*   exists (fun n => [true; false]). *)
+(*   - eauto. *)
+(*   - intros b; exists 1; destruct b; cbn; eauto. *)
+(* Qed. *)
 
-Lemma count_bool :
-  enumerable__T bool.
-Proof.
-  exists (fun n => match n with 0 => Some true | _ => Some false end).
-  intros []. now exists 0. now exists 1.
-Qed.
+(* Lemma count_bool : *)
+(*   enumerable__T bool. *)
+(* Proof. *)
+(*   exists (fun n => match n with 0 => Some true | _ => Some false end). *)
+(*   intros []. now exists 0. now exists 1. *)
+(* Qed. *)
 
-Instance enumT_nat : enumT nat.
-Proof.
-  exists (fix f n := match n with 0 => [0] | S n => f n ++ [S n] end).
-  - intros ?; cbn; eauto.
-  - intros n. exists n. destruct n; eauto.
-Defined.
+(* Instance enumT_nat : enumT nat. *)
+(* Proof. *)
+(*   exists (fix f n := match n with 0 => [0] | S n => f n ++ [S n] end). *)
+(*   - intros ?; cbn; eauto. *)
+(*   - intros n. exists n. destruct n; eauto. *)
+(* Defined. *)
 
-Lemma count_nat :
-  enumerable__T nat.
-Proof.
-  exists Some. intros n. now exists n.
-Qed.
+(* Lemma count_nat : *)
+(*   enumerable__T nat. *)
+(* Proof. *)
+(*   exists Some. intros n. now exists n. *)
+(* Qed. *)
 
-Lemma T_nat_in n m : m <= n -> m el L_T nat n.
-Proof.
-  induction 1.
-  - destruct m; cbn. tauto. apply in_app_iff. cbn. tauto. 
-  - cbn. apply in_app_iff. now left.
-Qed.
+(* Lemma T_nat_in n m : m <= n -> m el L_T nat n. *)
+(* Proof. *)
+(*   induction 1. *)
+(*   - destruct m; cbn. tauto. apply in_app_iff. cbn. tauto.  *)
+(*   - cbn. apply in_app_iff. now left. *)
+(* Qed. *)
 
-Lemma T_nat_length n : length (L_T nat n) = S n.
-Proof.
-  induction n; cbn; try rewrite app_length. omega. cbn in *. omega. 
-Qed.
+(* Lemma T_nat_length n : length (L_T nat n) = S n. *)
+(* Proof. *)
+(*   induction n; cbn; try rewrite app_length. omega. cbn in *. omega.  *)
+(* Qed. *)
 
-Section enumerable_prod.
+(* Section enumerable_prod. *)
 
-  Variable X Y : Type.
+(*   Variable X Y : Type. *)
 
-  Section fixLs.
+(*   Section fixLs. *)
     
-    Variables (L_X : enumT X).
-    Variables (L_Y : enumT Y).
+(*     Variables (L_X : enumT X). *)
+(*     Variables (L_Y : enumT Y). *)
     
-    Fixpoint T_prod (n : nat) : list (X * Y) :=
-      match n
-      with
-      | 0 => [ (x,y) | (x,y) ∈ (L_T X 0 × L_T Y 0) ]
-      | S n => T_prod n ++ [ (x,y) | (x,y) ∈ (L_T X n  × L_T Y n) ]
-      end.
+(*     Fixpoint T_prod (n : nat) : list (X * Y) := *)
+(*       match n *)
+(*       with *)
+(*       | 0 => [ (x,y) | (x,y) ∈ (L_T X 0 × L_T Y 0) ] *)
+(*       | S n => T_prod n ++ [ (x,y) | (x,y) ∈ (L_T X n  × L_T Y n) ] *)
+(*       end. *)
 
-    Lemma T_prod_cum : cumulative T_prod.
-    Proof.
-      intros ?; cbn; eauto.
-    Qed.
+(*     Lemma T_prod_cum : cumulative T_prod. *)
+(*     Proof. *)
+(*       intros ?; cbn; eauto. *)
+(*     Qed. *)
 
-  End fixLs.
+(*   End fixLs. *)
   
-  Lemma T_prod_el LX LY (a : X * Y)  :
-    exists n, a el T_prod LX LY n.
-  Proof.
-    destruct a. destruct (el_T x) as [m1], (el_T y) as [m2].
-    exists (1 + m1 + m2). cbn. in_app 2.
-    in_collect (x,y); eapply cum_ge'; eauto; omega.
-  Qed.
+(*   Lemma T_prod_el LX LY (a : X * Y)  : *)
+(*     exists n, a el T_prod LX LY n. *)
+(*   Proof. *)
+(*     destruct a. destruct (el_T x) as [m1], (el_T y) as [m2]. *)
+(*     exists (1 + m1 + m2). cbn. in_app 2. *)
+(*     in_collect (x,y); eapply cum_ge'; eauto; omega. *)
+(*   Qed. *)
 
-  Global Instance prod_enumerable (LX : enumT X) (LY : enumT Y) : enumT (X * Y). 
-  Proof.
-    exists (T_prod LX LY).
-    - apply T_prod_cum.
-    - apply T_prod_el.
-  Defined.
+(*   Global Instance prod_enumerable (LX : enumT X) (LY : enumT Y) : enumT (X * Y).  *)
+(*   Proof. *)
+(*     exists (T_prod LX LY). *)
+(*     - apply T_prod_cum. *)
+(*     - apply T_prod_el. *)
+(*   Defined. *)
 
-End enumerable_prod.
+(* End enumerable_prod. *)
 
-Lemma C_exhaustive n m : (n,m) el L_T (1 + n + m).
-Proof.
-  cbn. in_app 2. in_collect (n, m); apply T_nat_in; omega.  
-Qed.
+(* Lemma C_exhaustive n m : (n,m) el L_T (1 + n + m). *)
+(* Proof. *)
+(*   cbn. in_app 2. in_collect (n, m); apply T_nat_in; omega.   *)
+(* Qed. *)
 
-Lemma C_longenough n : length (L_T (nat * nat) n) > n.
-Proof.
-  induction n; cbn.
-  - omega.
-  - rewrite app_length, map_length, prod_length, T_nat_length. cbn in *. remember (n + n * S n) as k. omega.
-Qed.
+(* Lemma C_longenough n : length (L_T (nat * nat) n) > n. *)
+(* Proof. *)
+(*   induction n; cbn. *)
+(*   - omega. *)
+(*   - rewrite app_length, map_length, prod_length, T_nat_length. cbn in *. remember (n + n * S n) as k. omega. *)
+(* Qed. *)
 
-Definition R_nat_nat n : option (nat * nat) := nthe n (L_T n).
+(* Definition R_nat_nat n : option (nat * nat) := nthe n (L_T n). *)
 
-Lemma pairs_retract :  forall p, exists n, R_nat_nat n = Some p. 
-Proof.
-  intros [n m].  
-  unfold R_nat_nat. destruct(pos (fun x y => Dec (x = y)) (n,m) (L_T (1 + n + m))) as [ k | ] eqn:A.
-  exists k. destruct (nthe k (L_T k)) eqn:B.
-  - eapply pos_nthe in A.
-    destruct (le_lt_dec k (1 + n + m)) as [D | ?].
-    + destruct (cum_ge (@cum_T (nat * nat) _) D) as [B' HB]. rewrite HB in A.
-      rewrite (nthe_app_l _ B) in A. now injection A.
-    + assert (1 + n + m <= k) as D by omega.
-      destruct (cum_ge (@cum_T (nat * nat) _) D) as [B' HB]. rewrite HB in B.
-      rewrite (nthe_app_l  _ A) in B. now injection B.
-  - exfalso. edestruct nthe_length. 2:{ rewrite e in B. inv B. } eapply C_longenough.
-  - exfalso. destruct (el_pos (fun x y => Dec (x = y)) (C_exhaustive n m)) as [k H]. congruence.
-Qed.
+(* Lemma pairs_retract :  forall p, exists n, R_nat_nat n = Some p.  *)
+(* Proof. *)
+(*   intros [n m].   *)
+(*   unfold R_nat_nat. destruct(pos (fun x y => Dec (x = y)) (n,m) (L_T (1 + n + m))) as [ k | ] eqn:A. *)
+(*   exists k. destruct (nthe k (L_T k)) eqn:B. *)
+(*   - eapply pos_nthe in A. *)
+(*     destruct (le_lt_dec k (1 + n + m)) as [D | ?]. *)
+(*     + destruct (cum_ge (@cum_T (nat * nat) _) D) as [B' HB]. rewrite HB in A. *)
+(*       rewrite (nthe_app_l _ B) in A. now injection A. *)
+(*     + assert (1 + n + m <= k) as D by omega. *)
+(*       destruct (cum_ge (@cum_T (nat * nat) _) D) as [B' HB]. rewrite HB in B. *)
+(*       rewrite (nthe_app_l  _ A) in B. now injection B. *)
+(*   - exfalso. edestruct nthe_length. 2:{ rewrite e in B. inv B. } eapply C_longenough. *)
+(*   - exfalso. destruct (el_pos (fun x y => Dec (x = y)) (C_exhaustive n m)) as [k H]. congruence. *)
+(* Qed. *)
 
-Lemma enumerable_nat_nat : enumerable__T (nat * nat).
-Proof.
-  exists R_nat_nat. eapply pairs_retract.
-Qed.
+(* Lemma enumerable_nat_nat : enumerable__T (nat * nat). *)
+(* Proof. *)
+(*   exists R_nat_nat. eapply pairs_retract. *)
+(* Qed. *)
   
-Section enum_enumerable.
+(* Section enum_enumerable. *)
   
-  Context X L p { enum_X : @enum X p L }.
+(*   Context X L p { enum_X : @enum X p L }. *)
 
-  Definition ofNat n := match R_nat_nat n with Some (n, m) => nthe n ((L m)) | None => None end.
+(*   Definition ofNat n := match R_nat_nat n with Some (n, m) => nthe n ((L m)) | None => None end. *)
 
-  Lemma enum_count : enumerable p.
-  Proof.
-    exists ofNat. unfold R_nat_nat. destruct enum_X as [CX HX].
-    intros. rewrite HX.
-    - split; intros [n].
-      + eapply In_nth_error in H as [m].
-        destruct (pairs_retract (m, n)) as [k]. exists k. unfold ofNat. now rewrite H0.
-      + unfold ofNat in *. destruct R_nat_nat as [ [] | ].
-        eapply nth_error_In in H. eauto. inv H.
-  Defined.
+(*   Lemma enum_count : enumerable p. *)
+(*   Proof. *)
+(*     exists ofNat. unfold R_nat_nat. destruct enum_X as [CX HX]. *)
+(*     intros. rewrite HX. *)
+(*     - split; intros [n]. *)
+(*       + eapply In_nth_error in H as [m]. *)
+(*         destruct (pairs_retract (m, n)) as [k]. exists k. unfold ofNat. now rewrite H0. *)
+(*       + unfold ofNat in *. destruct R_nat_nat as [ [] | ]. *)
+(*         eapply nth_error_In in H. eauto. inv H. *)
+(*   Defined. *)
   
-End enum_enumerable.
+(* End enum_enumerable. *)
 
-(** ** Discrete types are closed under ... *)
+(* (** ** Discrete types are closed under ... *) *)
 
-Lemma discrete_prod X Y : discrete X -> discrete Y -> discrete (X * Y).
-Proof.
-  intros [d1] % discrete_iff [d2] % discrete_iff.
-  eapply discrete_iff. eauto.
-Qed.
+(* Lemma discrete_prod X Y : discrete X -> discrete Y -> discrete (X * Y). *)
+(* Proof. *)
+(*   intros [d1] % discrete_iff [d2] % discrete_iff. *)
+(*   eapply discrete_iff. eauto. *)
+(* Qed. *)
 
-Lemma discrete_sum X Y : discrete X -> discrete Y -> discrete (X + Y).
-Proof.
-  intros [d1] % discrete_iff [d2] % discrete_iff.
-  eapply discrete_iff. eauto.
-Qed.
+(* Lemma discrete_sum X Y : discrete X -> discrete Y -> discrete (X + Y). *)
+(* Proof. *)
+(*   intros [d1] % discrete_iff [d2] % discrete_iff. *)
+(*   eapply discrete_iff. eauto. *)
+(* Qed. *)
 
 
-Lemma discrete_option X : discrete X -> discrete (option X).
-Proof.
-  intros [d1] % discrete_iff. eapply discrete_iff. eauto.
-Qed.
+(* Lemma discrete_option X : discrete X -> discrete (option X). *)
+(* Proof. *)
+(*   intros [d1] % discrete_iff. eapply discrete_iff. eauto. *)
+(* Qed. *)
 
-Lemma discrete_list X : discrete X -> discrete (list X).
-Proof.
-  intros [d1] % discrete_iff. eapply discrete_iff. eauto.
-Qed.
+(* Lemma discrete_list X : discrete X -> discrete (list X). *)
+(* Proof. *)
+(*   intros [d1] % discrete_iff. eapply discrete_iff. eauto. *)
+(* Qed. *)
 
-(** ** Enumerable types are closed under ... *)
+(* (** ** Enumerable types are closed under ... *) *)
 
-Lemma enumerable_enum X p :
-  (exists L, enum p L) <-> @enumerable X p.
-Proof.
-  split.
-  - intros [L]. eapply enum_count; eauto.
-  - intros [f]. destruct count_enum' with (e := f) as (L & ?).
-    eapply enum_to_cumulative. intros. now rewrite <- H0, H.
-Qed.
+(* Lemma enumerable_enum X p : *)
+(*   (exists L, enum p L) <-> @enumerable X p. *)
+(* Proof. *)
+(*   split. *)
+(*   - intros [L]. eapply enum_count; eauto. *)
+(*   - intros [f]. destruct count_enum' with (e := f) as (L & ?). *)
+(*     eapply enum_to_cumulative. intros. now rewrite <- H0, H. *)
+(* Qed. *)
 
-Lemma enum_enumT X :
-  enumerable__T X <-> inhabited (enumT X).
-Proof.
-  rewrite <- enumerable_enumerable_T, <-  enumerable_enum. split. 
-  - intros [L [] ]. econstructor. unshelve econstructor. exact L. all: firstorder.
-  - intros [ [] ]. exists L_T0. firstorder.
-Qed.
+(* Lemma enum_enumT X : *)
+(*   enumerable__T X <-> inhabited (enumT X). *)
+(* Proof. *)
+(*   rewrite <- enumerable_enumerable_T, <-  enumerable_enum. split.  *)
+(*   - intros [L [] ]. econstructor. unshelve econstructor. exact L. all: firstorder. *)
+(*   - intros [ [] ]. exists L_T0. firstorder. *)
+(* Qed. *)
 
-Lemma enumerable__T_prod X Y : enumerable__T X -> enumerable__T Y -> enumerable__T (X * Y).
-Proof.
-  intros [LX] % enum_enumT [LY] % enum_enumT.
-  eapply enum_enumT. econstructor.
-  exact _.  
-Qed.
+(* Lemma enumerable__T_prod X Y : enumerable__T X -> enumerable__T Y -> enumerable__T (X * Y). *)
+(* Proof. *)
+(*   intros [LX] % enum_enumT [LY] % enum_enumT. *)
+(*   eapply enum_enumT. econstructor. *)
+(*   exact _.   *)
+(* Qed. *)
 
-Lemma enumerable__T_sum X Y : enumerable__T X -> enumerable__T Y -> enumerable__T (X + Y).
-Proof.
-  intros [LX] % enum_enumT [LY] % enum_enumT.
-  eapply enum_enumT. econstructor.
-  exists (fix f n := match n with 0 => [] | S n => f n ++ [ inl x | x ∈ L_T X n ] ++ [inr y | y ∈ L_T Y n] end).
-  - eauto.
-  - intros [].
-    + destruct (el_T x) as [m]. exists (1 + m).
-      cbn. in_app 2. in_collect x. eauto.
-    + destruct (el_T y) as [m]. exists (1 + m).
-      cbn. in_app 3. in_collect y. eauto.
-Qed.
+(* Lemma enumerable__T_sum X Y : enumerable__T X -> enumerable__T Y -> enumerable__T (X + Y). *)
+(* Proof. *)
+(*   intros [LX] % enum_enumT [LY] % enum_enumT. *)
+(*   eapply enum_enumT. econstructor. *)
+(*   exists (fix f n := match n with 0 => [] | S n => f n ++ [ inl x | x ∈ L_T X n ] ++ [inr y | y ∈ L_T Y n] end). *)
+(*   - eauto. *)
+(*   - intros []. *)
+(*     + destruct (el_T x) as [m]. exists (1 + m). *)
+(*       cbn. in_app 2. in_collect x. eauto. *)
+(*     + destruct (el_T y) as [m]. exists (1 + m). *)
+(*       cbn. in_app 3. in_collect y. eauto. *)
+(* Qed. *)
 
-Lemma enumerable__T_option X : enumerable__T X -> enumerable__T (option X).
-Proof.
-  intros [f]. exists (fun n => match n with 0 => Some None | S n => Some (f n) end).
-  intros [].
-  - destruct (H x) as [n]. exists (S n). congruence.
-  - now exists 0.
-Qed.
+(* Lemma enumerable__T_option X : enumerable__T X -> enumerable__T (option X). *)
+(* Proof. *)
+(*   intros [f]. exists (fun n => match n with 0 => Some None | S n => Some (f n) end). *)
+(*   intros []. *)
+(*   - destruct (H x) as [n]. exists (S n). congruence. *)
+(*   - now exists 0. *)
+(* Qed. *)
 
-Section enumerable_list.
+(* Section enumerable_list. *)
 
-  Variable X : Type.
+(*   Variable X : Type. *)
 
-  Section fixL.
+(*   Section fixL. *)
     
-    Variables (LX : enumT X).
+(*     Variables (LX : enumT X). *)
 
-    Fixpoint T_list (n : nat) : list (list X) :=
-      match n
-      with
-      | 0 => [ [] ]
-      | S n => T_list n ++ [ x :: L | (x,L) ∈ (L_T X n × T_list n) ]
-      end.
+(*     Fixpoint T_list (n : nat) : list (list X) := *)
+(*       match n *)
+(*       with *)
+(*       | 0 => [ [] ] *)
+(*       | S n => T_list n ++ [ x :: L | (x,L) ∈ (L_T X n × T_list n) ] *)
+(*       end. *)
 
-    Lemma T_list_cum : cumulative T_list. 
-    Proof.
-      intros ?; cbn; eauto. 
-    Qed.
+(*     Lemma T_list_cum : cumulative T_list.  *)
+(*     Proof. *)
+(*       intros ?; cbn; eauto.  *)
+(*     Qed. *)
 
-  End fixL.
+(*   End fixL. *)
 
-  Lemma T_list_el LX l :
-    exists n, l el T_list LX n.
-  Proof.
-    induction l.
-    - exists 0. cbn. eauto.
-    - destruct IHl as [n IH].
-      destruct (el_T a) as [m ?].
-      exists (1 + n + m). cbn. intros. in_app 2.
-      in_collect (a,l).
-      all: eapply cum_ge'; eauto using T_list_cum; omega. 
-  Qed.
+(*   Lemma T_list_el LX l : *)
+(*     exists n, l el T_list LX n. *)
+(*   Proof. *)
+(*     induction l. *)
+(*     - exists 0. cbn. eauto. *)
+(*     - destruct IHl as [n IH]. *)
+(*       destruct (el_T a) as [m ?]. *)
+(*       exists (1 + n + m). cbn. intros. in_app 2. *)
+(*       in_collect (a,l). *)
+(*       all: eapply cum_ge'; eauto using T_list_cum; omega.  *)
+(*   Qed. *)
   
-  Global Instance enumerable_list (LX : enumT X) : enumT (list X).
-  Proof.
-    exists (T_list LX). apply T_list_cum. apply T_list_el.
-  Defined.
+(*   Global Instance enumerable_list (LX : enumT X) : enumT (list X). *)
+(*   Proof. *)
+(*     exists (T_list LX). apply T_list_cum. apply T_list_el. *)
+(*   Defined. *)
 
-End enumerable_list.
+(* End enumerable_list. *)
 
-Lemma enumerable__T_list X : enumerable__T X -> enumerable__T (list X).
-Proof.
-  intros [LX] % enum_enumT. eapply enum_enumT. econstructor.
-  exact _.
-Qed.
+(* Lemma enumerable__T_list X : enumerable__T X -> enumerable__T (list X). *)
+(* Proof. *)
+(*   intros [LX] % enum_enumT. eapply enum_enumT. econstructor. *)
+(*   exact _. *)
+(* Qed. *)
 
-(** ** Enumerable predicates are closed under ... *)
+(* (** ** Enumerable predicates are closed under ... *) *)
 
-Lemma enumerable_disj X (p q : X -> Prop) :
-  enumerable p -> enumerable q -> enumerable (fun x => p x \/ q x).
-Proof.
-  intros [Lp] % enumerable_enum [Lq] % enumerable_enum.
-  eapply enumerable_enum.
-  exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ Lp n] ++ [ y | y ∈ Lq n] end).
-  econstructor.
-  - eauto.
-  - intros. split.
-    + intros [].
-      * eapply H in H1 as [m]. exists (1 + m). cbn. in_app 2. in_collect x. eauto.
-      * eapply H0 in H1 as [m]. exists (1 + m). cbn. in_app 3. in_collect x. eauto.
-    + intros [m]. induction m.
-      * inv H1.
-      * inv_collect; firstorder.
-Qed.  
+(* Lemma enumerable_disj X (p q : X -> Prop) : *)
+(*   enumerable p -> enumerable q -> enumerable (fun x => p x \/ q x). *)
+(* Proof. *)
+(*   intros [Lp] % enumerable_enum [Lq] % enumerable_enum. *)
+(*   eapply enumerable_enum. *)
+(*   exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ Lp n] ++ [ y | y ∈ Lq n] end). *)
+(*   econstructor. *)
+(*   - eauto. *)
+(*   - intros. split. *)
+(*     + intros []. *)
+(*       * eapply H in H1 as [m]. exists (1 + m). cbn. in_app 2. in_collect x. eauto. *)
+(*       * eapply H0 in H1 as [m]. exists (1 + m). cbn. in_app 3. in_collect x. eauto. *)
+(*     + intros [m]. induction m. *)
+(*       * inv H1. *)
+(*       * inv_collect; firstorder. *)
+(* Qed. *)
 
-Lemma enumerable_conj X (p q : X -> Prop) :
-  discrete X -> enumerable p -> enumerable q -> enumerable (fun x => p x /\ q x).
-Proof.
-  intros [] % discrete_iff [Lp] % enumerable_enum [Lq] % enumerable_enum.
-  eapply enumerable_enum.
-  exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ Lp n, x el Lq n] end).
-  econstructor.
-  - eauto.
-  - intros. split.
-    + intros []. eapply H in H1 as [m1]. eapply H0 in H2 as [m2].
-      exists (1 + m1 + m2). cbn. in_app 2. in_collect x.
-      eapply cum_ge'; eauto. firstorder. omega.
-      eapply cum_ge'; eauto. firstorder. omega.
-    + intros [m]. induction m.
-      * inv H1.
-      * inv_collect; firstorder.
-Qed.
+(* Lemma enumerable_conj X (p q : X -> Prop) : *)
+(*   discrete X -> enumerable p -> enumerable q -> enumerable (fun x => p x /\ q x). *)
+(* Proof. *)
+(*   intros [] % discrete_iff [Lp] % enumerable_enum [Lq] % enumerable_enum. *)
+(*   eapply enumerable_enum. *)
+(*   exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ Lp n, x el Lq n] end). *)
+(*   econstructor. *)
+(*   - eauto. *)
+(*   - intros. split. *)
+(*     + intros []. eapply H in H1 as [m1]. eapply H0 in H2 as [m2]. *)
+(*       exists (1 + m1 + m2). cbn. in_app 2. in_collect x. *)
+(*       eapply cum_ge'; eauto. firstorder. omega. *)
+(*       eapply cum_ge'; eauto. firstorder. omega. *)
+(*     + intros [m]. induction m. *)
+(*       * inv H1. *)
+(*       * inv_collect; firstorder. *)
+(* Qed. *)
 
-Lemma projection X Y (p : X * Y -> Prop) :
-  enumerable p -> enumerable (fun x => exists y, p (x,y)).
-Proof.
-  intros [f].
-  exists (fun n => match f n with Some (x, y) => Some x | None => None end).
-  intros; split.
-  - intros [y ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
-  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0.
-    exists y. eapply H. eauto.
-Qed.
+(* Lemma projection X Y (p : X * Y -> Prop) : *)
+(*   enumerable p -> enumerable (fun x => exists y, p (x,y)). *)
+(* Proof. *)
+(*   intros [f]. *)
+(*   exists (fun n => match f n with Some (x, y) => Some x | None => None end). *)
+(*   intros; split. *)
+(*   - intros [y ?]. eapply H in H0 as [n]. exists n. now rewrite H0. *)
+(*   - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0. *)
+(*     exists y. eapply H. eauto. *)
+(* Qed. *)
 
-Lemma projection' X Y (p : X * Y -> Prop) :
-  enumerable p -> enumerable (fun y => exists x, p (x,y)).
-Proof.
-  intros [f].
-  exists (fun n => match f n with Some (x, y) => Some y | None => None end).
-  intros y; split.
-  - intros [x ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
-  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0.
-    exists x. eapply H. eauto.
-Qed.
+(* Lemma projection' X Y (p : X * Y -> Prop) : *)
+(*   enumerable p -> enumerable (fun y => exists x, p (x,y)). *)
+(* Proof. *)
+(*   intros [f]. *)
+(*   exists (fun n => match f n with Some (x, y) => Some y | None => None end). *)
+(*   intros y; split. *)
+(*   - intros [x ?]. eapply H in H0 as [n]. exists n. now rewrite H0. *)
+(*   - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0. *)
+(*     exists x. eapply H. eauto. *)
+(* Qed. *)

--- a/theories/FOL/DecidableEnumerable.v
+++ b/theories/FOL/DecidableEnumerable.v
@@ -1,6 +1,7 @@
 (** * Decidability and Enumerability *)
 
 From Undecidability Require Export Shared.Prelim.
+From Undecidability Require Export Shared.Dec.
 From Undecidability.Synthetic Require Export Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts MoreEnumerabilityFacts.
 
 (* (* ** Definitions *) *)

--- a/theories/FOL/Deduction.v
+++ b/theories/FOL/Deduction.v
@@ -246,15 +246,14 @@ Fixpoint L_ded {b} {s : nd} (A : list (form b)) (n : nat) : list (form b) :=
   end.
 
 Opaque in_dec.
-Opaque enumT_nat.
+(* Opaque enumT_nat. *)
 
 Hint Constructors prv : core.
 
-Lemma enum_prv b s A : enum (@prv s b A) (L_ded A).
+Lemma enum_prv b s A : list_enumerator (L_ded A) (@prv s b A) .
 Proof with try (eapply cum_ge'; eauto; omega).
-  repeat split.
-  - eauto. 
-  - rename x into phi. induction 1; try congruence; subst.
+  intros phi; split.
+  - induction 1; try congruence; subst.
     + now exists 0.
     + destruct IHprv as [m1]; eauto. destruct (el_T phi1) as [m2].
       exists (1 + m1 + m2). cbn. in_app 2.
@@ -278,7 +277,7 @@ Proof with try (eapply cum_ge'; eauto; omega).
     + destruct IHprv as [m1], (el_T phi) as [m2], (el_T true) as [m3]; eauto.
       exists (1 + m1 + m2 + m3). cbn. in_app 9.
       in_collect phi...
-  - intros [m]. revert A x H; induction m; intros; cbn in *.
+  - intros [m]. revert A phi H; induction m; intros; cbn in *.
      + eauto.
      + inv_collect; eauto.
        destruct b, s; inv_collect; eauto.
@@ -286,13 +285,13 @@ Qed.
 
 Lemma enumerable_min_prv : enumerable (prv_min []).
 Proof.
-  eapply enum_count, enum_prv.
+  eapply list_enumerable_enumerable. eexists. eapply enum_prv.
 Qed.
 Lemma enumerable_intu_prv : enumerable (prv_intu []).
 Proof.
-  eapply enum_count, enum_prv.
+  eapply list_enumerable_enumerable. eexists. eapply enum_prv.
 Qed.
 Lemma enumerable_class_prv : enumerable (prv_class []).
 Proof.
-  eapply enum_count, enum_prv.
+  eapply list_enumerable_enumerable. eexists. eapply enum_prv.
 Qed.

--- a/theories/FOL/FOL.v
+++ b/theories/FOL/FOL.v
@@ -61,16 +61,14 @@ Fixpoint L_term n : list term :=
   | S n => L_term n ++ [V n; P n] ++ [ t_f b t | (b,t) ∈ (L_T bool n × L_term n) ]
   end.
 
-Instance enumT_term : enumT term.
+Instance enumT_term : list_enumerator__T L_term term.
 Proof.
-  exists L_term.
-  - intros ?; cbn; eauto.
-  - intros t. induction t.
-    + exists (S v); cbn; eauto.
-    + exists (S p); cbn; eauto.
-    + destruct IHt as [m1], (el_T b) as [m2].
-      exists (1 + m1 + m2). cbn. in_app 4. in_collect (b, t); eapply cum_ge'; eauto; omega.
-    + exists 0. cbn; eauto.
+  intros t. induction t.
+  + exists (S v); cbn; eauto.
+  + exists (S p); cbn; eauto.
+  + destruct IHt as [m1], (el_T b) as [m2].
+    exists (1 + m1 + m2). cbn. in_app 4. in_collect (b, t); eapply cum_ge'; eauto; omega.
+  + exists 0. cbn; eauto.
 Qed.
 
 Fixpoint L_form {b} n : list (form b) :=
@@ -87,19 +85,17 @@ Fixpoint L_form {b} n : list (form b) :=
                end
   end.
 
-Instance enumT_form {b} : enumT (form b).
+Instance enumT_form {b} : list_enumerator__T L_form (form b).
 Proof with (try eapply cum_ge'; eauto; omega).
-  exists L_form.
-  - eauto.
-  - intros phi. induction phi.
-    + destruct (el_T t) as [m1], (el_T t0) as [m2]. exists (1 + m1 + m2). cbn.
-      in_app 3. in_collect (t, t0)...
-    + exists 1. cbn; eauto.
-    + exists 1; cbn; firstorder.
-    + destruct IHphi1 as [m1], IHphi2 as [m2]. exists (1 + m1 + m2). cbn.
-      in_app 4. in_collect (phi1, phi2)...
-    + destruct IHphi as [m1], (el_T n) as [m2]. exists (1 + m1 + m2). cbn -[L_T].
-      in_app 5. in_collect (n, phi)...
+  intros phi. induction phi.
+  + destruct (el_T t) as [m1], (el_T t0) as [m2]. exists (1 + m1 + m2). cbn.
+    in_app 3. in_collect (t, t0)...
+  + exists 1. cbn; eauto.
+  + exists 1; cbn; firstorder.
+  + destruct IHphi1 as [m1], IHphi2 as [m2]. exists (1 + m1 + m2). cbn.
+    in_app 4. in_collect (phi1, phi2)...
+  + destruct IHphi as [m1], (el_T n) as [m2]. exists (1 + m1 + m2). cbn -[L_T].
+    in_app 5. in_collect (n, phi)...
 Qed.
 
 Instance dec_term : eq_dec term.

--- a/theories/FOL/Infinite.v
+++ b/theories/FOL/Infinite.v
@@ -170,7 +170,7 @@ Section Inf.
   Lemma F_lt n m :
     n < m -> F n el LL m.
   Proof.
-    intros H. apply cum_ge' with (n0:=S n).
+    intros H. apply (cum_ge' (n:=S n)).
     - apply LL_cum.
     - apply F_el.
     - omega.

--- a/theories/FOL/MarkovPost.v
+++ b/theories/FOL/MarkovPost.v
@@ -66,7 +66,7 @@ Lemma decMP_to_eMP :
   (forall p : nat -> Prop, decidable p -> stable (exists n, p n)) -> (forall X (p : X -> Prop), enumerable p -> stable (exists n, p n)).
 Proof.
   intros dMP X p [e He] ?. destruct (dMP (fun n => e n <> None)).
-  - exists (fun n => match e n with Some _ => true | _ => false end). intros; destruct (e x); firstorder congruence.
+  - exists (fun n => match e n with Some _ => true | _ => false end). intros x; destruct (e x); firstorder congruence.
   - intros ?. eapply H. intros [x]. eapply H0. eapply He in H1 as [n].
     exists n. congruence.
   - destruct (e x) eqn:E; try congruence. exists x0. eapply He. now exists x. 
@@ -76,7 +76,7 @@ Lemma eMP_to_MP :
   (forall X (p : X -> Prop), enumerable p -> stable (exists n, p n)) -> MP.
 Proof.
   intros eMP f ?. destruct (eMP nat (fun n => f n = true)).
-  - eapply dec_count_enum. now exists f. exists Some. eauto.
+  - eapply dec_count_enum. now exists f. exists Some. red. eauto.
   - firstorder. 
   - eauto.
 Qed.
@@ -84,10 +84,11 @@ Qed.
 Lemma MP_enum_stable X (p : X -> Prop) :
   MP -> enumerable p -> discrete X -> forall x, stable (p x).
 Proof.
+  unfold enumerable, discrete, decidable, decider, enumerator, reflects.
   intros MP [f Hf] [d Hd] x. eapply MP_to_decMP with (p := fun n => f n = Some x) in MP.
   - intros H. rewrite Hf in *. now eapply MP.
   - exists (fun n => match f n with Some x' => d (x, x') | _ => false end).
-    intros x0. destruct (f x0). rewrite <- (Hd (x,x1)). split. inversion 1. eauto. intros ->. eauto.
+    intros x0. destruct (f x0). red. rewrite <- (Hd (x,x1)). split. inversion 1. eauto. intros ->. eauto.
     split; inversion 1.
 Qed.
 
@@ -114,7 +115,7 @@ Proof.
   - eapply discrete_iff. econstructor. exact _.
   - change (enumerable (fun m => exists n, (fun (x : nat * nat) => p (snd x)) (m,n))).
     apply projection. eapply dec_count_enum; try apply enumerable_nat_nat.
-    apply decidable_iff. constructor. intros [n m]. exact _.
+    apply decidable_iff. constructor. intros [n m]. exact _. eauto.
   - exists (fun _ => None). intros x. firstorder congruence.
   - contradiction.
 Qed.
@@ -132,5 +133,3 @@ Proof.
   - intros ? ? ? ? ?. eapply weakPost; eauto.
     eapply MP_Post; eauto.
 Qed.
-
-  

--- a/theories/FOL/Reductions.v
+++ b/theories/FOL/Reductions.v
@@ -5,13 +5,14 @@ From Undecidability Require Export Problems.Reduction DecidableEnumerable.
 Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> decidable q -> decidable p.
 Proof.
+  unfold decidable, decider, reduces, reduction, reflects.
   intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0.
 Qed.
 
 Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y).
 Proof.
-  intros [f]. exists f. intros x. now rewrite H.
+  intros [f]. exists f. intros x. red in H. now rewrite H.
 Qed.
 
 Section enum_red.

--- a/theories/FOL/Reductions.v
+++ b/theories/FOL/Reductions.v
@@ -1,79 +1,81 @@
 (** * Many-One Reductions *)
 
-From Undecidability Require Export Problems.Reduction DecidableEnumerable.
+From Undecidability.Synthetic Require Export Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts ReducibilityFacts.
 
-Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) :
-  p ⪯ q -> decidable q -> decidable p.
-Proof.
-  unfold decidable, decider, reduces, reduction, reflects.
-  intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0.
-Qed.
+(* From Undecidability Require Export Problems.Reduction DecidableEnumerable. *)
 
-Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
-  p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y).
-Proof.
-  intros [f]. exists f. intros x. red in H. now rewrite H.
-Qed.
+(* Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) : *)
+(*   p ⪯ q -> decidable q -> decidable p. *)
+(* Proof. *)
+(*   unfold decidable, decider, reduces, reduction, reflects. *)
+(*   intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0. *)
+(* Qed. *)
 
-Section enum_red.
+(* Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) : *)
+(*   p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y). *)
+(* Proof. *)
+(*   intros [f]. exists f. intros x. red in H. now rewrite H. *)
+(* Qed. *)
 
-  Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop).
-  Variables (f : X -> Y) (Hf : forall x, p x <-> q (f x)).
+(* Section enum_red. *)
 
-  Variables (Lq : _) (qe : enum q Lq).
+(*   Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop). *)
+(*   Variables (f : X -> Y) (Hf : forall x, p x <-> q (f x)). *)
 
-  Variables (x0 : X).
+(*   Variables (Lq : _) (qe : enum q Lq). *)
+
+(*   Variables (x0 : X). *)
   
-  Variables (d : eq_dec Y).
+(*   Variables (d : eq_dec Y). *)
   
-  Fixpoint L (LX : enumT X) n :=
-    match n with
-    | 0 => []
-    | S n => L LX n ++ [ x | x ∈ L_T X n , f x el Lq n ]
-    end.
+(*   Fixpoint L (LX : enumT X) n := *)
+(*     match n with *)
+(*     | 0 => [] *)
+(*     | S n => L LX n ++ [ x | x ∈ L_T X n , f x el Lq n ] *)
+(*     end. *)
 
-  Lemma enum_red LX :
-    enum p (L LX).
-  Proof.    
-    split.
-    - intros ?. cbn; eauto. 
-    - split.
-      + intros H.
-        eapply Hf in H. eapply qe in H as [m1]. destruct (el_T x) as [m2 ?]. 
-        exists (1 + m1 + m2). cbn. in_app 2.
-        in_collect x; eapply cum_ge'; eauto; try omega.
-        eapply qe.
-      + intros [m H]. induction m.
-        * inv H.
-        * cbn in H. inv_collect. 
-          eapply Hf. eapply qe. eauto.
-  Qed.
+(*   Lemma enum_red LX : *)
+(*     enum p (L LX). *)
+(*   Proof.     *)
+(*     split. *)
+(*     - intros ?. cbn; eauto.  *)
+(*     - split. *)
+(*       + intros H. *)
+(*         eapply Hf in H. eapply qe in H as [m1]. destruct (el_T x) as [m2 ?].  *)
+(*         exists (1 + m1 + m2). cbn. in_app 2. *)
+(*         in_collect x; eapply cum_ge'; eauto; try omega. *)
+(*         eapply qe. *)
+(*       + intros [m H]. induction m. *)
+(*         * inv H. *)
+(*         * cbn in H. inv_collect.  *)
+(*           eapply Hf. eapply qe. eauto. *)
+(*   Qed. *)
 
-End enum_red.
+(* End enum_red. *)
 
-Lemma enumerable_red X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> discrete Y -> enumerable q -> enumerable p.
-Proof.
-  intros [f] [] % enum_enumT [] % discrete_iff [L] % enumerable_enum.
-  eapply enum_count, enum_red with (Y := Y); eauto.
-Qed.
+(* Lemma enumerable_red X Y (p : X -> Prop) (q : Y -> Prop) : *)
+(*   p ⪯ q -> enumerable__T X -> discrete Y -> enumerable q -> enumerable p. *)
+(* Proof. *)
+(*   intros [f] [] % enum_enumT [] % discrete_iff [L] % enumerable_enum. *)
+(*   eapply enum_count, enum_red with (Y := Y); eauto. *)
+(* Qed. *)
 
-Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) ->
-  ~ decidable q /\ ~ decidable (compl q).
-Proof.
-  intros. split; intros ?.
-  - eapply H1. eapply dec_red in H2; eauto.
-    eapply dec_compl in H2. eapply dec_count_enum; eauto.
-  - eapply H1. eapply dec_red in H2; eauto.
-    eapply dec_count_enum; eauto. now eapply red_comp.
-Qed.
+(* Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) : *)
+(*   p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) -> *)
+(*   ~ decidable q /\ ~ decidable (compl q). *)
+(* Proof. *)
+(*   intros. split; intros ?. *)
+(*   - eapply H1. eapply dec_red in H2; eauto. *)
+(*     eapply dec_compl in H2. eapply dec_count_enum; eauto. *)
+(*   - eapply H1. eapply dec_red in H2; eauto. *)
+(*     eapply dec_count_enum; eauto. now eapply red_comp. *)
+(* Qed. *)
 
-Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) -> discrete Y ->
-  ~ enumerable (compl q).
-Proof.
-  intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto.
-  now eapply red_comp.
-Qed.
+(* Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) : *)
+(*   p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) -> discrete Y -> *)
+(*   ~ enumerable (compl q). *)
+(* Proof. *)
+(*   intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto. *)
+(*   now eapply red_comp. *)
+(* Qed. *)
 

--- a/theories/FOL/SemiDecidabilityFacts.v
+++ b/theories/FOL/SemiDecidabilityFacts.v
@@ -1,0 +1,18 @@
+Require Import Undecidability.Synthetic.DecidabilityFacts.
+
+
+Lemma decidable_semi_decidable {X} {p : X -> Prop} :
+  decidable p -> semi_decidable p.
+Proof.
+  intros [f H].
+  exists (fun x n => f x). intros x.
+  unfold decider, reflects in H.
+  rewrite H. firstorder. econstructor.
+Qed.
+
+Lemma decidable_compl_semi_decidable {X} {p : X -> Prop} :
+  decidable p -> semi_decidable (compl p).
+Proof.
+  intros H.
+  now eapply decidable_semi_decidable, decidable_compl.
+Qed.

--- a/theories/FOLP/FullFOL.v
+++ b/theories/FOLP/FullFOL.v
@@ -400,13 +400,12 @@ Definition tmap {S1 S2 : Signature} (f : @form S1 -> @form S2) (T : @theory S1) 
   fun phi => exists psi, T psi /\ f psi = phi.
 
 Lemma enum_tmap {S1 S2 : Signature} (f : @form S1 -> @form S2) (T : @theory S1) L :
-  enum T L -> enum (tmap f T) (L >> List.map f).
+  list_enumerator L T -> list_enumerator(L >> List.map f) (tmap f T).
 Proof.
-  intros []. split; unfold ">>".
-  - intros n. destruct (H n) as [A ->]. exists (List.map f A). apply map_app.
-  - intros x; split.
-    + intros (phi & [m Hin] % H0 & <-). exists m. apply in_map_iff. firstorder.
-    + intros (m & (phi & <- & Hphi) % in_map_iff). firstorder.
+  intros H0. unfold ">>".
+  intros x; split.
+  + intros (phi & [m Hin] % H0 & <-). exists m. apply in_map_iff. firstorder.
+  + intros (m & (phi & <- & Hphi) % in_map_iff). firstorder.
 Qed.
 
 Lemma tmap_contains_L {S1 S2 : Signature} (f : @form S1 -> @form S2) T A :

--- a/theories/FOLP/FullTarski.v
+++ b/theories/FOLP/FullTarski.v
@@ -18,7 +18,7 @@ Section Tarski.
         i_P : forall P : Preds, Vector.t domain (pred_ar P) -> Prop ;
       }.
 
-    Definition env := fin -> domain.
+    Definition env := nat -> domain.
 
     Context {I : interp }.
     Fixpoint eval (rho : env) (t : term) : domain :=

--- a/theories/FOLP/Syntax.v
+++ b/theories/FOLP/Syntax.v
@@ -14,55 +14,55 @@ Section fix_sig.
 Context {Sigma : Signature}.
 
 Inductive term  : Type :=
-  | var_term : (fin)  -> term
+  | var_term : (nat)  -> term
   | Func : forall (f : Funcs), Vector.t term (fun_ar f) -> term .
 
 Definition congr_Func { f : Funcs }  { s0 : Vector.t term (fun_ar f) } { t0 : Vector.t term (fun_ar f)} (H1 : s0 = t0) : Func  f s0 = Func  f t0 :=
   (eq_trans) (eq_refl) ((ap) (fun x => Func  f x) H1).
 
-Fixpoint subst_term   (sigmaterm : (fin)  -> term ) (s : term ) : _ :=
+Fixpoint subst_term   (sigmaterm : (nat)  -> term ) (s : term ) : _ :=
     match s with
     | var_term  s => sigmaterm s
     | Func  f s0 => Func  f (Vector.map (subst_term sigmaterm) s0)
     end.
 
-Definition up_term_term   (sigma : (fin)  -> term ) : _ :=
+Definition up_term_term   (sigma : (nat)  -> term ) : _ :=
   (scons) ((var_term ) (var_zero)) ((funcomp) (subst_term ((funcomp) (var_term ) (shift))) sigma).
 
 
-Definition upId_term_term  (sigma : (fin)  -> term ) (Eq : forall x, sigma x = (var_term ) x) : forall x, (up_term_term sigma) x = (var_term ) x :=
+Definition upId_term_term  (sigma : (nat)  -> term ) (Eq : forall x, sigma x = (var_term ) x) : forall x, (up_term_term sigma) x = (var_term ) x :=
   fun n => match n with
   | S fin_n => (ap) (subst_term ((funcomp) (var_term ) (shift))) (Eq fin_n)
   | 0 => eq_refl
   end.
 
 
-Fixpoint idSubst_term  (sigmaterm : (fin)  -> term ) (Eqterm : forall x, sigmaterm x = (var_term ) x) (s : term ) : subst_term sigmaterm s = s :=
+Fixpoint idSubst_term  (sigmaterm : (nat)  -> term ) (Eqterm : forall x, sigmaterm x = (var_term ) x) (s : term ) : subst_term sigmaterm s = s :=
     match s with
     | var_term  s => Eqterm s
     | Func  f s0 => congr_Func ((vec_id (idSubst_term sigmaterm Eqterm)) s0)
     end.
 
-Definition upExt_term_term   (sigma : (fin)  -> term ) (tau : (fin)  -> term ) (Eq : forall x, sigma x = tau x) : forall x, (up_term_term sigma) x = (up_term_term tau) x :=
+Definition upExt_term_term   (sigma : (nat)  -> term ) (tau : (nat)  -> term ) (Eq : forall x, sigma x = tau x) : forall x, (up_term_term sigma) x = (up_term_term tau) x :=
   fun n => match n with
   | S fin_n => (ap) (subst_term ((funcomp) (var_term) (shift))) (Eq fin_n)
   | 0 => eq_refl
   end.
 
 
-Fixpoint ext_term   (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (Eqterm : forall x, sigmaterm x = tauterm x) (s : term ) : subst_term sigmaterm s = subst_term tauterm s :=
+Fixpoint ext_term   (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (Eqterm : forall x, sigmaterm x = tauterm x) (s : term ) : subst_term sigmaterm s = subst_term tauterm s :=
     match s with
     | var_term  s => Eqterm s
     | Func  f s0 => congr_Func ((vec_ext (ext_term sigmaterm tauterm Eqterm)) s0)
     end.
 
-Fixpoint compSubstSubst_term    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (thetaterm : (fin)  -> term ) (Eqterm : forall x, ((funcomp) (subst_term tauterm) sigmaterm) x = thetaterm x) (s : term ) : subst_term tauterm (subst_term sigmaterm s) = subst_term thetaterm s :=
+Fixpoint compSubstSubst_term    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (thetaterm : (nat)  -> term ) (Eqterm : forall x, ((funcomp) (subst_term tauterm) sigmaterm) x = thetaterm x) (s : term ) : subst_term tauterm (subst_term sigmaterm s) = subst_term thetaterm s :=
     match s with
     | var_term  s => Eqterm s
     | Func  f s0 => congr_Func ((vec_comp (compSubstSubst_term sigmaterm tauterm thetaterm Eqterm)) s0)
     end.
 
-Definition up_subst_subst_term_term    (sigma : (fin)  -> term ) (tauterm : (fin)  -> term ) (theta : (fin)  -> term ) (Eq : forall x, ((funcomp) (subst_term tauterm) sigma) x = theta x) : forall x, ((funcomp) (subst_term (up_term_term tauterm)) (up_term_term sigma)) x = (up_term_term theta) x :=
+Definition up_subst_subst_term_term    (sigma : (nat)  -> term ) (tauterm : (nat)  -> term ) (theta : (nat)  -> term ) (Eq : forall x, ((funcomp) (subst_term tauterm) sigma) x = theta x) : forall x, ((funcomp) (subst_term (up_term_term tauterm)) (up_term_term sigma)) x = (up_term_term theta) x :=
   fun n => match n with
   | S fin_n => (eq_trans) (compSubstSubst_term ((funcomp) (var_term) (shift)) (up_term_term tauterm) ((funcomp) (up_term_term tauterm) (shift)) (fun x => eq_refl) (sigma fin_n)) ((eq_trans) ((eq_sym) (compSubstSubst_term tauterm ((funcomp) (var_term) (shift)) ((funcomp) (subst_term ((funcomp) (var_term ) (shift))) tauterm) (fun x => eq_refl) (sigma fin_n))) ((ap) (subst_term ((funcomp) (var_term ) (shift))) (Eq fin_n)))
   | 0 => eq_refl
@@ -71,13 +71,13 @@ Definition up_subst_subst_term_term    (sigma : (fin)  -> term ) (tauterm : (fin
 Lemma instId_term  : subst_term (var_term ) = (@id) (term ) .
 Proof. exact ((FunctionalExtensionality.functional_extensionality _ _ ) (fun x => idSubst_term (var_term ) (fun n => eq_refl) (((@id) (term )) x))). Qed.
 
-Lemma varL_term   (sigmaterm : (fin)  -> term ) : (funcomp) (subst_term sigmaterm) (var_term ) = sigmaterm .
+Lemma varL_term   (sigmaterm : (nat)  -> term ) : (funcomp) (subst_term sigmaterm) (var_term ) = sigmaterm .
 Proof. exact ((FunctionalExtensionality.functional_extensionality _ _ ) (fun x => eq_refl)). Qed.
 
-Lemma compComp_term    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (s : term ) : subst_term tauterm (subst_term sigmaterm s) = subst_term ((funcomp) (subst_term tauterm) sigmaterm) s .
+Lemma compComp_term    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (s : term ) : subst_term tauterm (subst_term sigmaterm s) = subst_term ((funcomp) (subst_term tauterm) sigmaterm) s .
 Proof. exact (compSubstSubst_term sigmaterm tauterm (_) (fun n => eq_refl) s). Qed.
 
-Lemma compComp'_term    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) : (funcomp) (subst_term tauterm) (subst_term sigmaterm) = subst_term ((funcomp) (subst_term tauterm) sigmaterm) .
+Lemma compComp'_term    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) : (funcomp) (subst_term tauterm) (subst_term sigmaterm) = subst_term ((funcomp) (subst_term tauterm) sigmaterm) .
 Proof. exact ((FunctionalExtensionality.functional_extensionality _ _ ) (fun n => compComp_term sigmaterm tauterm n)). Qed.
 
 Inductive form  : Type :=
@@ -98,7 +98,7 @@ Definition congr_Impl  { s0 : form  } { s1 : form  } { t0 : form  } { t1 : form 
 Definition congr_All  { s0 : form  } { t0 : form  } (H1 : s0 = t0) : All  s0 = All  t0 :=
   (eq_trans) (eq_refl) ((ap) (fun x => All  x) H1).
 
-Fixpoint subst_form   (sigmaterm : (fin)  -> term ) (s : form ) : _ :=
+Fixpoint subst_form   (sigmaterm : (nat)  -> term ) (s : form ) : _ :=
     match s with
     | Fal   => Fal
     | Pred  P s0 => Pred  P ((Vector.map (subst_term sigmaterm)) s0)
@@ -106,7 +106,7 @@ Fixpoint subst_form   (sigmaterm : (fin)  -> term ) (s : form ) : _ :=
     | All  s0 => All  ((subst_form (up_term_term sigmaterm)) s0)
     end.
 
-Fixpoint idSubst_form  (sigmaterm : (fin)  -> term ) (Eqterm : forall x, sigmaterm x = (var_term ) x) (s : form ) : subst_form sigmaterm s = s :=
+Fixpoint idSubst_form  (sigmaterm : (nat)  -> term ) (Eqterm : forall x, sigmaterm x = (var_term ) x) (s : form ) : subst_form sigmaterm s = s :=
     match s with
     | Fal   => congr_Fal
     | Pred  P s0 => congr_Pred ((vec_id (idSubst_term sigmaterm Eqterm)) s0)
@@ -114,7 +114,7 @@ Fixpoint idSubst_form  (sigmaterm : (fin)  -> term ) (Eqterm : forall x, sigmate
     | All  s0 => congr_All ((idSubst_form (up_term_term sigmaterm) (upId_term_term (_) Eqterm)) s0)
     end.
 
-Fixpoint ext_form   (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (Eqterm : forall x, sigmaterm x = tauterm x) (s : form ) : subst_form sigmaterm s = subst_form tauterm s :=
+Fixpoint ext_form   (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (Eqterm : forall x, sigmaterm x = tauterm x) (s : form ) : subst_form sigmaterm s = subst_form tauterm s :=
     match s with
     | Fal   => congr_Fal
     | Pred  P s0 => congr_Pred ((vec_ext (ext_term sigmaterm tauterm Eqterm)) s0)
@@ -122,7 +122,7 @@ Fixpoint ext_form   (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (E
     | All  s0 => congr_All ((ext_form (up_term_term sigmaterm) (up_term_term tauterm) (upExt_term_term (_) (_) Eqterm)) s0)
     end.
 
-Fixpoint compSubstSubst_form    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (thetaterm : (fin)  -> term ) (Eqterm : forall x, ((funcomp) (subst_term tauterm) sigmaterm) x = thetaterm x) (s : form ) : subst_form tauterm (subst_form sigmaterm s) = subst_form thetaterm s :=
+Fixpoint compSubstSubst_form    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (thetaterm : (nat)  -> term ) (Eqterm : forall x, ((funcomp) (subst_term tauterm) sigmaterm) x = thetaterm x) (s : form ) : subst_form tauterm (subst_form sigmaterm s) = subst_form thetaterm s :=
     match s with
     | Fal   => congr_Fal
     | Pred  P s0 => congr_Pred ((vec_comp (compSubstSubst_term sigmaterm tauterm thetaterm Eqterm)) s0)
@@ -133,19 +133,19 @@ Fixpoint compSubstSubst_form    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  
 Lemma instId_form  : subst_form (var_term ) = (@id) (form ) .
 Proof. exact ((FunctionalExtensionality.functional_extensionality _ _ ) (fun x => idSubst_form (var_term ) (fun n => eq_refl) (((@id) (form )) x))). Qed.
 
-Lemma compComp_form    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) (s : form ) : subst_form tauterm (subst_form sigmaterm s) = subst_form ((funcomp) (subst_term tauterm) sigmaterm) s .
+Lemma compComp_form    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) (s : form ) : subst_form tauterm (subst_form sigmaterm s) = subst_form ((funcomp) (subst_term tauterm) sigmaterm) s .
 Proof. exact (compSubstSubst_form sigmaterm tauterm (_) (fun n => eq_refl) s). Qed.
 
-Lemma compComp'_form    (sigmaterm : (fin)  -> term ) (tauterm : (fin)  -> term ) : (funcomp) (subst_form tauterm) (subst_form sigmaterm) = subst_form ((funcomp) (subst_term tauterm) sigmaterm) .
+Lemma compComp'_form    (sigmaterm : (nat)  -> term ) (tauterm : (nat)  -> term ) : (funcomp) (subst_form tauterm) (subst_form sigmaterm) = subst_form ((funcomp) (subst_term tauterm) sigmaterm) .
 Proof. exact ((FunctionalExtensionality.functional_extensionality _ _ ) (fun n => compComp_form sigmaterm tauterm n)). Qed.
 
 End fix_sig.
 
-Instance Subst_term (Sigma : Signature)   : Subst1 ((fin)  -> term ) (term ) (term ) := @subst_term Sigma.
+Instance Subst_term (Sigma : Signature)   : Subst1 ((nat)  -> term ) (term ) (term ) := @subst_term Sigma.
 
-Instance Subst_form (Sigma : Signature)   : Subst1 ((fin)  -> term ) (form ) (form ) := @subst_form Sigma.
+Instance Subst_form (Sigma : Signature)   : Subst1 ((nat)  -> term ) (form ) (form ) := @subst_form Sigma.
 
-Instance VarInstance_term (Sigma : Signature) : Var ((fin) ) (term ) := @var_term Sigma.
+Instance VarInstance_term (Sigma : Signature) : Var ((nat) ) (term ) := @var_term Sigma.
 
 Notation "x '__term'" := (var_term x) (at level 5, format "x __term") : subst_scope.
 

--- a/theories/FOLP/unscoped.v
+++ b/theories/FOLP/unscoped.v
@@ -4,7 +4,7 @@
 
 From Undecidability.FOLP Require Export axioms.
 
-Notation fin := nat.
+(* Notation fin := nat. *)
 Definition shift  := S.
 
 Definition scons {X: Type} (x : X) (xi : nat -> X) :=

--- a/theories/H10/FRACTRAN_DIO.v
+++ b/theories/H10/FRACTRAN_DIO.v
@@ -29,7 +29,7 @@ Proof.
     intros x; exists (f x); auto.
   + intros [f].
     exists (fun x => proj1_sig (f x)).
-    intros; apply (proj2_sig (f x)).
+    intros x; apply (proj2_sig (f x)).
 Qed.
 
 (** A diophantine logic satisfiability question is given

--- a/theories/ILL/UNDEC.v
+++ b/theories/ILL/UNDEC.v
@@ -75,55 +75,55 @@ Proof.
   exact EILL_ILL_PROVABILITY.
 Qed.
 
-(** * Formal Undecidability *)
+(* * Formal Undecidability *)
 
-Module Def_of_undec.
+(* Module Def_of_undec. *)
 
-  Inductive dec {X} (P : X -> Prop) : Prop := is_dec (H : forall x, { P x} + {~ P x}).
+(*   Inductive dec {X} (P : X -> Prop) : Prop := is_dec (H : forall x, { P x} + {~ P x}). *)
 
-  Notation compl P := (fun x => ~ P x).
+(*   Notation compl P := (fun x => ~ P x). *)
 
-  Notation "Q ⪯T P" := (dec (P) -> dec (Q)) (at level 20).
+(*   Notation "Q ⪯T P" := (dec (P) -> dec (Q)) (at level 20). *)
 
-  Lemma red_turing X Y (P : X -> Prop) (Q : Y -> Prop) : P ⪯ Q -> P ⪯T Q.
-  Proof.
-    intros (f & Hf) [ H ].
-    exists.
-    intros x; destruct (H (f x)) as [ H1 | H1 ]; 
-      rewrite <- Hf in H1; tauto.
-  Qed.
+(*   (* Lemma red_turing X Y (P : X -> Prop) (Q : Y -> Prop) : P ⪯ Q -> P ⪯T Q. *) *)
+(*   (* Proof. *) *)
+(*   (*   intros (f & Hf) [ H ]. *) *)
+(*   (*   exists. *) *)
+(*   (*   intros x; destruct (H (f x)) as [ H1 | H1 ];  *) *)
+(*   (*     rewrite <- Hf in H1; tauto. *) *)
+(*   (* Qed. *) *)
 
-  (* Lemma red_turing_compl X Y (Q : Y -> Prop) (P : X -> Prop) : *)
-  (*   Q ⪯ P -> compl Q ⪯T compl P. *)
-  (* Proof. *)
-  (*   intros [f] [d]. econstructor. intros x. *)
-  (*   destruct (d (f x)). *)
-  (*   + left. firstorder. *)
-  (*   + right. firstorder. *)
-  (* Qed. *)
+(*   (* Lemma red_turing_compl X Y (Q : Y -> Prop) (P : X -> Prop) : *) *)
+(*   (*   Q ⪯ P -> compl Q ⪯T compl P. *) *)
+(*   (* Proof. *) *)
+(*   (*   intros [f] [d]. econstructor. intros x. *) *)
+(*   (*   destruct (d (f x)). *) *)
+(*   (*   + left. firstorder. *) *)
+(*   (*   + right. firstorder. *) *)
+(*   (* Qed. *) *)
   
-  Inductive undec : forall X, (X -> Prop) -> Prop :=
-    undec_seed : undec PCP
-  | undec_red X (P : X -> Prop) Y (Q : Y -> Prop) : Q ⪯T P -> undec Q -> undec P.
+(*   Inductive undec : forall X, (X -> Prop) -> Prop := *)
+(*     undec_seed : undec PCP *)
+(*   | undec_red X (P : X -> Prop) Y (Q : Y -> Prop) : Q ⪯T P -> undec Q -> undec P. *)
 
-  Lemma red_undec  X Y (Q : Y -> Prop) (P : X -> Prop) :
-    Q ⪯ P -> undec Q -> undec P.
-  Proof.
-    intros. eapply undec_red. eapply red_turing; eauto. eauto.
-  Qed.
+(*   Lemma red_undec  X Y (Q : Y -> Prop) (P : X -> Prop) : *)
+(*     Q ⪯ P -> undec Q -> undec P. *)
+(*   Proof. *)
+(*     intros. eapply undec_red. eapply red_turing; eauto. eauto. *)
+(*   Qed. *)
     
-  Lemma undec_compl X (P : X -> Prop) :
-    undec (compl P) -> undec P.
-  Proof.
-    intros. eapply undec_red; try eassumption. firstorder.
-  Qed.
+(*   Lemma undec_compl X (P : X -> Prop) : *)
+(*     undec (compl P) -> undec P. *)
+(*   Proof. *)
+(*     intros. eapply undec_red; try eassumption. firstorder. *)
+(*   Qed. *)
   
-  Lemma undec_PCP X (P : X -> Prop) :
-    undec P <-> (PCP ⪯T P).
-  Proof.
-    split; intros.
-    - induction H; eauto.
-    - eauto using undec. 
-  Qed.
+(*   Lemma undec_PCP X (P : X -> Prop) : *)
+(*     undec P <-> (PCP ⪯T P). *)
+(*   Proof. *)
+(*     split; intros. *)
+(*     - induction H; eauto. *)
+(*     - eauto using undec.  *)
+(*   Qed. *)
     
-End Def_of_undec.
+(* End Def_of_undec. *)

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -201,9 +201,9 @@ Qed.
 
 Definition F1 {X} (T : nat -> list X) :=  (fun n => let (n, m) := unembed n in nth_error (T n) m).
 
-Instance term_F1 {X} `{registered X} : computable F1.
+Instance term_F1 {X} {H : registered X} :  @computable ((nat -> list X) -> nat -> option X) ((! nat ~> ! list X) ~> ! nat ~> ! option X) (@F1 X).
 Proof.
-  extract.
+  extract.  
 Qed.
 
 Lemma L_enumerable_enum {X} `{registered X} (p : X -> Prop) :

--- a/theories/L/Reductions/H10_to_L.v
+++ b/theories/L/Reductions/H10_to_L.v
@@ -49,12 +49,12 @@ Fixpoint L_poly n : list (poly) :=
   
 Instance term_L_poly : computable L_poly. extract. Qed.
 
-Program Instance enum_poly :
-  enumT (poly) := {| L_T := L_poly |}.
-Next Obligation.
-  rename x into p. induction p.
+Instance enum_poly :
+  list_enumerator__T L_poly poly.
+Proof.
+  intros p. induction p.
   + destruct (el_T n) as [m].
-    exists (1 + m). cbn. in_app 2. eauto.
+    exists (1 + m). cbn. in_app 2. in_collect n. exact H.
   + destruct (el_T n) as [m].
     exists (1 + m). cbn. in_app 3. eauto.
   + destruct IHp1 as [m1]. destruct IHp2 as [m2].
@@ -149,10 +149,16 @@ Proof.
   extract.
 Qed.
 
-Definition T_list_nat := @T_list nat _.
+Definition T_list_nat := @L_list nat opt_to_list.
+
+Instance computable_cumul : computable cumul.
+Proof.
+  extract.
+Qed.
 
 Instance term_T_list : computable T_list_nat.
 Proof.
+  unfold T_list_nat, L_list.
   change (computable
     (fix T_list (n : nat) : list (list nat) :=
        match n with
@@ -169,12 +175,12 @@ Proof.
   instantiate (1 := fun '( (p1,p2), L) => eval p1 L = eval p2 L).
   2:{ intros []. firstorder. }
   eapply L_enumerable_enum.
-  exists (fix L n := match n with 0 => [] | S n => L n ++ filter test_eq (list_prod (list_prod (L_T poly n) (L_T poly n)) (L_T (list nat) n)) end)%list.
+  exists (fix L n := match n with 0 => [] | S n => L n ++ filter test_eq (list_prod (list_prod (L_poly n) (L_poly n)) (T_list_nat  n)) end)%list.
   repeat split.
-  - cbn. change (T_list enumT_nat) with (T_list_nat). extract.
+  - extract.
   - eauto.
   - destruct x as [[p1 p2] L]. intros.
-    destruct (el_T p1) as [m1], (el_T p2) as [m2], (el_T L) as [m3].
+    destruct (enum_poly p1) as [m1], (enum_poly p2) as [m2], (enumerator__T_list opt_to_list _ L) as [m3].
     exists (1 + m1 + m2 + m3). in_app 2.
     fold plus. eapply in_filter_iff. split.
     + rewrite !in_prod_iff. repeat split; eapply cum_ge'; try eassumption; eauto; omega.

--- a/theories/L/Reductions/H10_to_L.v
+++ b/theories/L/Reductions/H10_to_L.v
@@ -151,7 +151,7 @@ Qed.
 
 Definition T_list_nat := @L_list nat opt_to_list.
 
-Instance computable_cumul : computable cumul.
+Instance computable_cumul {X} `{registered X} : computable (@cumul X).
 Proof.
   extract.
 Qed.

--- a/theories/PCP/PCP_undec.v
+++ b/theories/PCP/PCP_undec.v
@@ -1,4 +1,5 @@
 Require Import Undecidability.PCP.PCP.
+Require Import Undecidability.Synthetic.Undecidability.
 
 From Undecidability.PCP.Reductions Require 
   SR_to_MPCP MPCP_to_MPCPb MPCP_to_PCP PCP_to_PCPb PCPb_iff_iPCPb PCPb_iff_dPCPb.
@@ -9,8 +10,10 @@ Require Import Undecidability.Problems.Reduction.
 Require Undecidability.SR.SR_undec.
 
 (** The modified Post correspondence problem is undecidable. *)
-Lemma MPCP_undec : HaltTM 1 ⪯ MPCP.
+Lemma MPCP_undec : undecidable MPCP.
 Proof.
+  eapply undecidability_from_reducibility.
+  eapply undecidability_HaltTM.
   eapply reduces_transitive.
   exact SR_undec.SR_undec.
   exact SR_to_MPCP.reduction.
@@ -19,19 +22,19 @@ Qed.
 Check MPCP_undec.
 
 (** The modified Post correspondence problem restricted to binary strings is undecidable. *)
-Lemma MPCPb_undec : HaltTM 1 ⪯ MPCPb.
+Lemma MPCPb_undec : undecidable MPCPb.
 Proof.
-  eapply reduces_transitive.
-  exact MPCP_undec.
+  eapply undecidability_from_reducibility.
+  eapply MPCP_undec.
   exact MPCP_to_MPCPb.reduction.
 Qed.
 
 Check MPCPb_undec.
 
 (** The Post correspondence problem is undecidable. *)
-Lemma PCP_undec : HaltTM 1 ⪯ PCP.
+Lemma PCP_undec : undecidable PCP.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact MPCP_undec.
   exact MPCP_to_PCP.reduction.
 Qed.
@@ -39,9 +42,9 @@ Qed.
 Check PCP_undec.
 
 (** The Post correspondence problem restricted to binary strings is undecidable. *)
-Lemma PCPb_undec : HaltTM 1 ⪯ PCPb.
+Lemma PCPb_undec : undecidable PCPb.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact PCP_undec.
   exact PCP_to_PCPb.reduction.
 Qed.
@@ -49,9 +52,9 @@ Qed.
 Check PCPb_undec.
 
 (** The Post correspondence problem restricted to binary strings is undecidable. *)
-Lemma iPCPb_undec : HaltTM 1 ⪯ iPCPb.
+Lemma iPCPb_undec : undecidable iPCPb.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact PCPb_undec.
   exists id. exact PCPb_iff_iPCPb.PCPb_iff_iPCPb.
 Qed.
@@ -59,9 +62,9 @@ Qed.
 Check iPCPb_undec.
 
 (** The Post correspondence problem restricted to binary strings is undecidable. *)
-Lemma dPCPb_undec : HaltTM 1 ⪯ dPCPb.
+Lemma dPCPb_undec : undecidable dPCPb.
 Proof.
-  eapply reduces_transitive.
+  eapply undecidability_from_reducibility.
   exact PCPb_undec.
   exists id. exact PCPb_iff_dPCPb.PCPb_iff_dPCPb.
 Qed.

--- a/theories/Problems/Reduction.v
+++ b/theories/Problems/Reduction.v
@@ -1,71 +1,73 @@
 (** * Reductions *)
 
 Require Import Setoid.
+Require Export Undecidability.Synthetic.Definitions Undecidability.Synthetic.ReducibilityFacts.
 
-Set Implicit Arguments.
+(* Set Implicit Arguments. *)
 
-(** ** Definitions *)
+(* (** ** Definitions *) *)
 
-Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := exists f : X -> Y, forall x, p x <-> q (f x).
-Definition informatively_reduces X Y (P : X -> Prop) (Q : Y -> Prop) := { f : X -> Y | forall x, P x <-> Q (f x) }.
+(* Definition reduces X Y (p : X -> Prop) (q : Y -> Prop) := exists f : X -> Y, forall x, p x <-> q (f x). *)
+(* Definition informatively_reduces X Y (P : X -> Prop) (Q : Y -> Prop) := { f : X -> Y | forall x, P x <-> Q (f x) }. *)
 
-Infix "⪯" := reduces (at level 70).
-Infix "⪯ᵢ" := informatively_reduces (at level 70).
+(* Infix "⪯" := reduces (at level 70). *)
+(* Infix "⪯ᵢ" := informatively_reduces (at level 70). *)
 
-(** ** Pre-order properties *)
+(* (** ** Pre-order properties *) *)
 
-Section Properties.
+(* Section Properties. *)
 
-  Variables (X : Type) (P : X -> Prop)
-            (Y : Type) (Q : Y -> Prop)
-            (Z : Type) (R : Z -> Prop).
+(*   Variables (X : Type) (P : X -> Prop) *)
+(*             (Y : Type) (Q : Y -> Prop) *)
+(*             (Z : Type) (R : Z -> Prop). *)
 
-  Fact reduces_reflexive : P ⪯ P.
-  Proof. exists (fun x => x); tauto. Qed.
+(*   Fact reduces_reflexive : P ⪯ P. *)
+(*   Proof. exists (fun x => x); red; tauto. Qed. *)
 
-  Fact ireduces_reflexive : P ⪯ᵢ P.
-  Proof. exists (fun x => x); tauto. Qed.
+(*   Fact ireduces_reflexive : P ⪯ᵢ P. *)
+(*   Proof. exists (fun x => x); tauto. Qed. *)
 
-  Fact reduces_transitive : P ⪯ Q -> Q ⪯ R -> P ⪯ R.
-  Proof. 
-    intros (f & Hf) (g & Hg).
-    exists (fun x => g (f x)).
-    intro; rewrite Hf, Hg; tauto.
-  Qed.
+(*   Fact reduces_transitive : P ⪯ Q -> Q ⪯ R -> P ⪯ R. *)
+(*   Proof. *)
+(*     unfold reduces, reduction. *)
+(*     intros (f & Hf) (g & Hg). *)
+(*     exists (fun x => g (f x)). *)
+(*     intro; rewrite Hf, Hg; tauto. *)
+(*   Qed. *)
 
-  Fact ireduces_transitive : P ⪯ᵢ Q -> Q ⪯ᵢ R -> P ⪯ᵢ R.
-  Proof. 
-    intros (f & Hf) (g & Hg).
-    exists (fun x => g (f x)).
-    intro; rewrite Hf, Hg; tauto.
-  Qed.
+(*   Fact ireduces_transitive : P ⪯ᵢ Q -> Q ⪯ᵢ R -> P ⪯ᵢ R. *)
+(*   Proof.  *)
+(*     intros (f & Hf) (g & Hg). *)
+(*     exists (fun x => g (f x)). *)
+(*     intro; rewrite Hf, Hg; tauto. *)
+(*   Qed. *)
 
-  Fact ireduces_reduces : P ⪯ᵢ Q -> P ⪯ Q.
-  Proof. intros (f & ?); exists f; auto. Qed.
+(*   Fact ireduces_reduces : P ⪯ᵢ Q -> P ⪯ Q. *)
+(*   Proof. intros (f & ?); exists f; auto. Qed. *)
 
-  Fact reduces_ireduces : P ⪯ Q -> inhabited (P ⪯ᵢ Q).
-  Proof. intros (f & ?); exists; exists f; auto. Qed.
+(*   Fact reduces_ireduces : P ⪯ Q -> inhabited (P ⪯ᵢ Q). *)
+(*   Proof. intros (f & ?); exists; exists f; auto. Qed. *)
 
-  Fact reduces_ireduces_iff : P ⪯ Q <-> inhabited (P ⪯ᵢ Q).
-  Proof.
-    split.
-    + apply reduces_ireduces.
-    + intros []; apply ireduces_reduces; auto.
-  Qed.
+(*   Fact reduces_ireduces_iff : P ⪯ Q <-> inhabited (P ⪯ᵢ Q). *)
+(*   Proof. *)
+(*     split. *)
+(*     + apply reduces_ireduces. *)
+(*     + intros []; apply ireduces_reduces; auto. *)
+(*   Qed. *)
 
-  (** ** An equivalent dependent definition *)
+(*   (** ** An equivalent dependent definition *) *)
 
-  Fact ireduces_dependent :
-         (P ⪯ᵢ Q -> forall x, { y | P x <-> Q y })
-       * ((forall x, { y | P x <-> Q y }) -> P ⪯ᵢ Q).
-  Proof.
-    split.
-    + intros (f & Hf).
-      intros x; exists (f x); auto.
-    + intros f.
-      exists (fun x => proj1_sig (f x)).
-      intros; apply (proj2_sig (f x)).
-  Qed.
+(*   Fact ireduces_dependent : *)
+(*          (P ⪯ᵢ Q -> forall x, { y | P x <-> Q y }) *)
+(*        * ((forall x, { y | P x <-> Q y }) -> P ⪯ᵢ Q). *)
+(*   Proof. *)
+(*     split. *)
+(*     + intros (f & Hf). *)
+(*       intros x; exists (f x); auto. *)
+(*     + intros f. *)
+(*       exists (fun x => proj1_sig (f x)). *)
+(*       intros; apply (proj2_sig (f x)). *)
+(*   Qed. *)
 
-End Properties.
+(* End Properties. *)
 

--- a/theories/Problems/TM.v
+++ b/theories/Problems/TM.v
@@ -1,13 +1,2 @@
-From Undecidability.TM Require Export TM.
-
-Definition HaltsTM {sig: finType} {n: nat} (M : mTM sig n) (t : tapes sig n) :=
-  exists outc k, loopM (initc M t) k = Some outc.
-
-Definition HaltTM n (S: {sig:finType & mTM sig n & tapes sig n}) :=
-  HaltsTM (projT2 (sigT_of_sigT2 S)) (projT3 S).
-Arguments HaltTM :clear implicits.
-
-Definition HaltMTM : {'(n,sig) : nat * finType & mTM sig n & tapes sig n} -> Prop :=
-  fun '(existT2 _ _ (n, sig) M t) =>
-    HaltsTM M t.
+From Undecidability.TM Require Export Halting.
 

--- a/theories/SR/Util/singleTM.v
+++ b/theories/SR/Util/singleTM.v
@@ -100,7 +100,7 @@ we are on the right extremity of a non-empty tape (right overflow). *)
 
   Global Instance move_finC : finTypeC (EqType move).
   Proof.
-    apply (FinTypeC (enum := [L; R; TM.N])).
+    apply (FinTypeC (enum := [TM.L; R; TM.N])).
     intros []; now cbv.
   Qed.
     
@@ -115,7 +115,7 @@ we are on the right extremity of a non-empty tape (right overflow). *)
     }.
 
   Definition tape_move := fun (t : tape) (m : move) =>
-                            match m with  R => tape_move_right t | L => tape_move_left t | N => t end.
+                            match m with  R => tape_move_right t | TM.L => tape_move_left t | TM.N => t end.
 
   (* Writing on the tape *)
 

--- a/theories/Shared/Dec.v
+++ b/theories/Shared/Dec.v
@@ -2,6 +2,8 @@ Set Implicit Arguments.
 
 Hint Extern 4 => exact _ : core.
 
+Ltac inv H := inversion H; subst; clear H.
+
 Definition dec (X: Prop) : Type := {X} + {~ X}.
 
 Coercion dec2bool P (d: dec P) := if d then true else false.

--- a/theories/Shared/Dec.v
+++ b/theories/Shared/Dec.v
@@ -1,0 +1,209 @@
+Set Implicit Arguments.
+
+Hint Extern 4 => exact _ : core.
+
+Definition dec (X: Prop) : Type := {X} + {~ X}.
+
+Coercion dec2bool P (d: dec P) := if d then true else false.
+Definition is_true (b : bool) := b = true.
+
+Existing Class dec.
+
+Definition Dec (X: Prop) (d: dec X) : dec X := d.
+Arguments Dec X {d}.
+
+Lemma Dec_reflect (X: Prop) (d: dec X) :
+  is_true (Dec X) <-> X.
+Proof.
+  destruct d as [A|A]; cbv in *; intuition congruence.
+Qed.
+
+Lemma Dec_auto (X: Prop) (d: dec X) :
+  X -> is_true (Dec X).
+Proof.
+  destruct d as [A|A]; cbn; intuition congruence.
+Qed.
+
+(* Lemma Dec_auto_not (X: Prop) (d: dec X) : *)
+(*   ~ X -> ~ Dec X. *)
+(* Proof. *)
+(*   destruct d as [A|A]; cbn; tauto. *)
+(* Qed. *)
+
+(* Hint Resolve Dec_auto Dec_auto_not : core. *)
+Hint Extern 4 =>  (* Improves type class inference *)
+match goal with
+  | [  |- dec ((fun _ => _) _) ] => cbn
+end : typeclass_instances.
+
+Tactic Notation "decide" constr(p) := 
+  destruct (Dec p).
+Tactic Notation "decide" constr(p) "as" simple_intropattern(i) := 
+  destruct (Dec p) as i.
+Tactic Notation "decide" "_" :=
+  destruct (Dec _).
+
+Lemma Dec_true P {H : dec P} : dec2bool (Dec P) = true -> P.
+Proof.
+  decide P; cbv in *; firstorder.
+  congruence.
+Qed.
+
+Lemma Dec_false P {H : dec P} : dec2bool (Dec P) = false -> ~P.
+Proof.
+  decide P; cbv in *; firstorder.
+  congruence.
+Qed.
+
+Hint Extern 4 =>
+match goal with
+  [ H : dec2bool (Dec ?P) = true  |- _ ] => apply Dec_true in  H
+| [ H : dec2bool (Dec ?P) = true |- _ ] => apply Dec_false in H
+end : core.
+
+(** Decided propositions behave classically *)
+
+Lemma dec_DN X : 
+  dec X -> ~~ X -> X.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Lemma dec_DM_and X Y :  
+  dec X -> dec Y -> ~ (X /\ Y) -> ~ X \/ ~ Y.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Lemma dec_DM_impl X Y :  
+  dec X -> dec Y -> ~ (X -> Y) -> X /\ ~ Y.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+(** Propagation rules for decisions *)
+
+Fact dec_transfer P Q :
+  P <-> Q -> dec P -> dec Q.
+Proof.
+  unfold dec. tauto.
+Qed.
+
+Instance True_dec :
+  dec True.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Instance False_dec :
+  dec False.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Instance impl_dec (X Y : Prop) :  
+  dec X -> dec Y -> dec (X -> Y).
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Instance and_dec (X Y : Prop) :  
+  dec X -> dec Y -> dec (X /\ Y).
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Instance or_dec (X Y : Prop) : 
+  dec X -> dec Y -> dec (X \/ Y).
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+(* Coq standard modules make "not" and "iff" opaque for type class inference, 
+   can be seen with Print HintDb typeclass_instances. *)
+
+Instance not_dec (X : Prop) : 
+  dec X -> dec (~ X).
+Proof. 
+  unfold not. auto.
+Qed.
+
+Instance iff_dec (X Y : Prop) : 
+  dec X -> dec Y -> dec (X <-> Y).
+Proof. 
+  unfold iff. auto.
+Qed.
+
+(** Discrete types *)
+
+Notation "'eq_dec' X" := (forall x y : X, dec (x=y)) (at level 70).
+
+Structure eqType := EqType {
+  eqType_X :> Type;
+  eqType_dec : eq_dec eqType_X }.
+
+Arguments EqType X {_} : rename.
+
+Canonical Structure eqType_CS X (A: eq_dec X) := EqType X.
+
+Existing Instance eqType_dec.
+
+Instance unit_eq_dec :
+  eq_dec unit.
+Proof.
+  unfold dec. decide equality. 
+Qed.
+
+Instance bool_eq_dec : 
+  eq_dec bool.
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance nat_eq_dec : 
+  eq_dec nat.
+Proof.
+  unfold dec. decide equality.
+Defined.
+
+Instance prod_eq_dec X Y :  
+  eq_dec X -> eq_dec Y -> eq_dec (X * Y).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance list_eq_dec X :  
+  eq_dec X -> eq_dec (list X).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance sum_eq_dec X Y :  
+  eq_dec X -> eq_dec Y -> eq_dec (X + Y).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance option_eq_dec X :
+  eq_dec X -> eq_dec (option X).
+Proof.
+  unfold dec. decide equality.
+Defined.
+
+Instance Empty_set_eq_dec:
+  eq_dec Empty_set.
+Proof.
+  unfold dec. decide equality.
+Qed.
+
+Instance True_eq_dec:
+  eq_dec True.
+Proof.
+  intros x y. destruct x,y. now left.
+Qed.
+
+Instance False_eq_dec:
+  eq_dec False.
+Proof.
+  intros [].
+Qed.

--- a/theories/Shared/FilterFacts.v
+++ b/theories/Shared/FilterFacts.v
@@ -1,0 +1,100 @@
+Require Import List.
+
+(** Filter *)
+
+Section Filter.
+  Variable X : Type.
+  Implicit Types (x y: X) (A B C: list X) (p q: X -> bool).
+
+  Local Notation "x 'el' L" := (In x L) (at level 50).
+
+  Lemma in_filter_iff x p A :
+    x el filter p A <-> x el A /\ p x = true.
+  Proof. 
+    induction A as [|y A]; cbn.
+    - tauto.
+    - destruct (p y) eqn:E; cbn;
+      rewrite IHA; intuition; subst; auto. congruence.
+  Qed.
+
+  Local Notation "A '<<=' B" := (incl A B) (at level 50).
+
+  Lemma filter_incl p A :
+    filter p A <<= A.  
+  Proof.
+    intros x D. apply in_filter_iff in D. apply D.
+  Qed.
+
+  Lemma filter_mono p A B :
+    A <<= B -> filter p A <<= filter p B.
+  Proof.
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_id p A :
+    (forall x, x el A -> p x = true) -> filter p A = A.
+  Proof.
+    intros D.
+    induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:E.
+      + f_equal. eapply IHA. intros y H. apply D. cbn. eauto.
+      + exfalso. rewrite D in E. congruence. cbn. eauto.
+  Qed.
+
+  Lemma filter_app p A B :
+    filter p (A ++ B) = filter p A ++ filter p B.
+  Proof.
+    induction A as [|y A]; cbn.
+    - reflexivity.
+    - rewrite IHA. destruct (p y); reflexivity.  
+  Qed.
+
+  Lemma filter_fst p x A :
+    p x = true -> filter p (x::A) = x::filter p A.
+  Proof.
+    cbn. destruct (p x); auto. congruence.
+  Qed.
+
+  Lemma filter_fst' p x A :
+    p x = false -> filter p (x::A) = filter p A.
+  Proof.
+    cbn. destruct (p x); auto; congruence.
+  Qed.
+
+  Lemma filter_pq_mono p q A :
+    (forall x, x el A -> p x = true -> q x = true) -> filter p A <<= filter q A.
+  Proof. 
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_pq_eq p q A :
+    (forall x, x el A -> p x = q x) -> filter p A = filter q A.
+  Proof. 
+    intros C; induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:D, (q x) eqn:E.
+      + f_equal. eapply IHA. intros. eapply C. cbn. eauto.
+      + exfalso. enough (p x = q x) by congruence. firstorder.
+      + exfalso. enough (p x = q x) by congruence. firstorder.
+      + firstorder.
+  Qed.
+
+  Lemma filter_and p q A :
+    filter p (filter q A) = filter (fun x => andb (p x) (q x)) A.
+  Proof.
+    induction A as [|x A]; cbn. reflexivity.
+    destruct (p x) eqn:E, (q x); cbn;
+      try rewrite E; now rewrite IHA.
+  Qed.
+
+  Lemma filter_comm p q A :
+    filter p (filter q A) = filter q (filter p A).
+  Proof.
+    rewrite !filter_and. apply filter_pq_eq.
+    intros x _. now destruct (p x), (q x).
+  Qed.
+  
+End Filter.

--- a/theories/Shared/ListAutomation.v
+++ b/theories/Shared/ListAutomation.v
@@ -1,6 +1,7 @@
 Require Export List Undecidability.Shared.Dec Undecidability.Shared.FilterFacts.
+Export ListNotations.
 
-Local Notation "x 'el' L" := (In x L) (at level 80).
+Notation "x 'el' L" := (In x L) (at level 70).
 
 Instance list_in_dec X (x : X) (A : list X) :
   eq_dec X -> dec (x el A).

--- a/theories/Shared/ListAutomation.v
+++ b/theories/Shared/ListAutomation.v
@@ -1,0 +1,53 @@
+Require Export List Undecidability.Shared.Dec Undecidability.Shared.FilterFacts.
+
+Local Notation "x 'el' L" := (In x L) (at level 80).
+
+Instance list_in_dec X (x : X) (A : list X) :
+  eq_dec X -> dec (x el A).
+Proof.
+  intros D. apply in_dec. exact D.
+Qed.
+
+Lemma in_concat_iff A l (a:A) : a el concat l <-> exists l', a el l' /\ l' el l.
+Proof.
+  induction l; cbn.
+  - intuition. now destruct H. 
+  - rewrite in_app_iff, IHl. clear. firstorder subst. auto.
+Qed.
+
+Notation "( A × B × .. × C )" := (list_prod .. (list_prod A B) .. C) (at level 0, left associativity).
+
+Notation "[ s | p ∈ A ',' P ]" :=
+  (map (fun p => s) (filter (fun p => Dec P) A)) (p pattern).
+Notation "[ s | p ∈ A ]" :=
+  (map (fun p => s) A) (p pattern).
+
+Ltac in_app n :=
+  (match goal with
+  | [ |- In _ (_ ++ _) ] => 
+    match n with
+    | 0 => idtac
+    | 1 => eapply in_app_iff; left
+    | S ?n => eapply in_app_iff; right; in_app n
+    end
+  | [ |- In _ (_ :: _) ] => match n with 0 => idtac | 1 => left | S ?n => right; in_app n end
+  end) || (repeat (try right; eapply in_app_iff; right)).
+
+Lemma to_dec (P : Prop) `{dec P} : P <-> is_true (Dec P).
+Proof.
+  split; destruct (Dec P); cbn in *; firstorder congruence.
+Qed.
+
+Ltac in_collect a :=
+  eapply in_map_iff; exists a; split; [ eauto | match goal with [ |- In _ (filter _ _) ] =>  eapply in_filter_iff; split; [ try (rewrite !in_prod_iff; repeat split) | eapply Dec_auto; repeat split; eauto ] | _ => try (rewrite !in_prod_iff; repeat split) end ].
+Ltac inv_collect :=
+  repeat
+    (match goal with
+    | [ H : ?x el concat _ |- _ ] => eapply in_concat_iff in H as (? & ? & ?)
+    | [ H : ?x el map _ _ |- _ ] => let x := fresh "x" in eapply in_map_iff in H as (x & ? & ?)
+    | [ x : ?A * ?B |- _ ] => destruct x; subst
+    | [ H : ?x el filter _ _ |- _ ] => let H' := fresh "H" in eapply in_filter_iff in H as (? & H' % to_dec)
+    | [ H : ?x el list_prod _ _ |- _ ] => eapply in_prod_iff in H
+    | [ H : _ el _ ++ _ |- _ ] => try eapply in_app_iff in H as []
+    | [H : _ el _ :: _ |- _ ] => destruct H
+     end; intuition; subst).

--- a/theories/Shared/MoreListFacts.v
+++ b/theories/Shared/MoreListFacts.v
@@ -1,0 +1,40 @@
+Require Import List Undecidability.Shared.Dec Undecidability.Shared.FilterFacts.
+
+Notation "( A × B × .. × C )" := (list_prod .. (list_prod A B) .. C) (at level 0, left associativity).
+
+Notation "[ s | p ∈ A ',' P ]" :=
+  (map (fun p => s) (filter (fun p => Dec P) A)) (p pattern).
+Notation "[ s | p ∈ A ]" :=
+  (map (fun p => s) A) (p pattern).
+
+Ltac in_app n :=
+  (match goal with
+  | [ |- In _ (_ ++ _) ] => 
+    match n with
+    | 0 => idtac
+    | 1 => eapply in_app_iff; left
+    | S ?n => eapply in_app_iff; right; in_app n
+    end
+  | [ |- In _ (_ :: _) ] => match n with 0 => idtac | 1 => left | S ?n => right; in_app n end
+  end) || (repeat (try right; eapply in_app_iff; right)).
+
+Lemma to_dec (P : Prop) `{dec P} : P <-> Dec P.
+Proof.
+  firstorder. destruct (Dec P); cbn in *; firstorder.
+Qed.
+
+Local Notation "x 'el' L" := (In x L) (at level 50).
+
+Ltac in_collect a :=
+  eapply in_map_iff; exists a; split; [ eauto | match goal with [ |- In _ (filter _ _) ] =>  eapply in_filter_iff; split; [ try (rewrite !in_prod_iff; repeat split) | rewrite <- to_dec; repeat split; eauto ] | _ => try (rewrite !in_prod_iff; repeat split) end ].
+Ltac inv_collect :=
+  repeat
+    (match goal with
+    | [ H : ?x el concat _ |- _ ] => eapply in_concat_iff in H as (? & ? & ?)
+    | [ H : ?x el map _ _ |- _ ] => let x := fresh "x" in eapply in_map_iff in H as (x & ? & ?)
+    | [ x : ?A * ?B |- _ ] => destruct x; subst
+    | [ H : ?x el filter _ _ |- _ ] => let H' := fresh "H" in eapply in_filter_iff in H as (? & H' % to_dec)
+    | [ H : ?x el list_prod _ _ |- _ ] => eapply in_prod_iff in H
+    | [ H : _ el _ ++ _ |- _ ] => try eapply in_app_iff in H as []
+    | [H : _ el _ :: _ |- _ ] => destruct H
+     end; intuition; subst).

--- a/theories/Shared/embed_nat.v
+++ b/theories/Shared/embed_nat.v
@@ -1,0 +1,39 @@
+Require Import PeanoNat.
+
+(* bijection from nat * nat to nat *)
+Definition embed '(x, y) : nat := 
+  y + (nat_rec _ 0 (fun i m => (S i) + m) (y + x)).
+
+(* bijection from nat to nat * nat *)
+Definition unembed (n : nat) : nat * nat := 
+  nat_rec _ (0, 0) (fun _ '(x, y) => match x with S x => (x, S y) | _ => (S y, 0) end) n.
+
+Lemma embedP {xy: nat * nat} : unembed (embed xy) = xy.
+Proof.
+  assert (forall n, embed xy = n -> unembed n = xy).
+    intro n. revert xy. induction n as [|n IH].
+      intros [[|?] [|?]]; intro H; inversion H; reflexivity.
+    intros [x [|y]]; simpl.
+      case x as [|x]; simpl; intro H.
+        inversion H.
+      rewrite (IH (0, x)); [reflexivity|].
+      inversion H; simpl. rewrite Nat.add_0_r. reflexivity.
+    intro H. rewrite (IH (S x, y)); [reflexivity|]. 
+    inversion H. simpl. rewrite Nat.add_succ_r. reflexivity.
+  apply H. reflexivity.
+Qed.
+
+Lemma unembedP {n: nat} : embed (unembed n) = n.
+Proof.
+  induction n as [|n IH]; [reflexivity|].
+  simpl. revert IH. case (unembed n). intros x y.
+  case x as [|x]; intro Hx; rewrite <- Hx; simpl.
+    rewrite Nat.add_0_r. reflexivity.
+  rewrite ?Nat.add_succ_r. simpl. rewrite ?Nat.add_succ_r. reflexivity. 
+Qed.
+Arguments embed : simpl never.
+
+
+Module EmbedNatNotations.
+  Notation "⟨ a , b ⟩" := (embed (a, b)) (at level 0).
+End EmbedNatNotations.

--- a/theories/Shared/filter.v
+++ b/theories/Shared/filter.v
@@ -1,0 +1,100 @@
+Require Import List.
+
+(** Filter *)
+
+Section Filter.
+  Variable X : Type.
+  Implicit Types (x y: X) (A B C: list X) (p q: X -> bool).
+
+  Local Notation "x 'el' L" := (In x L) (at level 50).
+
+  Lemma in_filter_iff x p A :
+    x el filter p A <-> x el A /\ p x = true.
+  Proof. 
+    induction A as [|y A]; cbn.
+    - tauto.
+    - destruct (p y) eqn:E; cbn;
+      rewrite IHA; intuition; subst; auto. congruence.
+  Qed.
+
+  Local Notation "A '<<=' B" := (incl A B) (at level 50).
+
+  Lemma filter_incl p A :
+    filter p A <<= A.  
+  Proof.
+    intros x D. apply in_filter_iff in D. apply D.
+  Qed.
+
+  Lemma filter_mono p A B :
+    A <<= B -> filter p A <<= filter p B.
+  Proof.
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_id p A :
+    (forall x, x el A -> p x = true) -> filter p A = A.
+  Proof.
+    intros D.
+    induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:E.
+      + f_equal. eapply IHA. intros y H. apply D. cbn. eauto.
+      + exfalso. rewrite D in E. congruence. cbn. eauto.
+  Qed.
+
+  Lemma filter_app p A B :
+    filter p (A ++ B) = filter p A ++ filter p B.
+  Proof.
+    induction A as [|y A]; cbn.
+    - reflexivity.
+    - rewrite IHA. destruct (p y); reflexivity.  
+  Qed.
+
+  Lemma filter_fst p x A :
+    p x = true -> filter p (x::A) = x::filter p A.
+  Proof.
+    cbn. destruct (p x); auto. congruence.
+  Qed.
+
+  Lemma filter_fst' p x A :
+    p x = false -> filter p (x::A) = filter p A.
+  Proof.
+    cbn. destruct (p x); auto; congruence.
+  Qed.
+
+  Lemma filter_pq_mono p q A :
+    (forall x, x el A -> p x = true -> q x = true) -> filter p A <<= filter q A.
+  Proof. 
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_pq_eq p q A :
+    (forall x, x el A -> p x = q x) -> filter p A = filter q A.
+  Proof. 
+    intros C; induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:D, (q x) eqn:E.
+      + f_equal. eapply IHA. intros. eapply C. cbn. eauto.
+      + exfalso. enough (p x = q x) by congruence. firstorder.
+      + exfalso. enough (p x = q x) by congruence. firstorder.
+      + firstorder.
+  Qed.
+
+  Lemma filter_and p q A :
+    filter p (filter q A) = filter (fun x => andb (p x) (q x)) A.
+  Proof.
+    induction A as [|x A]; cbn. reflexivity.
+    destruct (p x) eqn:E, (q x); cbn;
+      try rewrite E; now rewrite IHA.
+  Qed.
+
+  Lemma filter_comm p q A :
+    filter p (filter q A) = filter q (filter p A).
+  Proof.
+    rewrite !filter_and. apply filter_pq_eq.
+    intros x _. now destruct (p x), (q x).
+  Qed.
+  
+End Filter.

--- a/theories/Synthetic/DecidabilityFacts.v
+++ b/theories/Synthetic/DecidabilityFacts.v
@@ -1,0 +1,143 @@
+Require Export Undecidability.Synthetic.Definitions Lia.
+Require Import Undecidability.Shared.Dec.
+Require Import Setoid Morphisms.
+
+Definition discrete X := decidable (fun '(x,y) => x = y :> X).
+
+(** Facts on reflects *)
+
+Lemma reflects_not b P :
+  reflects b P -> reflects (negb b) (~P).
+Proof.
+  unfold reflects.
+  destruct b; cbn; intuition congruence.
+Qed.
+
+Lemma reflects_conj {b1 b2 P1 P2} :
+  reflects b1 P1  -> reflects b2 P2 -> reflects (b1 && b2) (P1 /\ P2).
+Proof.
+  unfold reflects.
+  destruct b1, b2; cbn; firstorder congruence.
+Qed.
+
+Lemma reflects_disj {b1 b2 P1 P2} :
+  reflects b1 P1  -> reflects b2 P2 -> reflects (b1 || b2) (P1 \/ P2).
+Proof.
+  unfold reflects.
+  destruct b1, b2; cbn; firstorder congruence.
+Qed.
+
+Lemma reflects_prv b (P : Prop) : (b = true -> P) -> (b = false -> ~ P) -> reflects b P.
+Proof.
+  intros H1 H2.
+  destruct b; cbn; firstorder.
+Qed.
+
+(** Type-theoretic characterisations *)
+
+Lemma dec_decidable' X p :
+  (forall x : X, dec (p x)) -> { f : _ | forall x, p x <-> f x = true}.
+Proof.
+  intros d. exists (fun x => if d x then true else false). intros x. destruct (d x); firstorder congruence.
+Qed.
+
+Lemma decidable_iff X p :
+  decidable p <-> inhabited (forall x : X, dec (p x)).
+Proof.
+  split.
+  - intros [f H]. econstructor. intros x. specialize (H x). destruct (f x); firstorder congruence.
+  - intros [d]. eapply dec_decidable' in d as [f]. now exists f.
+Qed.
+
+(** Closure properties of decidability *)
+
+Lemma discrete_iff X :
+  discrete X <-> inhabited (eq_dec X).
+Proof.
+  split.
+  - intros [D] % decidable_iff. econstructor. intros x y; destruct (D (x,y)); firstorder.
+  - intros [d]. eapply decidable_iff. econstructor. intros (x,y). eapply d.
+Qed.
+
+Lemma dec_compl X p :
+  decidable p -> decidable (fun x : X => ~ p x).
+Proof.
+  intros [f H]. exists (fun x => negb (f x)).
+  intros x. eapply reflects_not, H.
+Qed.
+
+Lemma dec_conj X p q :
+  decidable p -> decidable q -> decidable (fun x : X => p x /\ q x).
+Proof.
+  intros [f] [g]. exists (fun x => andb (f x) (g x)).
+  intros x. eapply reflects_conj; eauto.
+Qed.
+
+Lemma dec_disj X p q :
+  decidable p -> decidable q -> decidable (fun x : X => p x \/ q x).
+Proof.
+  intros [f] [g]. exists (fun x => orb (f x) (g x)).
+  intros x. eapply reflects_disj; eauto.
+Qed.
+
+(** Proper lemmas *)
+
+Instance Proper_decides {X} :
+  Proper (pointwise_relation X (@eq bool) ==> pointwise_relation X iff ==> iff ) (@decider X).
+Proof.
+  intros f g H1 p q H2. red in H1, H2.
+  unfold decider, reflects. 
+  split; intros H x.
+  - now rewrite <- H2, H, H1.
+  - now rewrite H2, H, H1.
+Qed.
+
+Instance Proper_decidable {X} :
+  Proper (pointwise_relation X iff ==> iff) (@decidable X).
+Proof.
+  intros p q H2.
+  split; intros [f H]; exists f.
+  - now rewrite <- H2.
+  - now rewrite H2.
+Qed.
+
+(** Closure properties of discreteness *)
+
+Lemma discrete_bool : discrete bool.
+Proof.
+  eapply discrete_iff. econstructor. exact _.
+Qed.
+
+Lemma discrete_nat : discrete nat.
+Proof.
+  eapply discrete_iff. econstructor. exact _.
+Qed.
+
+Lemma discrete_nat_nat : discrete (nat * nat).
+Proof.
+  eapply discrete_iff. econstructor. exact _.
+Qed.
+
+Lemma discrete_prod X Y : discrete X -> discrete Y -> discrete (X * Y).
+Proof.
+  intros [d1] % discrete_iff [d2] % discrete_iff.
+  eapply discrete_iff. econstructor. exact _.
+Qed.
+
+Lemma discrete_sum X Y : discrete X -> discrete Y -> discrete (X + Y).
+Proof.
+  intros [d1] % discrete_iff [d2] % discrete_iff.
+  eapply discrete_iff. econstructor. exact _.
+Qed.
+
+Lemma discrete_option X : discrete X -> discrete (option X).
+Proof.
+  intros [d1] % discrete_iff. eapply discrete_iff.
+  econstructor. exact _.
+Qed.
+
+Lemma discrete_list X : discrete X -> discrete (list X).
+Proof.
+  intros [d1] % discrete_iff. eapply discrete_iff.
+  econstructor. exact _.
+Qed.

--- a/theories/Synthetic/Definitions.v
+++ b/theories/Synthetic/Definitions.v
@@ -1,0 +1,31 @@
+Definition compl {X} (p : X -> Prop) := fun x : X => ~ p x.
+Definition reflects (b : bool) (P : Prop) := P <-> b = true.
+
+Definition decider {X} (f : X -> bool) (P : X -> Prop) : Prop :=
+  forall x, reflects (f x) (P x).
+Definition decidable {X} (P : X -> Prop) : Prop :=
+  exists f : X -> bool, decider f P.
+Definition inf_decidable {X} (P : X -> Prop) : Type :=
+  { f : X -> bool | decider f P}.
+
+Definition enumerator{X} (f : nat -> option X) (p : X -> Prop) : Prop :=
+  forall x, p x <-> exists n, f n = Some x.
+Definition enumerable {X} (p : X -> Prop) : Prop :=
+  exists f : nat -> option X, enumerator f p.
+Definition inf_enumerable {X} (p : X -> Prop) : Type :=
+  { f : nat -> option X | enumerator f p}.
+
+Definition semi_decider {X} (f : X -> nat -> bool) (p : X -> Prop) : Prop :=
+  forall x, p x <-> exists n, f x n = true.
+Definition semi_decidable {X} (p : X -> Prop) : Prop :=
+  exists f : X -> nat -> bool, semi_decider f p.
+Definition inf_semi_decidable {X} (p : X -> Prop) : Type :=
+  { f : X -> nat -> bool | semi_decider f p}.
+
+Definition reduction {X Y} (f : X -> Y) (P : X -> Prop) (Q : Y -> Prop) :=
+  forall x, P x <-> Q (f x).
+Definition reduces {X Y} (P : X -> Prop) (Q : Y -> Prop) :=
+  exists f : X -> Y, reduction f P Q.
+Definition inf_reduces {X Y} (P : X -> Prop) (Q : Y -> Prop) :=
+  { f : X -> Y | reduction f P Q}.
+Notation "P ⪯ Q" := (reduces P Q) (at level 70).

--- a/theories/Synthetic/EnumerabilityFacts.v
+++ b/theories/Synthetic/EnumerabilityFacts.v
@@ -1,0 +1,122 @@
+From Undecidability.Synthetic Require Import DecidabilityFacts SemiDecidabilityFacts.
+From Undecidability.Shared Require Import embed_nat.
+
+Local Notation "'if!' x 'is' p 'then' a 'else' b" := (match x with p => a | _ => b end) (at level 0, p pattern).
+
+Lemma enumerable_semi_decidable {X} {p : X -> Prop} :
+  discrete X -> enumerable p -> semi_decidable p.
+Proof.
+  unfold enumerable, enumerator.
+  intros [d Hd] [f Hf].
+  exists (fun x n => if! f n is Some y then d (x,y) else false).
+  intros x. rewrite Hf. split.
+  - intros [n Hn]. exists n.
+    rewrite Hn. now eapply Hd.
+  - intros [n Hn]. exists n.
+    destruct (f n); inversion Hn.
+    eapply Hd in Hn. now subst.
+Qed.
+
+Definition enumerator__T' X f := forall x : X, exists n : nat, f n = Some x.
+Notation enumerator__T f X := (enumerator__T' X f).
+Definition enumerable__T X := exists f : nat -> option X, enumerator__T f X.
+
+Lemma semi_decidable_enumerable {X} {p : X -> Prop} :
+  enumerable__T X -> semi_decidable p -> enumerable p.
+Proof.
+  unfold semi_decidable, semi_decider.
+  intros [e He] [f Hf].
+  exists (fun p => let (n, m) := unembed p in
+           if! e n is Some x then if f x m then Some x else None else None).
+  intros x. rewrite Hf. split.
+  - intros [n Hn]. destruct (He x) as [m Hm].
+    exists (embed (m,n)). now rewrite embedP, Hm, Hn.
+  - intros [mn Hmn]. destruct (unembed mn) as (m, n).
+    destruct (e m) as [x'|]; try congruence.
+    destruct (f x' n) eqn:E; inversion Hmn. subst.
+    exists n. exact E.
+Qed.
+
+Theorem dec_count_enum {X} {p : X -> Prop} :
+  decidable p -> enumerable__T X -> enumerable p.
+Proof.
+  intros ? % decidable_semi_decidable ?.
+  now eapply semi_decidable_enumerable.
+Qed.
+
+Theorem dec_count_enum' X (p : X -> Prop) :
+  decidable p -> enumerable__T X -> enumerable (fun x => ~ p x).
+Proof.
+  intros ? % dec_compl ?. eapply dec_count_enum; eauto.
+Qed.
+
+Lemma enumerable_enumerable_T X :
+  enumerable (fun _ : X => True) <-> enumerable__T X.
+Proof.
+  split.
+  - intros [e He]. exists e. intros x. now eapply He.
+  - intros [c Hc]. exists c. intros x. split; eauto.
+Qed.
+
+(** Type enumerability facts  *)
+
+Definition nat_enum (n : nat) := Some n.
+Lemma enumerator__T_nat :
+  enumerator__T nat_enum nat.
+Proof.
+  intros n. cbv. eauto.
+Qed.
+
+Definition unit_enum (n : nat) := Some tt.
+Lemma enumerator__T_unit :
+  enumerator__T unit_enum unit.
+Proof.
+  intros []. cbv. now exists 0.
+Qed. 
+
+Definition bool_enum (n : nat) := Some (if! n is 0 then true else false).
+Lemma enumerator__T_bool :
+  enumerator__T bool_enum bool.
+Proof.
+  intros []. cbv.
+  - now exists 0.
+  - now exists 1.
+Qed.
+
+Definition prod_enum {X Y} (f1 : nat -> option X) (f2 : nat -> option Y) n : option (X * Y) :=
+  let (n, m) := unembed n in
+  if! (f1 n, f2 m) is (Some x, Some y) then Some (x, y) else None.
+Lemma enumerator__T_prod {X Y} f1 f2 :
+  enumerator__T f1 X -> enumerator__T f2 Y ->
+  enumerator__T (prod_enum f1 f2) (X * Y).
+Proof.
+  intros H1 H2 (x, y).
+  destruct (H1 x) as [n1 Hn1], (H2 y) as [n2 Hn2].
+  exists (embed (n1, n2)). unfold prod_enum.
+  now rewrite embedP, Hn1, Hn2.
+Qed.
+
+Definition option_enum {X} (f : nat -> option X) n :=
+  match n with 0 => Some None | S n => Some (f n) end.
+Lemma enumerator__T_option {X} f :
+  enumerator__T f X -> enumerator__T (option_enum f) (option X).
+Proof.
+  intros H [x | ].
+  - destruct (H x) as [n Hn]. exists (S n). cbn. now rewrite Hn.
+  - exists 0. reflexivity.
+Qed.
+
+Existing Class enumerator__T'.
+(* Existing Class enumerable__T. *)
+
+Lemma enumerator_enumerable {X} {f} :
+  enumerator__T f X -> enumerable__T X.
+Proof.
+  intros H. exists f. eapply H.
+Qed.
+Hint Resolve enumerator_enumerable : core.
+
+Existing Instance enumerator__T_prod.
+Existing Instance enumerator__T_option.
+Existing Instance enumerator__T_bool.
+Existing Instance enumerator__T_nat.

--- a/theories/Synthetic/ListEnumerabilityFacts.v
+++ b/theories/Synthetic/ListEnumerabilityFacts.v
@@ -1,0 +1,312 @@
+From Undecidability.Synthetic Require Import DecidabilityFacts SemiDecidabilityFacts EnumerabilityFacts.
+From Undecidability Require Import Shared.embed_nat.
+Require Import List.
+Import ListNotations.
+
+Definition cumulative {X} (L: nat -> list X) :=
+  forall n, exists A, L (S n) = L n ++ A.
+Hint Extern 0 (cumulative _) => intros ?; cbn; eauto : core.
+
+Lemma cum_ge {X} {L: nat -> list X} {n m} :
+  cumulative L -> m >= n -> exists A, L m = L n ++ A.
+Proof.
+  induction 2 as [|m _ IH].
+  - exists nil. now rewrite app_nil_r.
+  - destruct (H m) as (A&->), IH as [B ->].
+    exists (B ++ A). now rewrite app_assoc.
+Qed.
+
+Lemma cum_ge' {X} {L: nat -> list X} {x n m} :
+  cumulative L -> In x (L n) -> m >= n -> In x (L m).
+Proof.
+  intros ? H [A ->] % (cum_ge (L := L)). apply in_app_iff. eauto. eauto.
+Qed.
+
+Definition list_enumerator {X} (L: nat -> list X) (p : X -> Prop) :=
+  forall x, p x <-> exists m, In x (L m).
+Definition list_enumerable {X} (p : X -> Prop) :=
+  exists L, list_enumerator L p.
+
+Definition list_enumerator__T' X f := forall x : X, exists n : nat, In x (f n).
+Notation list_enumerator__T f X := (list_enumerator__T' X f).
+Definition list_enumerable__T X := exists f : nat -> list X, list_enumerator__T f X.
+Definition inf_list_enumerable__T X := { f : nat -> list X | list_enumerator__T f X }.
+
+Section enumerator_list_enumerator.
+
+  Variable X : Type.
+  Variable p : X -> Prop.
+  Variables (e : nat -> option X).
+
+  Let T (n : nat) : list X :=  match e n with Some x => [x] | None => [] end.
+
+  Lemma enumerator_to_list_enumerator : forall x, (exists n, e n = Some x) <-> (exists n, In x (T n)).
+  Proof.
+    split; intros [n H].
+    - exists n. unfold T. rewrite H. firstorder.
+    - unfold T in *. destruct (e n) eqn:E. inversion H; subst. eauto. inversion H0. inversion H.
+  Qed.
+
+End enumerator_list_enumerator.
+
+Lemma enumerable_list_enumerable {X} {p : X -> Prop} :
+  enumerable p -> list_enumerable p.
+Proof.
+  intros [f Hf]. eexists.
+  unfold list_enumerator.
+  intros x. rewrite <- enumerator_to_list_enumerator.
+  eapply Hf.
+Qed.
+
+Lemma enumerable__T_list_enumerable {X} :
+  enumerable__T X -> list_enumerable__T X.
+Proof.
+  intros [f Hf]. eexists.
+  unfold list_enumerator.
+  intros x. rewrite <- enumerator_to_list_enumerator.
+  eapply Hf.
+Qed.
+
+Section enumerator_list_enumerator.
+
+  Variable X : Type.
+  Variables (T : nat -> list X).
+
+  Let e (n : nat) : option X :=
+    let (n, m) := unembed n in
+    nth_error (T n) m.
+
+  Lemma list_enumerator_to_enumerator : forall x, (exists n, e n = Some x) <-> (exists n, In x (T n)).
+  Proof.
+    split; intros [k H].
+    - unfold e in *.
+      destruct (unembed k) as (n, m).
+      exists n. eapply (nth_error_In _ _ H).
+    - unfold e in *.
+      eapply In_nth_error in H as [m].
+      exists (embed (k, m)). now rewrite embedP, H.
+  Qed.
+
+End enumerator_list_enumerator.
+
+Lemma list_enumerator_enumerator {X} {p : X -> Prop} {T} :
+  list_enumerator T p -> enumerator (fun n => let (n, m) := unembed n in
+    nth_error (T n) m) p.
+Proof.
+  unfold list_enumerator.
+  intros H x. rewrite list_enumerator_to_enumerator. eauto.
+Qed.
+
+Lemma list_enumerable_enumerable {X} {p : X -> Prop} :
+  list_enumerable p -> enumerable p.
+Proof.
+  intros [T HT]. eexists.
+  unfold list_enumerator.
+  intros x. rewrite list_enumerator_to_enumerator.
+  eapply HT.
+Qed.
+
+Lemma list_enumerable__T_enumerable {X} :
+  list_enumerable__T X -> enumerable__T X.
+Proof.
+  intros [T HT]. eexists.
+  unfold list_enumerator.
+  intros x. rewrite list_enumerator_to_enumerator.
+  eapply HT.
+Qed.
+
+Lemma enum_enumT {X} :
+  enumerable__T X <-> list_enumerable__T X.
+Proof.
+  split.
+  eapply enumerable__T_list_enumerable.
+  eapply list_enumerable__T_enumerable.
+Qed.
+
+Definition to_cumul {X} (L : nat -> list X) := fix f n :=
+  match n with 0 => [] | S n => f n ++ L n end.
+
+Lemma to_cumul_cumulative {X} (L : nat -> list X) :
+  cumulative (to_cumul L).
+Proof.
+  eauto.
+Qed.
+
+Lemma to_cumul_spec {X} (L : nat -> list X) x :
+  (exists n, In x (L n)) <-> exists n, In x (to_cumul L n).
+Proof.
+  split.
+  - intros [n H].
+    exists (S n). cbn. eapply in_app_iff. eauto.
+  - intros [n H].
+    induction n; cbn in *.
+    + inversion H.
+    + eapply in_app_iff in H as [H | H]; eauto.
+Qed.
+
+Lemma cumul_In {X} (L : nat -> list X) x n :
+  In x (L n) -> In x (to_cumul L (S n)).
+Proof.
+  intros H. cbn. eapply in_app_iff. eauto.
+Qed.
+
+Lemma In_cumul {X} (L : nat -> list X) x n :
+  In x (to_cumul L n) -> exists n, In x (L n).
+Proof.
+  intros H. eapply to_cumul_spec. eauto.
+Qed.
+
+Hint Resolve cumul_In In_cumul : core.
+
+Lemma list_enumerator_to_cumul {X} {p : X -> Prop} {L} :
+  list_enumerator L p -> list_enumerator (to_cumul L) p. 
+Proof.
+  unfold list_enumerator.
+  intros. rewrite H.
+  eapply to_cumul_spec.
+Qed.
+
+Lemma cumul_spec__T {X} {L} :
+  list_enumerator__T L X -> list_enumerator__T (to_cumul L) X.
+Proof.
+  unfold list_enumerator__T.
+  intros. now rewrite <- to_cumul_spec.
+Qed.
+
+Lemma cumul_spec {X} {L} {p : X -> Prop} :
+  list_enumerator L p -> list_enumerator (to_cumul L) p.
+Proof.
+  unfold list_enumerator.
+  intros. now rewrite <- to_cumul_spec.
+Qed.
+
+Require Import Undecidability.Shared.ListAutomation.
+
+Notation cumul := (to_cumul).
+
+Section L_list_def.
+  Context {X : Type}.
+  Variable (L : nat -> list X).
+
+Fixpoint L_list (n : nat) : list (list X) :=
+  match n
+  with
+  | 0 => [ [] ]
+  | S n => L_list n ++ [ x :: L | (x,L) ∈ (cumul L n × L_list n) ]
+  end.
+End L_list_def.
+
+Lemma L_list_cumulative {X} L : cumulative (@L_list X L).
+Proof.
+  intros ?; cbn; eauto. 
+Qed.
+
+Lemma enumerator__T_list {X} L :
+  list_enumerator__T L X -> list_enumerator__T (L_list L) (list X).
+Proof.
+  intros H l.
+  induction l.
+  - exists 0. cbn. eauto.
+  - destruct IHl as [n IH].
+    destruct (cumul_spec__T H a) as [m ?].
+    exists (1 + n + m). cbn. intros. in_app 2.
+    in_collect (a,l).
+    all: eapply cum_ge'; eauto using L_list_cumulative; lia.
+Qed.
+
+Lemma  enumerable_list {X} : list_enumerable__T X -> list_enumerable__T (list X).
+Proof.
+  intros [L H].
+  eexists. now eapply enumerator__T_list.
+Qed.
+
+Hint Extern 4 => match goal with [H : list_enumerator _ ?p |- ?p _ ] => eapply H end : core.
+
+Lemma enumerable_conj X (p q : X -> Prop) :
+  discrete X -> enumerable p -> enumerable q -> enumerable (fun x => p x /\ q x).
+Proof.
+  intros [] % discrete_iff [Lp] % enumerable_list_enumerable [Lq] % enumerable_list_enumerable.
+  eapply list_enumerable_enumerable.
+  exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ cumul Lp n, x el cumul Lq n] end).
+  intros. split.
+  + intros []. eapply (cumul_spec H) in H1 as [m1]. eapply (cumul_spec H0) in H2 as [m2].
+    exists (1 + m1 + m2). cbn. in_app 2. in_collect x.
+    eapply cum_ge'; eauto. lia.
+    eapply cum_ge'; eauto. lia.
+  + intros [m]. induction m.
+    * inv H1.
+    * inv_collect; eauto.
+Qed.
+
+Lemma projection X Y (p : X * Y -> Prop) :
+  enumerable p -> enumerable (fun x => exists y, p (x,y)).
+Proof.
+  intros [f].
+  exists (fun n => match f n with Some (x, y) => Some x | None => None end).
+  intros; split.
+  - intros [y ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
+  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0.
+    exists y. eapply H. eauto.
+Qed.
+
+Lemma projection' X Y (p : X * Y -> Prop) :
+  enumerable p -> enumerable (fun y => exists x, p (x,y)).
+Proof.
+  intros [f].
+  exists (fun n => match f n with Some (x, y) => Some y | None => None end).
+  intros y; split.
+  - intros [x ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
+  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inv H0.
+    exists x. eapply H. eauto.
+Qed.
+
+(** Typeclasses  *)
+
+Definition L_T {X : Type} {f : nat -> list X} {H : list_enumerator__T f X} : nat -> list X.
+  exact (cumul f).
+Defined.
+Arguments L_T _ {_ _} _, {_ _ _}.
+
+Hint Unfold L_T : core.
+Hint Resolve cumul_In : core.
+
+Existing Class list_enumerator__T'.
+
+Definition el_T {X} {f} `{list_enumerator__T f X} : list_enumerator__T L_T X.
+Proof.
+  now eapply cumul_spec__T.
+Defined.
+
+Existing Instance enumerator__T_list.
+
+Instance enumerator__T_to_list {X} {f} :
+  list_enumerator__T f X -> enumerator__T (fun n => let (n, m) := unembed n in nth_error (f n) m) X | 100.
+Proof.
+  intros H x. eapply list_enumerator_to_enumerator in H. exact H.
+Qed.
+
+Instance enumerator__T_of_list {X} {f} :
+  enumerator__T f X -> list_enumerator__T (fun n => match f n with Some x => [x] | None => [] end) X | 100.
+Proof.
+  intros H x. eapply enumerator_to_list_enumerator. eauto.
+Qed.
+
+Existing Class inf_list_enumerable__T.
+Instance inf_to_enumerator {X} :
+  forall H : inf_list_enumerable__T X, list_enumerator__T (proj1_sig H) X | 100.
+Proof.
+  intros [? H]. eapply H.
+Defined.
+
+(** Compatibility  *)
+
+Hint Unfold enumerable list_enumerable : core.
+
+Hint Resolve enumerable_list_enumerable
+     list_enumerable_enumerable : core.
+
+Lemma enumerable_enum {X} {p : X -> Prop} :
+  enumerable p <-> list_enumerable p.
+Proof.
+  split; eauto.
+Qed.

--- a/theories/Synthetic/MoreEnumerabilityFacts.v
+++ b/theories/Synthetic/MoreEnumerabilityFacts.v
@@ -1,0 +1,67 @@
+From Undecidability.Synthetic Require Import DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts.
+From Undecidability.Shared Require Import ListAutomation.
+Require Import List.
+Import ListNotations.
+
+Lemma enumerable_enum {X} {p : X -> Prop} :
+  enumerable p <-> list_enumerable p.
+Proof.
+  split. eapply enumerable_list_enumerable. eapply list_enumerable_enumerable.
+Qed.
+
+Lemma enumerable_disj X (p q : X -> Prop) :
+  enumerable p -> enumerable q -> enumerable (fun x => p x \/ q x).
+Proof.
+  intros [Lp H] % enumerable_enum [Lq H0] % enumerable_enum.
+  eapply enumerable_enum.
+  exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ Lp n] ++ [ y | y ∈ Lq n] end).
+  intros x. split.
+  - intros [H1 | H1].
+    * eapply H in H1 as [m]. exists (1 + m). cbn. in_app 2. in_collect x. eauto.
+    * eapply H0 in H1 as [m]. exists (1 + m). cbn. in_app 3. in_collect x. eauto.
+  - intros [m]. induction m.
+    * inversion H1.
+    * inv_collect;
+      unfold list_enumerator in *; firstorder.
+Qed.
+
+Lemma enumerable_conj X (p q : X -> Prop) :
+  discrete X -> enumerable p -> enumerable q -> enumerable (fun x => p x /\ q x).
+Proof.
+  intros [] % discrete_iff [Lp] % enumerable_enum [Lq] % enumerable_enum.
+  eapply enumerable_enum.
+  exists (fix f n := match n with 0 => [] | S n => f n ++ [ x | x ∈ cumul Lp n, In x (cumul Lq n)] end).
+  intros x. split.
+  + intros []. eapply (list_enumerator_to_cumul H) in H1 as [m1].
+    eapply (list_enumerator_to_cumul H0) in H2 as [m2].
+    exists (1 + m1 + m2). cbn. in_app 2.
+    in_collect x.
+    eapply cum_ge'. eauto. eauto. lia.
+    eapply cum_ge'; eauto. lia.
+  + intros [m]. induction m.
+    * inversion H1.
+    * inv_collect. eapply (list_enumerator_to_cumul H). eauto.
+      eapply (list_enumerator_to_cumul H0). eauto.
+Qed.
+
+Lemma projection X Y (p : X * Y -> Prop) :
+  enumerable p -> enumerable (fun x => exists y, p (x,y)).
+Proof.
+  intros [f].
+  exists (fun n => match f n with Some (x, y) => Some x | None => None end).
+  intros; split.
+  - intros [y ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
+  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inversion H0; subst.
+    exists y. eapply H. eauto.
+Qed.
+
+Lemma projection' X Y (p : X * Y -> Prop) :
+  enumerable p -> enumerable (fun y => exists x, p (x,y)).
+Proof.
+  intros [f].
+  exists (fun n => match f n with Some (x, y) => Some y | None => None end).
+  intros y; split.
+  - intros [x ?]. eapply H in H0 as [n]. exists n. now rewrite H0.
+  - intros [n ?]. destruct (f n) as [ [] | ] eqn:E; inversion H0; subst.
+    exists x. eapply H. eauto.
+Qed.

--- a/theories/Synthetic/ReducibilityFacts.v
+++ b/theories/Synthetic/ReducibilityFacts.v
@@ -1,0 +1,147 @@
+From Undecidability.Synthetic Require Import DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts MoreEnumerabilityFacts.
+From Undecidability.Shared Require Import ListAutomation.
+Require Import List.
+Import ListNotations.
+
+Set Implicit Arguments.
+
+(** ** Definitions *)
+
+Infix "⪯ᵢ" := inf_reduces (at level 70).
+
+(** ** Pre-order properties *)
+
+Section Properties.
+
+  Variables (X : Type) (P : X -> Prop)
+            (Y : Type) (Q : Y -> Prop)
+            (Z : Type) (R : Z -> Prop).
+
+  Fact reduces_reflexive : P ⪯ P.
+  Proof. exists (fun x => x); red; tauto. Qed.
+
+  Fact ireduces_reflexive : P ⪯ᵢ P.
+  Proof. exists (fun x => x); red; tauto. Qed.
+
+  Fact reduces_transitive : P ⪯ Q -> Q ⪯ R -> P ⪯ R.
+  Proof.
+    unfold reduces, reduction.
+    intros (f & Hf) (g & Hg).
+    exists (fun x => g (f x)).
+    intro; rewrite Hf, Hg; tauto.
+  Qed.
+
+  Fact ireduces_transitive : P ⪯ᵢ Q -> Q ⪯ᵢ R -> P ⪯ᵢ R.
+  Proof.
+    unfold inf_reduces, reduction.
+    intros (f & Hf) (g & Hg).
+    exists (fun x => g (f x)).
+    intro; rewrite Hf, Hg; tauto.
+  Qed.
+
+  Fact ireduces_reduces : P ⪯ᵢ Q -> P ⪯ Q.
+  Proof. intros (f & ?); exists f; auto. Qed.
+
+  Fact reduces_ireduces : P ⪯ Q -> inhabited (P ⪯ᵢ Q).
+  Proof. intros (f & ?); exists; exists f; auto. Qed.
+
+  Fact reduces_ireduces_iff : P ⪯ Q <-> inhabited (P ⪯ᵢ Q).
+  Proof.
+    split.
+    + apply reduces_ireduces.
+    + intros []; apply ireduces_reduces; auto.
+  Qed.
+
+  (** ** An equivalent dependent definition *)
+
+  Fact ireduces_dependent :
+         (P ⪯ᵢ Q -> forall x, { y | P x <-> Q y })
+       * ((forall x, { y | P x <-> Q y }) -> P ⪯ᵢ Q).
+  Proof.
+    unfold inf_reduces, reduction.
+    split.
+    + intros (f & Hf).
+      intros x; exists (f x); auto.
+    + intros f.
+      exists (fun x => proj1_sig (f x)).
+      intros; apply (proj2_sig (f x)).
+  Qed.
+
+End Properties.
+
+Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) :
+  p ⪯ q -> decidable q -> decidable p.
+Proof.
+  unfold decidable, decider, reduces, reduction, reflects.
+  intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0.
+Qed.
+
+Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
+  p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y).
+Proof.
+  intros [f]. exists f. intros x. red in H. now rewrite H.
+Qed.
+
+Section enum_red.
+
+  Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop).
+  Variables (f : X -> Y) (Hf : forall x, p x <-> q (f x)).
+
+  Variables (Lq : _) (qe : list_enumerator Lq q).
+
+  Variables (x0 : X).
+  
+  Variables (d : eq_dec Y).
+  
+  Local Fixpoint L L' n :=
+    match n with
+    | 0 => []
+    | S n => L L' n ++ [ x | x ∈ cumul L' n , In (f x) (cumul Lq n) ]
+    end.
+
+  Lemma enum_red L' :
+    list_enumerator__T L' X ->
+    list_enumerator (L L') p.
+  Proof.
+    intros HL'.
+    split.
+    + intros H.
+      eapply Hf in H. eapply (cumul_spec qe) in H as [m1]. destruct (cumul_spec__T HL' x) as [m2 ?]. 
+      exists (1 + m1 + m2). cbn. in_app 2.
+      in_collect x.
+      eapply cum_ge'; eauto; try lia.
+      eapply cum_ge'; eauto; try lia.
+    + intros [m H]. induction m.
+      * inversion H.
+      * cbn in H. inv_collect. 
+        eapply Hf. eauto.
+  Qed.
+
+End enum_red.
+
+Lemma enumerable_red X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> discrete Y -> enumerable q -> enumerable p.
+Proof.
+  intros [f] [] % enum_enumT [] % discrete_iff [L] % enumerable_enum.
+  eapply list_enumerable_enumerable.
+  eexists. eapply enum_red; eauto.
+Qed.
+
+Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) ->
+  ~ decidable q /\ ~ decidable (compl q).
+Proof.
+  intros. split; intros ?.
+  - eapply H1. eapply dec_red in H2; eauto.
+    eapply dec_compl in H2. eapply dec_count_enum; eauto.
+  - eapply H1. eapply dec_red in H2; eauto.
+    eapply dec_count_enum; eauto. now eapply red_comp.
+Qed.
+
+Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> ~ enumerable (compl p) -> discrete Y ->
+  ~ enumerable (compl q).
+Proof.
+  intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto.
+  now eapply red_comp.
+Qed.

--- a/theories/Synthetic/SemiDecidabilityFacts.v
+++ b/theories/Synthetic/SemiDecidabilityFacts.v
@@ -1,0 +1,18 @@
+Require Import Undecidability.Synthetic.DecidabilityFacts.
+
+Lemma decidable_semi_decidable {X} {p : X -> Prop} :
+  decidable p -> semi_decidable p.
+Proof.
+  intros [f H].
+  exists (fun x n => f x). intros x.
+  unfold decider, reflects in H.
+  rewrite H. firstorder. econstructor.
+Qed.
+
+Lemma decidable_compl_semi_decidable {X} {p : X -> Prop} :
+  decidable p -> semi_decidable (compl p).
+Proof.
+  intros H.
+  now eapply decidable_semi_decidable, dec_compl.
+Qed.
+

--- a/theories/Synthetic/Undecidability.v
+++ b/theories/Synthetic/Undecidability.v
@@ -1,4 +1,4 @@
-Require Import Undecidability.Synthetic.Definitions.
+Require Export Undecidability.Synthetic.Definitions Undecidability.Synthetic.ReducibilityFacts.
 Require Import Undecidability.TM.Halting.
 
 Definition undecidable {X} (p : X -> Prop) :=

--- a/theories/Synthetic/Undecidability.v
+++ b/theories/Synthetic/Undecidability.v
@@ -1,0 +1,18 @@
+Require Import Undecidability.Synthetic.Definitions.
+Require Import Undecidability.TM.Halting.
+
+Definition undecidable {X} (p : X -> Prop) :=
+  decidable p -> decidable (HaltTM 1).
+
+Lemma undecidability_HaltTM :
+  undecidable (HaltTM 1).
+Proof.
+  intros H. exact H.
+Qed.
+
+Lemma undecidability_from_reducibility {X} {p : X -> Prop} {Y} {q : Y -> Prop} :
+  undecidable p -> p ⪯ q -> undecidable q.
+Proof.
+  unfold undecidable, decidable, decider, reduces, reduction, reflects.
+  intros H [f Hf] [d Hd]. eapply H. exists (fun x => d (f x)). intros x. rewrite Hf. eapply Hd.
+Qed.

--- a/theories/TM/Halting.v
+++ b/theories/TM/Halting.v
@@ -1,0 +1,12 @@
+From Undecidability.TM Require Export TM.
+
+Definition HaltsTM {sig: finType} {n: nat} (M : mTM sig n) (t : tapes sig n) :=
+  exists outc k, loopM (initc M t) k = Some outc.
+
+Definition HaltTM n (S: {sig:finType & mTM sig n & tapes sig n}) :=
+  HaltsTM (projT2 (sigT_of_sigT2 S)) (projT3 S).
+Arguments HaltTM :clear implicits.
+
+Definition HaltMTM : {'(n,sig) : nat * finType & mTM sig n & tapes sig n} -> Prop :=
+  fun '(existT2 _ _ (n, sig) M t) =>
+    HaltsTM M t.

--- a/theories/TRAKHTENBROT/decidable.v
+++ b/theories/TRAKHTENBROT/decidable.v
@@ -38,6 +38,7 @@ Qed.
 Fact ireduction_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
        p ⪯ᵢ q -> (forall y, decidable (q y)) -> forall x, decidable (p x).
 Proof.
+  unfold decidable, decider, inf_reduces, reduction.
   intros (f & Hf) Hq x.
   destruct (Hq (f x)); [ left | right ]; rewrite Hf; auto.
 Qed.   

--- a/theories/TRAKHTENBROT/enumerable.v
+++ b/theories/TRAKHTENBROT/enumerable.v
@@ -251,6 +251,7 @@ Section enumerable_reduction.
 
   Fact ireduction_rec_enum_t : p ⪯ᵢ q -> rec_enum_t q -> rec_enum_t p.
   Proof.
+    unfold inf_reduces, reduction.
     intros (f & Hf) (d & Hd).
     exists (fun n y => d n (f y)).
     intros x; rewrite Hf, Hd; tauto.

--- a/theories/TRAKHTENBROT/red_undec.v
+++ b/theories/TRAKHTENBROT/red_undec.v
@@ -281,7 +281,7 @@ Theorem FSAT_RELn_ANY Σ n r : ar_rels Σ r = n -> FSAT (Σrel n) ⪯ᵢ FSAT Σ
 Proof.
   intros Hr.
   destruct (SATn_SAT_reduction _ _ Hr) as (f & Hf).
-  exists f; apply Hf.
+  exists f; red; apply Hf.
 Qed.
 
 Section FINITARY_TO_BINARY.
@@ -348,7 +348,7 @@ Section DISCRETE_TO_BINARY.
     intros A.
     destruct (Sig_discrete_to_pos HΣ1 HΣ2 A) as (n & m & i & j & B & HB).
     destruct (@FINITARY_TO_BINARY (Σpos _ i j)) as (f & Hf); simpl; auto.
-    exists (f B).
+    exists (f B). red in Hf.
     rewrite <- Hf; apply HB.
   Qed.
 

--- a/theories/TRAKHTENBROT/red_utils.v
+++ b/theories/TRAKHTENBROT/red_utils.v
@@ -45,7 +45,7 @@ Qed.
 
 Theorem BPCP_BPCP_problem : BPCP ⪯ᵢ BPCP_problem.
 Proof.
-  exists (fun x => x); symmetry; apply BPCP_BPCP_problem_eq.
+  exists (fun x => x); red; symmetry; apply BPCP_BPCP_problem_eq.
 Qed.
 
 (** From a given (arbitrary) signature, 
@@ -73,7 +73,7 @@ Qed.
 Print Assumptions fo_form_fin_dec_SAT_discr_equiv. *)
 
 Corollary FIN_DEC_SAT_FIN_DISCR_DEC_SAT Σ : FSAT Σ ⪯ᵢ @fo_form_fin_discr_dec_SAT Σ.
-Proof. exists (fun A => A); apply fo_form_fin_dec_SAT_discr_equiv. Qed.
+Proof. exists (fun A => A); red; apply fo_form_fin_dec_SAT_discr_equiv. Qed.
 
 (* Check FIN_DEC_SAT_FIN_DISCR_DEC_SAT.
 Print Assumptions FIN_DEC_SAT_FIN_DISCR_DEC_SAT. *)

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -4,7 +4,18 @@
 COQDOCFLAGS = "--charset utf-8 -s --with-header ../website/resources/header.html --with-footer ../website/resources/footer.html --index indexpage"
 
 Shared/Prelim.v
+Shared/Dec.v
+Shared/ListAutomation.v
+Shared/FilterFacts.v
+Shared/embed_nat.v
 
+Synthetic/Definitions.v
+Synthetic/DecidabilityFacts.v
+Synthetic/SemiDecidabilityFacts.v
+Synthetic/EnumerabilityFacts.v
+Synthetic/ListEnumerabilityFacts.v
+Synthetic/MoreEnumerabilityFacts.v
+Synthetic/ReducibilityFacts.v
 
 Shared/Libs/DLW/Utils/focus.v
 Shared/Libs/DLW/Utils/utils_tac.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -10,6 +10,7 @@ Shared/FilterFacts.v
 Shared/embed_nat.v
 
 Synthetic/Definitions.v
+Synthetic/Undecidability.v
 Synthetic/DecidabilityFacts.v
 Synthetic/SemiDecidabilityFacts.v
 Synthetic/EnumerabilityFacts.v
@@ -220,6 +221,7 @@ H10C/h10c_utils.v
 TM/Prelim.v
 TM/Relations.v
 TM/TM.v
+TM/Halting.v
 TM/ArithPrelim.v
 TM/VectorPrelim.v
 


### PR DESCRIPTION
(I force pushed on the branch and github got confused, so reopening this PR)

I started reworking the files in the problem areas `Shared/Prelim.v,` `Problems/Reduction.v`, `FOL/DecidableEnumerable.v`, and `FOL/Reductions.v`.

What I propose is one central directory Synthetic, containing

- a file `Definitions.v` with definitions for all synthetic notions of decidability, enumerability, reduction and their informative counterparts.
- files `<Concept>Facts.v` for each of these concepts with the relevant facts previously somewhere in the FOL part
- a file `Undecidability.v` containing the definition of undecidability. This is not in the `Definitions` file to avoid a compile-dependency on Turing machines (and thus the base lib) for the early parts of the library.

I also started splitting up Shared/Prelim.v and only import (no exports!) the relevant chunks in the Facts files. The only exported notation is the notation for reduction and informative reduction.

This PR won't compile, because I haven't adapted everything yet, but the Synthetic directory compiles as is.

I switched from `informatively_` as prefix to `inf_` because the former leads to annoyingly long names which are hard to type, but that's up for discussion.