### PR TITLE
BinaryStackMachines to StackMachines

### DIFF
--- a/theories/ILL/ILL_undec.v
+++ b/theories/ILL/ILL_undec.v
@@ -14,9 +14,9 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.Synthetic.Undecidability.
 
-From Undecidability.PCP                  Require Import PCP PCP_undec.
-From Undecidability.BinaryStackMachines  Require Import BSM.
-From Undecidability.MinskyMachines       Require Import MM.
+From Undecidability.PCP              Require Import PCP PCP_undec.
+From Undecidability.StackMachines    Require Import BSM.
+From Undecidability.MinskyMachines   Require Import MM.
 
 From Undecidability.ILL 
   Require Import EILL ILL PCP_iBPCP iBPCP_MM MM_EILL EILL_ILL.

--- a/theories/ILL/Reductions/iBPCP_MM.v
+++ b/theories/ILL/Reductions/iBPCP_MM.v
@@ -19,7 +19,7 @@ From Undecidability.Shared.Libs.DLW
 From Undecidability.PCP
   Require Import PCP.
 
-From Undecidability.BinaryStackMachines
+From Undecidability.StackMachines
   Require Import BSM iPCPb_to_BSM_HALTING.
 
 From Undecidability.MinskyMachines

--- a/theories/MinskyMachines/MM/mm_comp.v
+++ b/theories/MinskyMachines/MM/mm_comp.v
@@ -7,14 +7,13 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega.
+Require Import List Arith Lia.
 
 From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils Utils.list_bool
-                 Vec.pos Vec.vec
-                 Code.subcode Code.sss Code.compiler_correction.
+  Require Import utils list_bool pos vec
+                 subcode sss compiler_correction.
 
-From Undecidability.BinaryStackMachines
+From Undecidability.StackMachines.BSM
   Require Import bsm_defs.
 
 From Undecidability.MinskyMachines.MM
@@ -91,7 +90,7 @@ Section simulator.
   Proof. destruct ii as [ | ? [] ]; simpl; auto. Qed.
     
   Fact bsm_instr_compile_length_geq ii : 1 <= bsm_instr_compile_length ii.
-  Proof. destruct ii as [ | ? [] ]; simpl; auto; omega. Qed.
+  Proof. destruct ii as [ | ? [] ]; simpl; auto; lia. Qed.
 
   Hint Resolve bsm_instr_compile_length_eq bsm_instr_compile_length_geq : core.
 
