### PR TITLE
Getting rid of legacy Problems directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feel free to contribute or start using the problems!
 - Halting problem for Minsky machines (`MM_HALTING` in [`MinskyMachines/MM.v`](theories/MinskyMachines/MM.v))
 - Halting problem for two counters Minsky machines (`MM2_HALTING` in [`MinskyMachines/MM2.v`](theories/MinskyMachines/MM2.v)) with 
   self-contained explanations, **`good seed`**
-- Halting problem for Binary Stack Machines (`BSM_HALTING` in [`MinskyMachines/MM.v`](theories/MinskyMachines/MM.v))
+- Halting problem for Binary Stack Machines (`BSM_HALTING` in [`StackMachines/BSM.v`](theories/StackMachines/BSM.v))
 - Halting problem for the call-by-value lambda-calculus (`HaltL` in [`L/L.v`](theories/L/L.v))
 - String rewriting (`SR` in [`StringRewriting/SR.v`](theories/StringRewriting/SR.v))
 - Entailment in Elementary Intuitionistic Linear Logic (`EILL_PROVABILITY` in [`ILL/EILL.v`](theories/ILL/EILL.v))

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ Feel free to contribute or start using the problems!
 
 - Post correspondence problem (`PCP` in [`PCP/PCP.v`](theories/PCP/PCP.v)), **`good seed`**
 - Halting problems for single-tape and multi-tape Turing machines (`HaltTM` in [`TM/TM.v`](theories/TM/TM.v))
-- Halting problem for Minsky machines (`MM_HALTING` in [`Problems/MM.v`](theories/Problems/MM.v))
-- Halting problem for two counters Minsky machines (`MM2_HALTING` in [`Problems/MM2.v`](theories/Problems/MM2.v)) with 
+- Halting problem for Minsky machines (`MM_HALTING` in [`MinskyMachines/MM.v`](theories/MinskyMachines/MM.v))
+- Halting problem for two counters Minsky machines (`MM2_HALTING` in [`MinskyMachines/MM2.v`](theories/MinskyMachines/MM2.v)) with 
   self-contained explanations, **`good seed`**
-- Halting problem for Binary Stack Machines (`BSM_HALTING` in [`Problems/BSM.v`](theories/Problems/BSM.v))
+- Halting problem for Binary Stack Machines (`BSM_HALTING` in [`MinskyMachines/MM.v`](theories/MinskyMachines/MM.v))
 - Halting problem for the call-by-value lambda-calculus (`HaltL` in [`L/L.v`](theories/L/L.v))
 - String rewriting (`SR` in [`StringRewriting/SR.v`](theories/StringRewriting/SR.v))
-- Entailment in Elementary Intuitionistic Linear Logic (`EILL_PROVABILITY` in [`Problems/ILL.v`](theories/Problems/ILL.v))
-- Entailment in Intuitionistic Linear Logic (`ILL_PROVABILITY` in [`Problems/ILL.v`](theories/Problems/ILL.v))
-- Entailment in Classical Linear Logic (`CLL_cf_PROVABILITY` in [`Problems/CLL.v`](theories/Problems/CLL.v))
+- Entailment in Elementary Intuitionistic Linear Logic (`EILL_PROVABILITY` in [`ILL/EILL.v`](theories/ILL/EILL.v))
+- Entailment in Intuitionistic Linear Logic (`ILL_PROVABILITY` in [`ILL/ILL.v`](theories/ILL/ILL.v))
+- Entailment in Classical Linear Logic (`CLL_cf_PROVABILITY` in [`ILL/CLL.v`](theories/ILL/CLL.v))
 - Provability in Minimal (Intuitionistic, Classical) First-Order Logic (`prv` in [`Problems/FOL.v`](theories/Problems/FOL.v))
 - Validity in Minimal (Intuitionistic, Classical) First-Order Logic (`valid` in [`Problems/FOL.v`](theories/Problems/FOL.v), `kvalid` in [`Problems/FOL.v`](theories/Problems/FOL.v))
 - Satisfiability in Intuitionistic (Classical) First-Order Logic (`satis` in [`Problems/FOL.v`](theories/Problems/FOL.v), `ksatis` in [`Problems/FOL.v`](theories/Problems/FOL.v))
