### PR TITLE
Timed option for make, new MetaCoq version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ install:
 - opam list
 
 script:
- - make -j ${NJOBS} all
+ - make -j ${NJOBS} all TIMED=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - NJOBS=2
   - COMPILER="4.07.1"
   matrix:
-  - COQ_VER="8.12.0" EQUATIONS_VER="1.2.3+8.12" METACOQ_VER="1.0~alpha3-uds-psl+8.12" SMPL_VER="8.12" BASE_VER="1.0.2+8.12"
+  - COQ_VER="8.12.0" EQUATIONS_VER="1.2.3+8.12" METACOQ_VER="1.0~beta1+8.12" SMPL_VER="8.12" BASE_VER="1.0.2+8.12"
   
 install:
 - curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 all:
-	+make -C theories all
+	export TIMED
+	$(MAKE) -C theories all
 
 install:
-	+make -C theories install
+	$(MAKE) -C theories install
 
 clean:
-	+make -C theories clean
+	$(MAKE) -C theories clean
 
 html:
-	+make -C theories html
+	$(MAKE) -C theories html
 
 .PHONY: all install html clean 
+
+dummy:
+
+%.vo: dummy
+	cd theories && $(MAKE) $@

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Coq Library of Undecidability Proofs
 
-[![Build Status](https://travis-ci.org/uds-psl/coq-library-undecidability.svg?branch=coq-8.12)](https://travis-ci.org/uds-psl/coq-library-undecidability)
+[![Build Status](https://travis-ci.com/uds-psl/coq-library-undecidability.svg?branch=coq-8.12)](https://travis-ci.com/uds-psl/coq-library-undecidability)
 
 This library contains undecidable problems and formalised reductions between them.
 Feel free to contribute or start using the problems!
@@ -73,7 +73,6 @@ opam install . --deps-only
 - `make all` builds the library
 - `make html` generates clickable coqdoc `.html` in the `website` subdirectory
 - `make clean` removes all build files in `theories` and `.html` files in the `website` directory
-- `make realclean` also removes all build files in the `external` directory. You have to run `make deps` again after this.
 
 ### Troubleshooting
 

--- a/opam
+++ b/opam
@@ -21,17 +21,14 @@ build: [
 install: [
   [make "install"]
 ]
-remove: [
-  ["rm" "-R" "%{lib}%/coq/user-contrib/Undecidability"]
-]
 depends: [
   "coq" {>= "8.12" & < "8.13~"}
   "coq-equations" {= "1.2.3+8.12"}
   "ocaml"
   "coq-smpl" {= "8.12"}
   "coq-psl-base-library" {="1.0.2+8.12"}
-  "coq-metacoq-template" {="1.0~alpha3-uds-psl+8.12" }
-  "coq-metacoq-checker" {="1.0~alpha3-uds-psl+8.12" }
+  "coq-metacoq-template" {="1.0~beta1+8.12" }
+  "coq-metacoq-checker" {="1.0~beta1+8.12" }
 ]
 
 synopsis: "A Coq Library of Undecidability Proofs"

--- a/theories/Makefile
+++ b/theories/Makefile
@@ -1,19 +1,20 @@
 all: Makefile.coq
-	+make -f Makefile.coq all
+	export TIMED
+	$(MAKE) -f Makefile.coq all
 
 html: Makefile.coq
-	+make -f Makefile.coq html
+	$(MAKE) -f Makefile.coq html
 	mv html/*.html ../website
 	rm -rf html
 
 install: Makefile.coq
-	+make -f Makefile.coq install
+	$(MAKE) -f Makefile.coq install
 
 uninstall: Makefile.coq
-	+make -f Makefile.coq uninstall
+	$(MAKE) -f Makefile.coq uninstall
 
 clean: Makefile.coq
-	+make -f Makefile.coq clean
+	$(MAKE) -f Makefile.coq clean
 	rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: _CoqProject
@@ -24,4 +25,4 @@ Makefile.coq: _CoqProject
 dummy:
 
 %.vo: Makefile.coq dummy
-	+make -f Makefile.coq $@
+	$(MAKE) -f Makefile.coq $@


### PR DESCRIPTION
This enables `make TIMED=1`, printing time information for every file. Travis is now using this option by default.

Also I changed the required MetaCoq package to the official `beta1` of MetaCoq. Nothing has to be done if you are on the old version though, they are compatible without any change.

Lastly, the CI shows up again in PRs thanks to a hint by @fakusb.