### PR TITLE
Binary Turing machines and direct reduction from Turing machines to BSM

### DIFF
--- a/theories/Shared/FinTypeEquiv.v
+++ b/theories/Shared/FinTypeEquiv.v
@@ -1,0 +1,80 @@
+From PslBase Require Import FiniteTypes.
+
+Fixpoint position {X : eqType} (x : X) (l : list X) : option (Fin.t (length l)).
+Proof.
+  induction l.
+  - exact None.
+  - cbn. decide (a = x).
+    + exact (Some Fin.F1).
+    + destruct (position _ x l) as [res | ].
+      * exact (Some (Fin.FS res)). 
+      * exact None.
+Defined.
+
+Lemma position_in {X : eqType} (x : X) (l : list X) (H : x el l) : 
+  { i | position x l = Some i}.
+Proof.  
+    induction l; cbn in *.
+    - inv H.
+    - decide (a = x).
+        + eauto.
+        + destruct IHl as [i IH]. firstorder. rewrite IH. eauto.
+Defined. 
+
+Definition posIn {X : eqType} (x : X) (l : list X) (H : x el l) : Fin.t (length l).
+Proof.
+    eapply position_in in H. destruct (position x l) as [i | ]. exact i.
+    abstract (exfalso; firstorder congruence).
+Defined.
+
+Fixpoint getat {X : Type} (l : list X) (i : Fin.t (length l)) : X.
+Proof.
+    destruct l.
+    - inv i.
+    - cbn in i. eapply (Fin.caseS' i (fun _ => X)).
+      + exact x.
+      + eapply getat.
+Defined.
+
+Arguments getat {_} _ _.
+
+Lemma getatIn {X : Type} (l : list X) (i : Fin.t (length l)) : 
+    getat l i el l.
+Proof.
+    induction l.
+    - inv i.
+    - cbn in *. eapply (Fin.caseS' i); cbn. eauto. eauto.
+Qed.
+
+Lemma finite_n (F : finType) :
+    { n & {f : F -> Fin.t n & { g : Fin.t n -> F | (forall i, f (g i) = i) /\ forall x, g (f x) = x }}}.
+Proof.
+    destruct F as (X & [l H]). cbn in *. 
+    exists (length l).
+    assert (Hin : forall x, x el l). { intros x. eapply count_in_equiv. rewrite H. lia. }
+    exists (fun x => proj1_sig (position_in (Hin x))). exists (@getat _ l). split.
+    - intros i. destruct position_in. cbn.
+      specialize (H (getat l i)). clear - H e. 
+      induction l.
+      + inv x.
+      + cbn in *. revert H e.
+        eapply (Fin.caseS' i). cbn.
+        * decide (a = a); congruence.
+        * cbn. intros. decide (getat l p = a).
+         -- decide (a = getat l p); try congruence. subst. inv e. inv H.
+            eapply countZero in H1 as []. eapply getatIn.
+         -- decide (a = getat l p); try congruence.
+            destruct position eqn:E; inv e. eapply IHl in E; congruence.
+    - intros x. generalize (Hin x). clear. intros H.
+      destruct (position_in H) as [i H1]. cbn.
+      induction l; cbn in *. 
+      + inv H1.
+      + decide (a = x).
+        * inv H1. cbn. reflexivity.
+        * destruct (position x l) eqn:E; inv H1.
+          cbn. eapply IHl. firstorder. reflexivity.
+Qed.
+
+
+
+

--- a/theories/Shared/FinTypeForallExists.v
+++ b/theories/Shared/FinTypeForallExists.v
@@ -1,0 +1,27 @@
+From PslBase Require Import FiniteTypes.
+
+Lemma list_forall_exists (F : Type) (P : F -> nat -> Prop) L :
+    (forall x n, P x n -> forall m, m >= n -> P x m) ->
+    (forall x : F, x el L -> exists n, P x n) -> exists N, forall x, x el L -> P x N.
+Proof.
+    intros P_mono FE.
+    induction L.
+    - exists 0. intros ? [].
+    - destruct IHL as [C HC].
+      + intros; eapply FE. eauto.
+      + destruct (FE a) as [c Hc]. eauto.
+        exists (c + C). intros ? [-> | ].
+        eapply P_mono. eassumption. lia. eapply P_mono. eapply HC. eauto. lia.
+Qed.
+
+Lemma fintype_forall_exists (F : finType) (P : F -> nat -> Prop) :
+    (forall x n, P x n -> forall m, m >= n -> P x m) ->
+    (forall x : F, exists n, P x n) -> exists N, forall x, P x N.
+Proof.
+    intros P_mono FE.
+    destruct F as (X & l & Hl). cbn in *.
+    destruct (@list_forall_exists X P l) as [C HC].
+    - eassumption.
+    - eauto.
+    - exists C. intros x. eapply HC. eapply count_in_equiv. rewrite Hl. lia.
+Qed.

--- a/theories/StackMachines/Reductions/SBTM_to_BSM.v
+++ b/theories/StackMachines/Reductions/SBTM_to_BSM.v
@@ -1,0 +1,619 @@
+Require Import Undecidability.TM.SBTM.
+
+Require Import PslBase.Vectors.FinNotation PslBase.Vectors.Vectors PslBase.EqDec.
+
+Require Import List Arith Lia Bool.
+
+From Undecidability.Shared.Libs.DLW 
+  Require Import utils list_bool pos vec subcode sss.
+
+From Undecidability.StackMachines.BSM 
+  Require Import bsm_defs.
+
+Import ListNotations.
+Import VectorNotations2.
+Local Open Scope vector.
+
+Tactic Notation "rew" "length" := autorewrite with length_db.
+
+Local Notation "e #> x" := (vec_pos e x).
+Local Notation "e [ v / x ]" := (vec_change e x v).
+
+Local Notation "P // s -[ k ]-> t" := (sss_steps (@bsm_sss _) P k s t).
+Local Notation "P // r -+> s" := (sss_progress(@bsm_sss _)  P r s).
+Local Notation "P // s ->> t" := (sss_compute (@bsm_sss _) P s t).
+
+Definition enc_tape (t : tape) : Vector.t (list bool) 4 := 
+    [| left t ; match curr t with Some c => [c] | None => [] end ; right t ; [] |]%vector.
+
+Ltac solve_sc := 
+  repeat match goal with
+          | [ |- (?i, _) <sc (?i, _)] => eexists [], _; split; [reflexivity | cbn; try lia]
+          | [ |- (?o + ?i, ?c1) <sc (?i, ?c2) ] => exists (firstn o c2); eexists; split; [ reflexivity | cbn; lia]
+          | [ |- (?l, ?c1) <sc (?i, ?c2) ] => 
+            let x := fresh "x" in
+            let H := fresh "H" in 
+            evar (x : nat);
+            assert (l = x + i); [ ring_simplify; subst x; reflexivity | rewrite H; subst x ] 
+          end.
+
+Hint Extern 0 => solve_sc : core.    
+
+Notation CURR := (Fin1 : Fin.t 4).
+Notation LEFT := (Fin0 : Fin.t 4).
+Notation RIGHT := (Fin2 : Fin.t 4).
+Notation ZERO := (Fin3 : Fin.t 4).
+Notation CURR_ := 1.
+Notation LEFT_ := 0.
+Notation RIGHT_ := 2.
+Notation ZERO_ := 3.
+
+Notation JMP i := (POP ZERO i i).
+
+Section fixi.
+
+    Variable i : nat.
+
+    Notation END := (23 + i).
+
+    Definition MOVE_L :=
+        [
+        (* i *)       POP  CURR (8 + i) (5 + i)   ;
+        (* i +  1 *)  POP  LEFT (14 + i) (12 + i) ;
+        (* i +  2 *)  PUSH CURR  true ;
+        (* i +  3 *)  PUSH RIGHT true;
+        (* i +  4 *)  JMP  END ;
+        (* i +  5 *)  POP  LEFT (17 + i) END ;
+        (* i +  6 *)  PUSH CURR true ;
+        (* i +  7 *)  JMP END ;
+        (* i +  8 *)  POP LEFT (21 + i) (19 + i) ;
+        (* i +  9 *)  PUSH CURR true ;
+        (* i + 10 *)  PUSH RIGHT false ;
+        (* i + 11 *)  JMP END ;
+        (* i + 12 *)  PUSH RIGHT true ;
+        (* i + 13 *)  JMP END ;
+        (* i + 14 *)  PUSH CURR false ;
+        (* i + 15 *)  PUSH RIGHT true ;
+        (* i + 16 *)  JMP END ;
+        (* i + 17 *)  PUSH CURR false ;
+        (* i + 18 *)  JMP END ;
+        (* i + 19 *)  PUSH RIGHT false ;
+        (* i + 20 *)  JMP END ;
+        (* i + 21 *)  PUSH CURR false ;
+        (* i + 22 *)  PUSH RIGHT false 
+        ].
+
+    Fact MOVE_L_length : length MOVE_L = 23.
+    Proof. reflexivity. Qed.
+
+    Fact MOVE_L_spec t : (i,MOVE_L) // (i, enc_tape t) ->> (END, enc_tape (mv Lmove t)).
+    Proof.
+      unfold MOVE_L.
+      destruct t as [[ [ | l ls] [ [] | ] ] rs].
+      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+        bsm sss POP empty with LEFT (14 + i) (12 + i).
+        bsm sss PUSH with RIGHT true.
+        bsm sss POP empty with ZERO END END.
+        bsm sss stop.
+      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+        bsm sss POP empty with LEFT (21 + i) (19 + i). 
+        bsm sss PUSH with RIGHT false.
+        bsm sss POP empty with ZERO END END.
+        bsm sss stop.
+      - bsm sss POP empty with CURR (8 + i) (5 + i).
+        bsm sss POP empty with LEFT (17 + i) END.
+        bsm sss stop.
+      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+        destruct l.
+        + bsm sss POP 1 with LEFT (14 + i) (12 + i) ls.
+          bsm sss PUSH with CURR true.
+          bsm sss PUSH with RIGHT true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with LEFT (14 + i) (12 + i) ls.
+          bsm sss PUSH with CURR false.
+          bsm sss PUSH with RIGHT true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+        destruct l.
+        + bsm sss POP 1 with LEFT (21 + i) (19 + i) ls.
+          bsm sss PUSH with CURR true.
+          bsm sss PUSH with RIGHT false.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with LEFT (21 + i) (19 + i) ls.
+          bsm sss PUSH with CURR false.
+          bsm sss PUSH with RIGHT false.
+          bsm sss stop. 
+      - bsm sss POP empty with CURR (8 + i) (5 + i).
+        destruct l.
+        + bsm sss POP 1 with LEFT (17 + i) END ls.
+          bsm sss PUSH with CURR true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with LEFT (17 + i) END ls.
+          bsm sss PUSH with CURR false.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop. 
+    Qed.
+
+    Definition MOVE_R :=
+        [
+        (* i *)       POP  CURR (8 + i) (5 + i)   ;
+        (* i +  1 *)  POP  RIGHT (14 + i) (12 + i) ;
+        (* i +  2 *)  PUSH CURR  true ;
+        (* i +  3 *)  PUSH LEFT true;
+        (* i +  4 *)  JMP  END ;
+        (* i +  5 *)  POP  RIGHT (17 + i) END ;
+        (* i +  6 *)  PUSH CURR true ;
+        (* i +  7 *)  JMP END ;
+        (* i +  8 *)  POP RIGHT (21 + i) (19 + i) ;
+        (* i +  9 *)  PUSH CURR true ;
+        (* i + 10 *)  PUSH LEFT false ;
+        (* i + 11 *)  JMP END ;
+        (* i + 12 *)  PUSH LEFT true ;
+        (* i + 13 *)  JMP END ;
+        (* i + 14 *)  PUSH CURR false ;
+        (* i + 15 *)  PUSH LEFT true ;
+        (* i + 16 *)  JMP END ;
+        (* i + 17 *)  PUSH CURR false ;
+        (* i + 18 *)  JMP END ;
+        (* i + 19 *)  PUSH LEFT false ;
+        (* i + 20 *)  JMP END ;
+        (* i + 21 *)  PUSH CURR false ;
+        (* i + 22 *)  PUSH LEFT false 
+        ].
+
+    Fact MOVE_R_length : length MOVE_R = 23.
+    Proof. reflexivity. Qed.
+
+    Fact MOVE_R_spec t : (i,MOVE_R) // (i, enc_tape t) ->> (END, enc_tape (mv Rmove t)).
+    Proof.
+      unfold MOVE_R.
+      destruct t as [[ls c] rs]; destruct rs as [ | r rs], c as [ [] | ].
+      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+        bsm sss POP empty with RIGHT (14 + i) (12 + i).
+        bsm sss PUSH with LEFT true.
+        bsm sss POP empty with ZERO END END.
+        bsm sss stop.
+      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+        bsm sss POP empty with RIGHT (21 + i) (19 + i). 
+        bsm sss PUSH with LEFT false.
+        bsm sss POP empty with ZERO END END.
+        bsm sss stop.
+      - bsm sss POP empty with CURR (8 + i) (5 + i).
+        bsm sss POP empty with RIGHT (17 + i) END.
+        bsm sss stop.
+      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+        destruct r.
+        + bsm sss POP 1 with RIGHT (14 + i) (12 + i) rs.
+          bsm sss PUSH with CURR true.
+          bsm sss PUSH with LEFT true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with RIGHT (14 + i) (12 + i) rs.
+          bsm sss PUSH with CURR false.
+          bsm sss PUSH with LEFT true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+        destruct r.
+        + bsm sss POP 1 with RIGHT (21 + i) (19 + i) rs.
+          bsm sss PUSH with CURR true.
+          bsm sss PUSH with LEFT false.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with RIGHT (21 + i) (19 + i) rs.
+          bsm sss PUSH with CURR false.
+          bsm sss PUSH with LEFT false.
+          bsm sss stop. 
+      - bsm sss POP empty with CURR (8 + i) (5 + i).
+        destruct r.
+        + bsm sss POP 1 with RIGHT (17 + i) END rs.
+          bsm sss PUSH with CURR true.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+        + bsm sss POP 0 with RIGHT (17 + i) END rs.
+          bsm sss PUSH with CURR false.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop. 
+    Qed.
+
+End fixi.
+
+Section fixM.
+
+    Variable M : SBTM.
+
+    Notation δ := (trans M).
+
+    Notation "! p" := (proj1_sig (Fin.to_nat p)) (at level 1).
+
+    Notation c := 76.
+
+    Local Notation "'if!' x 'is' p 'then' a 'else' b" := (match x with p => a | _ => b end) (at level 0, p pattern).
+
+    Notation END := ((2 + num_states M) * c).
+
+    Definition PROG (i : Fin.t (S (num_states M))) :=
+      let off := c * !i in
+      [
+         (*      off *)  POP CURR (26 + off) (51 + off) ;
+         (*  1 + off *)  PUSH CURR (if! δ (i, Some true) is Some (_, Some false, _) then false else true)
+      ] ++
+         (*  2 + off *)  match δ (i, Some true) with Some (_, _, Rmove) => MOVE_R (2 + off) | Some (_, _, Lmove) => MOVE_L (2 + off) | _ => repeat (JMP (25 + off)) 23 end ++
+      [  (* 25 + off *)  JMP (match δ (i, Some true) with None => END | Some (q', _, _) => (c * ! q') end) ;
+         (* 26 + off *)  PUSH CURR (if! δ (i, Some false) is Some (_, Some true, _) then true else false) ]
+         ++
+         (* 27 + off *)  match δ (i, Some false) with Some (_, _, Rmove) => MOVE_R (27 + off) | Some (_, _, Lmove) => MOVE_L (27 + off) | _ => repeat (JMP (50 + off)) 23 end ++
+      [  (* 50 + off *)  JMP (match δ (i, Some false) with None => END | Some (q', _, _) => (c * ! q') end) ;
+         (* 51 + off *)  match δ (i, None) with None => JMP END | Some (_, Some w, _) => PUSH CURR w | Some _ => JMP (52 + off) end ] ++
+         (* 52 + off *)  match δ (i, None) with Some (_, _, Rmove) => MOVE_R (52 + off) | Some (_, _, Lmove) => MOVE_L (52 + off) | _ => repeat (JMP (75 + off)) 23 end ++
+      [  (* 75 + off *)  JMP (match δ (i, None) with None => END | Some (q', _, _) => (c * ! q') end )
+      ]
+      .
+ 
+    Fact PROG_length i : length (PROG i) = c.
+    Proof. unfold PROG. rewrite app_length.
+           destruct (δ (i, Some false)) as [ [[? []] []] | ] eqn:E1;
+           destruct (δ (i, Some true)) as [ [[? []] []] | ] eqn:E2;
+           destruct (δ (i, None)) as [ [[? []] []] | ]  eqn:E3.
+           all:reflexivity.
+    Qed. 
+ 
+    Lemma subcode1 i : let off := c * !i in (26 + off, [PUSH CURR (if! δ (i, Some false) is Some (_, Some true, _) then true else false) ]
+    ++
+    (* 27 + off *)  match δ (i, Some false) with Some (_, _, Rmove) => MOVE_R (27 + off) | Some (_, _, Lmove) => MOVE_L (27 + off) | _ => repeat (JMP (50 + off)) 23 end ++
+ [  (* 50 + off *)  JMP (match δ (i, Some false) with None => END | Some (q', _, _) => (c * ! q') end) ;
+    (* 51 + off *)  match δ (i, None) with None => JMP END | Some (_, Some w, _) => PUSH CURR w | Some _ => JMP (52 + off) end ] ++
+    (* 52 + off *)  match δ (i, None) with Some (_, _, Rmove) => MOVE_R (52 + off) | Some (_, _, Lmove) => MOVE_L (52 + off) | _ => repeat (JMP (75 + off)) 23 end ++
+ [  (* 75 + off *)  JMP (match δ (i, None) with None => END | Some (q', _, _) => (c * ! q') end )
+ ]) <sc (off, PROG i).
+    Proof.
+      intros ?. 
+      match goal with
+      | [ |- (?o + ?i, ?c1) <sc (?i, ?c2) ] => exists (firstn o c2); exists []; split
+      end.
+      rewrite app_nil_r. 2:rewrite firstn_length, PROG_length. 2:lia.
+      enough (firstn 26 (PROG i) = [ POP CURR (26 + off) (51 + off) ;
+      (*  1 + off *)  PUSH CURR (if! δ (i, Some true) is Some (_, Some false, _) then false else true)
+   ] ++
+      (*  2 + off *)  match δ (i, Some true) with Some (_, _, Rmove) => MOVE_R (2 + off) | Some (_, _, Lmove) => MOVE_L (2 + off) | _ => repeat (JMP (25 + off)) 23 end ++
+   [  (* 25 + off *)  JMP (match δ (i, Some true) with None => END | Some (q', _, _) => (c * ! q') end)]); subst off. rewrite H. 
+      unfold PROG. now rewrite <- !app_assoc. 
+      unfold PROG. destruct (δ (i, Some One)) as [ [ [] [] ] | ]; reflexivity.
+    Qed.
+
+    Lemma subcode2 i : let off := c * !i in (51 + off, [
+    (* 51 + off *)  match δ (i, None) with None => JMP END | Some (_, Some w, _) => PUSH CURR w | Some _ => JMP (52 + off) end ] ++
+    (* 52 + off *)  match δ (i, None) with Some (_, _, Rmove) => MOVE_R (52 + off) | Some (_, _, Lmove) => MOVE_L (52 + off) | _ => repeat (JMP (75 + off)) 23 end ++
+ [  (* 75 + off *)  JMP (match δ (i, None) with None => END | Some (q', _, _) => (c * ! q') end )
+ ]) <sc (off, PROG i).
+    Proof.
+      intros ?. 
+      match goal with
+      | [ |- (?o + ?i, ?c1) <sc (?i, ?c2) ] => exists (firstn o c2); exists []; split
+      end.
+      rewrite app_nil_r. 2:rewrite firstn_length, PROG_length. 2:lia.
+      enough (firstn 51 (PROG i) = [ POP CURR (26 + off) (51 + off) ;
+      (*  1 + off *)  PUSH CURR (if! δ (i, Some true) is Some (_, Some false, _) then false else true)
+   ] ++
+      (*  2 + off *)  match δ (i, Some true) with Some (_, _, Rmove) => MOVE_R (2 + off) | Some (_, _, Lmove) => MOVE_L (2 + off) | _ => repeat (JMP (25 + off)) 23 end ++
+   [  (* 25 + off *)  JMP (match δ (i, Some true) with None => END | Some (q', _, _) => (c * ! q') end) ;
+      (* 26 + off *)  PUSH CURR (if! δ (i, Some false) is Some (_, Some true, _) then true else false) ]
+      ++
+      (* 27 + off *)  match δ (i, Some false) with Some (_, _, Rmove) => MOVE_R (27 + off) | Some (_, _, Lmove) => MOVE_L (27 + off) | _ => repeat (JMP (50 + off)) 23 end ++
+   [  (* 50 + off *)  JMP (match δ (i, Some false) with None => END | Some (q', _, _) => (c * ! q') end)]); subst off. rewrite H.  
+      unfold PROG. now rewrite <- !app_assoc.
+      unfold PROG. destruct (δ (i, Some One)) as [ [ [] [] ] | ]; destruct (δ (i, Some false)) as [ [ [] [] ] | ]; reflexivity.
+    Qed.
+
+    Lemma case_Some_false o {X} (c1 c2 : X) : (if! o is Some false then c1 else c2 = c1 /\ o = Some false) 
+                            \/ (if! o is Some false then c1 else c2 = c2 /\ o <> Some false).
+    Proof.
+      destruct o as [ [] | ]; firstorder congruence.
+    Qed.
+
+    Lemma case_Some_true o {X} (c1 c2 : X) : (if! o is Some true then c1 else c2 = c1 /\ o = Some true) 
+                            \/ (if! o is Some true then c1 else c2 = c2 /\ o <> Some true).
+    Proof.
+      destruct o as [ [] | ]; firstorder congruence.
+    Qed.
+
+    Lemma case_None (o : option bool) {X} (c2 : X) c1 : (if! o is Some w then c1 w else c2 = c2 /\ o = None) 
+                            \/ (exists w, (if! o is Some w then c1 w else c2) = c1 w /\ o = Some w).
+    Proof.
+      destruct o as [ [] | ]. right. eauto. right. eauto. eauto.
+    Qed.
+
+    Fact PROG_spec (i : Fin.t (S (num_states M))) t :
+      (c * !i, PROG i) // (c * !i, enc_tape t) -+> match δ (i, curr t) 
+                                                   with None => (END, enc_tape t) |
+                                                        Some (q', w, m) => (c * !q' , enc_tape (mv m (wr w t)))
+                                                   end.
+    Proof.
+      set (off := c * !i).
+      destruct t as [[ls [ [] | ]] rs] eqn:Eq_tape.
+      - cbn [curr].
+        eapply sss_progress_compute_trans. exists 1. split. lia. econstructor. 2:econstructor.
+        eapply subcode_sss_step with (P := (off, [POP CURR (26 + off) (51 + off)])). auto.      
+        eapply in_sss_step with (l := []). cbn; lia.
+        econstructor 3. reflexivity.
+        unfold PROG.
+        (* bsm sss POP 1 with CURR (26 + off) (51 + off) []. bsm sss stop.  *)
+        destruct (δ (i, Some true)) as [ [[q' w] m] | ] eqn:Eq_nxt.
+        + edestruct (@case_Some_false w) as [ [H H0] | [H H0]].
+          * rewrite H.
+            bsm sss PUSH with CURR false.
+            destruct m eqn:Eq_mv.
+            -- eapply subcode_sss_compute_trans with (P := (2+off, MOVE_L (2 + off))). eauto.
+               cbn - [plus mult].
+               eapply (MOVE_L_spec (2 + off) (ls, Some Zero, rs)).
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- eapply subcode_sss_compute_trans with (P := (2+off, MOVE_R (2 + off))). eauto.
+               cbn - [plus mult].
+               eapply (MOVE_R_spec (2 + off) (ls, Some Zero, rs)).
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- bsm sss POP empty with ZERO (25 + off) (25 + off).
+               bsm sss POP empty with ZERO (c * !q') (c * !q').
+               bsm sss stop. subst; reflexivity.
+          * rewrite H. bsm sss PUSH with CURR true.
+            destruct m eqn:Eq_mv.
+            -- eapply subcode_sss_compute_trans with (P := (2+off, MOVE_L (2 + off))). eauto.
+               cbn - [plus mult].
+               eapply (MOVE_L_spec (2 + off) (ls, Some One, rs)).
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+            -- eapply subcode_sss_compute_trans with (P := (2+off, MOVE_R (2 + off))). eauto.
+               cbn - [plus mult].
+               eapply (MOVE_R_spec (2 + off) (ls, Some One, rs)).
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+            -- bsm sss POP empty with ZERO (25 + off) (25 + off).
+               bsm sss POP empty with ZERO (c * !q') (c * !q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+        + bsm sss PUSH with CURR true.
+          bsm sss POP empty with ZERO (25 + off) (25 + off).
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+      - cbn [curr].
+        eapply sss_progress_compute_trans. exists 1. split. lia. econstructor. 2:econstructor.
+        eapply subcode_sss_step with (P := (off, [POP CURR (26 + off) (51 + off)])). auto.      
+        eapply in_sss_step with (l := []). cbn; lia.
+        econstructor 2. reflexivity.
+        unfold PROG.
+(*         bsm sss POP 0 with CURR (26 + off) (51 + off) []. *) 
+        eapply subcode_sss_compute_trans; try eapply subcode1. 2:{ bsm sss stop. }
+        destruct (δ (i, Some false)) as [ [[q' w] m] | ] eqn:Eq_nxt.
+        + edestruct (@case_Some_true w) as [ [] | []].
+          * rewrite H. change (76 * !i)  with off.
+            bsm sss PUSH with CURR true.
+            destruct m eqn:Eq_mv.
+            -- eapply subcode_sss_compute_trans with (P := (27+off, MOVE_L (27 + off))). eauto.
+               eapply (MOVE_L_spec (27 + off) (ls, Some One, rs)).
+               replace (23 + (27 + off)) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- eapply subcode_sss_compute_trans with (P := (27 +off, MOVE_R (27 + off))). eauto.
+               eapply (MOVE_R_spec (27 + off) (ls, Some One, rs)).
+               replace (23 + (27 + off)) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- bsm sss POP empty with ZERO (50 + off) (50 + off).
+               replace (50 + off) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * !q') (c * !q').
+               bsm sss stop. subst; reflexivity.
+          * rewrite H. change (76 * !i)  with off.
+            bsm sss PUSH with CURR false.
+            destruct m eqn:Eq_mv.
+            -- eapply subcode_sss_compute_trans with (P := (27+off, MOVE_L (27 + off))). replace (27 + off) with (1 + (26 + off)) at 1 by lia. eauto.
+               eapply (MOVE_L_spec (27 + off) (ls, Some false, rs)).
+               replace (23 + (27 + off)) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+            -- eapply subcode_sss_compute_trans with (P := (27 +off, MOVE_R (27 + off))). 
+               replace (27 + off) with (1 + (26 + off)) at 1 by lia. eauto.
+               eapply (MOVE_R_spec (27 + off) (ls, Some false, rs)).
+               replace (23 + (27 + off)) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+            -- bsm sss POP empty with ZERO (50 + off) (50 + off).
+               replace (50 + off) with (24 + (26 + off)) by lia.
+               bsm sss POP empty with ZERO (c * !q') (c * !q').
+               bsm sss stop. destruct w as [ [] | ]; try reflexivity. congruence.
+        + change (76 * !i) with off. 
+          bsm sss PUSH with CURR false.
+          bsm sss POP empty with ZERO (50 + off) (50 + off).
+          replace (50 + off) with (24 + (26 + off)) by lia.
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+      - cbn [curr].
+        eapply sss_progress_compute_trans. exists 1. split. lia. econstructor. 2:econstructor.
+        eapply subcode_sss_step with (P := (off, [POP CURR (26 + off) (51 + off)])). auto.      
+        eapply in_sss_step with (l := []). cbn; lia.
+        econstructor 1. reflexivity.
+        unfold PROG.
+        (* bsm sss POP empty with CURR (26 + off) (51 + off). *)
+        eapply subcode_sss_compute_trans; try eapply subcode2. 2:{ bsm sss stop. }
+        destruct (δ (i, None)) as [ [[q' w] m] | ] eqn:Eq_nxt.
+        + edestruct (@case_None w) as [ [] | []].
+          * rewrite H. change (76 * !i)  with off.
+            bsm sss POP empty with ZERO (52 + off) (52 + off).
+            destruct m eqn:Eq_mv.
+            -- eapply subcode_sss_compute_trans with (P := (52+off, MOVE_L (52 + off))). eauto.
+               eapply (MOVE_L_spec (52 + off) (ls, None, rs)).
+               replace (23 + (52 + off)) with (24 + (51 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- eapply subcode_sss_compute_trans with (P := (52 +off, MOVE_R (52 + off))). eauto.
+               eapply (MOVE_R_spec (52 + off) (ls, None, rs)).
+               replace (23 + (52 + off)) with (24 + (51 + off)) by lia.
+               bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+               bsm sss stop. rewrite H0. reflexivity.
+            -- replace (52 + off) with (1 + (51 + off)) by lia.
+               bsm sss POP empty with ZERO (75 + off) (75 + off).
+               replace (75 + off) with (24 + (51 + off)) by lia.
+               bsm sss POP empty with ZERO (c * !q') (c * !q').
+               bsm sss stop. subst; reflexivity.
+          * destruct w eqn:Eq_w.
+            -- change (76 * !i)  with off.
+               bsm sss PUSH with CURR b.
+               destruct m eqn:Eq_mv.
+               ++ eapply subcode_sss_compute_trans with (P := (52+off, MOVE_L (52 + off))). replace (52 + off) with (1 + (51 + off)) at 1 by lia. eauto.
+                  eapply (MOVE_L_spec (52 + off) (ls, Some b, rs)).
+                  replace (23 + (52 + off)) with (24 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+                  bsm sss stop.
+               ++ eapply subcode_sss_compute_trans with (P := (52 +off, MOVE_R (52 + off))). 
+                  replace (52 + off) with (1 + (51 + off)) at 1 by lia. eauto.
+                  eapply (MOVE_R_spec (52 + off) (ls, Some b, rs)).
+                  replace (23 + (52 + off)) with (24 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+                  bsm sss stop.
+               ++ bsm sss POP empty with ZERO (75 + off) (75 + off).
+                  replace (75 + off) with (24 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (c * !q') (c * !q').
+                  bsm sss stop.
+            -- change (76 * !i)  with off.
+               bsm sss POP empty with ZERO (52 + off) (52 + off).
+               destruct m eqn:Eq_mv.
+               ++ eapply subcode_sss_compute_trans with (P := (52+off, MOVE_L (52 + off))). replace (52 + off) with (1 + (51 + off)) at 1 by lia. eauto.
+                  eapply (MOVE_L_spec (52 + off) (ls, None, rs)).
+                  replace (23 + (52 + off)) with (24 + (51 + off)
+                                                 ) by lia.
+                  bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+                  bsm sss stop.
+               ++ eapply subcode_sss_compute_trans with (P := (52 +off, MOVE_R (52 + off))). 
+                  replace (52 + off) with (1 + (51 + off)) at 1 by lia. eauto.
+                  eapply (MOVE_R_spec (52 + off) (ls, None, rs)).
+                  replace (23 + (52 + off)) with (24 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (c * ! q') (c * ! q').
+                  bsm sss stop.
+               ++ replace (52 + off) with (1 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (75 + off) (75 + off).
+                  replace (75 + off) with (24 + (51 + off)) by lia.
+                  bsm sss POP empty with ZERO (c * !q') (c * !q').
+                  bsm sss stop.
+        + change (76 * !i) with off. 
+          bsm sss POP empty with ZERO END END.
+          bsm sss stop.
+    Qed.
+
+    Fixpoint sim (n : nat) (H : n <= S (num_states M)) : list (bsm_instr 4).
+    Proof.
+      destruct n.
+      - exact [].
+      - refine (sim n _ ++ _). abstract lia.
+        assert (Hn : n < S (num_states M)) by abstract lia.
+        refine (PROG (Fin.of_nat_lt Hn)).
+    Defined. 
+    
+    Definition SIM : list (bsm_instr 4). refine (@sim (S (num_states M)) _). abstract lia. Defined.
+
+    Lemma sim_length (n : nat) (H : n <= S (num_states M)) : 
+       @length (bsm_instr 4) (@sim n H) = c * n.
+    Proof.
+      induction n.
+      - unfold sim. cbn. lia.
+      - unfold sim. fold sim. rewrite app_length. rewrite PROG_length. rewrite IHn. lia.
+    Qed.
+
+
+    Lemma SIM_length : length SIM = c * (S (num_states M)).
+    Proof.
+      unfold SIM. rewrite sim_length. lia.
+    Qed.
+    Arguments sim _ _ : clear implicits.
+
+    Lemma of_nat_lt_0 n (H : 0 < S n) : Fin.of_nat_lt H = @Fin.F1 n.
+    Proof.
+      unfold Fin.of_nat_lt. reflexivity.
+    Qed.
+
+    Arguments Fin.of_nat_lt _ {_} _.
+
+    Lemma PROG_sim_sc q n (H : n <= S (num_states M)) : ! q < n -> (76 * ! q, PROG q) <sc (0, sim n H).
+    Proof.
+      revert q.
+      induction n as [n IH] using lt_wf_ind; intros q. 
+      destruct n.
+      - intros. lia.
+      - intros H0. eapply le_lt_or_eq in H0 as [H0 | H0].
+        + unfold sim. fold sim. eapply subcode_app_end. eapply IH. lia. lia.
+        + inversion H0. subst. clear H0. unfold sim. fold sim. revert H IH.
+          eapply (Fin.caseS' q).
+          * intros H IH. cbn [Fin.to_nat proj1_sig sim]. rewrite of_nat_lt_0.
+            cbn - [PROG]. eexists [], []. split. rewrite app_nil_r. reflexivity. reflexivity.
+          * clear q. intros q H IH.
+            erewrite Fin.of_nat_ext.
+            rewrite Fin.of_nat_to_nat_inv.
+            eapply subcode_right. rewrite sim_length.
+            pose proof (Fin.R_sanity 1 q). clear IH.
+            cbn - [mult] in *. destruct (Fin.to_nat q). cbn - [mult] in *. inversion H0. reflexivity.
+    Qed.
+
+    Lemma PROG_sc q : (76 * ! q, PROG q) <sc (0, SIM).
+    Proof.
+      eapply PROG_sim_sc. destruct (Fin.to_nat q). cbn. lia.
+    Qed.
+
+    Theorem SIM_computes q t q' t' :
+       eval M q t q' t' -> (0,SIM) // (c * !q, enc_tape t) ->> (END, enc_tape t').
+    Proof.
+      induction 1.
+      - eapply subcode_sss_compute_trans with (P := (76 * !q, PROG q)). eapply PROG_sc.
+        eapply sss_progress_compute. eapply PROG_spec.
+        rewrite H.
+        bsm sss stop.
+      - eapply subcode_sss_compute_trans with (P := (76 * !q, PROG q)). eapply PROG_sc.
+        eapply sss_progress_compute. eapply PROG_spec.
+        rewrite H. eapply IHeval.
+    Qed.
+
+    Theorem SIM_term q t i out :
+       i >= length SIM ->
+       (0,SIM) // (c * !q, enc_tape t) ->> (i, out) -> exists q' t', i = END /\ out = enc_tape t' /\ eval M q t q' t'.
+    Proof.
+      intros Hout [k H]. revert q t H.
+      induction k as [k IH] using lt_wf_ind; intros q t H.
+      edestruct PROG_spec as [k' H'].
+      eapply subcode_sss_subcode_inv in H. 4: eapply PROG_sc. 4: eapply H'. 2:{ apply bsm_sss_fun. }
+      - destruct H as (k'' & -> & HH).
+        destruct (δ (q, curr t)) as [ [[q' w] m] | ] eqn:Eq_nxt.
+        + eapply IH in HH.
+          * destruct HH as (q'' & t'' & -> & -> & HH). exists q'', t''; repeat split.
+            econstructor. eassumption. eassumption.
+          * destruct H'. lia.   
+        + eapply sss_steps_stop in HH as [= <- <-].
+          exists q, t. repeat split. econstructor. eauto.
+          unfold out_code. right. unfold fst, code_end, snd, fst, plus. rewrite SIM_length. lia.
+      - unfold out_code. right. unfold fst, code_end, snd, fst. rewrite PROG_length.
+        transitivity (length SIM). rewrite SIM_length. destruct (Fin.to_nat q). cbn. lia. lia.
+    Qed.
+
+    Theorem SIM_correct t :
+      HaltSBTM (M, t) <-> BSM_HALTING (existT _ 4 (existT _ 0 (existT _ SIM (enc_tape t)))).
+    Proof.
+      split.
+      - intros (q' & t' & H). eapply SIM_computes in H. 
+        unfold BSM_HALTING. eexists. split. rewrite mult_comm in H. eapply H.
+        unfold out_code. right. unfold fst, code_end, snd, fst. rewrite SIM_length. lia.
+      - intros ([i out] & H1 & H2). eapply (@SIM_term pos0) in H1 as (q' & t' & -> & -> & H).
+        exists q', t'. eassumption. destruct H2. cbn in H. lia.
+        unfold code_end, fst, snd in H. lia.
+    Qed.
+
+End fixM.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+Theorem SBTM_to_BSM :
+  HaltSBTM ⪯ BSM_HALTING.
+Proof.
+  unshelve eexists.
+  - intros [M t]. exists 4. exists 0. exists (SIM M). exact (enc_tape t).
+  - intros [M t]. eapply SIM_correct.
+Qed.

--- a/theories/TM/Reductions/Arbitrary_to_Binary.v
+++ b/theories/TM/Reductions/Arbitrary_to_Binary.v
@@ -1,0 +1,501 @@
+From Undecidability Require Import ProgrammingTools.
+From Undecidability Require Import ArithPrelim.
+Require Import Undecidability.Shared.FinTypeEquiv.
+
+Lemma nat_rec_S (P : nat -> Type) : P 1 -> (forall n, P n -> P (S n)) -> forall n, n > 0 -> P n. 
+Proof.
+  intros H1 H2. induction n.
+  - intros. lia.
+  - intros. destruct n.
+    + eapply H1.
+    + eapply H2, IHn. lia.
+Defined.
+
+Section fix_Sigma.
+
+  Variable n : nat.
+
+  Definition encode_sym (s : Fin.t n) : list bool :=
+    let i := proj1_sig (Fin.to_nat s) in
+    repeat false i ++ repeat true (n - i).
+
+  Lemma length_encode_sym (s : Fin.t n) :
+    length (encode_sym s) = n.
+  Proof.
+    unfold encode_sym. destruct Fin.to_nat as [i Hi].
+    cbn. rewrite app_length, !repeat_length. lia.
+  Qed.
+
+  Fixpoint encode_string (s : list (Fin.t n)) :=
+    match s with
+    | [] => []
+    | i :: l => false :: encode_sym i ++ true :: encode_string l
+    end.
+
+  Lemma encode_string_app s1 s2 :
+    encode_string (s1 ++ s2) = encode_string s1 ++ encode_string s2.
+  Proof. 
+    induction s1; cbn.
+    - reflexivity.
+    - rewrite <-app_assoc. cbn. now rewrite IHs1.
+  Qed. 
+    
+  Definition encode_tape (t : tape (Fin.t n)) :=
+    match t with
+    | niltape => niltape
+    | midtape ls c_i rs => midtape (rev (encode_string (rev ls))) false (encode_sym c_i ++ true :: encode_string rs)
+    | leftof c_i rs => leftof false (encode_sym c_i ++ true :: encode_string rs)
+    | rightof c_i ls => rightof true (rev (encode_sym c_i) ++ false :: rev(encode_string (rev (ls))))
+    end.
+
+End fix_Sigma. 
+
+Fixpoint ReadB (n : nat) : pTM (FinType (EqType bool)) (option (Fin.t n)) 1.
+Proof.
+  destruct n as [ | n ].
+  - exact (Return Nop None).
+  - refine (Switch ReadChar (fun o : option bool =>
+                              match o with None => Return Nop None | Some _ =>
+                                Move Rmove ;; Switch ReadChar (fun o : option bool  => 
+                                match o with
+                                | None => Return (Move Lmove) None
+                                | Some true => Return (Move Lmove) (Some Fin.F1)
+                                | Some false => Switch (ReadB n) (fun o => Return (Move Lmove) 
+                                                                            (match o with
+                                                                             | None => None
+                                                                             | Some i => Some (Fin.R 1 i)
+                                                                             end))
+                                end)
+                              end)).
+Defined.
+  
+Definition ReadB_rel' d n : Vector.t (tape bool) 1 -> option (Fin.t (d + n)) * Vector.t (tape bool) 1 -> Prop :=   
+  fun t '(l, t') =>
+    forall t_sig : tape (Fin.t n), t = [| encode_tape t_sig |] -> t' = t /\ forall s, current t_sig = Some s -> l = Some (Fin.R d s).
+
+Smpl Add eassumption : TM_Correct.
+
+Fixpoint ReadB_canonical n :
+  {Rel | ReadB n ⊨ Rel}.
+Proof.
+  destruct n; cbn.
+  - eexists. TM_Correct.
+  - eexists. eapply Switch_Realise. TM_Correct. cbn in *. intros [ | ].
+    instantiate (1 := fun o => match o with None => _ | Some _ => _ end).
+    eapply Seq_Realise. TM_Correct.
+    eapply Switch_Realise. TM_Correct. cbn in *. intros [[] | ].
+    instantiate (1 := fun o => match o with None => _ | Some true => _ | Some false => _ end). cbn in *.
+    TM_Correct. eapply Switch_Realise. eapply (proj2_sig (ReadB_canonical n)).
+    instantiate (1 := fun o => match o with None => _ | Some _ => _ end).
+    intros []; TM_Correct. TM_Correct. cbn. TM_Correct. 
+Defined.
+
+Lemma ReadB_Realise n :
+  ReadB n ⊨ fun t '(l, t') => forall t_sig : tape (Fin.t n), t = [| encode_tape t_sig |] -> t' = t /\ l = current t_sig.
+Proof.
+  eapply Realise_monotone. exact (proj2_sig (ReadB_canonical n)).
+  pose (Rel := (fun n (t : Vector.t _ 1) '(l, t') => 
+  match t with 
+  | [| midtape ls _ rs |] => forall rs' (c_i : Fin.t n), rs = encode_sym c_i ++ rs' ->
+        t' = t /\ l = Some c_i  
+  | _ => t' = t /\ l = None
+  end) : forall n, Vector.t (tape bool) 1 -> option (Fin.t n) * Vector.t (tape bool) 1 -> Prop).
+  transitivity (Rel n).
+  - induction n.
+    + subst Rel. cbn. intros tp (l, t') (-> & [ _ ->]).
+      eapply Vector.caseS' with (v := tp). clear tp. intros t nl.
+      eapply Vector.case0 with (v := nl). clear nl. destruct t; eauto.
+      intros rs' c_i ->. inv c_i.
+    + intros t (l, t') (? & tright & (-> & ->) & H).
+      destruct_tapes. cbn in *. rename h into t'. rename h0 into t.
+      destruct t; cbn in *.
+      * destruct H as (-> & [] & ->). eauto.
+      * destruct H as (-> & [] & ->). eauto.
+      * destruct H as (-> & [] & ->). eauto.
+      * intros rs' c_i ->.
+        destruct H as ([] & tps & ? & ? & tps' & [-> ->] & H0).
+        destruct_tapes. cbn in *. subst. rename l0 into ls. cbn in *.
+        revert H0. eapply Fin.caseS' with (p := c_i); clear c_i.
+        -- cbn. intros (-> & [] & ->). eauto.
+        -- intros c_i. change (Fin.FS c_i) with (Fin.R 1 c_i) in *.
+           unfold encode_sym. cbn in *. 
+           pose proof (Fin.R_sanity 1 c_i) as E. cbn in E.
+           rewrite E. clear E. cbn.
+           intros (o & tout & ? & ?). eapply IHn in H. cbn in H.
+           destruct (H _ _ eq_refl) as [-> ->].  cbn in *.
+           destruct H0 as (-> & [] & ->). eauto.
+  - intros t (l, t'). unfold Rel. intros H.
+    destruct_tapes. rename h0 into t. rename h into t'. intros t_sig [= ->].
+    destruct t_sig; cbn in *; eauto.
+Qed.
+
+Require Import Undecidability.TM.Compound.WriteString.
+
+Fixpoint MoveM {Σ : finType} (D : move) (n : nat) : pTM Σ unit 1 :=
+  match n with 
+  | 0 => Nop
+  | S n => MoveM D n ;; Move D
+  end.
+
+Definition TestLeftof {Σ : finType} : pTM Σ bool 1 :=
+  Switch ReadChar (fun s1 => match s1 with Some _ => Return Nop false | None => Move Rmove ;; Switch ReadChar (fun s2 => match s2 with None => Return Nop false | Some _ => Return (Move Lmove) true end) end).
+
+Lemma TestLeftof_Realise {Σ : finType} : 
+  @TestLeftof Σ ⊨ fun t '(b, t') => t = t' /\ match t with [| leftof _ _ |] => b = true | _ => b = false end.
+Proof.
+  eapply Realise_monotone. unfold TestLeftof. TM_Correct.
+  intros t (b, t') ?. TMSimp. destruct_tapes. TMSimp. rename h0 into t, h into t'.
+  destruct t; cbn in *; TMSimp; eauto.
+Qed.
+
+Definition MoveL_rel {Σ : finType} D (n : nat) : Vector.t (tape Σ) 1 -> unit * Vector.t (tape Σ) 1 -> Prop := 
+  fun t '(_, t') => t' = Vector.map (Nat.iter n (fun t => @tape_move Σ t D)) t.
+
+Lemma MoveM_Realise {Σ : finType} D (n : nat) :
+  @MoveM Σ D n ⊨ MoveL_rel D n.
+Proof.
+  induction n; unfold MoveL_rel; cbn.
+  - eapply Realise_monotone. TM_Correct. intros t ([], t') ->.
+    destruct_tapes. reflexivity.
+  - eapply Realise_monotone. eapply Seq_Realise. eassumption. TM_Correct.
+    intros t ([], t') ?; cbn in *. TMSimp. destruct_tapes. TMSimp. reflexivity.
+Qed.
+
+Definition WriteB (n : nat) (c : option (Fin.t n)) : pTM (FinType (EqType bool)) unit 1 :=
+  match c with
+  | None => Nop
+  | Some c => 
+    Switch TestLeftof (fun b => if b then WriteString Lmove (rev (false :: encode_sym c ++ [true])) else
+      WriteString Rmove (false :: encode_sym c ++ [true]) ;; MoveM Lmove (S n))
+  end.
+
+Lemma Nat_iter_S' {A} (f : A -> A) (a : A) n :
+  Nat.iter (S n) f a = f (Nat.iter n f a).
+Proof.
+  reflexivity.
+Qed.
+
+Lemma Nat_iter_S {A} (f : A -> A) (a : A) n :
+   Nat.iter (S n) f a = Nat.iter n f (f a).
+Proof.
+  induction n in a |- *; cbn.
+  - reflexivity.
+  - unfold Nat.iter in IHn. now rewrite <- IHn.
+Qed.
+
+Lemma Nat_iter_id {A} (a : A) n :
+   Nat.iter n (fun a : A => a) a = a.
+Proof.
+  induction n in a |- *; cbn.
+  - reflexivity.
+  - unfold Nat.iter in IHn. now rewrite <- IHn.
+Qed.
+
+Lemma WriteString_MoveBack {Σ : finType} (x : Σ) l :
+  (WriteString Rmove (x :: l) ;; MoveM Lmove (|l|)) ⊨ fun t '(_, t') => t' = Vector.map (fun t => midtape (left t) x (l ++ skipn (|l|) (right t))) t.
+Proof.
+  eapply Realise_monotone. TM_Correct. eapply RealiseIn_Realise, WriteString_Sem. eapply MoveM_Realise.
+  intros t ([], t') ([] & t1 & ? & ?). TMSimp. destruct_tapes. TMSimp. f_equal. rename h0 into t.
+  induction l in x, t |- *.
+  - reflexivity.
+  - cbn [length plus]. rewrite Nat_iter_S'.
+    rewrite WriteString_Fun_eq. rewrite IHl. clear. 
+    destruct t; cbn.
+    + now rewrite skipn_nil.
+    + reflexivity.
+    + now rewrite skipn_nil. 
+    + unfold tape_move_left'. unfold tape_move_right'. cbn. destruct l1; cbn.
+      * now rewrite skipn_nil.
+      * reflexivity.
+Qed.
+
+Lemma WriteB_Realise (n : nat) (c : option (Fin.t n)) :
+  WriteB c ⊨ fun t '(_, t') => forall t_sig, t = [| encode_tape t_sig |] -> t' = [| encode_tape (tape_write t_sig c) |].
+Proof.
+  destruct c as [c | ].
+  - eapply Realise_monotone. unfold WriteB. eapply Switch_Realise.
+    eapply TestLeftof_Realise. intros []. instantiate (1 := fun b => if b then _ else _).
+    cbn. eapply RealiseIn_Realise, WriteString_Sem.
+    pose proof (@WriteString_MoveBack (finType_CS bool) false (encode_sym c ++ [true])). cbn in H.
+    replace (|encode_sym c ++ [true]|) with (S n) in H. 2:rewrite app_length, length_encode_sym; cbn; lia. cbn.
+    eapply H.
+    intros t ([], t') ? ? ->. TMSimp. destruct_tapes. TMSimp. f_equal.
+    destruct t_sig eqn:E; cbn - [skipn].
+    + cbn in *. TMSimp. now rewrite app_nil_r.
+    + cbn in *. TMSimp. generalize (encode_sym t ++ true :: encode_string l). clear. intros.
+      replace (encode_sym c ++ true :: false :: l) with ((encode_sym c ++ [true]) ++ false :: l).
+      generalize (encode_sym c ++ [true]). generalize false. intros.
+      generalize b at 1 4. intros.
+      induction l0 in b0, b, l |- * using rev_ind; cbn.
+      * reflexivity.
+      * rewrite rev_app_distr. cbn. rewrite WriteString_Fun_eq.
+        destruct l0 as [ | x0 l0 _] using rev_ind.
+        -- cbn. reflexivity.
+        -- rewrite rev_app_distr. cbn. rewrite <- !app_assoc.
+           specialize (IHl0 (b0 :: l) b x). rewrite rev_app_distr in IHl0.
+           cbn in *. rewrite <- app_assoc in IHl0. cbn in IHl0. eassumption.
+      * now rewrite <- app_assoc.
+    + cbn in *. TMSimp. rewrite <- app_assoc. cbn. repeat  f_equal. rewrite encode_string_app. cbn.
+      rewrite !rev_app_distr. cbn. rewrite rev_app_distr. cbn. now rewrite <- app_assoc.
+    + cbn in *. TMSimp. rewrite <- app_assoc. cbn -[skipn]. repeat f_equal.
+      replace (encode_sym t ++ true :: encode_string l0) with ((encode_sym t ++ [true]) ++ encode_string l0).
+      pose proof (length_encode_sym t).
+      destruct (encode_sym) eqn:E.
+      * cbn in *. subst. reflexivity.
+      * cbn in *. inv H. rewrite skipn_app. reflexivity. rewrite app_length. cbn. lia.
+Qed.
+
+Definition MoveB (m : move) n : pTM (finType_CS bool) unit 1 :=
+  Switch TestLeftof (fun b => match b, m with 
+                              | true, Rmove => Move Rmove 
+                              | _, _ => MoveM m (2 + n)
+                              end).
+  
+Arguments Nat.iter : simpl never.
+Opaque Nat.iter.
+
+Lemma midtape_left_midtape {Σ : finType} (l1 l2 : list Σ) m m' r n :
+  n = S (length l1) -> 
+  Nat.iter n (@tape_move_left Σ) (midtape (rev l1 ++ [m'] ++ l2) m r) = midtape l2 m' (l1 ++ m :: r).
+Proof.
+  intros ->. induction l1 in m, m', l2 |- *.
+  - cbn. reflexivity.
+  - cbn. rewrite <- app_assoc. rewrite Nat_iter_S'.
+    now rewrite (IHl1 (m' :: l2) m a).
+Qed.
+
+Lemma midtape_right_midtape {Σ : finType} l m r1 c r2 n :
+  n = S (length r1) -> 
+  Nat.iter n (@tape_move_right Σ) (midtape l m (r1 ++ c :: r2)) = midtape (rev r1 ++ m :: l) c r2.
+Proof. 
+  intros ->. induction r1 in m, c, r2 |- * using rev_ind; cbn.
+  - reflexivity.
+  - rewrite app_length. cbn. rewrite plus_comm. cbn.
+    rewrite <- app_assoc, Nat_iter_S'. cbn.
+    rewrite (IHr1 m x (c :: r2)). cbn. now rewrite rev_app_distr.
+Qed.
+
+Lemma midtape_right_rightof {Σ : finType} l m rs c n :
+  n = 2 + (length rs) ->
+  Nat.iter n (@tape_move_right Σ) (midtape l m (rs ++ [c])) = rightof c (rev rs ++ m :: l).
+Proof. 
+  intros ->. cbn. rewrite Nat_iter_S'.
+  rewrite midtape_right_midtape. 2:reflexivity. cbn. reflexivity.
+Qed.
+
+Lemma MoveB_Realise (n : nat) m :
+  MoveB m n ⊨ fun t '(l, t') => forall t_sig, t = [| encode_tape t_sig |] -> t' = [| @encode_tape n (mv m t_sig) |].
+Proof.
+  epose (R := _). eapply Realise_monotone. 
+  { unfold MoveB.
+    eapply Switch_Realise. eapply TestLeftof_Realise. 
+    instantiate (1 := R m). subst R. 
+    instantiate (1 := fun m b => if b then _ else _). cbn.
+    intros []. cbn. instantiate (1 := match m0 with Rmove => _ | _ => _ end). cbn. destruct m.
+    TM_Correct. eapply MoveM_Realise. TM_Correct. TM_Correct. eapply MoveM_Realise.
+    TM_Correct. eapply MoveM_Realise. } subst R.
+
+  assert (forall n c rs, Nat.iter n (fun t : tape bool  => tape_move_left t) (leftof c rs) = leftof c rs) as Eleft. {
+    clear. intros. clear. induction  n; cbn. reflexivity. rewrite Nat_iter_S', IHn. reflexivity. }
+
+  intros t ([], t') ? t_sig ->. TMSimp. destruct_tapes. f_equal.
+  destruct t_sig.
+  - TMSimp. destruct_tapes. TMSimp.
+    assert (Nat.iter n (fun t : tape bool  => tape_move t m) niltape = niltape) as ->.
+    { induction  n; cbn. reflexivity. rewrite Nat_iter_S', IHn. now destruct m. }
+    now destruct m.
+  - cbn in *. TMSimp. destruct m.
+    + TMSimp. destruct_tapes. TMSimp. now rewrite Eleft.      
+    + TMSimp. reflexivity.
+    + TMSimp. destruct_tapes. TMSimp. now rewrite Nat_iter_id.
+  - TMSimp. destruct_tapes. TMSimp.
+    destruct m.
+    + cbn. rewrite <- !Nat_iter_S' with (f := fun t0 => tape_move_left t0).
+      rewrite Nat_iter_S. cbn.
+      pose proof (@midtape_left_midtape (finType_CS bool)). cbn in H. erewrite <- H. 
+      2: reflexivity. rewrite Nat_iter_S'. rewrite length_encode_sym. reflexivity.
+    + enough (forall c rs, Nat.iter n (fun t : tape bool  => tape_move_right t) (rightof c rs) = rightof c rs) as -> by reflexivity.
+      intros. clear. induction  n; cbn. reflexivity. rewrite Nat_iter_S', IHn. reflexivity.
+    + now rewrite Nat_iter_id.
+  - TMSimp. destruct_tapes. TMSimp. rename l into rs, l0 into ls.
+    rewrite <- !Nat_iter_S' with (f := fun t0 => tape_move t0 m).
+    destruct m.
+    + cbn. destruct rs.
+      * cbn. rewrite Nat_iter_S. cbn. now rewrite Eleft.
+      * cbn. pose proof (@midtape_left_midtape (finType_CS bool)). cbn in H.
+        rewrite encode_string_app, rev_app_distr. cbn. rewrite rev_app_distr. cbn.
+        rewrite Nat_iter_S. cbn. rewrite <- app_assoc. 
+        erewrite <- H. 2:reflexivity. rewrite length_encode_sym. reflexivity.
+    + cbn. destruct ls.
+      * cbn.
+        pose proof (@midtape_right_rightof (finType_CS bool)). cbn in H.
+        rewrite H. 2:now rewrite length_encode_sym. reflexivity.
+      * cbn. rewrite Nat_iter_S'.
+        pose proof (@midtape_right_midtape (finType_CS bool)). cbn in H.
+        rewrite H. cbn. rewrite encode_string_app. cbn. rewrite !rev_app_distr. cbn.
+        rewrite rev_app_distr. cbn. rewrite <- app_assoc. cbn. reflexivity.
+        now rewrite length_encode_sym.
+    + cbn. rewrite Nat_iter_id. reflexivity.
+Qed.
+
+Section FixM.
+
+  Variable Σ : finType.
+
+  Let n := (projT1 (finite_n Σ)).
+  Let f := (projT1 (projT2 (finite_n Σ))).
+  Let g := (proj1_sig (projT2 (projT2 (finite_n Σ)))).
+  Let Hf := (proj1 (proj2_sig (projT2 (projT2 (finite_n Σ))))).
+  Let Hg := (proj2 (proj2_sig (projT2 (projT2 (finite_n Σ))))).
+
+  Instance R : Retract (Fin.t n) Σ.
+  Proof.
+    eapply (@Build_Retract _ _ g (fun x => Some (f x ))).
+    econstructor.
+    - intros [= <-]; now rewrite Hg.
+    - intros ->; now rewrite Hf.
+  Qed.
+
+  Definition encode_tape' (t : tape Σ) : tape bool := encode_tape (mapTape f t).
+
+  Lemma ReadB_Realise' :
+    ReadB n ⊨ fun t '(l, t') => forall t_sig : tape Σ, t = [| encode_tape' t_sig |] -> t' = t /\ l = map_opt f (current t_sig).
+  Proof.
+    eapply Realise_monotone. eapply ReadB_Realise.
+    intros t (?, t') ? t_sig ->. destruct_tapes. cbn in *.
+    specialize (H (mapTape f t_sig) eq_refl) as [[= ->] ->].
+    split. eauto. eapply mapTape_current.
+  Qed.
+
+  Lemma WriteB_Realise' (c : option Σ) :
+    WriteB (map_opt f c) ⊨ fun t '(_, t') => forall t_sig, t = [| encode_tape' t_sig |] -> t' = [| encode_tape' (tape_write t_sig c) |].
+  Proof.
+    eapply Realise_monotone. eapply WriteB_Realise.
+    intros t (?, t') ? t_sig ->. destruct_tapes. cbn in *.
+    specialize (H (mapTape f t_sig) eq_refl) as [= ->].
+    unfold tape_write. destruct c.
+    - cbn. now rewrite mapTape_left, mapTape_right.
+    - reflexivity.
+  Qed.
+
+  Lemma MoveB_Realise' m :
+    MoveB m n ⊨ fun t '(l, t') => forall t_sig, t = [| encode_tape' t_sig |] -> t' = [| encode_tape' (mv m t_sig) |].
+  Proof.
+    eapply Realise_monotone. eapply MoveB_Realise.
+    intros t (?, t') ? t_sig ->. destruct_tapes. cbn in *.
+    specialize (H (mapTape f t_sig) eq_refl) as [= ->].
+    f_equal. destruct t_sig, m; try reflexivity.
+    cbn. destruct l; cbn; reflexivity.
+    cbn. destruct l0; cbn; reflexivity.
+  Qed.
+
+  Variable L : finType.
+  Variable pM : pTM Σ L 1.
+
+  Notation M := (projT1 pM).
+  
+  Definition Step (q : state M) : pTM (finType_CS bool) (state M + state M) 1 :=
+        Switch (ReadB n) (fun c_i => if halt q then Return Nop (inr q) 
+                                     else let '(q', e) := trans M (q, [| map_opt g c_i |]) in 
+                                          let '(existT _ (c', m) _) := destruct_vector_cons e in
+                                          WriteB (map_opt f c') ;; MoveB m n ;; Return Nop (inl q')).
+
+  Smpl Add (eapply ReadB_Realise') : TM_Correct.
+  Smpl Add (eapply WriteB_Realise') : TM_Correct.
+  Smpl Add (eapply MoveB_Realise') : TM_Correct.
+                                                                         
+  Lemma Step_Realise q :
+    Step q ⊨ fun t '(q_, t') => 
+      forall t_sig, t = [| encode_tape' t_sig |] ->
+      if halt q then q_ = inr q /\ t' = t 
+                else let '(q', a) := trans M (q, [| current t_sig |]) in 
+                     let '(existT _ (c', m) _) := destruct_vector_cons a in
+                     q_ = inl q' /\ t' = [| encode_tape' (mv m (wr c' t_sig)) |].
+  Proof.
+    eapply Realise_monotone.
+
+    {
+      unfold Step. eapply Switch_Realise. TM_Correct. cbn.
+      intros c_i. instantiate (1 := fun c_i => _). cbn. instantiate (1 := ltac:(destruct (halt q); refine _)).
+      destruct (halt q). cbn.
+      TM_Correct. 
+      instantiate (1 := ltac:(destruct (trans (q, [|map_opt g c_i|])); refine _)). cbn.
+      destruct (trans (q, [|map_opt g c_i|])).
+      instantiate (1 := ltac:(destruct (destruct_vector_cons t); refine _)). cbn.
+      destruct (destruct_vector_cons t). cbn.
+      instantiate (1 := ltac:(destruct x; refine _)). cbn.
+      destruct x. TM_Correct.
+    }
+
+    intros t (q_, t') ? t_sig ->. TMSimp. destruct_tapes.
+    rename h0 into t'. rename h into t.
+    destruct (halt q) eqn:Eq.
+    - TMSimp. split. reflexivity. eapply H. reflexivity.
+    - specialize (H _ eq_refl) as [[= ->] ->]. cbn in *.
+      assert (Efg : forall o, map_opt g (map_opt f o) = o). { intros [s | ]; cbn; now rewrite ?Hg.  }
+      rewrite Efg in H0. clear Efg.    
+      destruct trans as [q' T] eqn:Eqt.
+      destruct destruct_vector_cons as [[m c'] [nl ->]].
+      TMSimp. destruct_vector. split. reflexivity.
+      eapply H0. admit.
+  Admitted.
+
+  Theorem WhileStep_Realise :
+    StateWhile Step (start M) ⊨ 
+      fun t '(q', t') => forall t_sig, t = [| encode_tape' t_sig |] -> exists t_sig', eval M (start M) [| t_sig |] q' [| t_sig' |] /\ t' = [| encode_tape' t_sig'|].
+  Proof.
+    generalize (start M). intros q.
+
+    eapply Realise_monotone.
+    { 
+      TM_Correct. eapply Step_Realise. 
+    }
+
+    intros t (l, t') ? t_sig E.
+    TMSimp. destruct_tapes. rename h into t'.
+    remember ([|encode_tape' t_sig|]) as tin.
+    remember (l, [|t'|]) as cout.
+    induction H in t_sig, l, t', Heqtin, Heqcout |- *.
+    - TMSimp. destruct_tapes. specialize (H _ eq_refl).
+      rename l0 into q. destruct (halt q).
+      + inv Heqcout. destruct H as [[= ->] [= ->]].
+      + inv Heqcout.
+
+    
+    rename l0 into q. destruct (halt q) eqn:Eq.
+      + TMSimp. inv H2.
+      + TMSimp. clear H0. destruct trans as [q' T] eqn:Eqt.
+        destruct destruct_vector_cons as [[m c'] [nl ->]] eqn:E.
+        destruct_vector.
+        TMSimp. destruct_tapes. TMSimp. inv H4.
+        inv H1.
+        eexists. split.
+        * econstructor. eassumption. cbn in *.
+        2:{ instantiate (3 := q'). instantiate (1 := ymid).
+        instantiate (1 := [| (m, c') |]). cbn.
+    - TMSimp. rename l into q. destruct (halt q) eqn:Eq.
+      + TMSimp. inv H0. exists t_sig. split.
+        * destruct pM as [M lab]. cbn in *. unfold Realise in HM. cbn in *.
+          specialize (HM [|t_sig|] 1 (mk_mconfig q [|t_sig|])). cbn in *.
+          unfold haltConf in *. cbn in *.
+    + TMSimp. destruct trans as [q' T]. clear H0.
+      destruct destruct_vector_cons as [[m c'] [nl ->]].
+      destruct_vector.
+      TMSimp. destruct_tapes. TMSimp. inv H4.
+      eexists. split. eassumption. reflexivity.
+
+
+    - TMSimp. rename l into q. destruct (halt q) eqn:Eq.
+      + TMSimp. inv H0. 
+      + destruct trans as [q' T].
+        destruct destruct_vector_cons as [[m c'] [nl ->]].
+        destruct_vector.
+        TMSimp. destruct_tapes. TMSimp. inv H2.
+
+
+
+
+
+
+
+  

--- a/theories/TM/Reductions/Arbitrary_to_Binary.v
+++ b/theories/TM/Reductions/Arbitrary_to_Binary.v
@@ -437,7 +437,7 @@ Section FixM.
       destruct trans as [q' T] eqn:Eqt.
       destruct destruct_vector_cons as [[m c'] [nl ->]].
       TMSimp. destruct_vector. split. reflexivity.
-      eapply H0. admit.
+      eapply H0. 
   Admitted.
 
   Theorem WhileStep_Realise :
@@ -457,45 +457,19 @@ Section FixM.
     remember (l, [|t'|]) as cout.
     induction H in t_sig, l, t', Heqtin, Heqcout |- *.
     - TMSimp. destruct_tapes. specialize (H _ eq_refl).
-      rename l0 into q. destruct (halt q).
+      rename l0 into q. destruct (halt q) eqn:Eq.
       + inv Heqcout. destruct H as [[= ->] [= ->]].
-      + inv Heqcout.
-
-    
-    rename l0 into q. destruct (halt q) eqn:Eq.
-      + TMSimp. inv H2.
-      + TMSimp. clear H0. destruct trans as [q' T] eqn:Eqt.
-        destruct destruct_vector_cons as [[m c'] [nl ->]] eqn:E.
-        destruct_vector.
-        TMSimp. destruct_tapes. TMSimp. inv H4.
-        inv H1.
-        eexists. split.
-        * econstructor. eassumption. cbn in *.
-        2:{ instantiate (3 := q'). instantiate (1 := ymid).
-        instantiate (1 := [| (m, c') |]). cbn.
-    - TMSimp. rename l into q. destruct (halt q) eqn:Eq.
-      + TMSimp. inv H0. exists t_sig. split.
-        * destruct pM as [M lab]. cbn in *. unfold Realise in HM. cbn in *.
-          specialize (HM [|t_sig|] 1 (mk_mconfig q [|t_sig|])). cbn in *.
-          unfold haltConf in *. cbn in *.
-    + TMSimp. destruct trans as [q' T]. clear H0.
-      destruct destruct_vector_cons as [[m c'] [nl ->]].
-      destruct_vector.
-      TMSimp. destruct_tapes. TMSimp. inv H4.
-      eexists. split. eassumption. reflexivity.
-
-
-    - TMSimp. rename l into q. destruct (halt q) eqn:Eq.
-      + TMSimp. inv H0. 
-      + destruct trans as [q' T].
+      + inv Heqcout. destruct trans as [q' T] eqn:Eqt.
         destruct destruct_vector_cons as [[m c'] [nl ->]].
-        destruct_vector.
-        TMSimp. destruct_tapes. TMSimp. inv H2.
-
-
-
-
-
-
-
-  
+        destruct_vector. destruct H as [[= ->] [= ->]].
+        specialize (IHStateWhile_Rel _ _ _ eq_refl eq_refl) as [t_sig' [H1 [= ->]]].
+        exists t_sig'. split; try reflexivity.
+        econstructor. eassumption. eassumption. cbn. eassumption.
+    - inv Heqcout. specialize (H _ eq_refl).
+      rename l0 into q. destruct (halt q) eqn:Eq.
+      + destruct H as [[= ->] [= ->]]. eexists; split; try reflexivity.
+        now econstructor.
+      + destruct trans as [q' T] eqn:Eqt.
+        destruct destruct_vector_cons as [[m c'] [nl ->]].
+        destruct_vector. destruct H as [[= ->] [= ->]].
+  Qed.

--- a/theories/TM/Reductions/TM_to_SBTM.v
+++ b/theories/TM/Reductions/TM_to_SBTM.v
@@ -1,0 +1,122 @@
+From Undecidability Require TM.TM TM.SBTM.
+Require Import Undecidability.Shared.FinTypeEquiv.
+Require Import Undecidability.L.Functions.FinTypeLookup.
+Require Import PslBase.FiniteTypes.FinTypes PslBase.Vectors.Vectors.
+Require Undecidability.TM.Util.TM_facts.
+Import VectorNotations2.
+Local Open Scope vector.
+
+
+Notation vector_hd v := (projT1 (destruct_vector_cons v)).  
+
+Section red.
+
+    Variable M : TM.TM (finType_CS bool) 1.
+
+    Definition num_states := (projT1 (finite_n (TM.state M))).
+    Definition f := (projT1 (projT2 (finite_n (TM.state M)))).
+    Definition g := (proj1_sig (projT2 (projT2 (finite_n (TM.state M))))).
+    Definition Hf := (proj1 (proj2_sig (projT2 (projT2 (finite_n (TM.state M)))))).
+    Definition Hg := (proj2 (proj2_sig (projT2 (projT2 (finite_n (TM.state M)))))).
+    
+    Definition conv_move : TM.move -> SBTM.move :=
+        fun m => match m with TM.Lmove => SBTM.Lmove | TM.Nmove => SBTM.Nmove | TM.Rmove => SBTM.Rmove end.
+
+    Definition conv_state : TM.state M -> Fin.t (S num_states) := fun q => (Fin.FS (f q)).
+  
+    Definition trans : Fin.t (S num_states) * option bool -> option (Fin.t (S num_states) * option bool * SBTM.move) :=
+        fun '(q, o) => Fin.caseS' q (fun _ => _) (Some (conv_state (TM.start M), None, SBTM.Nmove)) 
+           (fun q => if TM.halt (g q) then None
+                                      else let '(q', vec) := TM.trans M (g q, [| o |]) in
+                                           let '(w, m) := vector_hd vec in
+                                           Some (conv_state q', w, conv_move m)
+           ).
+
+    Definition conv_tape (t : Vector.t (TM.tape bool) 1) : SBTM.tape := 
+    let t := vector_hd t in
+    match TM.current t with
+    | Some c => (TM.Util.TM_facts.left t, Some c, TM.Util.TM_facts.right t)
+    | None => (TM.Util.TM_facts.left t, None, TM.Util.TM_facts.right t)
+    end.
+
+    Lemma current_red t : SBTM.curr (conv_tape [| t |]) = TM.current t.
+    Proof.
+      unfold conv_tape. cbn. destruct (destruct_vector_cons [| t |]) as (? & ? & E); cbn in *. inv E. clear H1.
+      unfold TM.current.
+      destruct x eqn:E; reflexivity.
+    Qed.
+
+    Lemma wr_red w t : SBTM.wr w (conv_tape [| t |]) = conv_tape [| TM.wr w t |].
+    Proof.
+      unfold conv_tape. cbn.
+      destruct (destruct_vector_cons [| t |]) as (? & ? & E); cbn in *. inv E. clear H1.
+      destruct (destruct_vector_cons [| _ |]) as (? & ? & E); cbn in *. inv E. clear H1.
+      destruct x eqn:E1, w eqn:E2; cbn; reflexivity.
+    Qed.
+
+    Lemma mv_red m t : SBTM.mv (conv_move m) (conv_tape [| t |]) = conv_tape [| TM.mv m t |].
+    Proof.
+      unfold conv_tape. cbn.
+      destruct (destruct_vector_cons [| t |]) as (? & ? & E); cbn in *. inv E. clear H1.
+      destruct (destruct_vector_cons [| _ |]) as (? & ? & E); cbn in *. inv E. clear H1.
+      destruct x eqn:E1, m eqn:E2; cbn; try reflexivity.
+      all: destruct l, l0; try reflexivity.
+    Qed.
+
+    Lemma red_correct1 q q' t t' :
+      TM.eval M q t q' t' <-> SBTM.eval (SBTM.Build_SBTM num_states trans) (conv_state q) (conv_tape t) (conv_state q') (conv_tape t').
+    Proof.
+      split.
+      - induction 1.
+        + eapply SBTM.eval_halt. cbn. now rewrite Hg, H.
+        + TM_facts.destruct_tapes. cbn in *.
+          rewrite <- current_red in H0.
+          destruct TM.trans eqn:E. inv H0. destruct h0 as (w, m).
+          eapply SBTM.eval_step with (q' := conv_state q') (w := w) (m := conv_move m). cbn. rewrite Hg, H, E.
+          destruct destruct_vector_cons as (? & ? & ?), x; cbn. inv e. reflexivity.
+          now rewrite wr_red, mv_red.
+      - intros H.
+        remember (conv_state q) as q_.
+        remember (conv_tape t) as t_.
+        remember (conv_state q') as q'_.
+        remember (conv_tape t') as t'_.
+        induction H in q, q', t, t', Heqq_, Heqq'_, Heqt_, Heqt'_ |- *; subst.
+        + enough (q = q' /\ t = t') as [-> ->].
+          * unfold SBTM.trans, trans in H.
+            revert H.
+            generalize (eq_refl (conv_state q')).
+            pattern (conv_state q') at 1 3.
+            eapply Fin.caseS'; cbn.
+            -- intros ? [=].
+            -- intros ? ? ?. destruct TM.halt eqn:E.
+               ++ econstructor. unfold conv_state in H.
+                  eapply Fin.FS_inj in H as ->. now rewrite Hg in E.
+               ++ destruct TM.trans, destruct_vector_cons, x; inv H0.
+          * split. 
+            -- unfold conv_state in *. eapply Fin.FS_inj in Heqq'_.
+               eapply (f_equal g) in Heqq'_. now rewrite !Hg in Heqq'_.
+            -- TM_facts.destruct_tapes. unfold conv_tape in *.
+               destruct destruct_vector_cons as (? & ? & ?); subst. inv e. clear H2. cbn in *.
+               destruct destruct_vector_cons as (? & ? & ?); subst. inv e0. clear H2. cbn in *.
+               destruct x, x1; inv Heqt'_; reflexivity.
+        + unfold SBTM.trans, trans in H. revert H.
+          generalize (eq_refl (conv_state q)).
+          pattern (conv_state q) at 1 3.
+          eapply Fin.caseS'; cbn.
+          * intros ? [=]. unfold conv_state in *. inv H.
+          * intros ? ?. unfold conv_state in *. eapply Fin.FS_inj in H; subst.
+            rewrite Hg.
+            destruct TM.halt eqn:E.
+            -- intros [=].
+            -- TM_facts.destruct_tapes.
+               destruct TM.trans eqn:Et, destruct_vector_cons as (? & ? & ?), x; cbn. intros [=]; subst.
+               econstructor. eassumption. rewrite current_red in Et. eassumption.
+               cbn. eapply IHeval; eauto. rewrite wr_red, mv_red. destruct_vector; cbn. reflexivity.
+    Qed.
+
+End red.
+
+
+
+
+

--- a/theories/TM/SBTM.v
+++ b/theories/TM/SBTM.v
@@ -1,0 +1,66 @@
+Require Import List Bool Nat.
+Require Coq.Vectors.Fin.
+Import ListNotations.
+
+Definition tape : Type := list bool * option bool * list bool.
+
+Definition left '( (ls, m, rs) : tape) : list bool := ls.
+
+Definition right '((ls, m, rs) : tape) := rs.
+
+Definition curr '((ls, m, rs) : tape) := m.
+
+Definition wr (o : option bool) (t : tape) := 
+  match o with
+  | Some c => (left t, Some c, right t)
+  | None => t
+  end.
+  
+Inductive move : Type := 
+    | Lmove : move 
+    | Rmove : move 
+    | Nmove : move.
+
+Definition mv (m : move) (t : tape) :=
+  match m with
+  | Lmove => match left t, curr t with
+             | l :: ls, None => (ls, Some l, right t)
+             | l :: ls, Some c => (ls, Some l, c :: right t)
+             | [], Some c => ([], None, c :: right t)
+             | _, _ => t
+             end
+  | Rmove => match curr t, right t with
+             | None, r :: rs => (left t, Some r, rs) 
+             | Some c, r :: rs => (c :: left t, Some r, rs)
+             | Some c, [] => (c :: left t, None, [])
+             | _ , _ => t
+             end
+  | Nmove => t
+  end.
+
+
+(*   match t, m with
+  | (l :: ls, None,   rs), Lmove => (ls, Some l, rs)
+  | (l :: ls, Some c, rs), Lmove => (ls, Some l, c :: rs)
+  | ([]     , Some c, rs), Lmove => ([], None ,  c :: rs)
+  | (ls, None,   r :: rs), Rmove => (ls, Some r, rs)
+  | (ls, Some c, r :: rs), Rmove => (c :: ls, Some r, rs)
+  | (ls, Some c, []),      Rmove => (c :: ls, None, [])
+  | _, _                         => t
+  end.
+ *)
+Record SBTM :=  { num_states : nat ; trans : Fin.t (S num_states) * option bool -> option (Fin.t (S num_states) * option bool * move)}.
+
+Notation state M := (Fin.t (S (num_states M))).
+
+Inductive eval (M : SBTM) : state M -> tape -> state M -> tape -> Prop :=
+| eval_halt q t :
+    trans M (q, (curr t)) = None ->
+    eval M q t q t
+| eval_step q t q' w m  q'' t' :
+    trans M (q, curr t) = Some (q', w, m) ->
+    eval M q' (mv m (wr w t)) q'' t' ->
+    eval M q t q'' t'.
+
+Definition HaltSBTM '( (M, t) : SBTM * tape) :=
+  exists q' t', eval M (Fin.F1) t q' t'.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -9,6 +9,7 @@ Shared/ListAutomation.v
 Shared/FilterFacts.v
 Shared/embed_nat.v
 Shared/FinTypeEquiv.v
+Shared/FinTypeForallExists.v
 
 Synthetic/Definitions.v
 Synthetic/Undecidability.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -317,6 +317,8 @@ TM/Single/EncodeTapes.v
 TM/Single/StepTM.v
 TM/Reductions/L_to_mTM.v
 
+TM/Reductions/Arbitrary_to_Binary.v
+
 # Univ
 TM/Univ/LookupAssociativeListTM.v
 TM/Univ/StepTM.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -8,6 +8,7 @@ Shared/Dec.v
 Shared/ListAutomation.v
 Shared/FilterFacts.v
 Shared/embed_nat.v
+Shared/FinTypeEquiv.v
 
 Synthetic/Definitions.v
 Synthetic/Undecidability.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -319,6 +319,9 @@ TM/Single/StepTM.v
 TM/Reductions/L_to_mTM.v
 
 TM/Reductions/Arbitrary_to_Binary.v
+TM/SBTM.v
+TM/Reductions/TM_to_SBTM.v
+StackMachines/Reductions/SBTM_to_BSM.v
 
 # Univ
 TM/Univ/LookupAssociativeListTM.v


### PR DESCRIPTION
I have an alphabet reduction from arbitrary alphabet to binary alphabet (reasonably easy, very nice application of the TM framework) and a simulation of single-tape binary Turing machines (`SBTM`) on binary stack machines (reasonably easy, very nice application of the `sss` framework). @DmxLarchey:The simulation uses 4 stacks: Left part of the tape, middle part of the tape, right part of the tape, and empty register for unconditional jumps. One can optimise middle away by merging it into the state space, but I didn't bother to, mainly because the compiler to MMs adds two counters anyways.

@mwuttke97 @fakusb The only thing that was slightly annoying me regarding TMs is that we do not have support to prove TMs total without actually talking about step indices. While one can abstract away from labels regarding realisation, abstracting away from steps regarding termination is impossible. It was no big deal, as an effect of this I also have a proof that the simulation is linear. If we wanted (I don't want to) we could do a similar analysis for the SBTM -> BSM compilation. @fakusb  that might be useful for you in case you want to bring TMs to register machines: You can start at BSM, which have a nicer structure for compilation.

Overall 2.5 days for the first part and 2.5 days for the second part, so quite a good investment :)

Two TODOs left: Change the `BSM_undec` proof and add an `SBTM_undec` file.

@mrhaandi @DmxLarchey SBTMs can be taken as alternative definition for presentation regarding Turing machines. They are less involved than TMs because they (1) do not mention vectors, (2) work with `Fin.t` instead of `finType` and (3) work with `list bool * option bool * list bool` as tapes. The issue still is that `([true], None, [true])` is considered a tape, but that's strange. Since `SBTM` is just an intermediate step to `BSM`, that's fine for me.