-- Halting problem for FRACTRAN programs (`FRACTRAN_REG_HALTING` in [`Problems/FRACTRAN.v`](theories/Problems/FRACTRAN.v)), **`good seed`**
+- Halting problem for FRACTRAN programs (`FRACTRAN_REG_HALTING` in [`FRACTRAN/FRACTRAN.v`](theories/FRACTRAN/FRACTRAN.v)), **`good seed`**
 - [Hilbert's 10th problem](https://uds-psl.github.io/H10), i.e. solvability of a single diophantine equation (`H10` in 
-  in [`Problems/DIOPHANTINE.v`](theories/Problems/DIOPHANTINE.v))
+  in [`H10/H10.v`](theories/H10/H10.v))
 - Satisfiability of elementary Diophantine constraints of the form `x = 1`, `x = y + z` or `x = y · z` (`H10C_SAT` in [`DiophantineConstraints/H10C.v`](theories/DiophantineConstraints/H10C.v)), **`good seed`**
 - Satisfiability of uniform Diophantine constraints of the form `x = 1 + y + z · z` (`H10UC_SAT` in [`DiophantineConstraints/H10C.v`](theories/DiophantineConstraints/H10C.v)), **`good seed`**
 - One counter machine halting problem (`CM1c4_HALT` in [`CounterMachines/CM1.v`](theories/CounterMachines/CM1.v)), **`good seed`**

--- a/theories/CounterMachines/Reductions/MM2_HALTING_to_CM1c4_HALT.v
+++ b/theories/CounterMachines/Reductions/MM2_HALTING_to_CM1c4_HALT.v
@@ -15,7 +15,7 @@ Require Import List.
 Import ListNotations.
 Require Import PeanoNat Lia Relations.Relation_Operators Relations.Operators_Properties.
 
-Require Import Undecidability.Problems.MM2.
+Require Import Undecidability.MinskyMachines.MM2.
 Require Undecidability.CounterMachines.CM1.
 From Undecidability.CounterMachines.Util Require Import 
   Nat_facts List_facts CM1_facts MM2_facts.

--- a/theories/CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
+++ b/theories/CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
@@ -14,7 +14,7 @@
 Require Import List Lia Relations.Relation_Operators Relations.Operators_Properties.
 Import ListNotations.
 
-Require Import Undecidability.Problems.MM2.
+Require Import Undecidability.MinskyMachines.MM2.
 Require Undecidability.CounterMachines.CM2.
 
 From Undecidability.CounterMachines.Util Require Import 

--- a/theories/CounterMachines/Util/MM2_facts.v
+++ b/theories/CounterMachines/Util/MM2_facts.v
@@ -1,7 +1,7 @@
 Require Import List Arith Lia.
 Import ListNotations.
 
-Require Import Undecidability.Problems.MM2.
+Require Import Undecidability.MinskyMachines.MM2.
 
 From Coq Require Import ssreflect ssrbool ssrfun.
 

--- a/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
@@ -12,7 +12,7 @@ Require Import List Arith Omega Lia Max.
 Require Import Undecidability.Synthetic.Undecidability.
 
 From Undecidability Require Import Shared.Libs.DLW.Utils.utils H10.Dio.dio_logic H10.Dio.dio_elem.
-From Undecidability Require Import H10.FRACTRAN_DIO Problems.FRACTRAN.
+From Undecidability Require Import H10.FRACTRAN_DIO FRACTRAN.FRACTRAN.
 Require Import Undecidability.DiophantineConstraints.H10C.
 
 Set Implicit Arguments.

