### PR TITLE
Branch for Coq 8.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Feel free to contribute or start using the problems!
 
 ## Existing undecidable problems
 
-- Post correspondence problem (`PCP` in [`Problems/PCP.v`](theories/Problems/PCP.v)), **`good seed`**
-- Halting problems for single-tape and multi-tape Turing machines (`Halt` in [`Problems/TM.v`](theories/Problems/TM.v))
+- Post correspondence problem (`PCP` in [`PCP/PCP.v`](theories/PCP/PCP.v)), **`good seed`**
+- Halting problems for single-tape and multi-tape Turing machines (`HaltTM` in [`TM/TM.v`](theories/TM/TM.v))
 - Halting problem for Minsky machines (`MM_HALTING` in [`Problems/MM.v`](theories/Problems/MM.v))
 - Halting problem for two counters Minsky machines (`MM2_HALTING` in [`Problems/MM2.v`](theories/Problems/MM2.v)) with 
   self-contained explanations, **`good seed`**
 - Halting problem for Binary Stack Machines (`BSM_HALTING` in [`Problems/BSM.v`](theories/Problems/BSM.v))
-- Halting problem for the call-by-value lambda-calculus (`eva` in [`Problems/L.v`](theories/Problems/L.v))
+- Halting problem for the call-by-value lambda-calculus (`HaltL` in [`L/L.v`](theories/L/L.v))
 - String rewriting (`SR` in [`StringRewriting/SR.v`](theories/StringRewriting/SR.v))
 - Entailment in Elementary Intuitionistic Linear Logic (`EILL_PROVABILITY` in [`Problems/ILL.v`](theories/Problems/ILL.v))
 - Entailment in Intuitionistic Linear Logic (`ILL_PROVABILITY` in [`Problems/ILL.v`](theories/Problems/ILL.v))
@@ -43,7 +43,7 @@ If you cannot use `opam 2`, you can use the `noopam` branch of this repository, 
 We recommend creating a fresh opam switch:
 
 ```
-opam switch create coq-library-undecidability 4.07.1+flambda
+opam switch create coq-library-undecidability 4.09.1+flambda
 eval $(opam env)
 ```
 
@@ -57,7 +57,7 @@ opam install coq-library-undecidability.dev+8.12
 
 ### Manual installation
 
-You need `Coq 8.12` built on OCAML `> 4.07.1`, the [Smpl](https://github.com/uds-psl/smpl) package, the [PSL Base](https://github.com/uds-psl/base-library) library, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
+You need `Coq 8.12` built on OCAML `>= 4.07.1`, the [Smpl](https://github.com/uds-psl/smpl) package, the [PSL Base](https://github.com/uds-psl/base-library) library, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
 
 ```
 opam switch create coq-library-undecidability 4.09.1+flambda
@@ -76,6 +76,14 @@ opam install . --deps-only
 
 ## Published work and technical reports
 
+### Papers and abstracts on the library
+
+A Coq Library of Undecidable Problems. Yannick Forster, Dominique Larchey-Wendling, Andrej Dudenhefner, Edith Heiter, Dominik Kirst, Fabian Kunze, Gert Smolka, Simon Spies, Dominik Wehr, Maximilian Wuttke. CoqPL '20. https://popl20.sigplan.org/details/CoqPL-2020-papers/5/A-Coq-Library-of-Undecidable-Problems
+
+### Papers and abstracts on problems and proofs included in the library
+
+- Trakhtenbrot's Theorem in Coq - A Constructive Approach to Finite Model Theory. Dominik Kirst and Dominique Larchey-Wendkling. IJCAR 2020. Subdirectory `TRAKTHENBROT`. https://www.ps.uni-saarland.de/extras/fol-trakh/
+- Undecidability of Semi-Unification on a Napkin. Andrej Dudenhefner. FSCD 2020. Subdirectory `SUP`. https://www.ps.uni-saarland.de/Publications/documents/Dudenhefner_2020_Semi-unification.pdf
 - Undecidability of Higher-Order Unification Formalised in Coq. Simon Spies and Yannick Forster. Technical report. Subdirectory `HOU`. https://www.ps.uni-saarland.de/Publications/details/SpiesForster:2019:UndecidabilityHOU.html
 - Verified Programming of Turing Machines in Coq. Yannick Forster, Fabian Kunze, Maximilian Wuttke. Technical report. Subdirectory `TM`. https://github.com/uds-psl/tm-verification-framework/
 - Hilbert's Tenth Problem in Coq. Dominique Larchey-Wendling and Yannick Forster. FSCD '19. Subdirectory `H10`. https://uds-psl.github.io/H10

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ opam install coq-library-undecidability.dev+8.12
 You need `Coq 8.12` built on OCAML `>= 4.07.1`, the [Smpl](https://github.com/uds-psl/smpl) package, the [PSL Base](https://github.com/uds-psl/base-library) library, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
 
 ```
-opam switch create coq-library-undecidability 4.09.1+flambda
+opam switch create coq-library-undecidability 4.07.1+flambda
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git
@@ -73,6 +73,20 @@ opam install . --deps-only
 - `make html` generates clickable coqdoc `.html` in the `website` subdirectory
 - `make clean` removes all build files in `theories` and `.html` files in the `website` directory
 - `make realclean` also removes all build files in the `external` directory. You have to run `make deps` again after this.
+
+### Troubleshooting
+
+#### Windows
+
+If you use Visual Studio Code on Windows 10 with Windows Subsystem for Linux (WSL), then local opam switches may cause issues.
+To avoid this, you can use a non-local opam switch, i.e. `opam switch create 4.07.1+flambda`.
+
+#### Coq version
+
+Be careful that this branch only compiles under Coq 8.12. If you want to use a different Coq version you have to change to a different branch.
+Due to compatibility issues, not every branch contains exactly the same problems. 
+We recommend to use the newest branch if possible.
+
 
 ## Published work and technical reports
 


### PR DESCRIPTION
There's a `coq-8.12` branch now which I can compile locally, works on Travis and compiles on Andrej's Windows machine. I didn't use PRs to create it because there was nothing to merge against, so I'm opening this PR to have a central point for discussion.

The opam packages for `smpl` and the `base-library` are done. The official MetaCoq opam package is on its way, I created an internal version to make it easier to install. It's important to run `opam update` first, afterwards `opam install . --deps-only` should install the necessary packages.

There are some more warnings now, but not too many, I'll try to fix them in later PRs.

I'd also like to brush up the README a bit, feel free to mention relevant feedback here. I added the recent papers and fixed some links in the problems list.

We could add a `Troubleshooting` section and include hints how to use the library under Windows and how to use `vscoq` and WSL together. @mrhaandi do you have suggestions for concrete bits of text to put there?

If there are no requests I'd also like to make `coq-8.12` the default branch.

@fakusb, it might be easiest to port `coq-library-complexity` quickly so we can fix things in our library that you need. The representation of constant names in MetaCoq changed significantly (paths are now explicitly represented), which means I had to touch various parts of the L extraction. Also `lia` behaves differently on 8.12. If you encounter bugs and report them there are good chances the fixes will make it into 8.12.1. Andrej encountered two lia regressions in his code which we're currently workarounding.