### PR TITLE
Removing Shared.Prelim where I know how to ...

### DIFF
--- a/theories/PCP/Reductions/PCP_to_PCPb.v
+++ b/theories/PCP/Reductions/PCP_to_PCPb.v
@@ -6,8 +6,6 @@ Require Import Undecidability.PCP.Util.Facts.
 
 Require Import Undecidability.Problems.Reduction.
 
-Require Import Undecidability.Shared.Prelim.
-
 (** ** PCP reduces to BPCP *)
 
 (* natural numbers n to bitstrings of the form 1^n *)
@@ -116,9 +114,11 @@ Proof.
   induction A in B |- *; intros H; cbn.
   * firstorder.
   * intros ? [| H0]; subst.
-    -- unfold f. eapply in_map_iff. exists a.
+    - unfold f. eapply in_map_iff. exists a.
       constructor; eauto.
-    -- eapply IHA in H0; eauto. 
+      apply H; simpl; auto.
+    - eapply IHA in H0; eauto.
+      intros ? ?; apply H; simpl; auto. 
 Qed.
 
 Lemma f_g_subset B A : A <<= f B -> g A <<= B.

--- a/theories/PCP/Reductions/PCPb_iff_dPCPb.v
+++ b/theories/PCP/Reductions/PCPb_iff_dPCPb.v
@@ -1,13 +1,7 @@
-Require Import List.
-Import ListNotations.
+Require Import Undecidability.Synthetic.Undecidability.
 
-Require Import Undecidability.PCP.PCP.
-Require Import Undecidability.PCP.Util.Facts.
-Require Import Undecidability.PCP.Reductions.PCPX_iff_dPCP.
-
-Require Import Undecidability.Problems.Reduction.
-
-Require Import Undecidability.Shared.Prelim.
+From Undecidability.PCP
+  Require Import PCP Util.Facts PCPX_iff_dPCP.
 
 Lemma PCPb_iff_dPCPb P : PCPb P <-> dPCPb P.
 Proof. apply PCPX_iff_dPCP. Qed.

--- a/theories/PCP/Reductions/PCPb_iff_iPCPb.v
+++ b/theories/PCP/Reductions/PCPb_iff_iPCPb.v
@@ -7,7 +7,6 @@ Require Import Undecidability.PCP.Util.PCP_facts.
 
 Require Import Undecidability.Problems.Reduction.
 
-Require Import Undecidability.Shared.Prelim.
 (** ** BPCP reduces to iBPCP *)
 
 Definition f (P : stack bool) (A : stack bool) := omap (fun x => pos card_eq x P) A.
@@ -17,7 +16,9 @@ Proof.
   intros H. induction A as [ | (x,y) ].
   - reflexivity.
   - cbn. assert ((x, y) el P) as [n E] % (el_pos card_eq) by firstorder.
-    rewrite E. cbn. unfold f in IHA. rewrite IHA; eauto. now erewrite pos_nth; eauto.
+    rewrite E. cbn. unfold f in IHA. rewrite IHA; eauto. 
+    + now erewrite pos_nth; eauto.
+    + intros ? ?; apply H; simpl; auto.
 Qed.
 
 Lemma itau_tau2 P A : A <<= P -> itau2 P (f P A) = tau2 A.
@@ -25,7 +26,9 @@ Proof.
   intros H. induction A as [ | (x,y) ].
   - reflexivity.
   - cbn. assert ((x, y) el P) as [n E] % (el_pos card_eq) by firstorder.
-    rewrite E. cbn. unfold f in IHA. rewrite IHA; eauto. now erewrite pos_nth; eauto.
+    rewrite E. cbn. unfold f in IHA. rewrite IHA; eauto. 
+    + now erewrite pos_nth; eauto.
+    + intros ? ?; apply H; simpl; auto.
 Qed.
 
 Definition g (P : stack bool) (A : list nat) := map (fun n => nth n P ( [], [] )) A.

--- a/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
+++ b/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
@@ -8,8 +8,8 @@
 (**************************************************************)
 
 Require Import List Arith Lia.
+Import ListNotations.
 
-Require Import Undecidability.Shared.Prelim.
 Require Import Undecidability.Synthetic.Undecidability.
 
 From Undecidability.Shared.Libs.DLW 
@@ -62,7 +62,7 @@ Section iPCPb_to_BSM_HALTING.
     exact (vec_set_pos (fun _ => nil)).
   Defined.
 
-  Goal forall x, | pcp_bsm x| >= 80.
+  Goal forall x, length(pcp_bsm x) >= 80.
     intros; rewrite pcp_bsm_size; lia.
   Qed.
   


### PR DESCRIPTION
There are not many places ... `eauto` does a lot in the background when `Shared.Prelim` is loaded, and sometimes like in the `PCP.Reductions`, I cannot even figure out what it does!!