--- a/theories/Problems/BSM.v
+++ b/theories/Problems/BSM.v
@@ -1,8 +1,0 @@
-From Undecidability.StackMachines Require Export BSM.
-
-(* The halting problem for binary stack machines *)
-
-(* Certified Undecidability of Intuitionistic Linear Logic via Binary Stack Machines and Minsky Machines. Yannick Forster and Dominique Larchey-Wendling. CPP '19. http://uds-psl.github.io/ill-undecidability/ *)
-
-About BSM_HALTING. (* Halting problem for Binary Stack machines machines *)
-

--- a/theories/Problems/CLL.v
+++ b/theories/Problems/CLL.v
@@ -1,3 +1,0 @@
-From Undecidability.ILL Require Export CLL.
-
-About CLL_cf_PROVABILITY.   (* Provability for cut-free classical linear logic *)

--- a/theories/Problems/DIOPHANTINE.v
+++ b/theories/Problems/DIOPHANTINE.v
@@ -1,9 +1,0 @@
-From Undecidability.H10 Require Export FRACTRAN_DIO H10.
-
-(** The solvability problem for lists of elementary diophantine constraints *)
-
-About DIO_ELEM_SAT.
-
-(** Hilbert's Tenth problem, solvability of a single diophantine equation *)
-
-About H10. 

--- a/theories/Problems/FRACTRAN.v
+++ b/theories/Problems/FRACTRAN.v
@@ -1,5 +1,0 @@
-From Undecidability.FRACTRAN Require Export FRACTRAN.
-
-(* The halting problem for regular FRACTRAN programs *)
-
-About FRACTRAN_REG_HALTING. 

--- a/theories/Problems/ILL.v
+++ b/theories/Problems/ILL.v
@@ -1,7 +1,0 @@
-From Undecidability.ILL Require Export EILL ILL.
-
-(** Certified Undecidability of Intuitionistic Linear Logic via Binary Stack Machines and Minsky Machines. 
-    Yannick Forster and Dominique Larchey-Wendling. CPP '19. http://uds-psl.github.io/ill-undecidability/ *)
-
-About EILL_PROVABILITY.  (* Provability for elementary linear logic *)
-About ILL_PROVABILITY.   (* Provability for linear logic *)

--- a/theories/Problems/MM.v
+++ b/theories/Problems/MM.v
@@ -1,7 +1,0 @@
-From Undecidability.MinskyMachines Require Export MM.
-
-(* The halting problem for Minsky machines *)
-
-(* Certified Undecidability of Intuitionistic Linear Logic via Binary Stack Machines and Minsky Machines. Yannick Forster and Dominique Larchey-Wendling. CPP '19. http://uds-psl.github.io/ill-undecidability/ *)
-
-About MM_HALTING. (* Halting problem for Minsky machines *)

--- a/theories/Problems/MM2.v
+++ b/theories/Problems/MM2.v
@@ -1,1 +1,0 @@
-From Undecidability.MinskyMachines Require Export MM2.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -682,13 +682,6 @@ SystemF/Reductions/SysF_TYP_to_SysF_TC.v
 
 #Legacy Problems
 Problems/FOL.v
-Problems/MM.v
-Problems/MM2.v
-Problems/BSM.v
-Problems/ILL.v
-Problems/CLL.v
-Problems/FRACTRAN.v
-Problems/DIOPHANTINE.v
 Problems/RA_UNIV.v
 
 Problems/FOLFS.v


### PR DESCRIPTION
I did remove the following `*.v` in `theories/Problems/`

- `MM.v`
- `MM2.v`
- `BSM.v`
- `ILL.v`
- `CLL.v`
- `FRACTRAN.v`
- `DIOPHANTINE.v`

both the files themselves and the pointers to them in `_CoqProject` and `README.md`.

Remaining is `FOL.v` and `FOLFS.v` and also `RA_UNIV.v`.