@@ -262,7 +261,7 @@ Section simulator.
         apply Q_spec1 in H1.
         destruct H1 as (w' & (H1 & H0) & H2 & H3).
         split.
-        2: simpl; omega.
+        2: simpl; lia.
         apply sss_compute_trans with (st2 := (iE,w')).
         revert H1; apply subcode_sss_compute; auto.
         apply sss_progress_compute.

--- a/theories/MinskyMachines/MM/mm_comp_old.v
+++ b/theories/MinskyMachines/MM/mm_comp_old.v
@@ -7,14 +7,14 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega.
+Require Import List Arith Lia.
 
 From Undecidability.Shared.Libs.DLW 
   Require Import Utils.utils Utils.list_bool
                  Vec.pos Vec.vec
                  Code.subcode Code.sss Code.compiler.
 
-From Undecidability.BinaryStackMachines
+From Undecidability.StackMachines
   Require Import bsm_defs.
 
 From Undecidability.MinskyMachines.MM
@@ -78,7 +78,7 @@ Section compiler.
   Proof. destruct ii as [ | ? [] ]; simpl; auto. Qed.
     
   Fact bsm_instr_compile_length_geq ii : 1 <= bsm_instr_compile_length ii.
-  Proof. destruct ii as [ | ? [] ]; simpl; auto; omega. Qed.
+  Proof. destruct ii as [ | ? [] ]; simpl; auto; lia. Qed.
   
   Let err := length_compiler bsm_instr_compile_length (snd P)+1.
   
@@ -113,7 +113,7 @@ Section compiler.
   Proof. 
     apply linker_out_code.
     apply bsm_instr_compile_length_eq.
-    unfold err; omega.
+    unfold err; lia.
   Qed.
   
   Fact bsm_linker_out_err i : out_code i P -> lnk i = err.
@@ -122,7 +122,7 @@ Section compiler.
     destruct (eq_nat_dec i (code_end P)) as [ E | D ].
     rewrite E; intros _; apply linker_code_end.
     intros; apply linker_err_code.
-    simpl in D, H; omega.
+    simpl in D, H; lia.
   Qed.
 
   Notation Hc := bsm_coherence.
@@ -406,7 +406,7 @@ Section compiler.
     { revert H4; apply subcode_out_code; auto. }
     assert (in_code (lnk i1) (lnk i1, comp i1 ii)) as G3.
     { simpl; generalize (bsm_instr_compile_length_geq ii);
-      rewrite bsm_instr_compile_length_eq; omega. }
+      rewrite bsm_instr_compile_length_eq; lia. }
     rewrite <- H2 in H5.
     destruct H1 as (F1 & F2 & F4).
     destruct ii as [ x j k | x [] ]; 
@@ -583,7 +583,7 @@ Section compiler.
   Proof.
     unfold err, bsm_simulator; subcode_tac; solve list eq.
     rewrite bsm_compiler_length.
-    unfold snd; omega.
+    unfold snd; lia.
   Qed.
   
   Theorem bsm_simulator_correct v : (exists q w, P /BSM/ (fst P,v) ->> (q,w) /\ out_code q P) 

--- a/theories/MinskyMachines/MM_undec.v
+++ b/theories/MinskyMachines/MM_undec.v
@@ -11,7 +11,7 @@
 
 Require Import Undecidability.Synthetic.Undecidability.
 
-From Undecidability.BinaryStackMachines Require Import BSM BSM_undec.
+From Undecidability.StackMachines Require Import BSM BSM_undec.
 From Undecidability.MinskyMachines Require Import MM Reductions.BSM_MM.
 
 Lemma MM_HALTS_ON_ZERO_undec : undecidable MM_HALTS_ON_ZERO.

--- a/theories/MinskyMachines/Reductions/BSM_MM.v
+++ b/theories/MinskyMachines/Reductions/BSM_MM.v
@@ -10,11 +10,9 @@
 Require Import Undecidability.Synthetic.Undecidability.
 
 From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils Utils.list_bool
-                 Vec.pos Vec.vec
-                 Code.subcode Code.sss.
+  Require Import utils list_bool pos vec subcode sss.
 
-From Undecidability.BinaryStackMachines
+From Undecidability.StackMachines
   Require Import bsm_defs.
 
 From Undecidability.MinskyMachines.MM

--- a/theories/MinskyMachines/Reductions/PCPb_to_MM.v
+++ b/theories/MinskyMachines/Reductions/PCPb_to_MM.v
@@ -9,9 +9,9 @@
 
 Require Import Undecidability.Synthetic.Undecidability.
 
-From Undecidability.PCP                  Require Import PCP PCPb_iff_iPCPb.
-From Undecidability.BinaryStackMachines  Require Import BSM iPCPb_to_BSM_HALTING.
-From Undecidability.MinskyMachines       Require Import MM BSM_MM.
+From Undecidability.PCP              Require Import PCP PCPb_iff_iPCPb.
+From Undecidability.StackMachines    Require Import BSM iPCPb_to_BSM_HALTING.
+From Undecidability.MinskyMachines   Require Import MM BSM_MM.
  
 Theorem PCPb_MM_HALTS_ON_ZERO : PCPb ⪯ MM_HALTS_ON_ZERO.
 Proof.

--- a/theories/Problems/BSM.v
+++ b/theories/Problems/BSM.v
@@ -1,4 +1,4 @@
-From Undecidability.BinaryStackMachines Require Export BSM.
+From Undecidability.StackMachines Require Export BSM.
 
 (* The halting problem for binary stack machines *)
 

--- a/theories/Reductions/BPCP_to_BSM.v
+++ b/theories/Reductions/BPCP_to_BSM.v
@@ -1,2 +1,2 @@
-Require Export Undecidability.BinaryStackMachines.Reductions.iPCPb_to_BSM_HALTING.
+Require Export Undecidability.StackMachines.Reductions.iPCPb_to_BSM_HALTING.
 

--- a/theories/StackMachines/BSM.v
+++ b/theories/StackMachines/BSM.v
@@ -10,7 +10,7 @@
 Require Import List Bool.
 
 From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.list_bool Vec.pos Vec.vec Code.sss.
+  Require Import list_bool pos vec sss.
 
 Set Implicit Arguments.
 

--- a/theories/StackMachines/BSM/bsm_defs.v
+++ b/theories/StackMachines/BSM/bsm_defs.v
@@ -7,14 +7,12 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega Bool.
+Require Import List Arith Lia Bool.
 
 From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils Utils.list_bool 
-                 Vec.pos Vec.vec
-                 Code.subcode Code.sss.
+  Require Import utils list_bool pos vec subcode sss.
 
-From Undecidability.BinaryStackMachines 
+From Undecidability.StackMachines 
   Require Export BSM.
 
 Set Implicit Arguments.
@@ -91,7 +89,7 @@ Section Binary_Stack_Machine.
     apply subcode_sss_compute_trans with (1 := H1).
     exists 1; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; omega.
+    simpl; lia.
     constructor; auto.
   Qed.
 
@@ -105,7 +103,7 @@ Section Binary_Stack_Machine.
     apply subcode_sss_compute_trans with (1 := H1).
     exists 1; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; omega.
+    simpl; lia.
     constructor; auto.
   Qed.
 
@@ -119,7 +117,7 @@ Section Binary_Stack_Machine.
     apply subcode_sss_compute_trans with (1 := H1).
     exists 1; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; omega.
+    simpl; lia.
     constructor; auto.
   Qed.
 
@@ -144,7 +142,7 @@ Section Binary_Stack_Machine.
     apply subcode_sss_compute_trans with (1 := H1).
     exists 1; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; omega.
+    simpl; lia.
     constructor; auto.
   Qed.
 
@@ -162,7 +160,7 @@ Section Binary_Stack_Machine.
     exists b.
     destruct H4 as (st2 & ? & H4 & H5); subst.
     split.
-    omega.
+    lia.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     inversion H4; subst; try mydiscr; myinj.
   Qed.
@@ -181,7 +179,7 @@ Section Binary_Stack_Machine.
     exists b.
     destruct H4 as (st2 & ? & H4 & H5); subst.
     split.
-    omega.
+    lia.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     inversion H4; subst; try mydiscr; myinj.
   Qed.
@@ -214,7 +212,7 @@ Section Binary_Stack_Machine.
     exists b.
     destruct H4 as (st2 & ? & H4 & H5); subst.
     split.
-    omega.
+    lia.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     inversion H4; subst; try mydiscr; myinj.
   Qed.
@@ -232,7 +230,7 @@ Section Binary_Stack_Machine.
     exists a.
     destruct H4 as (st2 & ? & H4 & H5); subst.
     split.
-    omega.
+    lia.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     inversion H4; subst; auto.
   Qed.

--- a/theories/StackMachines/BSM/bsm_pcp.v
+++ b/theories/StackMachines/BSM/bsm_pcp.v
@@ -12,7 +12,7 @@ Require Import List Arith Lia Bool.
 From Undecidability.Shared.Libs.DLW 
   Require Import utils list_bool pos vec subcode sss.
 
-From Undecidability.BinaryStackMachines.BSM
+From Undecidability.StackMachines.BSM
   Require Import tiles_solvable bsm_defs bsm_utils.
 
 Set Implicit Arguments.

--- a/theories/StackMachines/BSM/bsm_utils.v
+++ b/theories/StackMachines/BSM/bsm_utils.v
@@ -7,14 +7,12 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Omega Bool.
+Require Import List Arith Lia Bool.
 
 From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils Utils.list_bool 
-                 Vec.pos Vec.vec
-                 Code.subcode Code.sss.
+  Require Import utils list_bool pos vec subcode sss.
 
-From Undecidability.BinaryStackMachines.BSM 
+From Undecidability.StackMachines.BSM 
   Require Import tiles_solvable bsm_defs.
 
 Set Implicit Arguments.
@@ -418,7 +416,7 @@ Section Binary_Stack_Machines.
       apply subcode_sss_compute with (P := (1+i,half_tile l)).
       subcode_tac; solve list eq.
       eq goal IHl; do 2 f_equal.
-      omega.
+      lia.
       apply vec_pos_ext; intros z; dest z x.
       solve list eq.
     Qed.
@@ -455,7 +453,7 @@ Section Binary_Stack_Machines.
       with    (length (half_tile y (rev low)) + (length (half_tile x (rev high)) + i)).
       replace (v#>y) with (v[(high ++ v#>x)/x]#>y) by rew vec.
       apply half_tile_spec.
-      rew length; omega.
+      rew length; lia.
     Qed.
 
   End tile.
@@ -505,7 +503,7 @@ Section Binary_Stack_Machines.
       2: dest z x. 
       change (b :: list_repeat b k ++ v#>y)
       with (list_repeat b (S k) ++ v#>y).
-      replace (S k) with (k+1) by omega.
+      replace (S k) with (k+1) by lia.
       rewrite list_repeat_plus; solve list eq.
     Qed.
 
@@ -534,7 +532,7 @@ Section Binary_Stack_Machines.
       2: dest z x. 
       change (b :: list_repeat b k ++ v#>y)
       with (list_repeat b (S k) ++ v#>y).
-      replace (S k) with (k+1) by omega.
+      replace (S k) with (k+1) by lia.
       rewrite list_repeat_plus; solve list eq.
     Qed.
 
@@ -604,7 +602,7 @@ Section Binary_Stack_Machines.
       apply transfer_ones_spec_1 with (k := k) (l := v#>y); rew vec.
       f_equal.
       apply vec_pos_ext; intros z; dest z y; dest z x.
-      replace (S k) with (k+1) by omega.
+      replace (S k) with (k+1) by lia.
       rewrite list_repeat_plus; auto.
  
       bsm sss stop.
@@ -668,11 +666,11 @@ Section Binary_Stack_Machines.
     Fact decoder_length s i lt : length (decoder s i lt) = length_decoder lt.
     Proof.
       revert s i; induction lt as [ | (th,tl) lt IHlt ]; intros s i; rew length; auto.
-      simpl; rew length; rewrite IHlt; omega.
+      simpl; rew length; rewrite IHlt; lia.
     Qed.
 
     Fact length_decoder_size lt : length_decoder lt = 2+3*length lt+size_cards lt.
-    Proof. induction lt as [ | [] ]; simpl; auto; omega. Qed.
+    Proof. induction lt as [ | [] ]; simpl; auto; lia. Qed.
 
     Local Fact decoder_spec_rec s i mm ll th tl lr lc v w :
            v#>c  = list_repeat Zero (length ll) ++ One :: lc
@@ -692,7 +690,7 @@ Section Binary_Stack_Machines.
                                            (st2 := (1+length (tile h l th tl)+i,v[lc/c][(th++v#>h)/h][(tl++v#>l)/l])); auto.
       apply tile_spec; auto.
       f_equal.
-      rew length; omega.
+      rew length; lia.
       apply vec_pos_ext; intros z; dest z l.
    
       bsm sss PUSH with c Zero.
@@ -776,12 +774,12 @@ Section Binary_Stack_Machines.
       unfold decoder; fold decoder.
       destruct k as [ | k ].
 
-      simpl in H2; omega.
+      simpl in H2; lia.
 
       simpl in H1, H2.
       destruct (IHll (3 + length (tile h l t1 t2) + i) lc (v[(list_repeat Zero k++lc)/c]) k)
         as (r & Hr); rew vec.
-      omega.
+      lia.
       exists r.
       bsm sss POP 0 with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k++lc).
       revert Hr; rew vec; apply subcode_sss_compute; auto.
@@ -936,7 +934,7 @@ Section Binary_Stack_Machines.
 
       apply Exists_cons in Hln.
       destruct Hln as [ Hln | Hln ].
-      omega.
+      lia.
       specialize (IHln Hln).
       destruct (nth_split _ (nil,nil) Hx) as (ll & lr & H3 & H4).
       revert H3; generalize (nth x lt (nil,nil)); intros (th, tl) H3.
@@ -1120,12 +1118,12 @@ Section Binary_Stack_Machines.
       Definition length_main_loop := 52 + lFD.
 
       Fact main_loop_length : length main_loop = length_main_loop.
-      Proof. unfold main_loop, length_main_loop, lFD; rew length; omega. Qed.
+      Proof. unfold main_loop, length_main_loop, lFD; rew length; lia. Qed.
 
       Fact main_loop_size : length_main_loop = 59+3*length lt+size_cards lt.
       Proof.
         unfold length_main_loop, lFD, length_full_decoder.
-        rewrite length_decoder_size; omega.
+        rewrite length_decoder_size; lia.
       Qed.
 
       Fact main_loop_ok_spec v ln :

--- a/theories/StackMachines/BSM/tiles_solvable.v
+++ b/theories/StackMachines/BSM/tiles_solvable.v
@@ -7,10 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Max Omega Wellfounded Bool.
-
-From Undecidability.Shared.Libs.DLW 
-  Require Import Utils.utils Utils.list_bool.
+Require Import List.
 
 Set Implicit Arguments.
 

--- a/theories/StackMachines/BSM_undec.v
+++ b/theories/StackMachines/BSM_undec.v
@@ -12,8 +12,8 @@ Require Import Undecidability.Synthetic.Undecidability.
 From Undecidability.PCP
   Require Import PCP PCP_undec.
 
-From Undecidability.BinaryStackMachines 
-  Require Import BSM Reductions.iPCPb_to_BSM_HALTING.
+From Undecidability.StackMachines 
+  Require Import BSM iPCPb_to_BSM_HALTING.
 
 Theorem BSM_undec : undecidable (BSM_HALTING).
 Proof.

--- a/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
+++ b/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
@@ -15,7 +15,7 @@ Require Import Undecidability.Synthetic.Undecidability.
 From Undecidability.Shared.Libs.DLW 
   Require Import utils list_bool pos vec subcode sss.
 
-From Undecidability.BinaryStackMachines.BSM 
+From Undecidability.StackMachines.BSM 
   Require Import tiles_solvable bsm_defs bsm_utils bsm_pcp.
 
 From Undecidability.PCP 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -131,14 +131,6 @@ FOL/BPCP_CND.v
 FOL/Weakening.v
 FOL/Infinite.v
 
-BinaryStackMachines/BSM.v
-BinaryStackMachines/BSM_undec.v
-BinaryStackMachines/Reductions/iPCPb_to_BSM_HALTING.v
-
-BinaryStackMachines/BSM/bsm_defs.v
-BinaryStackMachines/BSM/bsm_utils.v
-BinaryStackMachines/BSM/bsm_pcp.v
-BinaryStackMachines/BSM/tiles_solvable.v
 
 MinskyMachines/MM.v             # generic X-bounded MM (X=pos n or X=nat is type of registers) 
                                 # with CPP19 semantics (MM) and alternate semantics (MMA)
@@ -582,10 +574,17 @@ CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
 CounterMachines/Reductions/HaltTM_to_CM1c4_HALT.v
 
 #Stack Machines
+StackMachines/BSM.v
+StackMachines/BSM_undec.v
 StackMachines/SMN.v
 StackMachines/SMN_undec.v
 StackMachines/SSM.v
 StackMachines/SSM_undec.v
+
+StackMachines/BSM/bsm_defs.v
+StackMachines/BSM/bsm_utils.v
+StackMachines/BSM/bsm_pcp.v
+StackMachines/BSM/tiles_solvable.v
 
 StackMachines/Util/Facts.v
 StackMachines/Util/Nat_facts.v
@@ -595,11 +594,13 @@ StackMachines/Util/SMX.v
 StackMachines/Util/SMX_facts.v
 StackMachines/Util/SMN_facts.v
 StackMachines/Util/CSSM_facts.v
+
 StackMachines/Reductions/CM1_to_SMX.v
 StackMachines/Reductions/CM1c4_HALT_to_SMNdl_UB.v
 StackMachines/Reductions/SMN_transform.v
 StackMachines/Reductions/SMNdl_UB_to_CSSM_UB.v
 StackMachines/Reductions/HaltTM_to_CSSM_UB.v
+StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
 
 #Semi-unification
 SemiUnification/SemiU.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -117,6 +117,7 @@ CFG/Reductions/PCP_to_CFPI.v
 CFG/Reductions/CFPP_to_CFP.v
 CFG/Reductions/CFPI_to_CFI.v
 
+# First order logic
 FOL/DecidableEnumerable.v
 FOL/Reductions.v
 FOL/MarkovPost.v
@@ -131,7 +132,7 @@ FOL/BPCP_CND.v
 FOL/Weakening.v
 FOL/Infinite.v
 
-
+# Minsky machines with n counter (2 different semantics) and with 2 counters 
 MinskyMachines/MM.v             # generic X-bounded MM (X=pos n or X=nat is type of registers) 
                                 # with CPP19 semantics (MM) and alternate semantics (MMA)
 MinskyMachines/MMA.v            # simply exports MM.v
@@ -164,8 +165,7 @@ MinskyMachines/MMenv/env.v          # environments for nat-bounded MM
 MinskyMachines/MMenv/mme_defs.v     # X-bounded MM definitions      
 MinskyMachines/MMenv/mme_utils.v    # nat-bounded MM utils for MuRec ~~> MM(nat) compiler
 
-
-
+# Intuitionistic Linear Logic (cf CPP'19 YF&DLW)
 ILL/EILL.v
 ILL/ILL.v
 ILL/ILL_undec.v
@@ -179,6 +179,7 @@ ILL/Ll/ill.v
 ILL/Ll/eill.v
 ILL/Ll/eill_mm.v
 
+# µ-recursive algorithms
 MuRec/recalg.v
 MuRec/ra_utils.v
 MuRec/beta.v
@@ -200,6 +201,7 @@ MuRec/recursor.v
 MuRec/ra_sem_eq.v
 MuRec/ra_ca.v
 
+# FRACTRAN (from H10 FSCD'19, DLW & YF)
 FRACTRAN/FRACTRAN.v
 FRACTRAN/FRACTRAN_undec.v
 FRACTRAN/Reductions/MM_FRACTRAN.v
@@ -208,7 +210,7 @@ FRACTRAN/Utils/prime_seq.v
 FRACTRAN/FRACTRAN/fractran_utils.v
 FRACTRAN/FRACTRAN/mm_fractran.v
 
-H10/Fractran/fractran_dio.v
+# Hilbert Tenth problem (FSCD'19, DLW & YF)
 
 H10/ArithLibs/Zp.v
 H10/ArithLibs/matrix.v
@@ -228,6 +230,8 @@ H10/Dio/dio_cipher.v
 H10/Dio/dio_bounded.v
 H10/Dio/dio_rt_closure.v
 
+H10/Fractran/fractran_dio.v
+
 H10/FRACTRAN_DIO.v
 H10/DPRM.v
 H10/H10.v
@@ -235,8 +239,6 @@ H10/H10Z.v
 H10/H10_undec.v
 H10/H10Z_undec.v
 
-#H10/HaltTM_to_MM_HALTING.v
-#H10/HaltTM_to_H10.v
 
 # Basics
 TM/Prelim.v


### PR DESCRIPTION
Migration:
+ `BinaryStackMachines` to the _existing_ `StackMachines` directory
+ removal of `omega`, replaced by `lia` in those moves files.
