### PR TITLE
Removed external dependency on PslBase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.opam"
-          key: opam-${{github.base_ref}}-${{github.ref}} 
+          key: opam-noPslBase-${{github.base_ref}}-${{github.ref}} 
           restore-keys: |
-            opam--refs/heads/${{github.base_ref}}
+            opam-noPslBase--refs/heads/${{github.base_ref}}
 
       - name: Install OCaml
         uses: avsm/setup-ocaml@v1
@@ -27,7 +27,6 @@ jobs:
           fetch-depth: 1
 
       - run: opam repo add coq-released https://coq.inria.fr/opam/released
-      - run: opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git 
       - run: opam install . --deps-only --with-doc --with-test
 
       - run: opam exec -- make -j 2 all TIMED=1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ You need `Coq 8.12` built on OCAML `>= 4.07.1`, the [Smpl](https://github.com/ud
 opam switch create coq-library-undecidability 4.07.1+flambda
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam repo add psl-opam-repository https://github.com/uds-psl/psl-opam-repository.git
 opam install . --deps-only
 ```
 
@@ -129,4 +128,6 @@ A Coq Library of Undecidable Problems. Yannick Forster, Dominique Larchey-Wendli
 - Simon Spies
 - Maximilian Wuttke
 - Andrej Dudenhefner
+- Sigurd Schneider 
 
+Parts of the Coq Library of Undecidability Proofs reuse generic code initially developed as a library for the lecture ["Introduction to Computational Logics"](https://courses.ps.uni-saarland.de/icl_16/) at [Saarland University](https://www.uni-saarland.de/nc/en/home.html). That reused code was written by a subset of the above contributors, as well as Sigurd Schneider and Jan Christian Menz.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,5 @@ A Coq Library of Undecidable Problems. Yannick Forster, Dominique Larchey-Wendli
 - Simon Spies
 - Maximilian Wuttke
 - Andrej Dudenhefner
-- Sigurd Schneider 
 
 Parts of the Coq Library of Undecidability Proofs reuse generic code initially developed as a library for the lecture ["Introduction to Computational Logics"](https://courses.ps.uni-saarland.de/icl_16/) at [Saarland University](https://www.uni-saarland.de/nc/en/home.html). That reused code was written by a subset of the above contributors, as well as Sigurd Schneider and Jan Christian Menz.

--- a/opam
+++ b/opam
@@ -26,7 +26,6 @@ depends: [
   "coq-equations" {= "1.2.3+8.12"}
   "ocaml"
   "coq-smpl" {= "8.12"}
-  "coq-psl-base-library" {="1.0.2+8.12"}
   "coq-metacoq-template" {="1.0~beta1+8.12" }
   "coq-metacoq-checker" {="1.0~beta1+8.12" }
 ]

--- a/theories/L/AbstractMachines/FlatPro/LM_heap_def.v
+++ b/theories/L/AbstractMachines/FlatPro/LM_heap_def.v
@@ -1,6 +1,6 @@
 (** * Semantics of the Heap Machine *)
 
-Require Import PslBase.Base.
+Require Import Undecidability.Shared.Libs.PSL.Base.
 Require Import FunInd.
 From Undecidability.L Require Export Prelim.ARS Prelim.MoreBase AbstractMachines.FlatPro.Programs.
 

--- a/theories/L/AbstractMachines/TM_LHeapInterpreter/M_LHeapInterpreter.v
+++ b/theories/L/AbstractMachines/TM_LHeapInterpreter/M_LHeapInterpreter.v
@@ -99,7 +99,7 @@ Proof.
     {
       modpon HStar. destruct HStar as (T1&V1&heap1&HStar); modpon HStar.
       modpon HLastStep.
-      { instantiate (1 := [|_;_;_;_;_;_;_;_|]).
+      { instantiate (1 := [| _;_;_;_;_;_;_;_|]).
         intros i. destruct_fin i; eauto. }
       destruct HLastStep as (T2&V2&heap2&k&HLastStep). modpon HLastStep.
       do 3 eexists. exists (1 + k). repeat split. apply pow_add. do 2 eexists. rewrite <- rcomp_1. 1-3:now eauto.
@@ -148,7 +148,7 @@ Proof.
     exists (Step_steps T V Heap). repeat split.
     { hnf. do 3 eexists; repeat split; eauto. }
     intros ymid tmid HStep. cbn in HStep. modpon HStep.
-    { instantiate (1 := [|_;_;_;_;_;_;_;_|]).
+    { instantiate (1 := [| _;_;_;_;_;_;_;_|]).
       intros i0. specialize HInt with (i := i0). isRight_mono; cbn. destruct_fin i0; cbn; constructor.
     }
     destruct ymid as [ () | ]. 
@@ -204,7 +204,7 @@ Proof.
     eapply TM_eval_iff in HLoop as [n HLoop].
     pose proof Loop_Realise HLoop as HLoopRel. hnf in HLoopRel. modpon HLoopRel.
     1-3: apply initValue_contains_size.
-    instantiate (1 := [|_;_;_;_;_;_;_;_|]).
+    instantiate (1 := [| _;_;_;_;_;_;_;_|]).
     - intros i; destruct_fin i; cbn; eapply initRight_isRight_size.
     - destruct HLoopRel as (T'&V'&H'&k'&HStep&HTerm&_). cbn in *. hnf. eauto.
       apply steps_k_steps in HStep. eauto.

--- a/theories/L/AbstractMachines/TM_LHeapInterpreter/StepTM.v
+++ b/theories/L/AbstractMachines/TM_LHeapInterpreter/StepTM.v
@@ -271,7 +271,7 @@ Section StepMachine.
         rename H into HJumpTarget, H1 into HTailRec, H3 into HConsClos.
         modpon HJumpTarget.
         {
-          instantiate (1 := [|_;_;_|]).
+          instantiate (1 := [| _;_;_|]).
           intros i; destruct_fin i; cbn; simpl_surject; auto.
         }
         destruct HJumpTarget as (P'&Q'&HJumpTarget); modpon HJumpTarget.
@@ -287,7 +287,7 @@ Section StepMachine.
       }
       { (* Else, i.e. [jumpTarget 0 [] = None] *)
         modpon H.
-        { instantiate (1 := [|_;_;_|]).
+        { instantiate (1 := [| _;_;_|]).
           intros i; destruct_fin i; cbn; simpl_surject; auto. }
         assumption.
       }
@@ -333,7 +333,7 @@ Section StepMachine.
         - intros i; destruct_fin i; cbn; simpl_surject; TMSimp_goal; eauto; apply HInt. }
       intros tmid ymid (HJump&HJumpInj); TMSimp_old. modpon HJump.
       {
-        instantiate (1 := [|_;_;_|]).
+        instantiate (1 := [| _;_;_|]).
         intros i.
         generalize (HInt Fin0); generalize (HInt Fin1); generalize (HInt Fin2); intros.
         destruct_fin i; cbn; simpl_surject; TMSimp_goal; eauto.
@@ -935,7 +935,7 @@ Section StepMachine.
         }
           { (* lamT *)
             rename HCase into HStepLam. modpon HStepLam; TMSimp_goal; eauto; try contains_ext.
-            { instantiate (1 := [|_;_;_;_;_|]).
+            { instantiate (1 := [| _;_;_;_;_|]).
               intros i; destruct_fin i; auto; TMSimp_goal; cbn.
               all: try apply HInt.
               apply HCaseCom. (* somehow, auto uses [contains_ext] not correctly. *)
@@ -955,7 +955,7 @@ Section StepMachine.
           { (* appT *)
             rename HCase into HStepApp. cbn in HStepApp.
             cbv [put] in *. modpon HStepApp; TMSimp_goal; eauto; try contains_ext.
-            { instantiate (1 := [|_;_;_;_;_;_|]).
+            { instantiate (1 := [| _;_;_;_;_;_|]).
               intros i; destruct_fin i; auto; TMSimp_goal; auto.
               all: try apply HInt.
               apply HCaseCom. (* somehow, auto uses [contains_ext] not correctly. *)

--- a/theories/L/Complexity/UpToC.v
+++ b/theories/L/Complexity/UpToC.v
@@ -6,7 +6,7 @@ Require Export Lia Arith Ring.
 From Coq Require Import Setoid.
 From Coq Require Import CRelationClasses CMorphisms.
 Import CMorphisms.ProperNotations. 
-From PslBase Require FinTypes.
+From Undecidability.Shared.Libs.PSL Require FinTypes.
 
 Record leUpToC {X} (f g : X -> nat) : Type :=
   { c__leUpToC : nat;

--- a/theories/L/Complexity/UpToCNary.v
+++ b/theories/L/Complexity/UpToCNary.v
@@ -5,7 +5,7 @@ From Coq Require Import Setoid.
 From Coq Require Import CRelationClasses CMorphisms.
 From Undecidability Require Export UpToC.
 From Undecidability Require Export GenericNary.
-From PslBase Require FinTypes.
+From Undecidability.Shared.Libs.PSL Require FinTypes.
 
 Local Set Universe Polymorphism. 
 

--- a/theories/L/Datatypes/LFinType.v
+++ b/theories/L/Datatypes/LFinType.v
@@ -3,7 +3,7 @@ From Undecidability.L Require Import Datatypes.LNat Functions.EqBool.
 From Undecidability.L Require Import UpToC.
 
 Import Nat.
-Require Export PslBase.FiniteTypes.FinTypes.
+Require Export Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
 
 (** *** Encoding finite types *)
 (* This is not an instance because we only want it for very specific types. *)

--- a/theories/L/Datatypes/LNat.v
+++ b/theories/L/Datatypes/LNat.v
@@ -1,6 +1,6 @@
 From Undecidability.L Require Export Util.L_facts.
 From Undecidability.L.Tactics Require Export LTactics GenEncode.
-Require Import PslBase.Numbers.
+Require Import Undecidability.Shared.Libs.PSL.Numbers.
 
 Require Import Nat.
 From Undecidability.L Require Import Datatypes.LBool Functions.EqBool Datatypes.LProd. 

--- a/theories/L/Datatypes/LVector.v
+++ b/theories/L/Datatypes/LVector.v
@@ -1,7 +1,7 @@
 From Undecidability.L.Tactics Require Import LTactics GenEncode.
 From Undecidability.L.Datatypes Require Import LNat Lists LFinType.
 
-Require Import PslBase.Vectors.Vectors.
+Require Import Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 
 (** *** Encoding vectors *)
 

--- a/theories/L/Datatypes/Lists.v
+++ b/theories/L/Datatypes/Lists.v
@@ -2,7 +2,7 @@ From Undecidability.L.Tactics Require Import LTactics GenEncode.
 From Undecidability.L Require Import Functions.EqBool.
 From Undecidability.L.Datatypes Require Import LBool LNat LOptions LProd.
 From Undecidability.L Require Import UpToC.
-Require Export List PslBase.Lists.Filter Datatypes.
+Require Export List Undecidability.Shared.Libs.PSL.Lists.Filter Datatypes.
 
 (** ** Encoding of lists *)
 

--- a/theories/L/Functions/EnumInt.v
+++ b/theories/L/Functions/EnumInt.v
@@ -2,7 +2,7 @@ From Undecidability.L.Tactics Require Import LTactics.
 From Undecidability.L.Computability Require Import Enum.
 From Undecidability.L.Functions Require Import Encoding Equality.
 From Undecidability.L.Datatypes Require Import LNat Lists LProd.
-Require Import PslBase.Base Nat List Datatypes.
+Require Import Undecidability.Shared.Libs.PSL.Base Nat List Datatypes.
 
 Import Nat.
 (** ** Enumeratibility of L-terms *)

--- a/theories/L/Prelim/ARS.v
+++ b/theories/L/Prelim/ARS.v
@@ -1,7 +1,7 @@
 (** ** Abstract Reduction Systems *)
 (** from Semantics Lecture at Programming Systems Lab, https://www.ps.uni-saarland.de/courses/sem-ws13/ *)
 
-Require Export PslBase.Base Lia.
+Require Export Undecidability.Shared.Libs.PSL.Base Lia.
 
 Module ARSNotations.
   Notation "p '<=1' q" := (forall x, p x -> q x) (at level 70).

--- a/theories/L/Prelim/MoreBase.v
+++ b/theories/L/Prelim/MoreBase.v
@@ -1,4 +1,4 @@
-Require Export PslBase.Base Lia.
+Require Export Undecidability.Shared.Libs.PSL.Base Lia.
 From Undecidability.L Require Export MoreList.
 
 (** * Preliminaries *)

--- a/theories/L/Prelim/MoreList.v
+++ b/theories/L/Prelim/MoreList.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Base Lia.
+Require Import Undecidability.Shared.Libs.PSL.Base Lia.
 (** Nats smaller than n *)
 
 Fixpoint natsLess n : list nat :=

--- a/theories/L/Prelim/StringBase.v
+++ b/theories/L/Prelim/StringBase.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Base Ascii.
+Require Import Undecidability.Shared.Libs.PSL.Base Ascii.
 Require Export String.
 
 Fixpoint to_string (l : list ascii) :=

--- a/theories/L/Reductions/H10_to_L.v
+++ b/theories/L/Reductions/H10_to_L.v
@@ -1,6 +1,6 @@
 From Undecidability.H10 Require Import H10 dio_single dio_logic.
 Require Import Undecidability.FOL.PCP.
-Require Import PslBase.FiniteTypes PslBase.FiniteTypes.Arbitrary.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes Undecidability.Shared.Libs.PSL.FiniteTypes.Arbitrary.
 From Undecidability.L.Datatypes Require Import LNat Lists LProd.
 From Undecidability.L Require Import Tactics.LTactics Computability.MuRec Computability.Synthetic Tactics.GenEncode.
 From Undecidability.Shared.Libs.DLW.Vec Require Import pos.

--- a/theories/L/TM/TMEncoding.v
+++ b/theories/L/TM/TMEncoding.v
@@ -8,7 +8,7 @@ From Undecidability Require Import TM.Util.VectorPrelim.
 
 From Undecidability Require Import TM.Util.VectorPrelim.
 From Undecidability Require Import TM.Util.TM_facts.
-Require Import PslBase.FiniteTypes.FinTypes.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
 
 Import L_Notations.
 

--- a/theories/L/TM/TapeFuns.v
+++ b/theories/L/TM/TapeFuns.v
@@ -4,7 +4,7 @@ From Undecidability.L Require Import TM.TMEncoding.
 
 
 From Undecidability Require Import TM.Util.TM_facts.
-Require Import PslBase.FiniteTypes.FinTypes.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
 
 
 Section fix_sig.

--- a/theories/L/Tactics/Computable.v
+++ b/theories/L/Tactics/Computable.v
@@ -1,5 +1,5 @@
 From Undecidability.L Require Export Util.L_facts Tactics.Extract.
-Require Import PslBase.Bijection String.
+Require Import Undecidability.Shared.Libs.PSL.Bijection String.
 
 (** * Correctness and time bounds *)
 

--- a/theories/L/Tactics/ComputableTactics.v
+++ b/theories/L/Tactics/ComputableTactics.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Bijection MetaCoq.Template.All Strings.Ascii.
+Require Import Undecidability.Shared.Libs.PSL.Bijection MetaCoq.Template.All Strings.Ascii.
 From Undecidability.L Require Import Prelim.StringBase.
 From Undecidability.L.Tactics Require Import Lproc Computable ComputableTime Lsimpl mixedTactics Lbeta Lrewrite.
 Require Export Ring Arith Lia.

--- a/theories/L/Tactics/Extract.v
+++ b/theories/L/Tactics/Extract.v
@@ -1,6 +1,6 @@
 From Undecidability.L Require Import Util.L_facts Prelim.StringBase.
 From MetaCoq Require Import Template.All Checker.Checker.
-Require Import PslBase.Base. 
+Require Import Undecidability.Shared.Libs.PSL.Base. 
 Require Import String Ascii.
 
 Open Scope string_scope.

--- a/theories/L/Tactics/mixedTactics.v
+++ b/theories/L/Tactics/mixedTactics.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Base Lia Ring. 
+Require Import Undecidability.Shared.Libs.PSL.Base Lia Ring. 
 
 Tactic Notation "destruct" "_":= 
   match goal with

--- a/theories/L/Util/L_facts.v
+++ b/theories/L/Util/L_facts.v
@@ -1,5 +1,5 @@
 From Undecidability.L Require Export Prelim.ARS Prelim.MoreBase.
-From PslBase Require Export Base Bijection.
+From Undecidability.Shared.Libs.PSL Require Export Base Bijection.
 From Undecidability.L Require Export L.
 
 Require Import Lia.

--- a/theories/Shared/FinTypeEquiv.v
+++ b/theories/Shared/FinTypeEquiv.v
@@ -1,4 +1,4 @@
-From PslBase Require Import FiniteTypes.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.
 
 Fixpoint position {X : eqType} (x : X) (l : list X) : option (Fin.t (length l)).
 Proof.

--- a/theories/Shared/FinTypeForallExists.v
+++ b/theories/Shared/FinTypeForallExists.v
@@ -1,4 +1,4 @@
-From PslBase Require Import FiniteTypes.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.
 
 Lemma list_forall_exists (F : Type) (P : F -> nat -> Prop) L :
     (forall x n, P x n -> forall m, m >= n -> P x m) ->

--- a/theories/Shared/Libs/PSL/Base.v
+++ b/theories/Shared/Libs/PSL/Base.v
@@ -1,0 +1,17 @@
+(** * Base Library for ICL
+
+   - Version: 3 October 2016
+   - Author: Gert Smolka, Saarland University
+   - Acknowlegments: Sigurd Schneider, Dominik Kirst, Yannick Forster, Fabian Kunze, Maximilian Wuttke
+ *)
+
+From Undecidability.Shared.Libs.PSL Require Export 
+        Prelim
+        Numbers
+        BaseLists
+        Lists.Cardinality
+        Dupfree
+        Filter
+        Position
+        Power
+        Removal.

--- a/theories/Shared/Libs/PSL/Bijection.v
+++ b/theories/Shared/Libs/PSL/Bijection.v
@@ -1,0 +1,52 @@
+(** * Bijective functions *)
+
+(* Author: Maximilian Wuttke *)
+
+
+From Undecidability.Shared.Libs.PSL Require Import Base.
+
+
+Section Bijection.
+  Variable X Y : Type.
+
+  (*
+   *      f
+   *   ------>
+   * X         Y
+   *   <------
+   *      g
+   *)
+
+  Definition left_inverse  (f : X -> Y) (g : Y -> X) := forall x : X, g (f x) = x.
+  Definition right_inverse (f : X -> Y) (g : Y -> X) := forall y : Y, f (g y) = y.
+  Definition inverse (f : X -> Y) (g : Y -> X) := left_inverse f g /\ right_inverse f g.
+
+  Definition injective (f : X -> Y) :=
+    forall x y, f x = f y -> x = y.
+
+  Lemma left_inv_inj (f : X -> Y) (g : Y -> X) : left_inverse f g -> injective f.
+  Proof.
+    intros HInv. hnf in *. intros x1 x2 Heq.
+    enough (g (f x1) = g (f x2)) as L by now rewrite !HInv in L.
+    f_equal. assumption.
+  Qed.
+
+  Definition surjective (f : X -> Y) :=
+    forall y, exists x, f x = y.
+
+  Lemma right_inv_surjective f g :
+    right_inverse f g -> surjective f.
+  Proof. intros HInv. hnf. eauto. Qed.
+
+  Definition bijective (f : X -> Y) :=
+    injective f /\ surjective f.
+  
+  Lemma inverse_bijective f g :
+    inverse f g -> bijective f.
+  Proof.
+    intros (HInv1&HInv2). hnf. split.
+    - eapply left_inv_inj; eauto.
+    - eapply right_inv_surjective; eauto.
+  Qed.
+
+End Bijection.

--- a/theories/Shared/Libs/PSL/EqDec.v
+++ b/theories/Shared/Libs/PSL/EqDec.v
@@ -1,0 +1,235 @@
+From Undecidability.Shared.Libs.PSL Require Import Prelim.
+
+(** * Decidable predicates *)
+
+
+Definition dec (X: Prop) : Type := {X} + {~ X}.
+
+Coercion dec2bool P (d: dec P) := if d then true else false.
+
+Existing Class dec.
+
+Definition Dec (X: Prop) (d: dec X) : dec X := d.
+Arguments Dec X {d}.
+
+Lemma Dec_reflect (X: Prop) (d: dec X) :
+  Dec X <-> X.
+Proof.
+  destruct d as [A|A]; cbv; firstorder congruence.
+Qed.
+
+Notation Decb X := (dec2bool (Dec X)).
+
+Lemma Dec_reflect_eq (X Y: Prop) (d: dec X) (e: dec Y) :
+ Decb X = Decb Y <->  (X <-> Y).
+Proof.
+  destruct d as [D|D], e as [E|E]; cbn; intuition congruence.
+Qed.
+
+Lemma Dec_auto (X: Prop) (d: dec X) :
+  X -> Dec X.
+Proof.
+  destruct d as [A|A]; cbn; intuition congruence.
+Qed.
+
+Lemma Dec_auto_not (X: Prop) (d: dec X) :
+  ~ X -> ~ Dec X.
+Proof.
+  destruct d as [A|A]; cbn; intuition congruence.
+Qed.
+
+Hint Resolve Dec_auto Dec_auto_not : core.
+Hint Extern 4 =>  (* Improves type class inference *)
+match goal with
+  | [  |- dec ((fun _ => _) _) ] => cbn
+end : typeclass_instances.
+
+Tactic Notation "decide" constr(p) := 
+  destruct (Dec p).
+Tactic Notation "decide" constr(p) "as" simple_intropattern(i) := 
+  destruct (Dec p) as i.
+Tactic Notation "decide" "_" :=
+  destruct (Dec _).
+Tactic Notation "have" constr(E) := let X := fresh "E" in decide E as [X|X]; subst; try congruence; try lia; clear X.
+
+Lemma Dec_true P {H : dec P} : dec2bool (Dec P) = true -> P.
+Proof.
+  decide P; cbv in *; firstorder.
+Qed.
+
+Lemma Dec_false P {H : dec P} : dec2bool (Dec P) = false -> ~P.
+Proof.
+  decide P; cbv in *; firstorder.
+Qed.
+
+Lemma Dec_true' (P : Prop) (d : dec P) : P -> Decb P = true.
+Proof. intros H. decide P; cbn; tauto. Qed.
+
+Lemma Dec_false' (P : Prop) (d : dec P) : (~ P) -> Decb P = false.
+Proof. intros H. decide P; cbn; tauto. Qed.
+
+Hint Extern 4 =>
+match goal with
+  [ H : dec2bool (Dec ?P) = true  |- _ ] => apply Dec_true in  H
+| [ H : dec2bool (Dec ?P) = false |- _ ] => apply Dec_false in H
+| [ |- dec2bool (Dec ?P) = true] => apply Dec_true'
+| [ |- dec2bool (Dec ?P) = false] => apply Dec_false'
+end : core.
+
+(** Decided propositions behave classically *)
+
+Lemma dec_DN X : 
+  dec X -> ~~ X -> X.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Lemma dec_DM_and X Y :  
+  dec X -> dec Y -> ~ (X /\ Y) -> ~ X \/ ~ Y.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+Lemma dec_DM_impl X Y :  
+  dec X -> dec Y -> ~ (X -> Y) -> X /\ ~ Y.
+Proof. 
+  unfold dec; tauto. 
+Qed.
+
+(** Propagation rules for decisions *)
+
+Fact dec_transfer P Q :
+  P <-> Q -> dec P -> dec Q.
+Proof.
+  unfold dec. tauto.
+Defined.
+
+Instance bool_dec (b: bool) :
+  dec b.
+Proof. 
+  unfold dec. destruct b; cbn; auto. 
+Defined.
+
+Instance True_dec :
+  dec True.
+Proof. 
+  unfold dec; tauto. 
+Defined.
+
+Instance False_dec :
+  dec False.
+Proof. 
+  unfold dec; tauto. 
+Defined.
+
+Instance impl_dec (X Y : Prop) :  
+  dec X -> dec Y -> dec (X -> Y).
+Proof. 
+  unfold dec; tauto. 
+Defined.
+
+Instance and_dec (X Y : Prop) :  
+  dec X -> dec Y -> dec (X /\ Y).
+Proof. 
+  unfold dec; tauto. 
+Defined.
+
+Instance or_dec (X Y : Prop) : 
+  dec X -> dec Y -> dec (X \/ Y).
+Proof. 
+  unfold dec; tauto. 
+Defined.
+
+(* Coq standard modules make "not" and "iff" opaque for type class inference, 
+   can be seen with Print HintDb typeclass_instances. *)
+
+Instance not_dec (X : Prop) : 
+  dec X -> dec (~ X).
+Proof. 
+  unfold not. auto.
+Defined.
+
+Instance iff_dec (X Y : Prop) : 
+  dec X -> dec Y -> dec (X <-> Y).
+Proof. 
+  unfold iff. auto.
+Defined.
+
+(** ** Discrete types *)
+
+Notation "'eq_dec' X" := (forall x y : X, dec (x=y)) (at level 70).
+
+Structure eqType :=
+  EqType {
+      eqType_X :> Type;
+      eqType_dec : eq_dec eqType_X
+    }.
+
+Arguments EqType X {_} : rename.
+
+Canonical Structure eqType_CS X (A: eq_dec X) := EqType X.
+
+Existing Instance eqType_dec.
+
+(** Print the base type of [eqType] in the Canonical Structure. *)
+Arguments eqType_CS (X) {_}.
+
+Instance unit_eq_dec :
+  eq_dec unit.
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance bool_eq_dec : 
+  eq_dec bool.
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance nat_eq_dec : 
+  eq_dec nat.
+Proof.
+  unfold dec. decide equality.
+Defined.
+
+Instance prod_eq_dec X Y :  
+  eq_dec X -> eq_dec Y -> eq_dec (X * Y).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance list_eq_dec X :  
+  eq_dec X -> eq_dec (list X).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance sum_eq_dec X Y :  
+  eq_dec X -> eq_dec Y -> eq_dec (X + Y).
+Proof.
+  unfold dec. decide equality. 
+Defined.
+
+Instance option_eq_dec X :
+  eq_dec X -> eq_dec (option X).
+Proof.
+  unfold dec. decide equality.
+Defined.
+
+Instance Empty_set_eq_dec:
+  eq_dec Empty_set.
+Proof.
+  unfold dec. decide equality.
+Defined.
+
+Instance True_eq_dec:
+  eq_dec True.
+Proof.
+  intros x y. destruct x,y. now left.
+Defined.
+
+Instance False_eq_dec:
+  eq_dec False.
+Proof.
+  intros [].
+Defined.

--- a/theories/Shared/Libs/PSL/FCI.v
+++ b/theories/Shared/Libs/PSL/FCI.v
@@ -1,0 +1,158 @@
+From Undecidability.Shared.Libs.PSL Require Import Lists.Cardinality Numbers.
+
+(** ** Finite inductive predicates *)
+
+Section Fip.
+  Variables (X: eqType) (sigma: list X -> X -> bool) (R: list X).
+  
+  Inductive fip : X -> Prop :=
+  | fip_intro A x : (forall x, x el A -> fip x) -> sigma A x -> x el R -> fip x.
+
+  Definition fip_monotone := forall A B x, A <<= B -> sigma A x -> sigma B x.
+  Definition fip_closed A := forall x, x el R -> sigma A x -> x el A.
+
+  Lemma fip_least A x :
+    fip_monotone -> fip_closed A -> fip x -> x el A.
+  Proof.
+    intros C D. induction 1 as [B x _ IH F G].
+    apply (D _ G). revert F. apply C. exact IH.
+  Qed.
+
+  Fixpoint fip_it n A : list X :=
+    match n, find (fun x => Dec (~ x el A /\ sigma A x)) R with
+    | S n', Some x => fip_it n' (x::A)
+    | _, _ =>  A
+    end.
+
+  Lemma fip_it_sound n A :
+    inclp A fip -> inclp (fip_it n A) fip.
+  Proof.
+    revert A; induction n as [|n IH]; cbn; intros A H.
+    - exact H.
+    - destruct (find _ R) as[x|] eqn:E.
+      (* New: Remember equation, apply find specs to it, elim Dec _ = true *)
+      + apply find_some in E as [H1 (H2&H3) % Dec_true].
+        apply IH. intros z [<-|H4].
+        * apply fip_intro with (A:= A); auto.
+        * apply H, H4.
+      + apply H.
+  Qed.
+
+  Lemma fip_it_closed n A :
+    A <<= R -> card R <= n + card A -> fip_closed (fip_it n A).
+  Proof.
+    revert A. induction n as [|n IH]; cbn; intros A H H1.
+    - enough (A === R) as (H2&H3) by (hnf; auto).
+      apply card_or in H as [H|H]. exact H. lia.
+    - destruct (find _ R) eqn:E.
+      + apply find_some in E as [H2 (H3&H4) % Dec_true]. apply IH. now auto. 
+        rewrite card_cons'. lia. auto.
+      + intros x H2 H3. apply dec_DN. now auto.
+        apply find_none with (x := x) in E; auto.
+        apply Dec_false in E; auto. 
+  Qed.
+
+  Theorem fip_dec x :
+    fip_monotone -> dec (fip x).
+  Proof.
+    intros D.
+    apply dec_transfer with (P:= x el fip_it (card R) nil); [ | now auto].
+    split.
+    - revert x. apply fip_it_sound. hnf. auto.
+    - apply (fip_least D). apply fip_it_closed. now auto. lia.
+  Qed.
+
+End Fip.
+
+(** ** Finite closure iteration *)
+
+Module FCI.
+Section FCI.
+  Variables (X: eqType) (sigma: list X -> X -> bool) (R: list X).
+
+  Lemma pick (A : list X) :
+    { x | x el R /\ sigma A x /\ ~ x el A } + { forall x, x el R -> sigma A x -> x el A }.
+  Proof.
+    destruct (cfind R (fun x => sigma A x /\ ~ x el A)) as [E|E].
+    - auto.
+    - right. intros x F G.
+      decide (x el A). assumption. exfalso.
+      eapply E; eauto.
+  Qed.
+
+  Definition F (A : list X) : list X.
+    destruct (pick A) as [[x _]|_].
+    - exact (x::A).
+    - exact A.
+  Defined.
+
+  Definition C := it F (card R) nil.
+  
+  Lemma it_incl n : 
+    it F n nil <<= R.
+  Proof.
+    apply it_ind. now auto.
+    intros A E. unfold F. 
+    destruct (pick A) as [[x G]|G]; intuition.
+  Qed.
+  
+  Lemma incl :
+    C <<= R.
+  Proof.
+    apply it_incl.
+  Qed.
+
+  Lemma ind p :
+    (forall A x, inclp A p -> x el R -> sigma A x -> p x) -> inclp C p.
+  Proof.
+    intros B. unfold C. apply it_ind.
+    + intros x [].
+    + intros D G x. unfold F.
+      destruct (pick D) as [[y E]|E].
+      * intros [[]|]; intuition; eauto.
+      * intuition.
+  Qed.
+
+  Lemma fp : 
+    F C = C.
+  Proof.
+    pose (size (A : list X) := card R - card A).
+    replace C with (it F (size nil) nil).
+    - apply it_fp. intros n. cbn. 
+      set (J:= it F n nil). unfold FP, F.
+      destruct (pick J) as [[x B]|B].
+      + right.
+        assert (G: card J < card (x :: J)).
+        { apply card_lt with (x:=x); intuition. }
+        assert (H: card (x :: J) <= card R).
+        { apply card_le, incl_cons. apply B. apply it_incl. }
+        unfold size. lia.
+      + auto.
+    - unfold C, size. f_equal. change (card nil) with 0. lia.
+  Qed.
+  
+  Lemma closure x :
+    x el R -> sigma C x -> x el C.
+  Proof.
+    assert (A2:= fp).
+    unfold F in A2.
+    destruct (pick C) as [[y C]| B].
+    + contradiction (list_cycle A2). 
+    + apply B.
+  Qed.
+
+  Theorem fip_dec x :  (* Proof using FCI *)
+    fip_monotone sigma -> dec (fip sigma R x).
+  Proof.
+    intros D.
+    apply dec_transfer with (P:= x el C). 2:now auto.
+    split.
+    - revert x. apply FCI.ind. intros A x IH E F.
+      apply fip_intro with (A:=A); auto.
+    - apply (fip_least D). intros z. apply FCI.closure.
+  Qed.
+
+End FCI.
+End FCI.
+
+(* Print Graph. (* prints transitive closure of coercions *) *)

--- a/theories/Shared/Libs/PSL/FiniteTypes.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes.v
@@ -1,0 +1,12 @@
+From Undecidability.Shared.Libs.PSL Require Export 
+FiniteTypes.BasicDefinitions
+FiniteTypes.FinTypes
+FiniteTypes.BasicFinTypes
+FiniteTypes.CompoundFinTypes
+FiniteTypes.VectorFin
+FiniteTypes.FiniteFunction
+FiniteTypes.Cardinality
+FiniteTypes.DepPairs
+FiniteTypes.Arbitrary.
+
+

--- a/theories/Shared/Libs/PSL/FiniteTypes/Arbitrary.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/Arbitrary.v
@@ -1,0 +1,194 @@
+From Undecidability.Shared.Libs.PSL Require Import Base Bijection FiniteTypes.FinTypes.
+Require Import Coq.Vectors.Fin.
+
+Instance Fin_eq_dec n : eq_dec (Fin.t n).
+Proof.
+  intros; hnf.
+  destruct (eqb x y) eqn:E.
+  - left. now eapply eqb_eq.
+  - right. intros H. eapply eqb_eq in H. congruence.
+Defined.
+
+Definition all_Fin n := nat_rec (fun n0 : nat => list (t n0)) [] (fun (n0 : nat) (IHn : list (t n0)) => F1 :: map FS IHn) n.
+
+
+Lemma in_undup_iff (X: eqType) (A: list X) x : x el A <-> x el (undup A).
+Proof.
+  now rewrite undup_id_equi.
+Qed.
+
+(* (** * finTypes from Lists  *) *)
+(* (* Conversion of lists over eqTypes to finite types *) *)
+(* (* *) *)
+
+
+(** * Pure predicates  *)
+(* taken from the development of Herditarily finite sets by Prof. Smolka and Kathrin Stark. *)
+(* *)
+
+Definition pure (X:Type) (p: X -> Prop) {D:forall x, dec (p x)} x := if Dec (p x) then True else False.
+Arguments pure {X} p {D} x.
+
+Lemma pure_equiv  (X:Type) (p: X -> Prop) {D:forall x, dec (p x)} x : p x <-> pure p x.
+Proof.
+  unfold pure. now dec.
+Qed.
+
+Lemma pure_impure  (P: Prop) (_: dec P) (norm: if Dec (P) then True else False) : P.
+Proof.
+  dec; tauto.
+Qed.
+Ltac impurify H := pose proof (pure_impure H) as impureH; try (clear H; rename impureH into H).
+
+Lemma purify (X: Type) (p: X -> Prop) (D:forall x, dec (p x)) x (px: p x): pure p x.
+Proof.
+  now  apply pure_equiv.
+Qed.
+  
+Arguments purify {X} {p} {D} {x} px.
+
+Lemma pure_eq (X: Type) (p: X -> Prop) (D: forall x, dec (p x)) x (p1 p2: pure p x) : p1 = p2.
+Proof.
+  unfold pure in *.  dec.
+  + now destruct p1, p2.
+  + contradiction p1.
+Qed.
+
+(* (** * Definition of subtypes *) *)
+
+Definition subtype {X:Type} (p: X -> Prop) {D: forall x, dec (p x)} := { x:X | pure p x}.
+Arguments subtype {X} p {D}.
+
+Lemma subtype_extensionality (X: Type) (p: X -> Prop)  {D: forall x, dec (p x)} (x x': subtype p) : proj1_sig x = proj1_sig x' <-> x = x'.
+Proof.
+  split.
+  - intros H. destruct x, x'. cbn in H. subst x0. f_equal. apply pure_eq.
+  - congruence.
+Qed.
+
+Instance subType_eq_dec X (_:eq_dec X) (p: X -> Prop) (_: forall x, dec (p x)): eq_dec (subtype p).
+Proof.
+  intros y z. destruct y as [x p1], z as  [x' p2]. decide (x=x').
+  - left.  now apply subtype_extensionality.
+  - right. intro H. apply n. now inv H.
+Qed.
+
+(* Lemma proj1_sig_fun (X: eqType) (p: X -> Prop) (x x': X) (p1: p x) (p2: p x'): exist p x p1 = exist p x' p2 -> x = x'. *)
+(* Proof. *)
+(*   intro E. change x with (proj1_sig (exist p x p1)). change x' with (proj1_sig (exist p x' p2)). *)
+(*   now inv E. *)
+(* Qed. *)
+
+(* (** * Subtypes from lists *) *)
+
+(* Lemma in_undup_iff (X: eqType) (A: list X) x : x el A <-> x el (undup A). *)
+(* Proof. *)
+(*   now rewrite undup_id_equi. *)
+(* Qed. *)
+
+Fixpoint toSubList (X: Type) (A: list X) (p: X -> Prop) (D:forall x, dec (p x))  : list (subtype p) :=
+  match A with
+  | nil => nil
+  | cons x A' => match Dec (p x) with
+                | left px => (exist  _ x (purify px)) :: toSubList A' D
+                | right _ => toSubList  A' _ end
+  end.
+
+Arguments toSubList {X} A p {D}.
+
+Lemma toSubList_count (X: eqType) (p: X -> Prop) (A: list X) (_:forall x, dec (p x)) x:
+  count (toSubList A p) x = count A (proj1_sig x).
+Proof.
+  induction A.
+  - reflexivity.
+  - cbn. decide (p a).
+    + simpl. dec.
+      * congruence.
+      * now rewrite <- subtype_extensionality in e.
+      * change a with (proj1_sig (exist (pure p) a (purify p0)))  in e. now rewrite subtype_extensionality in e.
+      * exact IHA.
+    + destruct x.  cbn. dec.
+      * subst a. now impurify p0.
+      * exact IHA.
+Qed.
+
+(* Lemma subType_enum_ok (X:finType) (p: X -> Prop) (_: forall x, dec (p x)) x: *)
+(*   count (toSubList (elem X) p) x = 1. *)
+(* Proof. *)
+(*   rewrite toSubList_count. apply enum_ok. *)
+(* Qed. *)
+
+Notation "'Subtype' p"  := (finTypeC (EqType (subtype p))) (at level 5).
+
+(* Instance finTypeC_sub (X:finType) (p: X -> Prop) (_:forall x, dec (p x)): Subtype p. *)
+(* Proof. *)
+(*   econstructor.  apply subType_enum_ok. *)
+(* Defined. *)
+
+(** * finTypes from Lists  *)
+(* Conversion of lists over eqTypes to finite types *)
+(* *)
+Lemma enum_ok_fromList (X: eqType) (A: list X) x : count (undup (toSubList A (fun x => x el A))) x = 1.
+Proof.
+  apply dupfreeCount.
+  - apply dupfree_undup.
+  - rewrite <- in_undup_iff. apply countIn. cbn in *.
+    rewrite toSubList_count.
+    destruct x as [x p]. cbn. apply InCount. now impurify p.
+Qed.
+
+Instance fromListC (X: eqType) (A: list X) : Subtype (fun x => x el A).
+Proof.
+econstructor. intros [x p]. apply enum_ok_fromList.
+Defined.
+
+(* (* Canonical Structure finType_fromList (X: eqType) (A: list X) := FinType (EqSubType (fun x => x el A)). *) *)
+
+(* (* Lemma finType_fromList_correct (X: eqType) (A: list X) : *) *)
+(* (*   map (@proj1_sig _ _) (elem (finType_fromList A)) === A. *) *)
+(* (* Proof. *) *)
+(* (*   cbn. split. *) *)
+(* (*   -  intros x H. destruct (in_map_iff (@proj1_sig _ _) (undup (toSubList A (fun x => x el A))) x) as [H0 _]. *) *)
+(* (*      specialize (H0 H). destruct H0 as [[y p] [E _]]. cbn in *. subst y. now impurify p. *) *)
+(* (*   - intros x H. apply in_map_iff. *) *)
+(* (*     eexists. Unshelve. Focus 2. *) *)
+(* (*     + exists x. unfold pure. now dec. *) *)
+(* (*     + cbn. split; auto. apply countIn with (A:= undup (toSubList A _)). rewrite enum_ok_fromList. lia. *) *)
+(* (* Qed. *) *)
+
+
+
+(*   Definition finType_of := {x : X | x el A}. *)
+
+(*   Lemma eqType_finType_of : eq_dec finType_of. *)
+(*   Proof. *)
+(*     eapply subType_eq_dec. *)
+      
+    
+
+  (* Lemma enum_ok_fromList (X: eqType) (A: list X) x : count (undup (toSubList A (fun x => x el A))) x = 1. *)
+  (* Proof. *)
+  (*   apply dupfreeCount. *)
+  (*   - apply dupfree_undup. *)
+  (*   - rewrite <- in_undup. apply countIn. rewrite toSubList_count. *)
+  (*     destruct x as [x p]. cbn. apply InCount. now impurify p. *)
+  (* Qed. *)
+  
+(* Instance fromListC (X: eqType) (A: list X) : finTypeC (EqSubType (fun x => x el A)). *)
+(* Proof. *)
+(* econstructor. intros [x p]. apply enum_ok_fromList. *)
+(* Defined. *)
+
+(* Canonical Structure finType_fromList (X: eqType) (A: list X) := FinType (EqSubType (fun x => x el A)). *)
+
+(* Lemma finType_fromList_correct (X: eqType) (A: list X) : *)
+(*   map (@proj1_sig _ _) (elem (finType_fromList A)) === A. *)
+(* Proof. *)
+(*   cbn. split. *)
+(*   -  intros x H. destruct (in_map_iff (@proj1_sig _ _) (undup (toSubList A (fun x => x el A))) x) as [H0 _]. *)
+(*      specialize (H0 H). destruct H0 as [[y p] [E _]]. cbn in *. subst y. now impurify p. *)
+(*   - intros x H. apply in_map_iff. *)
+(*     eexists. Unshelve. Focus 2. *)
+(*     + exists x. unfold pure. now dec. *)
+(*     + cbn. split; auto. apply countIn with (A:= undup (toSubList A _)). rewrite enum_ok_fromList. lia. *)
+(* Qed.  *)

--- a/theories/Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
@@ -1,0 +1,205 @@
+(* * Basic definitions of decidablility and Functions
+- includes basic Lemmas about said functions 
+ *)
+
+From Undecidability.Shared.Libs.PSL Require Export Base.
+
+(** * Definition of useful tactics *)
+
+(** dec is used to destruct all decisions appearing in the goal or assumptions. *)
+Ltac dec := repeat (destruct Dec).
+
+(** This tactic completely solves listComplete goals for base types *)
+Ltac listComplete := intros x; simpl; dec; destruct x; try congruence.
+(** simplifies (decision x = x) *)
+Ltac deq x := destruct (Dec (x=x)) as [[]  | isnotequal]; [> | contradict isnotequal; reflexivity] .
+
+
+
+(** Function that takes two lists and returns the list of all pairs of elements from the two lists *)
+Fixpoint prodLists {X Y: Type} (A: list X) (B: list Y) {struct A} :=
+  match A with
+  | nil => nil
+  | cons x A' => map (fun y => (x,y)) B ++ prodLists A' B end.
+
+(** Crossing any list with the empty list always yields the empty list *)
+Lemma prod_nil (X Y: Type) (A: list X) :
+  prodLists A ([]: list Y) = [].
+Proof.
+  induction A.
+  - reflexivity.
+  - cbn. assumption.
+Qed.
+
+(** This function takes a (A: list X) and yields a list (option X) which for every x in A contains Some x. The resultung list also contains None. The order is preserved. None is the first element of the resulting list. *)
+
+Definition toOptionList {X: Type} (A: list X) :=
+  None :: map (@Some _) A .
+
+(** This function counts the number of occurences of an element in a given list and returns the result *)
+Fixpoint count (X: Type) `{eq_dec X}  (A: list  X) (x:  X) {struct A} : nat :=
+  match A with
+  | nil => O
+  | cons y A' =>  if Dec (x=y) then S(count A' x) else count A' x end.
+
+Definition toSumList1 {X: Type}  (Y: Type) (A: list X): list (X + Y) :=
+  map inl A.
+Definition toSumList2 {Y: Type}  (X: Type) (A: list Y): list (X + Y) :=
+  map inr A.
+
+(** * Basic lemmas about functions *)
+
+(** In the list containing all pairs of (x,y') with y' from a list B the pair (x,y) is contained exactly as many times as y is contained in the list B. *)
+
+Lemma countMap (X Y: eqType) (x:X) (B: list Y) y :
+  count ( map (fun y => (x,y)) B) (x, y) = count B y.
+Proof.
+  induction B.
+  - reflexivity.
+  - simpl. dec;  congruence.
+Qed.
+
+(** If a list is split somewhere in two list the number of occurences of an element in the list is equal to the sum of the number of occurences in the left and the right part. *)
+
+Lemma countSplit (X: eqType) (A B: list X) (x: X)  : count A x + count B x = count (A ++ B) x.
+Proof.
+  induction A.
+  - reflexivity.
+  - cbn. decide (x=a).
+    +cbn. f_equal; exact IHA.
+    + exact IHA.
+Qed.
+
+(** In a list of tupels with x as a left element the number of tupels with something different from x as a left element is 0. *)
+Lemma countMapZero  (X Y: eqType) (x x':X) (B: list Y) y : x' <> x -> count  ( map (fun y => (x,y)) B) (x', y) =0.
+Proof.
+  intros ineq. induction B.
+  - reflexivity.
+  -  simpl. dec.
+     + inversion e; congruence.
+     + exact IHB.
+Qed.
+
+
+Lemma notInZero (X: eqType) (x: X) A :
+  not (x el A) <-> count A x = 0.
+Proof.
+  split; induction A.
+  -  reflexivity.
+  - intros H. cbn in *. dec.
+    + exfalso. apply H. left. congruence.
+    + apply IHA. intros F. apply H. now right.
+  - tauto.
+  - cbn. dec.
+    + subst a. lia.
+    + intros H [E | E].
+      * now symmetry in E.
+      * tauto.
+Qed.
+
+Lemma countIn (X:eqType) (x:X) A:
+  count A x > 0 -> x el A.
+Proof.
+  induction A.
+  - cbn. lia.
+  - cbn.  dec.
+    + intros. left. symmetry. exact e.
+    + intros. right. apply IHA. exact H.
+Qed.
+
+Lemma InCount (X:eqType) (x:X) A:
+  x el A -> count A x > 0.
+Proof.
+  induction A.
+  - intros [].
+  - intros [[] | E]; cbn.
+    + deq a. lia.
+    + specialize (IHA E). dec; lia.
+Qed.
+
+Lemma count_in_equiv (X: eqType) (x:X) A : count A x > 0 <-> x el A.
+Proof.
+  split.
+  - apply countIn.
+  - apply InCount.
+Qed.
+
+
+Lemma countApp (X: eqType) (x: X) (A B: list X) :
+  count (A ++ x::B) x > 0.
+Proof.
+  auto using InCount.
+Qed.
+
+
+(**  Dupfree Lists containing every x countain x exactly once *)
+Lemma dupfreeCount (X: eqType) (x:X) (A: list X) : dupfree A -> x el A -> count A x = 1.
+Proof.
+  intros D E. induction D.
+  -  contradiction E.
+  - cbn. dec.
+    + f_equal. subst x0. now apply notInZero.
+    + destruct E as [E | E]; [> congruence | auto].
+Qed.        
+
+(** toSumlist1 does not change the number of occurences of an existing element in the list *)
+Lemma toSumList1_count (X: eqType) (x: X) (Y: eqType) (A: list X) :
+  count (toSumList1 Y A) (inl x) =  count A x .
+Proof.
+  induction A; simpl; dec; congruence.  
+Qed.
+
+(** toSumlist2 odes not change the numbe of occurences of an existing element in the list *)
+Lemma toSumList2_count (X Y: eqType) (y: Y) (A: list Y):
+  count (toSumList2 X A) (inr y) = count A y.
+Proof.
+  induction A; simpl; dec; congruence.  
+Qed.
+
+(** to sumList1 does not produce inr proofs *)
+Lemma toSumList1_missing (X Y: eqType) (y: Y) (A: list X):
+  count (toSumList1 Y A ) (inr y) = 0.                           
+Proof.
+  induction A; dec; firstorder.
+Qed.
+
+(** toSumlist2 does not produce inl proofs *)
+Lemma toSumList2_missing (X Y: eqType) (x: X) (A: list Y):
+  count (toSumList2 X A ) (inl x) = 0.                           
+Proof.
+  induction A; dec; firstorder.
+Qed.
+
+
+(** * Cardinality Lemmas for lists*)
+Lemma cons_incll (X: Type) (A B: list X) (x:X) : x::A <<= B -> A <<= B.
+Proof.
+  unfold "<<=". auto.
+Qed.
+
+Lemma card_length_leq (X: eqType) (A: list X) : card A <= length A.
+Proof.
+  induction A; auto. cbn. dec; lia.
+Qed.
+
+(** * Various helpful Lemmas *)
+
+
+(** If the concatenation of two lists is nil then each list was nil *)
+Lemma appendNil (X: Type) (A B: list X) :
+  A ++ B = nil -> A = nil /\ B = nil.
+Proof.
+  intros H. assert (|A ++ B| = 0) by now rewrite H.
+  rewrite app_length in H0. rewrite <- !length_zero_iff_nil. lia.
+Qed.
+
+Lemma countZero (X: eqType) (x: X) (A: list X) : count A x = 0 -> not (x el A).
+Proof.
+  induction A; cbn in *; dec; firstorder congruence.
+Qed.
+
+(** The product of two numbers is greater zero if both numbers are greater zero *)
+Lemma NullMul a b : a > 0 -> b > 0 -> a * b > 0.
+Proof.
+  induction 1; cbn; lia.
+Qed.

--- a/theories/Shared/Libs/PSL/FiniteTypes/BasicFinTypes.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/BasicFinTypes.v
@@ -1,0 +1,64 @@
+From Undecidability.Shared.Libs.PSL Require Import FinTypes.
+
+(** * Completeness Lemmas for lists of basic types *)
+
+Lemma bool_enum_ok x:
+  count  [true; false] x = 1.
+Proof.
+  simpl. dec; destruct x; congruence.
+Qed.
+
+Lemma unit_enum_ok x:
+  count [tt] x = 1.
+Proof.
+  simpl. destruct x; dec; congruence.
+Qed.
+
+Lemma Empty_set_enum_ok (x: Empty_set):
+  count nil x = 1.
+Proof.
+  tauto.
+Qed.
+
+Lemma True_enum_ok x:
+  count [I] x = 1.
+Proof.
+  simpl; dec;  destruct x; congruence.
+Qed.
+
+Lemma False_enum_ok (x: False):
+  count nil x = 1.
+Proof.
+  tauto.
+Qed.
+
+(** ** Declaration of finTypeCs for base types as instances of the type class *)
+
+Instance finTypeC_Empty_set: finTypeC (EqType Empty_set).
+Proof.
+  econstructor. eapply Empty_set_enum_ok.
+Defined.
+
+Instance finTypeC_bool: finTypeC (EqType bool).
+Proof.
+  econstructor. apply bool_enum_ok.
+Defined.
+
+Instance finTypeC_unit: finTypeC (EqType unit).
+Proof. econstructor. apply unit_enum_ok.
+Defined.
+
+(* Instance finTypeC_empty : finTypeC (EqType emptu *)
+(* Proof. *)
+(*   econstructor. apply Empty_set_enum_ok. *)
+(* Defined. *)
+
+Instance finTypeC_True : finTypeC (EqType True).
+Proof.
+  econstructor. apply True_enum_ok.
+Defined.
+
+Instance  finTypeC_False : finTypeC (EqType False).
+Proof.
+  econstructor. apply False_enum_ok.
+Defined.

--- a/theories/Shared/Libs/PSL/FiniteTypes/Cardinality.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/Cardinality.v
@@ -1,0 +1,152 @@
+From Undecidability.Shared.Libs.PSL Require Import FinTypes.
+
+Definition Cardinality (F: finType) := | elem F |.
+
+(** * Dupfreeness *)
+(* Proofs about dupfreeness *)
+
+
+Lemma dupfree_countOne (X: eqType) (A: list X) : (forall x, count A x <= 1) -> dupfree A.
+Proof.
+  induction A.
+  - constructor.
+  - intro H. constructor.
+    + cbn in H.  specialize (H a). deq a. assert (count A a = 0) by lia. now apply countZero.
+    + apply IHA. intro x. specialize (H x). cbn in H. dec; lia.
+Qed.
+
+Lemma dupfree_elements (X: finType) : dupfree (elem X).
+Proof.
+  destruct X as [X [A AI]]. assert (forall x, count A x <= 1) as H'.
+  {
+    intro x. specialize (AI x). lia.
+  }
+  now apply dupfree_countOne.  
+Qed.
+
+Lemma dupfree_length (X: finType) (A: list X) : dupfree A -> |A| <= Cardinality X.
+Proof.
+  unfold Cardinality.  intros D.
+  rewrite <- (dupfree_card D). rewrite <- (dupfree_card (dupfree_elements X)).
+  apply card_le. apply allSub.
+Qed.
+
+Lemma disjoint_concat X (A: list (list X)) (B: list X) : (forall C, C el A -> disjoint B C) -> disjoint B (concat A).
+Proof.
+  intros H. induction A.
+  - cbn. auto.
+  - cbn. apply disjoint_symm. apply disjoint_app. split; auto using disjoint_symm.
+Qed.
+
+Lemma dupfree_concat (X: Type) (A: list (list X)) : (forall B, B el A -> dupfree B) /\ (forall B C, B <> C -> B el A -> C el A -> disjoint B C) -> dupfree A -> dupfree (concat A).
+Proof.
+  induction A.
+  - constructor.
+  - intros [H H'] D. cbn. apply dupfree_app.
+    + apply disjoint_concat. intros C E. apply H'; auto. inv D. intro G; apply H2. now subst a.
+    + now apply H.
+    + inv D; apply IHA; auto.
+Qed.     
+
+(* (** * Proofs about Cardinality *) *)
+
+(* Lemma Card_positiv (X: finType) (x:X) : Cardinality X > 0. *)
+(* Proof. *)
+(*   pose proof (elem_spec x).  unfold Cardinality.  destruct (elem X). *)
+(*   - contradiction H. *)
+(*   - cbn. lia. *)
+(* Qed.  *)
+
+(* Lemma Cardinality_card_eq (X: finType): card (elem X) = Cardinality X. *)
+(* Proof. *)
+(*   apply dupfree_card. apply dupfree_elements. *)
+(* Qed. *)
+
+(* Lemma card_upper_bound (X: finType) (A: list X): card A <= Cardinality X. *)
+(* Proof. *)
+(*  rewrite <-  Cardinality_card_eq. apply card_le. apply allSub. *)
+(* Qed.   *)
+
+
+(* Lemma injective_dupfree (X: finType) (Y: Type) (A: list X) (f: X -> Y) : injective f -> dupfree (getImage f). *)
+(* Proof. *)
+(*   intro inj. unfold injective in inj. *)
+(*   unfold getImage. apply dupfree_map. *)
+(*   - firstorder. *)
+(*   - apply dupfree_elements. *)
+(* Qed. *)
+
+(* Theorem pidgeonHole_inj (X Y: finType) (f: X -> Y) (inj: injective f): Cardinality X <= Cardinality Y. *)
+(* Proof. *)
+(*   rewrite <- (getImage_length f). apply dupfree_length. apply (injective_dupfree (elem X) inj). *)
+(* Qed. *)
+
+(* Lemma surj_sub (X Y: finType) (f: X -> Y) (surj: surjective f): elem Y <<= getImage f. *)
+(* Proof. *)
+(* intros y E. specialize (surj y). destruct surj as [x H]. subst y. apply getImage_in. *)
+(* Qed. *)
+
+(* Theorem pidgeonHole_surj (X Y: finType) (f: X -> Y) (surj: surjective f): Cardinality X >= Cardinality Y. *)
+(* Proof. *)
+(*   rewrite <- (getImage_length f). rewrite <- Cardinality_card_eq. *)
+(*     pose proof (card_le (surj_sub surj)) as H. pose proof (card_length_leq (getImage f)) as H'. lia. *)
+(* Qed. *)
+
+(* Lemma eq_iff (x y: nat) : x >= y /\ x <= y -> x = y. *)
+(* Proof. *)
+(*   lia. *)
+(* Qed. *)
+
+(* Corollary pidgeonHole_bij (X Y: finType) (f: X -> Y) (bij: bijective f): *)
+(*   Cardinality X = Cardinality Y. *)
+(* Proof. *)
+(*   destruct bij as [inj surj]. apply eq_iff. split. *)
+(*   - now eapply pidgeonHole_surj. *)
+(*   - eapply pidgeonHole_inj; eauto. *)
+(* Qed.     *)
+
+(* Lemma Prod_Card (X Y: finType) : Cardinality (X (x) Y) = Cardinality X * Cardinality Y. *)
+(* Proof. *)
+(*   cbn.  unfold prodLists. unfold Cardinality. induction (elem X).  *)
+(*   - reflexivity. *)
+(*   - cbn. rewrite app_length. rewrite IHl. f_equal. apply map_length. *)
+(* Qed.     *)
+
+(* Lemma Option_Card (X: finType) : Cardinality (? X) = S(Cardinality X). *)
+(* Proof. *)
+(*   cbn. now rewrite map_length. *)
+(* Qed. *)
+
+(* Lemma SumCard (X Y: finType) : Cardinality (finType_sum X Y) = Cardinality X + Cardinality Y. *)
+(* Proof. *)
+(*   unfold Cardinality. cbn. rewrite app_length. unfold toSumList1, toSumList2. now  repeat rewrite map_length. *)
+(* Qed. *)
+
+(* Lemma extPow_length X Y L P: |@extensionalPower X Y L P| = | L |. *)
+(* Proof. *)
+(*   induction L. *)
+(*   -  reflexivity. *)
+(*   - simpl. f_equal. apply IHL. *)
+(* Qed. *)
+
+
+(* Lemma concat_map_length (X: Type) (A: list X) (B: list (list X)) : *)
+(* | concat (map (fun x => map (cons x) B) A) |= |A| * |B|. *)
+(* Proof. *)
+(*   induction A. *)
+(*   - reflexivity. *)
+(*   - cbn. rewrite app_length. rewrite map_length. congruence. *)
+(* Qed.     *)
+  
+(* Lemma images_length Y (A: list Y) n : |images A n| = (|A| ^ n)%nat. *)
+(* Proof. *)
+(*   induction n. *)
+(*   - reflexivity. *)
+(*   - cbn. rewrite concat_map_length.  now rewrite IHn. *)
+(* Qed. *)
+
+(* Lemma Vector_Card (X Y: finType): Cardinality (Y ^ X) = (Cardinality Y ^ (Cardinality X ))%nat. *)
+(* Proof. *)
+(*   cbn. rewrite extPow_length. now rewrite images_length. *)
+(* Qed. *)
+

--- a/theories/Shared/Libs/PSL/FiniteTypes/CompoundFinTypes.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/CompoundFinTypes.v
@@ -1,0 +1,92 @@
+From Undecidability.Shared.Libs.PSL Require Import FinTypes.
+
+(** * Definition of prod as finType *)
+
+Lemma ProdCount (T1 T2: eqType) (A: list T1) (B: list T2) (a:T1) (b:T2)  :
+  count (prodLists A B) (a,b) =  count A a * count B b .
+Proof.
+  induction A.
+  - reflexivity.
+  - cbn. rewrite <- countSplit. decide (a = a0) as [E | E].
+    + cbn. f_equal. subst a0. apply countMap. eauto.
+    + rewrite <- plus_O_n. f_equal. now apply countMapZero. eauto.
+Qed.
+
+Lemma prod_enum_ok (T1 T2: finType) (x: T1 * T2):
+  count (prodLists (elem T1) (elem T2)) x = 1.
+Proof.
+  destruct x as [x y]. rewrite ProdCount. unfold elem.
+  now repeat rewrite enum_ok.
+Qed.
+
+Instance finTypeC_Prod (F1 F2: finType) : finTypeC (EqType (F1 * F2)).
+Proof.
+  econstructor.  apply prod_enum_ok.
+Defined.
+
+(** * Definition of option as finType *)
+
+(** Wrapping elements in "Some" does not change the number of occurences in a list *)
+Lemma SomeElement (X: eqType) (A: list X) x:
+  count (toOptionList A) (Some x) = count A x .
+Proof.
+  unfold toOptionList. simpl. dec; try congruence.
+  induction A.
+  + tauto.  
+  + simpl. dec; congruence.
+Qed.
+
+(** A list produced by toOptionList contains None exactly once *)
+Lemma NoneElement (X: eqType) (A: list X) :
+  count (toOptionList A) None = 1.
+Proof.
+  unfold toOptionList. simpl. dec; try congruence. f_equal.
+  induction A.
+  - reflexivity.
+  - simpl; dec; congruence.    
+Qed.
+
+Lemma option_enum_ok (T: finType) x :
+  count (toOptionList (elem T)) x = 1.
+Proof.
+  destruct x.
+  + rewrite SomeElement. apply enum_ok.
+  + apply NoneElement.
+Qed.
+
+Instance  finTypeC_Option(F: finType): finTypeC (EqType (option F)).
+Proof.
+  eapply FinTypeC.  apply option_enum_ok.
+Defined.
+
+(** * Definition of sum as finType *)
+
+(** The sum of two nats can only be 1 if one of them is 1 and the other one is 0 *)
+Lemma proveOne m n: m = 1 /\ n = 0 \/ n = 1 /\ m = 0 -> m + n = 1.
+Proof.
+  lia.
+Qed.
+
+Lemma sum_enum_ok (X: finType) (Y: finType) x :
+  count (toSumList1 Y (elem X) ++ toSumList2 X (elem Y)) x = 1.
+Proof.
+  rewrite <- countSplit. apply proveOne. destruct x.
+  - left. split; cbn.
+    + rewrite toSumList1_count. apply enum_ok.
+    + apply toSumList2_missing.
+  - right. split; cbn.
+    + rewrite toSumList2_count. apply enum_ok.
+    + apply toSumList1_missing.
+Qed.
+
+(** Instance declaration for sum types for  the type class *)
+Instance finTypeC_sum (X Y: finType) : finTypeC (EqType ( X + Y)).
+Proof.
+  eapply FinTypeC. apply sum_enum_ok.
+Defined.
+
+(* Some hints to make the typeclass inference work *)
+
+Hint Extern 4 (finTypeC (EqType (_ * _))) => eapply finTypeC_Prod : typeclass_instances.
+Hint Extern 4 (finTypeC (EqType (_ + _))) => eapply finTypeC_sum : typeclass_instances.
+Hint Extern 4 (finTypeC (EqType (option _))) => eapply finTypeC_Option : typeclass_instances.

--- a/theories/Shared/Libs/PSL/FiniteTypes/DepPairs.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/DepPairs.v
@@ -1,0 +1,102 @@
+(** Instance declaration for dependent pairs *)
+
+From Undecidability.Shared.Libs.PSL Require Import Base FinTypes.
+From Coq Require Import EqdepFacts List.
+
+Instance eqType_depPair (F : eqType) (a : F -> eqType) : eq_dec {f : F & a f}.
+Proof.
+  intros [x fx] [y fy]. eapply dec_transfer. now rewrite eq_sigT_iff_eq_dep.
+  decide (x=y).
+  subst y. decide (fx = fy).
+  +subst fy. left. reflexivity.
+  +right. intros eq. apply n. apply Eqdep_dec.eq_dep_eq_dec in eq. auto. intros. decide (x0=y);econstructor;eassumption;eauto.
+  +right. intros eq. now inv eq.
+Qed.
+
+Instance finType_depPair (F : finType) (a : F -> finType) : finTypeC (EqType( {f : F & a f} )).
+Proof. 
+  exists (undup (concat (map (fun f => map (fun x => existT a _ x) (elem (a f))) (elem F)))).
+  intros H. hnf in H. apply dupfreeCount. now apply dupfree_undup.
+  rewrite undup_id_equi. apply in_concat_iff.
+  exists ((fun f : F => map (fun x : a f => existT (fun x0 : F => a x0) f x) (elem (a f))) (projT1 H)).
+  split.
+  -rewrite in_map_iff. destruct H. cbn. exists e. split.
+   +reflexivity.
+   +apply countIn. setoid_rewrite enum_ok. lia.
+  -rewrite in_map_iff. eexists. split. reflexivity.
+   apply countIn. setoid_rewrite enum_ok. lia. 
+Qed.
+
+Hint Extern 4 (finTypeC (EqType ({_ : _ & _}))) => eapply finType_depPair : typeclass_instances.
+
+(* (** * Dependent pairs *) *)
+
+(* Fixpoint toSigTList (X: Type) (f: X -> finType) (A: list X) : list (sigT f) := *)
+(*   match A with *)
+(*   | nil => nil *)
+(*   | cons x A' => (map (existT f x) (elem (f x))) ++ toSigTList f A' end. *)
+
+
+(* Lemma countMapExistT (X: eqType) (f: X -> eqType) (x:X) (A: list (f x)) (y: f x) : *)
+(*   count (map (existT f x) A) (existT f x y) = count A y. *)
+(* Proof. *)
+(*   induction A. *)
+(*   -  reflexivity. *)
+(*   - simpl. dec. *)
+(*     + subst a. f_equal. apply IHA. *)
+(*     + contradict n. exact (sigT_proj2_fun _ e). *)
+(*     + subst a. contradict n. reflexivity. *)
+(*     + exact IHA. *)
+(* Qed.       *)
+
+(* Lemma countMapExistT_Zero (X: eqType) (f: X -> eqType) (x x':X) (A: list (f x)) (y: f x') : *)
+(*   x <> x' -> count (map (existT f x) A) (existT f x' y) = 0. *)
+(* Proof. *)
+(*   intros E. induction A. *)
+(*   - reflexivity. *)
+(*   - simpl. dec. *)
+(*     + contradict E. eapply sigT_proj1_fun; eauto. *)
+(*     + exact IHA. *)
+(* Qed. *)
+
+(* Lemma toSigTList_count (X: eqType) (f: X -> finType) (A: list X) (s: sigT f): *)
+(*   count (toSigTList f A) s = count A (projT1 s). *)
+(* Proof. *)
+(*   induction A. *)
+(*   - reflexivity. *)
+(*   -  destruct s. cbn in *. rewrite <- countSplit. rewrite IHA. dec. *)
+(*     + change (S (count A x)) with (1 + count A x). f_equal. subst a. *)
+(*       rewrite (@countMapExistT _ f x (elem (f x)) e). apply enum_ok. *)
+(*     + change (count A x) with (0+ (count A x)). f_equal. rewrite (@countMapExistT_Zero _ f a x); auto. *)
+(* Qed. *)
+
+(* Lemma sigT_enum_ok (X:finType) (f: X -> finType) (s: sigT f) : count (toSigTList f (elem X)) s = 1. *)
+(* Proof. *)
+(*   rewrite toSigTList_count. now pose proof (enum_ok (projT1 s)). *)
+(* Qed. *)
+
+(* Instance finTypeC_sigT (X: finType) (f: X -> finType): finTypeC (EqSigT f). *)
+(* Proof. *)
+(*   econstructor.  apply sigT_enum_ok. *)
+(* Defined. *)
+
+(* Canonical Structure finType_sigT (X: finType) (f: X -> finType) := FinType (EqSigT f). *)
+
+(* Lemma finType_sigT_correct (X: finType) (f: X -> finType): *)
+(*   sigT f = finType_sigT f. *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+
+(* Lemma finType_sigT_enum (X: finType) (f: X -> finType) : *)
+(*   toSigTList f (elem X) = (elem (finType_sigT f)). *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+(* Set Printing Coercions. *)
+(* Lemma tofinType_sigT_correct (X: finType) (f: X -> finType) : *)
+(*   tofinType (sigT f) = finType_sigT f. *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+(* Unset Printing Coercions. *)

--- a/theories/Shared/Libs/PSL/FiniteTypes/FinTypes.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/FinTypes.v
@@ -1,0 +1,172 @@
+From Undecidability.Shared.Libs.PSL Require Export BasicDefinitions.
+From Undecidability.Shared.Libs.PSL Require Import Bijection.
+
+(** ** Formalisation of finite types using canonical structures and type classes *)
+
+(** * Definition of finite Types *)
+
+Class finTypeC  (type:eqType) : Type :=
+  FinTypeC {
+      enum: list type;
+      enum_ok: forall x: type, count enum x = 1
+    }.
+
+Structure finType : Type :=
+  FinType
+    {
+      type:> eqType;
+      class: finTypeC type
+    }.
+
+Arguments FinType type {class}.
+Existing Instance class | 0.
+
+
+(* This is a hack to work-around a problem with a class of hacks *)
+Hint Extern 5 (finTypeC (EqType ?x)) => unfold x : typeclass_instances.
+
+Canonical Structure finType_CS (X : Type) {p : eq_dec X} {class : finTypeC (EqType X)} : finType := FinType (EqType X).
+
+(** Print the base type of [finType] in the Canonical Structure. *)
+Arguments finType_CS (X) {_ _}.
+
+Definition elem (F: finType) := @enum (type F) (class F).
+Hint Unfold elem : core.
+Hint Unfold class : core.
+
+Lemma elem_spec (X: finType) (x:X) : x el (elem X).
+Proof.
+  apply countIn.  pose proof (enum_ok x) as H. unfold elem. lia. 
+Qed.
+
+Hint Resolve elem_spec : core.
+Hint Resolve enum_ok : core.
+
+Lemma allSub (X: finType) (A:list X) : A <<= elem X.
+Proof.
+  intros x _. apply elem_spec.
+Qed.
+Hint Resolve allSub : core.
+
+(** A properties that hold on every element of (elem X) hold for every element of the finType X *)
+Theorem Equivalence_property_all (X: finType) (p: X -> Prop) :
+  (forall x, p x) <-> forall x, x el (elem X) -> p x.
+Proof.
+  split; auto. 
+Qed.
+
+Theorem Equivalence_property_exists (X: finType) (p:X -> Prop):
+  (exists x, p x) <-> exists x, x el (elem X) /\ p x.
+Proof.
+  split.
+  - intros [x P]. eauto.
+  - intros [x [E P]]. eauto.
+Qed.
+
+Instance finType_forall_dec (X: finType) (p: X -> Prop): (forall x, dec (p x)) -> dec (forall x, p x).
+Proof.
+  intros D. eapply dec_transfer.
+  - symmetry. exact (Equivalence_property_all p).
+  - auto.
+Qed.
+
+Instance finType_exists_dec (X:finType) (p: X -> Prop) : (forall x, dec (p x)) -> dec (exists x, p x).
+Proof.
+  intros D. eapply dec_transfer.
+  - symmetry. exact (Equivalence_property_exists p).
+  - auto.
+Qed.
+
+Definition finType_cc (X: finType) (p: X -> Prop) (D: forall x, dec (p x)) : (exists x, p x) -> {x | p x}.
+Proof.
+  intro H.
+  assert(exists x, x el (elem X) /\ p x) as E by firstorder.
+  pose proof (list_cc D E) as [x G].
+  now exists x.
+Defined.
+
+Definition pickx (X: finType): X + (X -> False).
+Proof.
+  destruct X as [X [enum ok]]. induction enum.
+  - right. intro x. discriminate (ok x).
+  - tauto.
+Defined.
+
+(** * Properties of decidable Propositions *)
+
+Lemma DM_notAll (X: finType) (p: X -> Prop) (D:forall x, dec (p x)): (~ (forall x, p x)) <-> exists x, ~ (p x).
+Proof.     
+  decide (exists x,~ p x); firstorder.
+Qed.
+
+Lemma DM_exists (X: finType) (p: X -> Prop) (D: forall x, dec (p x)):
+  (exists x, p x) <->  ~(forall x, ~ p x).
+Proof.
+  split.
+  - firstorder.
+  - decide (exists x, p x); firstorder.
+Qed.
+
+(* Index is an injective function *)
+
+
+Fixpoint  getPosition {E: eqType} (A: list E) x := match A with
+                                                   | nil => 0
+                                                   | cons x' A' => if Dec (x=x') then 0 else 1 + getPosition A' x end.
+
+Lemma getPosition_correct {E: eqType} (x:E) A: if Dec (x el A) then forall z, (nth (getPosition A x) A z) = x else getPosition A x = |A |.
+Proof.
+  induction A;cbn.
+  -repeat destruct Dec;tauto.
+  -repeat destruct Dec;intuition; congruence.
+Qed.
+
+Lemma getPosition_nth (X:eqType) k (d :X) xs:
+  Dupfree.dupfree xs ->
+  k < length xs ->
+  getPosition xs (nth k xs d) = k.
+Proof.
+  induction xs in k|-*. now cbn.
+  intros H1 H2. inv H1.
+  cbn. destruct k.
+  -decide _. all:easy.
+  -decide _.
+   +subst a. cbn in H2. edestruct H3. eapply nth_In. lia.
+   + cbn in H2. rewrite IHxs. all:try easy;lia.
+Qed.
+
+Definition pos_def (X : eqType) (x : X) A n :=  match pos x A with None => n | Some n => n end. 
+
+Definition index {F: finType} (x:F) := getPosition (elem F) x.
+
+Lemma index_nth {F : finType} (x:F) y: nth (index x) (elem F) y = x.
+  unfold index, elem, enum.
+  destruct F as [[X E] [A all_A]];cbn.
+  pose proof (getPosition_correct x A) as H.
+  destruct Dec. auto. apply notInZero in n. now setoid_rewrite all_A in n.
+Qed.
+ 
+Lemma injective_index (A: finType) (x1 x2 : A) : index x1 = index x2 -> x1 = x2.
+Proof.
+  destruct (elem A) eqn:E.
+  - hnf. intros. assert (x1 el elem A) by eauto using elem_spec. rewrite E in H0. auto.
+  - clear E. eapply (left_inv_inj (g := (fun y => nth y (elem A) e))).
+    hnf. intros. now rewrite index_nth.
+Qed.
+
+Lemma index_le (A:finType) (x:A): index x < length (elem A).
+Proof.
+  unfold index.
+  assert (H:x el elem A) by apply elem_spec.
+  revert H.
+  generalize (elem A). intros l H.
+  induction l;cbn;[|decide _].
+  -easy.
+  -lia.
+  -destruct H. congruence. apply IHl in H. lia.
+Qed.
+
+Lemma index_leq (A:finType) (x:A): index x <= length (elem A).
+Proof.
+  eapply Nat.lt_le_incl,index_le.
+Qed.

--- a/theories/Shared/Libs/PSL/FiniteTypes/FiniteFunction.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/FiniteFunction.v
@@ -1,0 +1,400 @@
+From Undecidability.Shared.Libs.PSL Require Import FinTypes Base.
+From Undecidability.Shared.Libs.PSL Require Import Bijection.
+
+(* Require Import Vector. *)
+
+(* Definition vector X Y := Vector.t Y (|elem X|). *)
+
+Definition finfunc_table (A : finType) (B: Type) (f: A -> B) :=
+  List.map (fun x => (x, f x)) (elem A).
+
+(* Now we prove that the tranformation of a function of finite domain to a table is correct *)
+
+Lemma finfunc_comp (A : finType) (B: Type) (f: A -> B) a : (a,f a) el finfunc_table f.
+Proof.
+  unfold finfunc_table. now eapply (in_map (fun x => (x, f x))).
+Qed.
+
+Lemma finfunc_sound (A : finType) (B : Type) (f: A -> B) a b: (a,b) el finfunc_table f -> b = f a.
+Proof.
+  unfold finfunc_table. rewrite in_map_iff. firstorder congruence.
+Qed.
+
+Lemma finfunc_sound_cor (A : finType) (B:Type) (f: A -> B) a b b' : (a,b) el finfunc_table f -> (a,b') el finfunc_table f -> b = b'.
+Proof.
+  intros H1 H2. specialize (finfunc_sound H1). specialize (finfunc_sound H2). congruence. 
+Qed.
+
+
+Definition lookup (A : eqType) (B : Type) (l : list (A * B)) (a : A) (def : B) : B :=
+  match (filter (fun p => Dec (fst p = a)) l) with
+    List.nil => def
+  | p :: _ => snd p
+  end.
+
+
+Lemma lookup_sound (A: eqType) (B: Type) (L : list (prod A B)) a b def :
+  (forall a' b1 b2, (a',b1) el L -> (a',b2) el L -> b1=b2) -> (a,b) el L -> lookup L a def = b.
+Proof.
+  intros H1 H2. unfold lookup.
+  destruct filter eqn:E.
+  - assert ((a,b) el filter (fun p : A * B => Dec (fst p = a)) L) by ( rewrite in_filter_iff ; eauto).
+    now rewrite E in H. 
+  - destruct p. assert ((e,b0) el (filter (fun p : A * B => Dec (fst p = a)) L)) by now rewrite E.
+    rewrite in_filter_iff in H. 
+    dec; cbn in *; subst; firstorder.
+Qed.
+
+Lemma lookup_complete (A: eqType) (B: Type) (L : list (prod A B)) a def :
+  {(a,lookup L a def) el L } + {~(exists b, (a,b) el L) /\ lookup L a def  = def}.
+Proof.
+  unfold lookup.
+  destruct filter eqn:E.
+  - right. split. 2:easy.
+    intros (x&?).
+    assert ((a,x) el filter (fun p : A * B => Dec (fst p = a)) L).
+    {rewrite in_filter_iff;cbn. decide _;try easy. }
+    rewrite E in H0. easy. 
+  - assert (p el (filter (fun p : A * B => Dec (fst p = a)) L)) by now rewrite E.
+    rewrite in_filter_iff in H.
+    destruct p.
+    dec; cbn in *; subst; firstorder.
+Qed.
+
+Lemma finfunc_correct (A: finType) B (f: A -> B) a  def: lookup (finfunc_table f) a def = f a.
+Proof.
+  eapply lookup_sound; [ apply finfunc_sound_cor | apply finfunc_comp ].
+Qed.
+
+
+(* Now we can prove that the transformation of the function table into another type is correct as long
+as the conversion is injective *)
+
+Lemma finfunc_conv (A: finType) (cA : eqType) (B cB : Type) (f: A -> B) (mA : A -> cA) (mB : B -> cB) a def:
+  injective mA -> lookup (List.map (fun x => (mA (fst x), mB (snd x))) (finfunc_table f))  (mA a) def = mB (f a).
+Proof.
+  intros INJ.
+  erewrite lookup_sound; eauto.
+  - intros a' b1 b2 H1 H2. rewrite in_map_iff in *. destruct H1 as [[] [L1 R1]]. destruct H2 as [[] [L2 R2]].
+    cbn in *.
+    inv L1; inv L2. rewrite (finfunc_sound R1), (finfunc_sound R2), (INJ e e0); congruence.
+  - rewrite in_map_iff. exists (a, f a). subst. split; auto. apply finfunc_comp.
+Qed.
+
+
+
+
+(* (** * Definition of vectors (extensional/ set theoretic functions)  *)
+ (*   structure containing a list representing the image and a proof that the list has exactly as many elements as the source type *) *)
+(* Definition Card_X_eq X Y (A: list Y) := |A| = Cardinality X. *)
+(* Definition vector (X: finType) (Y: Type) := subtype (@Card_X_eq X Y). *)
+(* Notation "X --> Y" := (vector X Y) (at level 55, right associativity). *)
+(* Hint Unfold pure. *)
+(* Hint Unfold Card_X_eq. *)
+(* (** Projects the list from a STF *) *)
+(* Definition image (X: finType) (Y: Type) (f: X --> Y) := proj1_sig  f. *)
+
+(* (** Instance Declaration for Type Dec Type class for vectors. *) *)
+(* Instance vector_eq_dec (X: finType) (Y: eqType) : eq_dec (X --> Y). *)
+(* Proof. *)
+(*   auto. *)
+(* Qed. *)
+
+(* Canonical Structure EqVect (X: finType) (Y: eqType) := EqType (X --> Y). *)
+
+(* (** Function which produces a list of all list containing elements from A with length n *) *)
+(* Fixpoint images (Y: Type) (A: list Y) (n: nat): list (list Y) := *)
+(*   match n with *)
+(*   | 0 => [[]] *)
+(*   | S n' => concat (map (fun x => map (cons x) (images A n')) A) *)
+(*   end. *)
+
+(* Lemma imagesNonempty (Y: Type) y (A: list Y) : forall n, images (y::A) n <> nil. *)
+(* Proof. *)
+(*   intro n. induction n. *)
+(*   - cbn. congruence. *)
+(*   - cbn. intro H. pose proof (app_eq_nil _ _ H) as [E1 E2]. clear H. pose proof (map_eq_nil _ _ E1).  auto. *)
+(* Qed. *)
+
+(* (** If x is unequal to y then a list starting with y cannot be found in a list of list all starting with x *) *)
+(* Lemma notInMapCons (X: Type) (x y: X) (A: list X) (B: list (list X)): *)
+(*   x <> y -> y::A el (map (cons x) B) -> False. *)
+(* Proof. *)
+(*   intros neq E. rewrite in_map_iff in E. destruct E as [C [E _]]. congruence. *)
+(* Qed. *)
+
+(* Definition mC X B := (fun x:X => map (cons x) B). *)
+(* Definition mmC  X B (A: list X) := map (mC B) A. *)
+
+(* Lemma disjoint_map_cons X (A: list (list X)) (x y: X): x <> y -> disjoint (map (cons x) A) (map (cons y) A). *)
+(* Proof. *)
+(*   intro N; induction A. *)
+(*   - cbn. auto. *)
+(*   - cbn. unfold disjoint. intros [B [H1 H2]]. destruct H1, H2. *)
+(*     + congruence. *)
+(*     + subst B. eapply notInMapCons. Focus 2. *)
+(*       * apply H0. *)
+(*       * congruence. *)
+(*     + subst B. eapply notInMapCons; eauto. *)
+(*     + apply IHA. now exists B. *)
+(* Qed.   *)
+
+(* Lemma disjoint_in (X: Type) x A (B: list (list X)) (E: B <> nil) B' (H: ~ x el A): B' el map (mC B) A -> disjoint (map (cons x) B) B'.  *)
+(* Proof. *)
+(*   destruct B; try congruence. *)
+(*   intro H'. induction A. *)
+(*   - contradiction H'. *)
+(*   - pose proof (negOr H) as [G G']. destruct H' as [H' | H']. *)
+(*     + subst B'. apply disjoint_map_cons; congruence. *)
+(*     + apply IHA; auto. *)
+(* Qed. *)
+
+(* Lemma disjoint_in_map_map_cons X  (A: list X) (B C C': list (list X)) (H: C <> C') (E: C el (mmC B A)) (E': C' el (mmC B A)) (N: B <> nil) (D: dupfree A): *)
+(*   disjoint C C'. *)
+(* Proof.  *)
+(*   induction D. *)
+(*   - contradiction E. *)
+(*   - destruct B; try congruence; clear N. destruct E, E'; try congruence. *)
+(*     + subst C. eapply disjoint_in; now eauto. *)
+(*     + subst C'. apply disjoint_symm. eapply disjoint_in; now  eauto. *)
+(*     + now apply IHD. *)
+(* Qed.       *)
+
+(* Lemma dupfree_concat_map_cons (X: Type) (A: list X) (B: list (list X)): *)
+(*   dupfree A -> dupfree B -> B <> nil ->  dupfree (concat (map (fun x => map (cons x) B) A)). *)
+(* Proof. *)
+(*   intros D D' N. apply dupfree_concat; try split. *)
+(*   - intros C E. induction D. *)
+(*     +  contradiction E. *)
+(*     + destruct E; auto. subst C. apply dupfree_map; auto. congruence. *)
+(*   -  intros B' B'' E E' H. eapply disjoint_in_map_map_cons; eauto. *)
+(*   - apply dupfree_map; auto. intros x y _ _ E. destruct B. *)
+(*     + congruence. *)
+(*     +  cbn in E. now inv E. *)
+(* Qed. *)
+
+(* Lemma imagesDupfree (Y: Type) (A: list Y) (n:nat) : dupfree A -> dupfree (images A n). *)
+(* Proof. *)
+(*   induction n. *)
+(*   - now repeat constructor. *)
+(*   - cbn. intro D. destruct A. *)
+(*     +constructor. *)
+(*     + apply dupfree_concat_map_cons; auto. apply imagesNonempty. *)
+(* Qed. *)
+
+(* Lemma inConcatCons (Y: Type) (A C: list Y) (B: list (list Y)) y: y el A /\ C el B -> (y::C) el (concat (map (fun x => map (cons x) B) A)). *)
+(* Proof. *)
+(*   intros [E E']. induction A. *)
+(*   - contradiction E. *)
+(*   - cbn. destruct E as [E | E]. *)
+(*     + subst a. apply in_app_iff. left. apply in_map_iff. now exists C. *)
+(*                                                                     + auto.  *)
+(* Qed.                                                                *)
+
+(* Lemma inImages (Y: Type) (A B: list Y): (forall x, x el B -> x el A) -> B el images A (|B|). *)
+(* Proof. *)
+(*   intros E. induction B. *)
+(*   - cbn. now left. *)
+(*   - cbn. apply inConcatCons. auto. *)
+(* Qed.       *)
+
+(* (** images produces a list of containing all lists of correct length *) *)
+(* Lemma vector_enum_ok (X: finType) (Y: finType) f: *)
+(* |f| = Cardinality X -> count (images  (elem Y) (Cardinality X)) f= 1. *)
+(* Proof. *)
+(*   intros H. apply dupfreeCount. *)
+(*   - apply imagesDupfree. apply dupfree_elements. *)
+(*   - rewrite <- H. now apply inImages. *)
+(* Qed. *)
+
+(* (** FunctionLists A n only produces lists of length n *) *)
+(* Lemma imagesInnerLength (Y: Type) (n: nat) : *)
+(*   forall (A: list Y) B, B el (images A n) -> | B | = n. *)
+(* Proof. *)
+(*   induction n; intros A B; cbn. *)
+(*   - intros H. destruct H; try tauto. now subst B. *)
+(*   - pattern A at 1. generalize A at 2. induction A; cbn. *)
+(*     +  tauto. *)
+(*     + intros C E. destruct (in_app_or  _ _ B E) as [H|H]. *)
+(*       * pose proof (in_map_iff (cons a)  (images C n) B) as [G _]. specialize (G H); clear H. *)
+(*         destruct G as [D [H G]]. specialize (IHn  _ _ G). subst B. cbn. lia. *)
+(*       * now apply (IHA C). *)
+(* Qed. *)
+
+(* (** Function converting a list (list Y) containing lists of length Cardinality X into a lists of vectors (X --> Y) *) *)
+(* Definition extensionalPower (X Y: finType) (L: list (list Y))  (P: L <<= images (elem Y) (Cardinality X)): list (X --> Y). *)
+(* Proof. *)
+(*   revert L P. *)
+(*   refine (fix extPow L P :=  _). destruct L. *)
+(*   -  exact nil. *)
+(*   - apply cons. *)
+(*     + exists l. specialize (P l (or_introl eq_refl)). unfold pure. dec; auto. contradiction ( n (imagesInnerLength P)). *)
+(*     + eapply extPow. intros A E. apply P. exact (or_intror E). *)
+(* Defined. *)
+
+(* (** To vectors  are equal if there images are equal *) *)
+(* Lemma vector_extensionality (X: finType) (Y: Type) (F G: X --> Y) : (image F = image G) -> F = G. *)
+(* Proof. *)
+(*   apply subtype_extensionality.  *)
+(* Qed. *)
+
+(* (** The number if occurences of a function in extensionalpower is equal to the number of occurences of its image in the original list given to extensionalpower as an argument *) *)
+(*  Lemma counttFL X Y L P f : *)
+(*   count (@extensionalPower X Y L P) f = count L (image f). *)
+(* Proof. *)
+(*   induction L. *)
+(*   -   reflexivity. *)
+(*   - simpl. dec; rename a into A; decide (image f = A). *)
+(*     +  now rewrite IHL. *)
+(*     +contradict n. now subst f.       *)
+(*     +  contradict n. now apply vector_extensionality. *)
+(*     + apply IHL.         *)
+(* Qed. *)
+
+(* Instance finTypeC_vector (X Y: finType) : *)
+(*   finTypeC (EqVect X Y). *)
+(* Proof. *)
+(*  apply (FinTypeC (enum := @extensionalPower _ _ (images (elem Y) (Cardinality X)) (fun x => fun y => y))). *)
+(*  intro f. rewrite counttFL. apply vector_enum_ok. destruct f as [A p]. cbn. now impurify p. *)
+(* Defined. *)
+
+(* Canonical Structure finType_vector (X Y: finType) := FinType (EqVect X Y). *)
+
+(* Notation "Y ^ X" := (finType_vector X Y). *)
+
+(* Lemma finType_vector_correct (X Y: finType): *)
+(*   X --> Y =  Y^ X. *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+
+(* Lemma finType_vector_enum (X Y: finType): *)
+(*   elem (Y^ X) = @extensionalPower _ _ (images (elem Y) (Cardinality X)) (fun x => fun y => y). *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+
+(* Set Printing Coercions. *)
+
+(* Lemma tofinType_vector_correct (X Y: finType): *)
+(*   tofinType (X --> Y) = Y ^ X. *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+(* Unset Printing Coercions. *)
+(* (** ** Conversion between vectors and functions *) *)
+
+
+(* (** Function that applies a vector to an argument *)                 *)
+(* Definition applyVect (X: finType) (Y: Type) (f: X --> Y): X -> Y. *)
+(* Proof. *)
+(*   refine (fun x: X => _). *)
+(*   destruct (elem X) eqn: E. *)
+(*   - exfalso. pose proof (elem_spec x). now rewrite E in H.     *)
+(*   - destruct f as [image p]. destruct image. *)
+(*     + exfalso. unfold Card_X_eq, Cardinality in p. rewrite E in p. now impurify p. *)
+(*     + exact (getAt (y::image0) (index x) y). *)
+(* Defined. *)
+
+(* Coercion applyVect: vector >-> Funclass. *)
+
+(* (** A function converting A function f into the list representing its image on elements of A*) *)
+(* Definition getImage {X: finType} {Y: Type} (f: X -> Y) :=map f (elem X). *)
+
+(* (** getImage contains the right elements *) *)
+(* Lemma getImage_in (X: finType) (Y: Type) (f: X -> Y) (x:X) : (f x) el (getImage f). *)
+(* Proof. *)
+(*   unfold getImage. now apply in_map. *)
+(*  Qed. *)
+(* (** getImage only produces lists of the correct length *) *)
+(* Lemma getImage_length (X: finType) (Y: Type) (f: X -> Y) :  |getImage f| = Cardinality X. *)
+(* Proof. *)
+(*   apply map_length. *)
+(* Qed. *)
+
+(* (** Function converting a function into a vector *) *)
+(* Definition vectorise {X: finType} {Y: Type} (f: X -> Y) : X --> Y := *)
+(*   exist (pure (@Card_X_eq X Y)) (getImage f) (purify (getImage_length f)). *)
+
+(* Lemma getImage_correct (X:finType) (Y:Type) (f: X -> Y): *)
+(*   getImage f = image (vectorise f). *)
+(* Proof. *)
+(*   reflexivity. *)
+(* Qed. *)
+
+(* (** A generalisation of a late case of apply_toVector_inverse *) *)
+(* Lemma HelpApply (X: eqType) (Y: Type) (A: list X) (f: X -> Y) x y (C: count A x > 0): *)
+(*   getAt (map f A) (getPosition A x) y = f x. *)
+(* Proof. *)
+(*   induction A. *)
+(*   - cbn in *. lia. *)
+(*   - cbn in *. dec. *)
+(*     + congruence. *)
+(*     + now apply IHA. *)
+(* Qed. *)
+
+(* (** If a function is converted into a vector and then applied to an argument the result is the same as if one had just applied the function to the argument *) *)
+(* Lemma apply_vectorise_inverse (X: finType) (Y: Type) (f: X -> Y) (x: X) : *)
+(*     (vectorise f) x = f x.   *)
+(* Proof. *)
+(*  destruct X as [X [A ok]]. destruct A. *)
+(*   - discriminate (ok x). *)
+(*   - cbn  in  *. specialize (ok x). dec. *)
+(*     + congruence. *)
+(*     + apply HelpApply. lia. *)
+(* Qed. *)
+
+(* (** The position of x in a list containg x exactly once is one greater than the size of the sublist befor x *) *)
+(* Lemma countNumberApp (X: eqType) (x:X) (A B: list X)  (ok : count (A ++ x::B) x = 1) : *)
+(*   getPosition (A ++ x::B) x = |A|. *)
+(* Proof. *)
+(*   induction A. *)
+(*   - cbn. now deq x. *)
+(*   - cbn in *. dec. *)
+(*     + inv ok. pose proof (countApp a A B). lia. *)
+(*     + auto. *)
+(* Qed. *)
+
+(* Lemma getAt_correct (Y:Type) (A A': list Y) y y': *)
+(* getAt (A' ++ y::A) (|A'|) y' = y. *)
+(* Proof. *)
+(*   induction A'; cbn. *)
+(*   - reflexivity. *)
+(*   - cbn in *. apply IHA'. *)
+(* Qed.     *)
+
+(* Lemma rightResult (X: finType) (x:X) (B B': list X) (Y: Type)  (y:Y) (A A': list Y) (H:  pure (@Card_X_eq X Y) (A' ++ y::A))  (H': |A'| = | B'|)  (G: elem X = B' ++ x::B): *)
+(*  ((exist _ _ H): X --> Y) x = y. *)
+(* Proof. *)
+(* destruct X as [X [C ok]]. unfold applyVect. cbn in *. subst C. destruct B'; destruct A' ; cbn in *; impurify H; unfold Card_X_eq in H;  cbn in H. *)
+(*   -  now deq x.  *)
+(*   -  rewrite app_length in H.  inv H. lia. *)
+(*   - rewrite app_length in H. cbn in H. lia. *)
+(*   - specialize (ok x). dec. *)
+(*     + subst e. inv ok.  pose proof countApp x B' B. lia. *)
+(*     + rewrite countNumberApp; auto. *)
+(*    inv H'. eapply getAt_correct. *)
+(* Qed.       *)
+
+(* Lemma vectorise_apply_inverse' (X: finType) (B B': list X) (Y: Type) (A A' A'': list Y) (H: pure (@Card_X_eq X Y) A'') (H': |A'| = | B' |) (H'': |A| = | B|) (E: A' ++ A = A'') (G: elem X = B' ++ B) : *)
+(*   map ((exist _ _ H): X --> Y) B= A. *)
+(*   Proof. *)
+(*     revert A A' B' H' H'' E G. induction B; intros A A' B' H' H'' E G. *)
+(*     - cbn. symmetry. now rewrite <- length_zero_iff_nil. *)
+(*     - cbn. destruct A; try (discriminate H''). f_equal. *)
+(*       +  subst A''. eapply rightResult. *)
+(*         * inv H'. exact H1. *)
+(*         * exact G. *)
+(*       + apply (IHB A (A' ++ [y]) (B' ++ [a])). *)
+(*         * repeat rewrite app_length. cbn. lia. *)
+(*         * now inv H''. *)
+(*         *  now rewrite app_assoc_reverse. *)
+(*         * rewrite G.  replace (a::B) with ([a]++B) by auto. now rewrite app_assoc. *)
+(*   Qed. *)
+
+(* Lemma vectorise_apply_inverse (X: finType) (Y: Type) (f: X --> Y): vectorise f = f. *)
+(* Proof. *)
+(*   apply vector_extensionality. cbn. destruct f as [A p]. *)
+(*   eapply vectorise_apply_inverse'; eauto using app_nil_l; now impurify p. *)
+(* Qed. *)
+

--- a/theories/Shared/Libs/PSL/FiniteTypes/VectorFin.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/VectorFin.v
@@ -1,0 +1,92 @@
+From Undecidability.Shared.Libs.PSL Require Import BasicDefinitions.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.FinTypes.
+From Undecidability.Shared.Libs.PSL Require Import Vectors.Vectors.
+From Undecidability.Shared.Libs.PSL Require Import Vectors.VectorDupfree.
+Import VectorNotations2.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.Cardinality.
+
+Definition Fin_initVect (n : nat) : Vector.t (Fin.t n) n :=
+  tabulate (fun i : Fin.t n => i).
+
+Lemma Fin_initVect_dupfree n :
+  dupfree (Fin_initVect n).
+Proof.
+  unfold Fin_initVect.
+  eapply dupfree_tabulate_injective.
+  firstorder.
+Qed.
+
+Lemma Fin_initVect_full n k :
+  Vector.In k (Fin_initVect n).
+Proof.
+  unfold Fin_initVect.
+  apply in_tabulate. eauto.
+Qed.
+
+Definition Fin_initVect_nth (n : nat) (k : Fin.t n) :
+  Vector.nth (Fin_initVect n) k = k.
+Proof. unfold Fin_initVect. apply nth_tabulate. Qed.
+
+Import VecToListCoercion.
+
+Instance Fin_finTypeC n : finTypeC (EqType (Fin.t n)).
+Proof.
+  constructor 1 with (enum := Fin_initVect n).
+  intros x. cbn in x.
+  eapply dupfreeCount.
+  - eapply tolist_dupfree. apply Fin_initVect_dupfree.
+  - eapply tolist_In. apply Fin_initVect_full.
+Defined.
+
+Hint Extern 4 (finTypeC (EqType (Fin.t _))) => eapply Fin_finTypeC : typeclass_instances.
+
+Lemma Fin_cardinality n : Cardinality (finType_CS (Fin.t n)) = n.
+Proof.
+  unfold Cardinality, elem, enum. cbn. unfold Fin_initVect. now rewrite vector_to_list_length. 
+Qed.
+
+(** Function that produces a list of all Vectors of length n over A *)
+Fixpoint Vector_pow {X: Type} (A: list X) n {struct n} : list (Vector.t X n) :=
+  match n with
+  | 0 => [Vector.nil _]
+  | S n => concat (map (fun a => map (fun v => a:::v) (Vector_pow A n) ) A)
+  end.
+
+Instance Vector_finTypeC (A:finType) n: finTypeC (EqType (Vector.t A n)).
+Proof.
+  exists (undup ((Vector_pow (elem A) n))). cbn in *.
+  intros v. eapply dupfreeCount.
+  - eapply dupfree_undup.
+  - rewrite undup_id_equi. induction v; cbn.
+    + eauto.
+    + eapply in_concat_iff. eexists; split.
+      2:eapply in_map_iff. 2:eexists.
+      2:split. 2:reflexivity.
+      eapply in_map_iff. eauto.
+      eapply elem_spec.
+Defined.
+      
+Hint Extern 4 (finTypeC (EqType (Vector.t _ _))) => eapply Vector_finTypeC : typeclass_instances.
+
+
+Lemma ProdCount (T1 T2: eqType) (A: list T1) (B: list T2) (a:T1) (b:T2)  :
+  BasicDefinitions.count (prodLists A B) (a,b) =  BasicDefinitions.count A a * BasicDefinitions.count B b .
+Proof.
+  induction A.
+  - reflexivity.
+  - cbn. rewrite <- countSplit. decide (a = a0) as [E | E].
+    + cbn. f_equal. subst a0. apply countMap. eauto.
+    + rewrite <- plus_O_n. f_equal. now apply countMapZero. eauto.
+Qed.
+
+Lemma prod_enum_ok (T1 T2: finType) (x: T1 * T2):
+  BasicDefinitions.count (prodLists (elem T1) (elem T2)) x = 1.
+Proof.
+  destruct x as [x y]. rewrite ProdCount. unfold elem.
+  now repeat rewrite enum_ok.
+Qed.
+
+Instance finTypeC_Prod (F1 F2: finType) : finTypeC (EqType (F1 * F2)).
+Proof.
+  econstructor.  apply prod_enum_ok.
+Defined.

--- a/theories/Shared/Libs/PSL/Inhabited.v
+++ b/theories/Shared/Libs/PSL/Inhabited.v
@@ -1,0 +1,73 @@
+(** * Inhabited types *)
+
+(* Author: Maximilian Wuttke *)
+
+
+From Undecidability.Shared.Libs.PSL Require Prelim.
+From Coq.Vectors Require Import Vector Fin.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.FinTypes.
+
+Class inhabitedC (X : Type) :=
+    {
+      default : X;
+    }.
+
+Instance inhabited_unit : inhabitedC unit.
+Proof. do 2 constructor. Defined.
+
+Instance inhabited_True : inhabitedC True.
+Proof. do 2 constructor. Defined.
+
+Instance inhabited_inl (A B : Type) (inh_a : inhabitedC A) : inhabitedC (A + B).
+Proof. constructor. left. apply default. Defined.
+
+Instance inhabited_inr (A B : Type) (inh_B : inhabitedC B) : inhabitedC (A + B).
+Proof. constructor. right. apply default. Defined.
+
+Instance inhabited_option (A : Type) : inhabitedC (option A).
+Proof. constructor. right. Defined.
+
+Instance inhabited_bool : inhabitedC bool.
+Proof. do 2 constructor. Defined.
+
+Instance inhabited_list (A : Type) : inhabitedC (list A).
+Proof. do 2 constructor. Defined.
+
+Instance inhabited_vector (A : Type) (n : nat) (inh_A : inhabitedC A) : inhabitedC (Vector.t A n).
+Proof. constructor. eapply VectorDef.const. apply default. Defined.
+
+Instance inhabited_fin (n : nat) : inhabitedC (Fin.t (S n)).
+Proof. repeat constructor. Defined.
+
+Instance inhabited_nat : inhabitedC nat.
+Proof. do 2 constructor. Defined.
+
+Instance inhabited_prod (A B : Type) : inhabitedC A -> inhabitedC B -> inhabitedC (A*B).
+Proof. intros ia ib. do 2 constructor; apply default. Defined.
+
+Instance inhabited_arrow (A B : Type) : inhabitedC B -> inhabitedC (A -> B).
+Proof. intros. constructor. intros _. apply default. Defined.
+
+Instance inhabited_arrow_empty (B : Type) : inhabitedC (Empty_set -> B).
+Proof. intros. constructor. apply Empty_set_rect. Defined.
+
+Instance inhabited_arrow_sum (A B C : Type) : inhabitedC (A->C) -> inhabitedC (B->C) -> inhabitedC (A+B->C).
+Proof. intros iac ibc. constructor. intros [?|?]. now apply iac. now apply ibc. Defined.
+
+Instance inhabited_arrow_prod (A B C : Type) : inhabitedC (A->B) -> inhabitedC (A->C) -> inhabitedC (A->B*C).
+Proof. intros iab iac. constructor. intros a. constructor. now apply iab. now apply iac. Defined.
+
+
+(** Derive inhabitedC instances, if an instance of this type is a hypothesis *)
+Hint Extern 10 => match goal with
+                | [ H : ?X |- inhabitedC ?X ] => now econstructor
+                end : typeclass_instances.
+(*
+Section Test.
+  Variable lie : False.
+  Compute default : False.
+  Variable somebool : bool.
+  (* This should prefer the instance, not the variable. *)
+  Compute default : bool.
+End Test.
+*)

--- a/theories/Shared/Libs/PSL/Lists/BaseLists.v
+++ b/theories/Shared/Libs/PSL/Lists/BaseLists.v
@@ -1,0 +1,596 @@
+From Undecidability.Shared.Libs.PSL Require Export Prelim EqDec.
+
+Export ListNotations.
+Notation "x 'el' A" := (In x A) (at level 70).
+Notation "A <<= B" := (incl A B) (at level 70).
+Notation "| A |" := (length A) (at level 65).
+Definition equi X (A B : list X) : Prop := incl A B /\ incl B A.
+Notation "A === B" := (equi A B) (at level 70).
+Hint Unfold equi : core.
+
+Hint Extern 4 => 
+match goal with
+|[ H: ?x el nil |- _ ] => destruct H
+end : core.
+
+(** ** Lists *)
+
+(* Register additional simplification rules with autorewrite / simpl_list *)
+(* Print Rewrite HintDb list. *)
+Hint Rewrite <- app_assoc : list.
+Hint Rewrite rev_app_distr map_app prod_length : list.
+
+Lemma list_cycle  (X : Type) (A : list X) x :
+  x::A <> A.
+Proof.
+  intros B.
+  assert (C: |x::A| <> |A|) by (cbn; lia).
+  apply C. now rewrite B.
+Qed.
+
+(** *** Decisions for lists *)
+
+Instance list_in_dec X (x : X) (A : list X) :  
+  eq_dec X -> dec (x el A).
+Proof.
+  intros D. apply in_dec. exact D.
+Qed.
+
+(* Certifying find *)
+
+Lemma cfind X A (p: X -> Prop) (p_dec: forall x, dec (p x)) :
+  {x | x el A /\ p x} + {forall x, x el A -> ~ p x}.
+Proof.
+  destruct (find (fun x => Dec (p x)) A) eqn:E.
+  - apply find_some in E. firstorder.
+  - right. intros. eapply find_none in E; eauto.
+Qed.
+
+Arguments cfind {X} A p {p_dec}.
+
+Instance list_forall_dec X A (p : X -> Prop) :
+  (forall x, dec (p x)) -> dec (forall x, x el A -> p x).
+Proof.
+  intros p_dec.
+  destruct (find (fun x => Dec (~ p x)) A) eqn:Eq.
+  - apply find_some in Eq as [H1 H0 %Dec_true]; right; auto. 
+  - left. intros x E. apply find_none with (x := x) in Eq. apply dec_DN; auto. auto.
+Qed.
+
+Instance list_exists_dec X A (p : X -> Prop) :
+  (forall x, dec (p x)) -> dec (exists x, x el A /\ p x).
+Proof.
+  intros p_dec.
+  destruct (find (fun x => Dec (p x)) A) eqn:Eq. (* New: eta expansion needed *)
+  - apply find_some in Eq as [H0 H1 %Dec_true]. firstorder. (* New: Need firstorder here *)
+  - right. intros [x [E F]]. apply find_none with (x := x) in Eq; auto. eauto. (* New: Why can't auto solve this? *)
+Qed.
+
+Lemma list_exists_DM X A  (p : X -> Prop) : 
+  (forall x, dec (p x)) ->
+  ~ (forall x, x el A -> ~ p x) -> exists x, x el A /\ p x.
+Proof. 
+  intros D E. 
+  destruct (find (fun x => Dec (p x)) A) eqn:Eq.
+  + apply find_some in Eq as [? ?%Dec_true]. eauto.
+  + exfalso. apply E. intros. apply find_none with (x := x) in Eq;  eauto. 
+Qed.
+
+Lemma list_exists_not_incl (X: eqType) (A B : list X) :
+  ~ A <<= B -> exists x, x el A /\ ~ x el B.
+Proof.
+  intros E.
+  apply list_exists_DM; auto.
+  intros F. apply E. intros x G.
+  apply dec_DN; auto.
+Qed.
+
+Lemma list_cc X (p : X -> Prop) A : 
+  (forall x, dec (p x)) -> 
+  (exists x, x el A /\ p x) -> {x | x el A /\ p x}.
+Proof.
+  intros D E. 
+  destruct (cfind A p) as [[x [F G]]|F].
+  - eauto.
+  - exfalso. destruct E as [x [G H]]. apply (F x); auto.
+Qed.
+
+
+
+(** *** Membership
+
+We use the following lemmas from Coq's standard library List.
+- [in_eq :  x el x::A]
+- [in_nil :  ~ x el nil]
+- [in_cons :  x el A -> x el y::A]
+- [in_or_app :  x el A \/ x el B -> x el A++B]
+- [in_app_iff :  x el A++B <-> x el A \/ x el B]
+- [in_map_iff :  y el map f A <-> exists x, f x = y /\ x el A]
+*)
+
+Hint Resolve in_eq in_nil in_cons in_or_app : core.
+
+Section Membership.
+  Variable X : Type.
+  Implicit Types (x y: X) (A B: list X).
+
+  Lemma in_sing x y :
+    x el [y] -> x = y.
+  Proof. 
+    cbn. intros [[]|[]]. reflexivity. 
+  Qed.
+
+  Lemma in_cons_neq x y A :
+    x el y::A -> x <> y -> x el A.
+  Proof. 
+    cbn. intros [[]|D] E; congruence. 
+  Qed.
+
+  Lemma not_in_cons x y A :
+    ~ x el y :: A -> x <> y /\ ~ x el A.
+  Proof.
+    intuition; subst; auto.
+  Qed.
+
+(** *** Disjointness *)
+
+  Definition disjoint A B :=
+    ~ exists x, x el A /\ x el B.
+
+  Lemma disjoint_forall A B :
+    disjoint A B <-> forall x, x el A -> ~ x el B.
+  Proof.
+    split.
+    - intros D x E F. apply D. exists x. auto.
+    - intros D [x [E F]]. exact (D x E F).
+  Qed.
+
+  Lemma disjoint_symm A B :
+    disjoint A B -> disjoint B A.
+  Proof.
+    firstorder.
+  Qed.
+
+  Lemma disjoint_incl A B B' :
+    B' <<= B -> disjoint A B -> disjoint A B'.
+  Proof.
+    firstorder.
+  Qed.
+
+  Lemma disjoint_nil B :
+    disjoint nil B.
+  Proof.
+    firstorder.
+  Qed.
+
+  Lemma disjoint_nil' A :
+    disjoint A nil.
+  Proof.
+    firstorder.
+  Qed.
+  
+  Lemma disjoint_cons x A B :
+    disjoint (x::A) B <-> ~ x el B /\ disjoint A B.
+  Proof.
+    split.
+    - intros D. split.
+      + intros E. apply D. eauto.
+      + intros [y [E F]]. apply D. eauto.
+    - intros [D E] [y [[F|F] G]]. 
+      + congruence.
+      + apply E. eauto.
+  Qed.
+
+  Lemma disjoint_app A B C :
+    disjoint (A ++ B) C <-> disjoint A C /\ disjoint B C.
+  Proof.
+    split.
+    - intros D. split.
+      + intros [x [E F]]. eauto 6.
+      + intros [x [E F]]. eauto 6.
+    - intros [D E] [x [F G]]. 
+      apply in_app_iff in F as [F|F]; eauto.
+  Qed.
+
+End Membership.
+
+Hint Resolve disjoint_nil disjoint_nil' : core.
+
+(** *** Inclusion
+
+We use the following lemmas from Coq's standard library List.
+- [incl_refl :  A <<= A]
+- [incl_tl :  A <<= B -> A <<= x::B]
+- [incl_cons : x el B -> A <<= B -> x::A <<= B]
+- [incl_appl : A <<= B -> A <<= B++C]
+- [incl_appr : A <<= C -> A <<= B++C]
+- [incl_app : A <<= C -> B <<= C -> A++B <<= C]
+*)
+
+Hint Resolve incl_refl incl_tl incl_cons incl_appl incl_appr incl_app : core.
+
+Lemma incl_nil X (A : list X) :
+  nil <<= A.
+
+Proof. intros x []. Qed.
+
+Hint Resolve incl_nil : core.
+
+Lemma incl_map X Y A B (f : X -> Y) :
+  A <<= B -> map f A <<= map f B.
+
+Proof.
+  intros D y E. apply in_map_iff in E as [x [E E']].
+  subst y. apply in_map_iff. eauto.
+Qed.
+
+Section Inclusion.
+  Variable X : Type.
+  Implicit Types A B : list X.
+
+  Lemma incl_nil_eq A :
+    A <<= nil -> A=nil.
+
+  Proof.
+    intros D. destruct A as [|x A].
+    - reflexivity.
+    - exfalso. apply (D x). auto.
+  Qed.
+
+  Lemma incl_shift x A B :
+    A <<= B -> x::A <<= x::B.
+
+  Proof. auto. Qed.
+
+  Lemma incl_lcons x A B :
+    x::A <<= B <-> x el B /\ A <<= B.
+  Proof. 
+    split. 
+    - intros D. split; hnf; auto.
+    - intros [D E] z [F|F]; subst; auto.
+  Qed.
+
+  Lemma incl_sing x A y :
+    x::A <<= [y] -> x = y /\ A <<= [y].
+  Proof.
+    rewrite incl_lcons. intros [D E].
+    apply in_sing in D. auto.
+  Qed.
+
+  Lemma incl_rcons x A B :
+    A <<= x::B -> ~ x el A -> A <<= B.
+
+  Proof. intros C D y E. destruct (C y E) as [F|F]; congruence. Qed.
+
+  Lemma incl_lrcons x A B :
+    x::A <<= x::B -> ~ x el A -> A <<= B.
+
+  Proof.
+    intros C D y E.
+    assert (F: y el x::B) by auto.
+    destruct F as [F|F]; congruence.
+  Qed.
+
+  Lemma incl_app_left A B C :
+    A ++ B <<= C -> A <<= C /\ B <<= C.
+  Proof.
+    firstorder.
+  Qed.
+
+End Inclusion.
+
+Definition inclp (X : Type) (A : list X) (p : X -> Prop) : Prop :=
+  forall x, x el A -> p x.
+
+(** *** Setoid rewriting with list inclusion and list equivalence *)
+
+Instance incl_preorder X : 
+  PreOrder (@incl X).
+Proof. 
+  constructor; hnf; unfold incl; auto. 
+Qed.
+
+Instance equi_Equivalence X : 
+  Equivalence (@equi X).
+Proof. 
+  constructor; hnf; firstorder. 
+Qed.
+
+Instance incl_equi_proper X : 
+  Proper (@equi X ==> @equi X ==> iff) (@incl X).
+Proof. 
+  hnf. intros A B D. hnf. firstorder. 
+Qed.
+
+Instance cons_incl_proper X x : 
+  Proper (@incl X ==> @incl X) (@cons X x).
+Proof.
+  hnf. apply incl_shift.
+Qed.
+
+Instance cons_equi_proper X x : 
+  Proper (@equi X ==> @equi X) (@cons X x).
+Proof. 
+  hnf. firstorder.
+Qed.
+
+Instance in_incl_proper X x : 
+  Proper (@incl X ==> Basics.impl) (@In X x).
+Proof.
+  intros A B D. hnf. auto.
+Qed.
+
+Instance in_equi_proper X x : 
+  Proper (@equi X ==> iff) (@In X x).
+Proof. 
+  intros A B D. firstorder. 
+Qed.
+
+Instance app_incl_proper X : 
+  Proper (@incl X ==> @incl X ==> @incl X) (@app X).
+Proof. 
+  intros A B D A' B' E. auto.
+Qed.
+
+Instance app_equi_proper X : 
+  Proper (@equi X ==> @equi X ==> @equi X) (@app X).
+Proof. 
+  hnf. intros A B D. hnf. intros A' B' E.
+  destruct D, E; auto.
+Qed.
+
+Section Equi.
+  Variable X : Type.
+  Implicit Types A B : list X.
+
+  Lemma equi_push x A :
+    x el A -> A === x::A.
+  Proof.
+    auto.
+  Qed.
+
+  Lemma equi_dup x A :
+    x::A === x::x::A.
+
+  Proof.
+    auto.
+  Qed.
+
+  Lemma equi_swap x y A:
+    x::y::A === y::x::A.
+  Proof.
+    split; intros z; cbn; tauto.
+  Qed.
+
+  Lemma equi_shift x A B :
+    x::A++B === A++x::B.
+  Proof. 
+    split; intros y.
+    - intros [D|D].
+      + subst; auto.
+      + apply in_app_iff in D as [D|D]; auto.
+    - intros D. apply in_app_iff in D as [D|D].
+      + auto.
+      + destruct D; subst; auto.
+  Qed.
+
+  Lemma equi_rotate x A :
+    x::A === A++[x]. 
+  Proof. 
+    split; intros y; cbn.
+    - intros [D|D]; subst; auto.
+    - intros D. apply in_app_iff in D as [D|D].
+      + auto.
+      + apply in_sing in D. auto.
+  Qed.
+  
+End Equi.
+
+Lemma in_concat_iff A l (a:A) : a el concat l <-> exists l', a el l' /\ l' el l.
+Proof.
+  induction l; cbn.
+  - intuition. now destruct H. 
+  - rewrite in_app_iff, IHl. firstorder subst. auto.
+Qed.
+
+
+Lemma app_comm_cons' (A : Type) (x y : list A) (a : A) :
+  x ++ a :: y = (x ++ [a]) ++ y.
+Proof. rewrite <- app_assoc. cbn. trivial. Qed.
+
+
+(** skipn *)
+
+Lemma skipn_nil (X : Type) (n : nat) : skipn n nil = @nil X.
+Proof. destruct n; cbn; auto. Qed.
+
+Lemma skipn_app (X : Type) (xs ys : list X) (n : nat) :
+  n = (| xs |) ->
+  skipn n (xs ++ ys) = ys.
+Proof.
+  intros ->. revert ys. induction xs; cbn; auto.
+Qed.
+
+Lemma skipn_length (X : Type) (n : nat) (xs : list X) :
+  length (skipn n xs) = length xs - n.
+Proof.
+  revert xs. induction n; intros; cbn.
+  - lia.
+  - destruct xs; cbn; auto.
+Qed.
+
+
+
+(** Repeat *)
+
+Lemma map_repeat (X Y : Type) (f : X -> Y) (n : nat) (a : X) :
+  map f (repeat a n) = repeat (f a) n.
+Proof. induction n; cbn in *; f_equal; auto. Qed.
+
+Lemma repeat_add_app (X : Type) (m n : nat) (a : X) :
+  repeat a (m + n) = repeat a m ++ repeat a n.
+Proof. induction m; cbn; f_equal; auto. Qed.
+
+Lemma repeat_S_cons (X : Type) (n : nat) (a : X) :
+  a :: repeat a n = repeat a n ++ [a].
+Proof.
+  replace (a :: repeat a n) with (repeat a (S n)) by trivial. replace (S n) with (n+1) by lia.
+  rewrite repeat_add_app. cbn. trivial.
+Qed.
+
+Lemma repeat_app_eq (X : Type) (m n : nat) (a : X) :
+  repeat a n ++ repeat a m = repeat a m ++ repeat a n.
+Proof. rewrite <- !repeat_add_app. f_equal. lia. Qed.
+
+Lemma repeat_eq_iff (X : Type) (n : nat) (a : X) x :
+  x = repeat a n <-> length x = n /\ forall y, y el x -> y = a.
+Proof.
+  split.
+  {
+    intros ->. split. apply repeat_length. apply repeat_spec.
+  }
+  {
+    revert x. induction n; intros x (H1&H2); cbn in *.
+    - destruct x; cbn in *; congruence.
+    - destruct x; cbn in *; inv H1. f_equal.
+      + apply H2. auto.
+      + apply IHn. auto.
+  }
+Qed.
+
+Lemma rev_repeat (X : Type) (n : nat) (a : X) :
+  rev (repeat a n) = repeat a n.
+Proof.
+  apply repeat_eq_iff. split.
+  - rewrite rev_length. rewrite repeat_length. auto.
+  - intros y Hx % in_rev. eapply repeat_spec; eauto.
+Qed.
+
+Lemma concat_repeat_repeat (X : Type) (n m : nat) (a : X) :
+  concat (repeat (repeat a n) m) = repeat a (m*n).
+Proof.
+  induction m as [ | m' IHm]; cbn.
+  - auto.
+  - rewrite repeat_add_app. f_equal. auto.
+Qed.
+
+
+Corollary skipn_repeat_add (X : Type) (n m : nat) (a : X) :
+  skipn n (repeat a (n + m)) = repeat a m.
+Proof.
+  rewrite repeat_add_app. erewrite skipn_app; eauto. symmetry. apply repeat_length.
+Qed.
+
+Corollary skipn_repeat (X : Type) (n : nat) (a : X) :
+  skipn n (repeat a n) = nil.
+Proof.
+  rewrite <- (app_nil_r (repeat a n)). erewrite skipn_app; eauto. symmetry. apply repeat_length.
+Qed.
+
+
+(** Facts about equality for [map] and [rev] *)
+Lemma rev_eq_nil (Z: Type) (l: list Z) :
+  rev l = nil -> l = nil.
+Proof. intros. destruct l; cbn in *. reflexivity. symmetry in H. now apply app_cons_not_nil in H. Qed.
+
+Lemma map_eq_nil (Y Z: Type) (f: Y->Z) (l: list Y) :
+  map f l = nil -> l = nil.
+Proof. intros. destruct l; cbn in *. reflexivity. congruence. Qed.
+
+Lemma map_eq_nil' (Y Z: Type) (f: Y->Z) (l: list Y) :
+  nil = map f l -> l = nil.
+Proof. now intros H % eq_sym % map_eq_nil. Qed.
+
+Lemma map_eq_cons (A B: Type) (f: A->B) (xs: list A) (y: B) (ys: list B) :
+  map f xs = y :: ys ->
+  exists x xs', xs = x :: xs' /\
+          y = f x /\
+          ys = map f xs'.
+Proof. induction xs; intros H; cbn in *; inv H; eauto. Qed.
+
+Lemma map_eq_cons' (A B: Type) (f: A -> B) (xs: list A) (y: B) (ys: list B) :
+  y :: ys = map f xs ->
+  exists x xs', xs = x :: xs' /\
+          y = f x /\
+          ys = map f xs'.
+Proof. now intros H % eq_sym % map_eq_cons. Qed.
+
+
+Lemma map_eq_app (A B: Type) (f: A -> B) (ls : list A) (xs ys : list B) :
+  map f ls = xs ++ ys ->
+  exists ls1 ls2, ls = ls1 ++ ls2 /\
+             xs = map f ls1 /\
+             ys = map f ls2.
+Proof.
+  revert xs ys. induction ls; intros; cbn in *.
+  - symmetry in H. apply app_eq_nil in H as (->&->). exists nil, nil. cbn. tauto.
+  - destruct xs; cbn in *.
+    + exists nil. eexists. repeat split. cbn. now subst.
+    + inv H. specialize IHls with (1 := H2) as (ls1&ls2&->&->&->).
+      repeat econstructor. 2: instantiate (1 := a :: ls1). all: reflexivity.
+Qed.
+
+Lemma rev_eq_cons (A: Type) (ls: list A) (x : A) (xs: list A) :
+  rev ls = x :: xs ->
+  ls = rev xs ++ [x].
+Proof. intros H. rewrite <- rev_involutive at 1. rewrite H. cbn. reflexivity. Qed.
+
+
+
+(** Injectivity of [map], if the function is injective *)
+Lemma map_injective (X Y: Type) (f: X -> Y) :
+  (forall x y, f x = f y -> x = y) ->
+  forall xs ys, map f xs = map f ys -> xs = ys.
+Proof.
+  intros HInj. hnf. intros x1. induction x1 as [ | x x1' IH]; intros; cbn in *.
+  - now apply map_eq_nil' in H.
+  - now apply map_eq_cons' in H as (l1&l2&->&->%HInj&->%IH).
+Qed.
+
+Instance map_ext_proper A B: Proper (@ pointwise_relation A B (@eq B) ==> (@eq (list A)) ==> (@eq (list B))) (@map A B).
+Proof.
+  intros f f' Hf a ? <-. induction a;cbn;congruence.
+Qed.
+
+(* ** Lemmas about [hd], [tl] and [removelast] *)
+
+Lemma tl_map (A B: Type) (f: A -> B) (xs : list A) :
+  tl (map f xs) = map f (tl xs).
+Proof. now destruct xs; cbn. Qed.
+
+
+(* Analogous to [removelast_app] *)
+
+Lemma tl_app (A: Type) (xs ys : list A) :
+  xs <> nil ->
+  tl (xs ++ ys) = tl xs ++ ys.
+Proof. destruct xs; cbn; congruence. Qed.
+
+Lemma tl_rev (A: Type) (xs : list A) :
+  tl (rev xs) = rev (removelast xs).
+Proof.
+  induction xs; cbn; auto.
+  destruct xs; cbn in *; auto.
+  rewrite tl_app; cbn in *.
+  - now rewrite IHxs.
+  - intros (H1&H2) % app_eq_nil; inv H2.
+Qed.
+
+Lemma hd_map (A B: Type) (f: A -> B) (xs : list A) (a : A) :
+  hd (f a) (map f xs) = f (hd a xs).
+Proof. destruct xs; cbn; auto. Qed.
+
+Lemma hd_app (A: Type) (xs ys : list A) a :
+  xs <> nil ->
+  hd a (xs ++ ys) = hd a xs.
+Proof. intros H. destruct xs; auto. now contradiction H. Qed.
+
+Lemma hd_rev (A: Type) (xs : list A) (a : A) :
+  hd a (rev xs) = last xs a.
+Proof.
+  induction xs; cbn; auto.
+  destruct xs; cbn; auto.
+  rewrite hd_app. now apply IHxs.
+  intros (H1&H2)%app_eq_nil; inv H2.
+Qed.
+

--- a/theories/Shared/Libs/PSL/Lists/Cardinality.v
+++ b/theories/Shared/Libs/PSL/Lists/Cardinality.v
@@ -1,0 +1,139 @@
+From Undecidability.Shared.Libs.PSL Require Export BaseLists Removal.
+
+(** *** Cardinality *)
+
+Section Cardinality.
+  Variable X : eqType.
+  Implicit Types A B : list X.
+
+  Fixpoint card A :=
+    match A with
+      | nil => 0
+      | x::A => if Dec (x el A) then card A else 1 + card A
+    end.
+
+  Lemma card_cons x A :
+    x el A -> card (x::A) = card A.
+  Proof.
+    intros H. cbn. decide (x el A) as [H1|H1]; tauto.
+  Qed.
+
+  Lemma card_cons' x A :
+    ~ x el A -> card (x::A) = 1 + card A.
+  Proof.
+    intros H. cbn. decide (x el A) as [H1|H1]; tauto.
+  Qed.
+  
+  Lemma card_in_rem x A :
+    x el A -> card A = 1 + card (rem A x).
+  Proof.
+    intros D. 
+    induction A as [|y A].
+    - contradiction D.
+    - decide (y = x) as [->|H].
+      + clear D. rewrite rem_fst.
+        cbn. decide (x el A) as [H1|H1].
+        * auto.
+        * now rewrite (rem_id H1).
+      + assert (x el A) as H1 by (destruct D; tauto). clear D.
+        rewrite (rem_fst' _ H). specialize (IHA H1).
+        simpl card at 2. 
+        decide (y el rem A x) as [H2|H2].
+        * rewrite card_cons. exact IHA.
+          apply in_rem_iff in H2. intuition.
+        * rewrite card_cons'. now rewrite IHA.
+          contradict H2.  now apply in_rem_iff.
+  Qed.
+  
+  Lemma card_not_in_rem A x :
+    ~ x el A -> card A = card (rem A x).
+  Proof.
+    intros D; rewrite rem_id; auto.
+  Qed.
+
+  Lemma card_le A B :
+    A <<= B -> card A <= card B.
+  Proof.
+  revert B. 
+  induction A as [|x A]; intros B D; cbn.
+  - lia.
+  - apply incl_lcons in D as [D D1].
+    decide (x el A) as [E|E].
+    + auto.
+    + rewrite (card_in_rem D).
+      enough (card A <= card (rem B x)) by lia.
+      apply IHA. auto.
+  Qed.
+
+  Lemma card_eq A B :
+    A === B -> card A = card B.
+  Proof.
+    intros [E F]. apply card_le in E. apply card_le in F. lia.
+  Qed.
+
+  Lemma card_cons_rem x A :
+    card (x::A) = 1 + card (rem A x).
+  Proof.
+    rewrite (card_eq (rem_equi x A)). cbn.
+    decide (x el rem A x) as [D|D].
+    - exfalso. apply in_rem_iff in D; tauto.
+    - reflexivity.
+  Qed.
+
+  Lemma card_0 A :
+    card A = 0 -> A = nil.
+  Proof.
+    destruct A as [|x A]; intros D.
+    - reflexivity.
+    - exfalso. rewrite card_cons_rem in D. lia.
+  Qed.
+
+  Lemma card_ex A B :
+    card A < card B -> exists x, x el B /\ ~ x el A.
+  Proof.
+    intros D.
+    decide (B <<= A) as [E|E].
+    - exfalso. apply card_le in E. lia.
+    - apply list_exists_not_incl; auto.
+  Qed.
+
+  Lemma card_equi A B :
+    A <<= B -> card A = card B -> A === B.
+  Proof.
+    revert B. 
+    induction A as [|x A]; cbn; intros B D E.
+    - symmetry in E. apply card_0 in E. now rewrite E.
+    - apply incl_lcons in D as [D D1].
+      decide (x el A) as [F|F].
+      + rewrite (IHA B); auto.
+      + rewrite (IHA (rem B x)).
+        * symmetry. apply rem_reorder, D.
+        * auto.
+        * apply card_in_rem in D. lia.
+  Qed.
+
+  Lemma card_lt A B x :
+    A <<= B -> x el B -> ~ x el A -> card A < card B.
+  Proof.
+    intros D E F.
+    decide (card A = card B) as [G|G].
+    + exfalso. apply F. apply (card_equi D); auto.
+    + apply card_le in D. lia.
+  Qed.
+
+  Lemma card_or A B :
+    A <<= B -> A === B \/ card A < card B.
+  Proof.
+    intros D.
+    decide (card A = card B) as [F|F].
+    - left. apply card_equi; auto.
+    - right. apply card_le in D. lia.
+  Qed.
+
+End Cardinality.
+
+Instance card_equi_proper (X: eqType) : 
+  Proper (@equi X ==> eq) (@card X).
+Proof. 
+  hnf. apply card_eq.
+Qed.

--- a/theories/Shared/Libs/PSL/Lists/Dupfree.v
+++ b/theories/Shared/Libs/PSL/Lists/Dupfree.v
@@ -1,0 +1,168 @@
+From Undecidability.Shared.Libs.PSL Require Export BaseLists Filter Lists.Cardinality.
+
+(** *** Duplicate-free lists *)
+
+Inductive dupfree (X : Type) : list X -> Prop :=
+| dupfreeN : dupfree nil
+| dupfreeC x A : ~ x el A -> dupfree A -> dupfree (x::A).
+
+Section Dupfree.
+  Variable X : Type.
+  Implicit Types A B : list X.
+
+  Lemma dupfree_cons x A :
+    dupfree (x::A) <-> ~ x el A /\ dupfree A.
+  Proof. 
+    split; intros D.
+    - inv D; auto.
+    - apply dupfreeC; tauto.
+  Qed.
+
+  Lemma dupfree_app A B :
+    disjoint A B -> dupfree A -> dupfree B -> dupfree (A++B).
+  Proof.
+    intros D E F. induction E as [|x A E' E]; cbn.
+    - exact F.
+    - apply disjoint_cons in D as [D D'].
+      constructor; [|exact (IHE D')].
+      intros G. apply in_app_iff in G; tauto.
+  Qed.
+
+  Lemma dupfree_map Y A (f : X -> Y) :
+    (forall x y, x el A -> y el A -> f x = f y -> x=y) -> 
+    dupfree A -> dupfree (map f A).
+  Proof.
+    intros D E. induction E as [|x A E' E]; cbn.
+    - constructor.
+    - constructor; [|now auto].
+      intros F. apply in_map_iff in F as [y [F F']].
+      rewrite (D y x) in F'; auto.
+  Qed.
+
+  Lemma dupfree_filter p A :
+    dupfree A -> dupfree (filter p A).
+  Proof.
+    intros D. induction D as [|x A C D]; cbn.
+    - left.
+    - destruct (p x) eqn:E; [|exact IHD].
+      right; [|exact IHD].
+      rewrite in_filter_iff, E. intuition.
+  Qed.
+
+End Dupfree.
+
+Lemma dupfree_concat X (A: list (list X)):
+  dupfree A ->
+  (forall A1 A2, A1 el A -> A2 el A -> A1 <> A2 -> disjoint A1 A2)
+  -> (forall A1, A1 el A -> dupfree A1)
+  -> dupfree (concat A).
+Proof.
+  induction A as [|A0 A].
+  -constructor.
+  -intros H1 H2 H3.  inv H1. 
+   cbn. eapply dupfree_app.
+   +hnf. setoid_rewrite in_concat_iff.
+    intros (a0&?&A1&?&?).
+    eapply (H2 A0 A1);eauto. congruence.
+   +eauto.
+   +apply IHA. all:eauto.
+Qed.
+
+Section Undup.
+  Variable X : eqType.
+  Implicit Types A B : list X.
+
+  Lemma dupfree_dec A :
+    dec (dupfree A).
+  Proof.
+    induction A as [|x A].
+    - left. left.
+    - decide (x el A) as [E|E].
+      + right. intros F. inv F; tauto.
+      + destruct (IHA) as [F|F].
+        * unfold dec. auto using dupfree.
+        * right. intros G. inv G; tauto.
+  Qed.
+
+  Lemma dupfree_card A :
+    dupfree A -> card A = |A|.
+  Proof.
+    induction 1 as [|x A D _ IH]; cbn.
+    - reflexivity.
+    - decide (x el A) as [G|].
+      + exfalso; auto.
+      + lia.
+  Qed.
+
+  Fixpoint undup (A : list X) : list X :=
+    match A with
+      | nil => nil
+      | x::A' => if Dec (x el A') then undup A' else  x :: undup A'
+    end.
+
+  Lemma undup_id_equi A :
+    undup A === A.
+  Proof.
+    induction A as [|x A]; cbn.
+    - reflexivity.
+    - decide (x el A) as [E|E]; rewrite IHA; auto.
+  Qed.
+
+  Lemma dupfree_undup A :
+    dupfree (undup A).
+  Proof.
+    induction A as [|x A]; cbn.
+    - left.
+    - decide (x el A) as [E|E]; auto.
+      right; auto. now rewrite undup_id_equi. 
+  Qed.
+
+  Lemma undup_incl A B :
+    A <<= B <-> undup A <<= undup B.
+  Proof.
+    now rewrite !undup_id_equi.
+  Qed.
+
+  Lemma undup_equi A B :
+    A === B <-> undup A === undup B.
+  Proof.
+    now rewrite !undup_id_equi.
+  Qed.
+
+  Lemma undup_id A :
+    dupfree A -> undup A = A.
+  Proof.
+    intros E. induction E as [|x A E F]; cbn.
+    - reflexivity.
+    - rewrite IHF. decide (x el A) as [G|G]; tauto.
+  Qed.
+
+  Lemma undup_idempotent A :
+    undup (undup A) = undup A.
+
+  Proof. apply undup_id, dupfree_undup. Qed.
+  
+  Lemma dupfree_Nodup A :
+    dupfree A <-> NoDup A.
+  Proof.
+    induction A;split;intros H;inv H;repeat econstructor;tauto.
+  Qed.
+
+  Lemma not_dupfree (A:list X):
+    ~dupfree A -> 
+    exists a A1 A2 A3, A = A1++a::A2++a::A3.
+  Proof.
+    intros DF. induction A. now destruct DF;eauto using dupfree.
+    destruct (dupfree_dec A).
+    decide (a el A).
+    -edestruct in_split as (A2&A3&eqA). eassumption.
+     rewrite eqA.
+     exists a,[],A2,A3. reflexivity. 
+    -edestruct DF. eauto using dupfree.
+    -edestruct IHA as (a'&A1&A2&A3&->). eassumption.
+     exists a',(a::A1),A2,A3. reflexivity.
+  Qed.
+
+End Undup.
+
+

--- a/theories/Shared/Libs/PSL/Lists/Filter.v
+++ b/theories/Shared/Libs/PSL/Lists/Filter.v
@@ -1,0 +1,110 @@
+From Undecidability.Shared.Libs.PSL Require Import BaseLists.
+
+(** *** Filter *)
+
+Section Filter.
+  Variable X : Type.
+  Implicit Types (x y: X) (A B C: list X) (p q: X -> bool).
+  
+  (* Fixpoint filter p A : list X := *)
+  (*   match A with *)
+  (*   | nil => nil *)
+  (*   | x::A' => if p x then x :: filter p A' else filter p A' *)
+  (*   end. *)
+
+  Lemma in_filter_iff x p A :
+    x el filter p A <-> x el A /\ p x.
+  Proof. 
+    induction A as [|y A]; cbn.
+    - tauto.
+    - destruct (p y) eqn:E; cbn;
+        rewrite IHA; intuition; subst; auto.
+      destruct (p x); auto.
+  Qed.
+
+  Lemma filter_incl p A :
+    filter p A <<= A.  
+  Proof.
+    intros x D. apply in_filter_iff in D. apply D.
+  Qed.
+
+  Lemma filter_mono p A B :
+    A <<= B -> filter p A <<= filter p B.
+  Proof.
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_id p A :
+    (forall x, x el A -> p x) -> filter p A = A.
+  Proof.
+    intros D.
+    induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:E.
+      + f_equal; auto.
+      + exfalso. apply bool_Prop_false in E. auto.
+  Qed.
+
+  Lemma filter_app p A B :
+    filter p (A ++ B) = filter p A ++ filter p B.
+  Proof.
+    induction A as [|y A]; cbn.
+    - reflexivity.
+    - rewrite IHA. destruct (p y); reflexivity.  
+  Qed.
+
+  Lemma filter_fst p x A :
+    p x -> filter p (x::A) = x::filter p A.
+  Proof.
+    cbn. destruct (p x); auto.
+  Qed.
+
+  Lemma filter_fst' p x A :
+    ~ p x -> filter p (x::A) = filter p A.
+  Proof.
+    cbn. destruct (p x); auto.
+  Qed.
+
+  Lemma filter_pq_mono p q A :
+    (forall x, x el A -> p x -> q x) -> filter p A <<= filter q A.
+  Proof. 
+    intros D x E. apply in_filter_iff in E as [E E'].
+    apply in_filter_iff. auto.
+  Qed.
+
+  Lemma filter_pq_eq p q A :
+    (forall x, x el A -> p x = q x) -> filter p A = filter q A.
+  Proof. 
+    intros C; induction A as [|x A]; cbn.
+    - reflexivity.
+    - destruct (p x) eqn:D, (q x) eqn:E.
+      + f_equal. auto.
+      + exfalso. enough (p x = q x) by congruence. auto.
+      + exfalso. enough (p x = q x) by congruence. auto.
+      + auto.
+  Qed.
+
+  Lemma filter_and p q A :
+    filter p (filter q A) = filter (fun x => p x && q x) A.
+  Proof.
+    induction A as [|x A]; cbn. reflexivity.
+    destruct (p x) eqn:E, (q x); cbn;
+      try rewrite E; now rewrite IHA.
+  Qed.
+
+  Lemma filter_comm p q A :
+    filter p (filter q A) = filter q (filter p A).
+  Proof.
+    rewrite !filter_and. apply filter_pq_eq.
+    intros x _. now destruct (p x), (q x).
+  Qed.
+  
+End Filter.
+
+
+Lemma filter_map X Y p (f: X -> Y) A :
+  filter p (map f A) = map f (filter (fun x => p (f x)) A).
+  induction A;cbn. reflexivity. destruct _;cbn; congruence.
+Qed.
+  

--- a/theories/Shared/Libs/PSL/Lists/Position.v
+++ b/theories/Shared/Libs/PSL/Lists/Position.v
@@ -1,0 +1,145 @@
+From Undecidability.Shared.Libs.PSL Require Export BaseLists Dupfree.
+
+Definition elAt := nth_error.
+Notation "A '.[' i  ']'" := (elAt A i) (no associativity, at level 50).
+
+Section Fix_X.
+
+  Variable X : eqType.
+  
+  Fixpoint pos (s : X) (A : list X) :=
+    match A with
+    | nil => None
+    | a :: A => if Dec (s = a) then Some 0 else match pos s A with None => None | Some n => Some (S n) end
+    end.
+  
+  Lemma el_pos s A : s el A -> exists m, pos s A = Some m.
+  Proof.
+    revert s; induction A; simpl; intros s H.
+    - contradiction.
+    - decide (s = a) as [D | D]; eauto; 
+        destruct H; try congruence.
+      destruct (IHA s H) as [n Hn]; eexists; now rewrite Hn.
+  Qed.
+  
+  Lemma pos_elAt s A i : pos s A = Some i -> A .[i] = Some s.
+  Proof.
+    revert i s. induction A; intros i s.
+    - destruct i; inversion 1.
+    - simpl. decide (s = a).
+      + inversion 1; subst; reflexivity.
+      + destruct i; destruct (pos s A) eqn:B; inversion 1; subst; eauto. 
+  Qed.
+  
+  Lemma elAt_app (A : list X) i B s : A .[i] = Some s -> (A ++ B).[i] = Some s.
+  Proof.
+    revert s B i. induction A; intros s B i H; destruct i; simpl; intuition; inv H.
+  Qed.
+  
+  Lemma elAt_el  A (s : X) m : A .[ m ] = Some s -> s el A.
+  Proof.
+    revert A. induction m; intros []; inversion 1; eauto.
+  Qed.
+  
+  Lemma el_elAt (s : X) A : s el A -> exists m, A .[ m ] = Some s.
+  Proof.
+    intros H; destruct (el_pos H);  eexists; eauto using pos_elAt.
+  Qed.
+
+  Lemma dupfree_elAt (A : list X) n m s : dupfree A -> A.[n] = Some s -> A.[m] = Some s -> n = m.
+  Proof with try tauto.
+    intros H; revert n m; induction A; simpl; intros n m H1 H2.
+    - destruct n; inv H1.
+    - destruct n, m; inv H...
+      + inv H1. simpl in H2. eapply elAt_el in H2...
+      + inv H2. simpl in H1. eapply elAt_el in H1... 
+      + inv H1. inv H2. rewrite IHA with n m... 
+  Qed.
+
+  Lemma nth_error_none A n l : nth_error l n = @None A -> length l <= n.
+  Proof. revert n;
+           induction l; intros n.
+         - simpl; lia.
+         - simpl. intros. destruct n. inv H. inv H. assert (| l | <= n). eauto. lia.
+  Qed.
+
+  Lemma pos_None (x : X) l l' : pos x l = None-> pos x l' = None -> pos x (l ++ l') = None.
+  Proof.
+    revert x l'; induction l; simpl; intros; eauto.
+    have (x = a).
+    destruct (pos x l) eqn:E; try congruence.
+    rewrite IHl; eauto.
+  Qed.
+
+  Lemma pos_first_S (x : X)  l l' i  : pos x l = Some i -> pos x (l ++ l') = Some i.
+  Proof.
+    revert x i; induction l; intros; simpl in *.
+    - inv H.
+    - decide (x = a); eauto.
+      destruct (pos x l) eqn:E.
+      + eapply IHl in E. now rewrite E.
+      + inv H.
+  Qed.
+
+  Lemma pos_second_S x l l' i : pos x l = None ->
+                                pos x l' = Some i ->
+                                pos x (l ++ l') = Some ( i + |l| ).
+  Proof.
+    revert i l'; induction l; simpl; intros.
+    - rewrite plus_comm. eauto.
+    - destruct _; subst; try congruence.
+      destruct (pos x l) eqn:EE. congruence.
+      erewrite IHl; eauto.
+  Qed.
+
+  Lemma pos_length (e : X) n E : pos e E = Some n -> n < |E|.
+  Proof.
+    revert e n; induction E; simpl; intros.
+    - inv H.
+    - decide (e = a).
+      + inv H. simpl. lia.
+      + destruct (pos e E) eqn:EE.
+        * inv H. assert (n1 < |E|) by eauto.  lia.
+        * inv H.
+  Qed.
+
+  Fixpoint replace (xs : list X) (y y' : X) :=
+    match xs with
+    | nil => nil
+    | x :: xs' => (if Dec (x = y) then y' else x) :: replace xs' y y'
+    end.
+
+  Lemma replace_same xs x : replace xs x x = xs.
+  Proof.
+    revert x; induction xs; intros; simpl; [ | destruct _; subst ]; congruence.
+  Qed.
+
+  Lemma replace_diff xs x y : x <> y -> ~ x el replace xs x y.
+  Proof.
+    revert x y; induction xs; intros; simpl; try destruct _; firstorder. 
+  Qed.
+
+  Lemma replace_pos xs x y y' : x <> y -> x <> y' -> pos x xs = pos x (replace xs y y').
+  Proof.
+    induction xs; intros; simpl.
+    - reflexivity.
+    - repeat destruct Dec; try congruence; try lia; subst. 
+      + rewrite IHxs; eauto. + rewrite IHxs; eauto.
+  Qed.
+
+End Fix_X.
+
+Arguments replace {_} _ _ _.
+
+
+
+(* Fixpoint  getPosition {E: eqType} (A: list E) x := match A with *)
+(*                                                    | nil => 0 *)
+(*                                                    | cons x' A' => if Dec (x=x') then 0 else 1 + getPosition A' x end. *)
+
+(* Lemma getPosition_correct {E: eqType} (x:E) A: if Dec (x el A) then forall z, (nth (getPosition A x) A z) = x else getPosition A x = |A |. *)
+(* Proof. *)
+(*   induction A;cbn. *)
+(*   -dec;tauto. *)
+(*   -dec;intuition; congruence. *)
+(* Qed. *)

--- a/theories/Shared/Libs/PSL/Lists/Power.v
+++ b/theories/Shared/Libs/PSL/Lists/Power.v
@@ -1,0 +1,178 @@
+From Undecidability.Shared.Libs.PSL Require Import BaseLists Dupfree.
+
+(** *** Power lists *)
+
+Section Power.
+  Variable X : Type.
+
+  Fixpoint power (U: list X ) : list (list X) :=
+    match U with
+    | nil => [nil]
+    | x :: U' => power U' ++ map (cons x) (power U')
+    end.
+  
+  Lemma power_incl A U :
+    A el power U -> A <<= U.
+  Proof.
+    revert A; induction U as [|x U]; cbn; intros A D.
+    - destruct D as [[]|[]]; auto.
+    - apply in_app_iff in D as [E|E]. now auto.
+      apply in_map_iff in E as [A' [E F]]. subst A.
+      auto.
+  Qed.
+
+  Lemma power_nil U :
+    nil el power U.
+  Proof.
+    induction U; cbn; auto.
+  Qed.
+
+End Power.
+
+Section PowerRep.
+  Variable X : eqType.
+  Implicit Types A U : list X.
+
+  Definition rep (A U : list X) : list X :=
+    filter (fun x => Dec (x el A)) U.
+
+  Lemma rep_cons A x U :
+    x el A -> rep A (x::U) = x :: rep A U.
+  Proof.
+    intros H. apply filter_fst. auto.
+  Qed.
+
+  Lemma rep_cons' A x U :
+    ~ x el A -> rep A (x::U) = rep A U.
+  Proof.
+    intros H. apply filter_fst'. auto.
+  Qed.
+
+  Lemma rep_cons_eq x A U :
+    ~ x el U -> rep (x::A) U = rep A U.
+  Proof.
+    intros D. apply filter_pq_eq. intros y E.
+    apply Dec_reflect_eq. split.
+    - intros [<-|F]; tauto.
+    - auto.
+  Qed.
+
+  Lemma rep_power A U :
+    rep A U el power U.
+  Proof.
+    revert A; induction U as [|x U]; intros A.
+    - cbn; auto.
+    - decide (x el A) as [H|H].
+      + rewrite (rep_cons _ H). cbn. auto using in_map.
+      + rewrite (rep_cons' _ H). cbn. auto.
+  Qed.
+
+  Lemma rep_incl A U :
+    rep A U <<= A.
+  Proof.
+    intros x. unfold rep. rewrite in_filter_iff, Dec_reflect.
+    intuition.
+  Qed.
+
+  Lemma rep_in x A U :
+    A <<= U -> x el A -> x el rep A U.
+  Proof.
+    intros D E. apply in_filter_iff; auto.
+  Qed.
+
+  Lemma rep_equi A U :
+    A <<= U -> rep A U === A.
+  Proof.
+    intros D. split. now apply rep_incl.
+    intros x. apply rep_in, D.
+  Qed.
+
+  Lemma rep_mono A B U :
+    A <<= B -> rep A U <<= rep B U.
+  Proof.
+    intros D. apply filter_pq_mono.
+    intros E; rewrite !Dec_reflect; auto.
+  Qed.
+
+  Lemma rep_eq' A B U :
+    (forall x, x el U -> (x el A <-> x el B)) -> rep A U = rep B U.
+  Proof.
+    intros D. apply filter_pq_eq. intros x E.
+    apply Dec_reflect_eq. auto.
+  Qed.
+
+  Lemma rep_eq A B U :
+    A === B -> rep A U = rep B U.
+  Proof.
+    intros D. apply filter_pq_eq. intros x E.
+    apply Dec_reflect_eq. firstorder.
+  Qed.
+
+  Lemma rep_injective A B U :
+    A <<= U -> B <<= U -> rep A U = rep B U -> A === B.
+  Proof.
+    intros D E F. transitivity (rep A U). 
+    - symmetry. apply rep_equi, D.
+    - rewrite F. apply rep_equi, E.
+  Qed.
+
+  Lemma rep_idempotent A U :
+    rep (rep A U) U = rep A U.
+  Proof. 
+    unfold rep at 1 3. apply filter_pq_eq.
+    intros x D. apply Dec_reflect_eq. split.
+    + apply rep_incl.
+    + intros E. apply in_filter_iff. auto.
+  Qed.
+    
+  Lemma dupfree_power U :
+    dupfree U -> dupfree (power U).
+  Proof.
+    intros D. induction D as [|x U E D]; cbn.
+    - constructor. now auto. constructor.
+    - apply dupfree_app.
+      + intros [A [F G]]. apply in_map_iff in G as [A' [G G']].
+        subst A. apply E. apply (power_incl F). auto.
+      + exact IHD.
+      + apply dupfree_map; congruence.
+  Qed.
+
+  Lemma dupfree_in_power U A :
+    A el power U -> dupfree U -> dupfree A.
+  Proof.
+    intros E D. revert A E.
+    induction D as [|x U D D']; cbn; intros A E.
+    - destruct E as [[]|[]]. constructor.
+    - apply in_app_iff in E as [E|E].
+      + auto.
+      + apply in_map_iff in E as [A' [E E']]. subst A.
+        constructor.
+        * intros F; apply D. apply (power_incl E'), F.
+        * auto.
+  Qed.
+
+  Lemma rep_dupfree A U :
+    dupfree U -> A el power U -> rep A U = A.
+  Proof.
+    intros D; revert A. 
+    induction D as [|x U E F]; intros A G.
+    - destruct G as [[]|[]]; reflexivity.
+    - cbn in G. apply in_app_iff in G as [G|G]. 
+      + rewrite rep_cons'. now auto.
+        contradict E. apply (power_incl G), E.
+      + apply in_map_iff in G as [A' [<- H]].
+        specialize (IHF _ H).
+        rewrite rep_cons. 2:now auto.
+        rewrite rep_cons_eq. now rewrite IHF. exact E.
+   Qed.
+
+  Lemma power_extensional A B U :
+    dupfree U -> A el power U -> B el power U -> A === B -> A = B.
+  Proof.
+    intros D E F G. 
+    rewrite <- (rep_dupfree D E). rewrite <- (rep_dupfree D F).
+    apply rep_eq, G.
+  Qed.
+
+End PowerRep.
+

--- a/theories/Shared/Libs/PSL/Lists/Removal.v
+++ b/theories/Shared/Libs/PSL/Lists/Removal.v
@@ -1,0 +1,123 @@
+From Undecidability.Shared.Libs.PSL Require Export BaseLists Filter.
+
+(** *** Element removal *)
+
+Section Removal.
+  Variable X : eqType.
+  Implicit Types (x y: X) (A B: list X).
+
+  Definition rem A x : list X :=
+    filter (fun z => Dec (z <> x)) A.
+
+  Lemma in_rem_iff x A y :
+    x el rem A y <-> x el A /\ x <> y.
+  Proof.
+    unfold rem. rewrite in_filter_iff, Dec_reflect. tauto.
+  Qed.
+
+  Lemma rem_not_in x y A :
+    x = y \/ ~ x el A -> ~ x el rem A y.
+  Proof.
+    unfold rem. rewrite in_filter_iff, Dec_reflect. tauto.
+  Qed.
+
+  Lemma rem_incl A x :
+    rem A x <<= A.
+  Proof.
+    apply filter_incl.
+  Qed.
+
+  Lemma rem_mono A B x :
+    A <<= B -> rem A x <<= rem B x.
+  Proof.
+    apply filter_mono.
+  Qed.
+
+  Lemma rem_cons A B x :
+    A <<= B -> rem (x::A) x <<= B.
+  Proof.
+    intros E y F. apply E. apply in_rem_iff in F.
+    destruct F as [[|]]; congruence.
+  Qed.
+
+  Lemma rem_cons' A B x y :
+    x el B -> rem A y <<= B -> rem (x::A) y <<= B.
+  Proof.
+    intros E F u G. 
+    apply in_rem_iff in G as [[[]|G] H]. exact E.
+    apply F. apply in_rem_iff. auto.
+  Qed.
+
+  Lemma rem_in x y A :
+    x el rem A y -> x el A.
+  Proof.
+    apply rem_incl.
+  Qed.
+
+  Lemma rem_neq x y A :
+    x <> y -> x el A -> x el rem A y.
+  Proof.
+    intros E F. apply in_rem_iff. auto.
+  Qed.
+
+  Lemma rem_app x A B :
+    x el A -> B <<= A ++ rem B x.
+  Proof.
+    intros E y F. decide (x=y) as [[]|]; auto using rem_neq.
+  Qed.
+
+  Lemma rem_app' x A B C :
+    rem A x <<= C -> rem B x <<= C -> rem (A ++ B) x <<= C.
+  Proof.
+    unfold rem; rewrite filter_app; auto.
+  Qed.
+
+  Lemma rem_equi x A :
+    x::A === x::rem A x.
+  Proof.
+    split; intros y; 
+    intros [[]|E]; decide (x=y) as [[]|D]; 
+    eauto using rem_in, rem_neq. 
+  Qed.
+
+  Lemma rem_comm A x y :
+    rem (rem A x) y = rem (rem A y) x.
+  Proof.
+    apply filter_comm.
+  Qed.
+
+  Lemma rem_fst x A :
+    rem (x::A) x = rem A x.
+  Proof.
+    unfold rem. rewrite filter_fst'; auto.
+  Qed.
+
+  Lemma rem_fst' x y A :
+    x <> y -> rem (x::A) y = x::rem A y.
+  Proof.
+    intros E. unfold rem. rewrite filter_fst; auto.
+  Qed.
+
+  Lemma rem_id x A :
+    ~ x el A -> rem A x = A.
+  Proof.
+    intros D. apply filter_id. intros y E.
+    apply Dec_reflect. congruence.
+  Qed.
+
+  Lemma rem_reorder x A :
+    x el A -> A === x :: rem A x.
+  Proof.
+    intros D. rewrite <- rem_equi. apply equi_push, D.
+  Qed.
+
+  Lemma rem_inclr A B x :
+    A <<= B -> ~ x el A -> A <<= rem B x.
+  Proof.
+    intros D E y F. apply in_rem_iff.
+    intuition; subst; auto. 
+  Qed.
+
+End Removal.
+
+Hint Resolve rem_not_in rem_incl rem_mono rem_cons rem_cons' rem_app rem_app' rem_in rem_neq rem_inclr : core.

--- a/theories/Shared/Libs/PSL/Numbers.v
+++ b/theories/Shared/Libs/PSL/Numbers.v
@@ -1,0 +1,74 @@
+From Undecidability.Shared.Libs.PSL Require Import Prelim.
+From Undecidability.Shared.Libs.PSL Require Import EqDec.
+
+(** ** Numbers **)
+
+Lemma complete_induction (p : nat -> Prop) (x : nat) :
+(forall x, (forall y, y<x -> p y) -> p x) -> p x.
+
+Proof. intros A. apply A. induction x ; intros y B.
+exfalso ; lia.
+apply A. intros z C. apply IHx. lia. Qed.
+
+Lemma size_induction X (f : X -> nat) (p : X -> Prop) :
+  (forall x, (forall y, f y < f x -> p y) -> p x) -> 
+  forall x, p x.
+
+Proof. 
+  intros IH x. apply IH. 
+  assert (G: forall n y, f y < n -> p y).
+  { intros n. induction n.
+    - intros y B. exfalso. lia.
+    - intros y B. apply IH. intros z C. apply IHn. lia. }
+  apply G.
+Qed.
+
+Instance nat_le_dec (x y : nat) : dec (x <= y) := 
+  le_dec x y.
+
+Lemma size_recursion (X : Type) (sigma : X -> nat) (p : X -> Type) :
+  (forall x, (forall y, sigma y < sigma x -> p y) -> p x) -> 
+  forall x, p x.
+Proof.
+  intros D x. apply D. revert x.
+  enough (forall n y, sigma y < n -> p y) by eauto.
+  intros n. induction n; intros y E. 
+  - exfalso; lia.
+  - apply D. intros x F.  apply IHn. lia.
+Qed.
+
+Arguments size_recursion {X} sigma {p} _ _.
+
+Section Iteration.
+  Variables (X: Type) (f: X -> X).
+
+  Fixpoint it (n : nat) (x : X) : X := 
+    match n with
+      | 0 => x
+      | S n' => f (it n' x)
+    end.
+
+  Lemma it_ind (p : X -> Prop) x n :
+    p x -> (forall z, p z -> p (f z)) -> p (it n x).
+  Proof.
+    intros A B. induction n; cbn; auto.
+  Qed.
+
+  Definition FP (x : X) : Prop := f x = x.
+
+  Lemma it_fp (sigma : X -> nat) x :
+    (forall n, FP (it n x) \/ sigma (it n x) > sigma (it (S n) x)) ->
+    FP (it (sigma x) x).
+  Proof.
+    intros A.
+    assert (B: forall n, FP (it n x) \/ sigma x >= n + sigma (it n x)).
+    { intros n; induction n; cbn.
+      - auto. 
+      - destruct IHn as [B|B].
+        + left. now rewrite B. 
+        + destruct (A n) as [C|C].
+          * left. now rewrite C. 
+          * right. cbn in C. lia. }
+    destruct (A (sigma x)), (B (sigma x)); auto; exfalso; lia.
+  Qed.
+End Iteration.

--- a/theories/Shared/Libs/PSL/Prelim.v
+++ b/theories/Shared/Libs/PSL/Prelim.v
@@ -1,0 +1,95 @@
+(** * Base Library for ICL
+
+   - Version: 3 October 2016
+   - Author: Gert Smolka, Saarland University
+   - Acknowlegments: Sigurd Schneider, Dominik Kirst, Yannick Forster, Fabian Kunze, Maximilian Wuttke
+ *)
+
+Require Export Bool Omega Lia List Setoid Morphisms.
+From Undecidability.Shared.Libs.PSL Require Export Tactics.
+
+Global Set Implicit Arguments. 
+Global Unset Strict Implicit.
+Global Unset Printing Records.
+Global Unset Printing Implicit Defensive.
+Global Set Regular Subst Tactic.
+
+Hint Extern 4 => exact _ : core.  (* makes auto use type class inference *)
+
+(** De Morgan laws *)
+
+Lemma DM_or (X Y : Prop) :
+  ~ (X \/ Y) <-> ~ X /\ ~ Y.
+Proof.
+  tauto.
+Qed.
+
+Lemma DM_exists X (p : X -> Prop) :
+  ~ (exists x, p x) <-> forall x, ~ p x.
+Proof.
+  firstorder.
+Qed.
+
+(** ** Boolean propositions and decisions *)
+
+Coercion is_true : bool >-> Sortclass.
+
+Lemma bool_Prop_true b :
+  b = true -> b.
+Proof.
+  intros A. rewrite A. reflexivity.
+Qed.
+
+Lemma bool_Prop_false b :
+  b = false -> ~ b.
+Proof.
+  intros A. rewrite A. cbn. intros H. congruence.
+Qed.
+
+Lemma bool_Prop_true' (b : bool) :
+  b -> b = true.
+Proof.
+  intros A. cbv in A. destruct b; tauto.
+Qed.
+
+Lemma bool_Prop_false' (b : bool) :
+  ~ b -> b = false.
+Proof.
+  intros A. cbv in A. destruct b; tauto.
+Qed.
+
+
+Hint Resolve bool_Prop_true bool_Prop_false : core.
+Hint Resolve bool_Prop_true' bool_Prop_false' : core.
+
+
+Definition bool2nat := fun b : bool => if b then 1 else 0.
+Definition nat2bool := fun n : nat => match n with 0 => false | _ => true end.
+(* Coercion nat2bool : nat >-> bool. *)
+Lemma bool_nat (b : bool) :
+  1 = bool2nat b -> b.
+Proof. intros; cbv in *. destruct b. auto. congruence. Qed.
+Lemma nat_bool (b : bool) :
+  b = nat2bool 1 -> b.
+Proof. intros; cbv in *. destruct b. auto. congruence. Qed.
+Hint Resolve bool_nat nat_bool : core.
+
+Ltac simpl_coerce :=
+  match goal with
+  | [ H: False |- _ ] => destruct H
+  | [ H: ~ is_true true |- _ ] => destruct H; congruence
+  | [ H: is_true false |- _ ] => congruence
+  end.
+
+
+Ltac simpl_congruence :=
+  match goal with
+  | [ H : 0 = S _ |- _] => congruence
+  | [ H : S _ = 0 |- _] => congruence
+  | [ H : S _ = 0 |- _] => congruence
+  | [ H : true = false |- _] => congruence
+  | [ H : false = true |- _] => congruence
+  end.
+
+Hint Extern 1 => simpl_coerce : core.
+Hint Extern 1 => simpl_congruence : core.

--- a/theories/Shared/Libs/PSL/Retracts.v
+++ b/theories/Shared/Libs/PSL/Retracts.v
@@ -1,0 +1,400 @@
+(** * Library for retracts  *)
+
+(* Author: Maximilian Wuttke *)
+
+From Undecidability.Shared.Libs.PSL Require Import Base.
+
+
+(*
+ * A retraction between types [A] and [B] is a tuple of two functions,
+ * [f : A -> B] (called the injection function) and [g : B -> option A] (called the retract function),
+ * such that the following triangle shaped diagram commutes:
+ *
+ *          f
+ *      A -----> B
+ *      |      /
+ * Some |     / g
+ *      |    /
+ *     \|/ |/_
+ *    option A
+ *
+ * That informally means, that the injective function [f] can be reverted by the retract function [g].
+ * Foramlly, for all values [x:A] and [y = f x], then [g y = Some x].  (Or: [forall x, g (f x) = Some x].)
+ *
+ * The retracts should also be "tight", which means that the retract function only reverts values in
+ * the image of [f]. Foramlly this means that whenever [g y = Some x], then also [y = f x]
+ *
+ * Altogether, we have that [forall x y, g y = Some x <-> y = f x].
+ *)
+
+
+Section Retract.
+
+  Variable X Y : Type.
+
+  Definition retract (f : X -> Y) (g : Y -> option X) := forall x y, g y = Some x <-> y = f x.
+
+  Class Retract :=
+    {
+      Retr_f : X -> Y;
+      Retr_g : Y -> option X;
+      Retr_retr : retract Retr_f Retr_g;
+    }.
+
+End Retract.
+
+Arguments Retr_f { _ _ _ }.
+Arguments Retr_g { _ _ _ }.
+
+Section Retract_Properties.
+
+  Variable X Y : Type.
+
+  Hypothesis I : Retract X Y.
+
+  Definition retract_g_adjoint : forall x, Retr_g (Retr_f x) = Some x.
+  Proof. intros. pose proof @Retr_retr _ _ I. hnf in H. now rewrite H. Qed.
+
+  Definition retract_g_inv : forall x y, Retr_g y = Some x -> y = Retr_f x.
+  Proof. intros. now apply Retr_retr. Qed.
+
+  Lemma retract_g_surjective : forall x, { y | Retr_g y = Some x }.
+  Proof. intros x. pose proof retract_g_adjoint x. cbn in H. eauto. Defined.
+
+  Lemma retract_f_injective : forall x1 x2, Retr_f x1 = Retr_f x2 -> x1 = x2.
+  Proof.
+    intros x1 x2 H.
+    enough (Some x1 = Some x2) by congruence.
+    erewrite <- !retract_g_adjoint.
+    now rewrite H.
+  Qed.
+
+  Lemma retract_g_Some x y :
+    Retr_g (Retr_f x) = Some y ->
+    x = y.
+  Proof. now intros H % retract_g_inv % retract_f_injective. Qed.
+
+  Lemma retract_g_None b :
+    Retr_g b = None ->
+    forall a, Retr_f a <> b.
+  Proof.
+    intros H a <-.
+    enough (Retr_g (Retr_f a) = Some a) by congruence.
+    apply retract_g_adjoint.
+  Qed.
+
+
+End Retract_Properties.
+
+
+(* This tactic replaces all occurrences of [g (f x)] with [Some x] for retracts. *)
+Ltac retract_adjoint :=
+  match goal with
+  | [ H : context [ Retr_g (Retr_f _) ] |- _ ] => rewrite retract_g_adjoint in H
+  | [   |- context [ Retr_g (Retr_f _) ]     ] => rewrite retract_g_adjoint
+  end.
+
+
+
+(*
+ * We can compose retractions, as shown in the following commuting diagram
+ *
+ *            f1        f2
+ *      A --------> B --------> C
+ *      |         / |         /
+ *      |        /  |Some    /
+ *      |       /   |       /
+ *      |      /    |      /
+ * Some |     / g1  |     / g2
+ *      |    /      |    /
+ *     \|/ |/_     \|/ |/_
+ *    option A <--- option B
+ *            map g1
+ *
+ *
+ * Where [map g1] is the function that takes an option [x : option B] and applys [Some] and [g1] if it is [Some],
+ * and else returns [None].
+ *
+ * Now [f2 ∘ f1] and [map g1 ∘ g2] gives a retract between [A] and [C].
+ *)
+
+Section ComposeRetracts.
+  Variable A B C : Type.
+
+  Definition retr_comp_f (f1 : B -> C) (f2 : A -> B) : A -> C := fun a => f1 (f2 a).
+  Definition retr_comp_g (g1 : C -> option B) (g2 : B -> option A) : C -> option A :=
+    fun c => match g1 c with
+          | Some b => g2 b
+          | None => None
+          end.
+
+  (* No instance (outside of this section), for obvious reasons... *)
+  Program Instance ComposeRetract (retr1 : Retract B C) (retr2 : Retract A B) : Retract A C :=
+    {|
+      Retr_f := retr_comp_f Retr_f Retr_f;
+      Retr_g := retr_comp_g Retr_g Retr_g;
+    |}.
+  Next Obligation.
+    abstract now
+      unfold retr_comp_f, retr_comp_g; intros a c; split;
+      [intros H; destruct (Retr_g c) as [ | ] eqn:E;
+       [ apply retract_g_inv in E as ->; now apply retract_g_inv in H as ->
+       | congruence
+       ]
+      | intros ->; now do 2 retract_adjoint
+      ].
+  Defined.
+
+End ComposeRetracts.
+
+
+(** We define some useful retracts. *)
+Section Usefull_Retracts.
+
+  Variable (A B C D : Type).
+
+
+  (** Identity retract *)
+  Global Program Instance Retract_id : Retract A A :=
+    {|
+      Retr_f a := a;
+      Retr_g b := Some b;
+    |}.
+  Next Obligation. abstract now hnf; firstorder congruence. Defined.
+
+
+  (** Empty retract *)
+  Global Program Instance Retract_Empty : Retract Empty_set A :=
+    {|
+      Retr_f e := @Empty_set_rect (fun _ => A) e;
+      Retr_g b := None;
+    |}.
+  Next Obligation. abstract now intros x; elim x. Defined.
+
+  (** Eliminate the [Empty_set] from the source sum type *)
+  Global Program Instance Retract_Empty_left `{retr: Retract A B} : Retract (A + Empty_set) B :=
+    {|
+      Retr_f a := match a with
+                  | inl a => Retr_f a
+                  | inr e => @Empty_set_rect (fun _ => B) e
+                  end;
+      Retr_g b := match Retr_g b with
+                  | Some a => Some (inl a)
+                  | None => None
+                  end;
+    |}.
+  Next Obligation.
+    abstract now intros [ a | [] ] b; split;
+      [ intros H; destruct (Retr_g b) eqn:E; inv H; now apply retract_g_inv in E
+      | intros ->; now retract_adjoint
+      ].
+  Defined.
+
+  Global Program Instance Retract_Empty_right `{retr: Retract A B} : Retract (Empty_set + A) B :=
+    {|
+      Retr_f a := match a with
+                  | inl e => @Empty_set_rect (fun _ => B) e
+                  | inr a => Retr_f a
+                  end;
+      Retr_g b := match Retr_g b with
+                  | Some a => Some (inr a)
+                  | None => None
+                  end;
+    |}.
+  Next Obligation.
+    abstract now intros [ [] | a ] b; split;
+      [ intros H; destruct (Retr_g b) eqn:E; inv H; now apply retract_g_inv in E
+      | intros ->; now retract_adjoint
+      ].
+  Defined.
+
+
+  (** We can introduce an additional [Some] and use the identity as the retract function *)
+  Global Program Instance Retract_option `{retr: Retract A B} : Retract A (option B) :=
+    {|
+      Retr_f a := Some (Retr_f a);
+      Retr_g ob := match ob with
+                    | Some b => Retr_g b
+                    | None => None
+                    end;
+    |}.
+  Next Obligation.
+    abstract now
+      split;
+      [ intros H; destruct y as [b|];
+        [ now apply retract_g_inv in H as ->
+        | inv H
+        ]
+      | intros ->; now retract_adjoint
+      ].
+  Defined.
+
+  (** We can introduce an additional [inl] *)
+
+  Definition retract_inl_f (f : A -> B) : A -> (B + C) := fun a => inl (f a).
+  Definition retract_inl_g (g : B -> option A) : B+C -> option A :=
+    fun x => match x with
+          | inl b => g b
+          | inr c => None
+          end.
+
+  Global Program Instance Retract_inl (retrAB : Retract A B) : Retract A (B + C) :=
+    {|
+      Retr_f := retract_inl_f Retr_f;
+      Retr_g := retract_inl_g Retr_g;
+    |}.
+  Next Obligation.
+    abstract now
+      unfold retract_inl_f, retract_inl_g; hnf; intros x y; split;
+      [ destruct y as [a|b]; [ now intros -> % retract_g_inv | congruence ]
+      | intros ->; now retract_adjoint
+      ].
+  Defined.
+
+
+  (** The same for [inr] *)
+
+  Definition retract_inr_f (f : A -> B) : A -> (C + B) := fun a => inr (f a).
+  Definition retract_inr_g (g : B -> option A) : C+B -> option A :=
+    fun x => match x with
+          | inr b => g b
+          | inl c => None
+          end.
+
+  Global Program Instance Retract_inr (retrAB : Retract A B) : Retract A (C + B) :=
+    {|
+      Retr_f := retract_inr_f Retr_f;
+      Retr_g := retract_inr_g Retr_g;
+    |}.
+  Next Obligation.
+    abstract now
+      unfold retract_inr_f, retract_inr_g; hnf; intros x y; split;
+      [ destruct y as [a|b]; [ congruence | now intros -> % retract_g_inv ]
+      | intros ->; now retract_adjoint
+      ].
+  Defined.
+
+
+
+  (** We can map retracts over sums, similiary as we have done with inversions *)
+
+  Section Retract_sum.
+
+    Definition retract_sum_f (f1: A -> C) (f2: B -> D) : A+B -> C+D :=
+      fun x => match x with
+            | inl a => inl (f1 a)
+            | inr b => inr (f2 b)
+            end.
+
+    Definition retract_sum_g (g1: C -> option A) (g2: D -> option B) : C+D -> option (A+B) :=
+      fun y => match y with
+            | inl c => match g1 c with
+                      | Some a => Some (inl a)
+                      | None => None
+                      end
+            | inr d => match g2 d with
+                      | Some b => Some (inr b)
+                      | None => None
+                      end
+            end.
+
+    Local Program Instance Retract_sum (retr1 : Retract A C) (retr2 : Retract B D) : Retract (A+B) (C+D) :=
+      {|
+        Retr_f := retract_sum_f Retr_f Retr_f;
+        Retr_g := retract_sum_g Retr_g Retr_g;
+      |}.
+    Next Obligation.
+      abstract now
+        unfold retract_sum_f, retract_sum_g; intros x y; split;
+        [ intros H; destruct y as [c|d];
+          [ destruct (Retr_g c) eqn:E1; inv H; f_equal; now apply retract_g_inv
+          | destruct (Retr_g d) eqn:E1; inv H; f_equal; now apply retract_g_inv
+          ]
+        | intros ->; destruct x as [a|b]; now retract_adjoint
+        ].
+    Defined.
+
+  End Retract_sum.
+
+End Usefull_Retracts.
+
+
+
+(* If we have a retract from [A] to [Z] and a retract from [B] to Z, in general it is not possible
+ * to build a retract from [A+B] to [Z]. For example, there can be no retract from [unit+unit] to
+ * [unit]. However, it is possible when the images of the injections are distint.
+ *)
+Section Join.
+
+  Variable A B Z : Type.
+
+  Variable retr1 : Retract A Z.
+  Variable retr2 : Retract B Z.
+
+  Local Arguments Retr_f {_ _} (Retract).
+  Local Arguments Retr_g {_ _} (Retract).
+
+  Definition retract_join_f s :=
+    match s with
+    | inl a => Retr_f retr1 a
+    | inr b => Retr_f retr2 b
+    end.
+
+  Definition retract_join_g z :=
+    match Retr_g retr1 z with
+    | Some a => Some (inl a)
+    | None =>
+      match Retr_g retr2 z with
+      | Some b => Some (inr b)
+      | None => None
+      end
+    end.
+
+  Hypothesis disjoint : forall (a : A) (b : B), Retr_f _ a <> Retr_f _ b.
+
+  Lemma retract_join : retract retract_join_f retract_join_g.
+  Proof.
+    unfold retract_join_f, retract_join_g. hnf; intros s z; split.
+    - destruct s as [a|b]; intros H.
+      + destruct (Retr_g retr1 z) eqn:E.
+        * inv H. now apply retract_g_inv in E.
+        * destruct (Retr_g retr2 z) eqn:E2; inv H.
+      + destruct (Retr_g retr1 z) eqn:E.
+        * inv H.
+        * destruct (Retr_g retr2 z) eqn:E2.
+          -- inv H. now apply retract_g_inv in E2.
+          -- inv H.
+    - intros ->. destruct s as [a|b]; retract_adjoint. reflexivity.
+      destruct (Retr_g retr1 (Retr_f retr2 b)) eqn:E.
+      + exfalso. apply retract_g_inv in E. symmetry in E. now apply disjoint in E.
+      + reflexivity.
+  Qed.
+
+  Local Instance Retract_join : Retract (A+B) Z := Build_Retract retract_join.
+
+End Join.
+
+
+
+
+
+(** More instances like [Retract_sum] for bigger sums. *)
+
+Section MoreSums.
+
+  Local Instance Retract_sum3 (A A' B B' C C' : Type) (retr1 : Retract A A') (retr2 : Retract B B') (retr3 : Retract C C') :
+    Retract (A+B+C) (A'+B'+C') := Retract_sum (Retract_sum retr1 retr2) retr3.
+
+  Local Instance Retract_sum4 (A A' B B' C C' D D' : Type) (retr1 : Retract A A') (retr2 : Retract B B') (retr3 : Retract C C') (retr4 : Retract D D') :
+    Retract (A+B+C+D) (A'+B'+C'+D') := Retract_sum (Retract_sum (Retract_sum retr1 retr2) retr3) retr4.
+
+  Local Instance Retract_sum5 (A A' B B' C C' D D' E E' : Type) (retr1 : Retract A A') (retr2 : Retract B B') (retr3 : Retract C C') (retr4 : Retract D D') (retr5 : Retract E E') :
+    Retract (A+B+C+D+E) (A'+B'+C'+D'+E') := Retract_sum (Retract_sum (Retract_sum (Retract_sum retr1 retr2) retr3) retr4) retr5.
+
+  Local Instance Retract_sum6 (A A' B B' C C' D D' E E' F F' : Type) (retr1 : Retract A A') (retr2 : Retract B B') (retr3 : Retract C C') (retr4 : Retract D D') (retr5 : Retract E E') (retr6 : Retract F F') :
+    Retract (A+B+C+D+E+F) (A'+B'+C'+D'+E'+F') := Retract_sum (Retract_sum (Retract_sum (Retract_sum (Retract_sum retr1 retr2) retr3) retr4) retr5) retr6.
+
+  Local Instance Retract_sum7 (A A' B B' C C' D D' E E' F F' G G' : Type) (retr1 : Retract A A') (retr2 : Retract B B') (retr3 : Retract C C') (retr4 : Retract D D') (retr5 : Retract E E') (retr6 : Retract F F') (retr7 : Retract G G') :
+    Retract (A+B+C+D+E+F+G) (A'+B'+C'+D'+E'+F'+G') := Retract_sum (Retract_sum (Retract_sum (Retract_sum (Retract_sum (Retract_sum retr1 retr2) retr3) retr4) retr5) retr6) retr7.
+
+End MoreSums.

--- a/theories/Shared/Libs/PSL/Tactics/AutoIndTac.v
+++ b/theories/Shared/Libs/PSL/Tactics/AutoIndTac.v
@@ -1,0 +1,122 @@
+
+
+(* Mostly taken form https://github.com/sigurdschneider/lvc/blob/23b7fa8cd0640503ff370144fb407192632f9cc6/Infra/AutoIndTac.v *)
+
+(* fail 1 will break from the 'match H with', and indicate to
+   the outer match that it should consider finding another 
+   hypothesis, see documentation on match goal and fail
+   This tactic is a variation of Tobias Tebbi's revert_except_until *)
+
+Ltac revert_all :=
+  repeat match goal with [ H : _ |- _ ] => revert H end.
+
+Tactic Notation "revert" "all" := revert_all.
+
+Ltac revert_except i :=
+  repeat match goal with [ H : _ |- _ ] => tryif unify H i then fail else revert H end.
+                         
+Tactic Notation "revert" "all" "except" ident(i) := revert_except i.
+
+Ltac clear_except i :=
+  repeat match goal with [ H : _ |- _ ] => tryif unify H i then fail else clear H end.
+                         
+Tactic Notation "clear" "all" "except" ident(i) := clear_except i.
+
+Ltac clear_all :=
+  repeat match goal with
+           [H : _ |- _] =>  clear H
+         end.
+
+
+(*
+(* succeed if H has a function type, fail otherwise *)
+Ltac is_ftype H := 
+  let t := type of H in
+    let t' := eval cbv in t in
+      match t' with
+        | _ -> _ => idtac
+      end.
+*)
+(* match on the type of E and remember each of it's arguments
+   that is not a variable by calling tac.
+   tac needs to do a remember exactly if x is not a var, and 
+   fail otherwise. (We need to fail, otherwise the repeat will
+   stop prematurely) 
+   try will silently ignore a fail 0, but will fail if a fail 1 or 
+   above occurs. Sequentialization makes sure fail 1 is executed 
+   if is_var is successful, hence try (is_var x; fail 1) will
+   fail exactly when x is a var. *)
+
+Ltac remember_arguments E :=
+  let tac x := (try (is_var x; fail 1); (*try (is_ftype x; fail 1);*) remember (x)) in
+  repeat (match type of E with
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ _ => tac x
+    | ?t ?x _ _ _ _ => tac x
+    | ?t ?x _ _ _ => tac x
+    | ?t ?x _ _ => tac x
+    | ?t ?x _ => tac x
+    | ?t ?x => tac x
+  end).
+
+(* from Coq.Program.Tactics *)
+Ltac clear_dup :=
+  match goal with
+    | [ H : ?X |- _ ] =>
+      match goal with
+        | [ H' : ?Y |- _ ] =>
+          match H with
+            | H' => fail 2
+            | _ => unify X Y ; (clear H' || clear H)
+          end
+      end
+  end.
+
+Ltac inv_eqs :=
+  repeat (match goal with
+              | [ H : @eq _ ?x ?x |- _ ] => fail (* nothing to do on x = x *)
+              | [ H : @eq _ ?x ?y |- _ ] => progress (inversion H; subst; try clear_dup)
+            end).
+
+(* this is a standard tactic *)
+Ltac clear_trivial_eqs :=
+  repeat (progress (match goal with
+              | [ H : @eq _ ?x ?x |- _ ] => clear H
+            end)).
+
+Tactic Notation "general" "induction" hyp(H) :=
+  remember_arguments H; revert_except H; 
+  induction H; intros; (try inv_eqs); (try clear_trivial_eqs).
+
+(* Module Test. *)
+(* Require Import List. *)
+
+(* Inductive decreasing : list nat -> Prop := *)
+(*   | base : decreasing nil *)
+(*   | step m n L : decreasing (n::L) -> n <= m -> decreasing (m :: n :: L). *)
+
+(* Lemma all_zero_by_hand L *)
+(*   : decreasing (0::L) -> forall x, In x L -> x = 0. *)
+(* Proof. *)
+(*   intros. remember (0::L). *)
+(*   revert dependent L. revert x. induction H; intros. *)
+(*   inversion Heql. *)
+(*   inversion Heql. subst. inversion H0; subst; firstorder. *)
+(* Qed. *)
+
+(* Lemma all_zero L *)
+(*   : decreasing (0::L) -> forall x, In x L -> x = 0. *)
+(* Proof. *)
+(*   intros. general induction H.  *)
+(*   inversion H0; subst; firstorder. *)
+(* Qed. *)
+(* End Test. *)

--- a/theories/Shared/Libs/PSL/Tactics/Tactics.v
+++ b/theories/Shared/Libs/PSL/Tactics/Tactics.v
@@ -1,0 +1,153 @@
+(** ** Inversion *)
+
+Ltac inv H := inversion H; subst; try clear H.
+
+
+(** ** Destructing *)
+
+Tactic Notation "destruct" "_":=
+  match goal with
+  | [ |- context[match ?X with _ => _ end] ] => destruct X
+  | [ H : context[match ?X with _ => _ end] |- _ ] => destruct X 
+  end.
+
+Tactic Notation "destruct" "_" "eqn" ":" ident(E)   :=
+  match goal with
+  | [ |- context[match ?X with _ => _ end] ] => destruct X eqn:E
+  | [ H : context[match ?X with _ => _ end] |- _ ] => destruct X eqn:E
+  end.
+
+Tactic Notation "destruct" "*" :=
+  repeat destruct _.
+
+Tactic Notation "destruct" "*" "eqn" ":" ident(E) :=
+  repeat (let E := fresh E in destruct _ eqn:E; try progress inv E); try now congruence.
+
+Tactic Notation "destruct" "*" "eqn" ":" "_" := destruct * eqn:E.
+
+Tactic Notation "intros" "***" := repeat (intros ?).
+
+Ltac fstep N := unfold N; fold N.
+
+(* From Program.Tactics *)
+Ltac destruct_one_pair :=
+ match goal with
+   | [H : (_ /\ _) |- _] => destruct H
+   | [H : prod _ _ |- _] => destruct H
+ end.
+
+Ltac destruct_pairs := repeat (destruct_one_pair).
+
+
+
+(** ** Assumption Locking *)
+
+
+(** [lock H] "locks" the goal [H], which syntactically adds [Lock], but it doesn't change the proof script. *)
+
+Definition Lock (X: Type) : Type := X.
+Global Opaque Lock. Arguments Lock : simpl never.
+
+Tactic Notation "lock" ident(H) :=
+  lazymatch type of H with
+  | ?X => change (Lock X) in H
+  end.
+
+Tactic Notation "unlock" ident(H) :=
+  lazymatch type of H with
+  | Lock ?X => change X in H
+  end.
+
+Tactic Notation "unlock" "all" :=
+  repeat multimatch goal with
+         | [ H : Lock ?X |- _ ] => change X in H
+         end.
+
+Tactic Notation "is_locked" ident(H) :=
+  lazymatch type of H with
+  | Lock _ => idtac
+  | _ => fail "unlocked"
+  end.
+
+Tactic Notation "is_unlocked" ident(H) :=
+  lazymatch type of H with
+  | Lock _  => fail "locked"
+  | _ => idtac
+  end.
+
+
+(*
+Goal True.
+  do 2 pose proof I.
+  lock H.
+  lock H0.
+  unlock H0.
+  do 2 pose proof I.
+  lock H0; lock H1.
+  unlock all.
+
+  is_unlocked H.
+  Fail is_locked H.
+
+  lock H.
+  is_locked H.
+  Fail is_unlocked H.
+
+  Show Proof. (* Locking and unlocking is not represented in the proof term. *)
+Abort.
+*)
+
+
+
+(** ** Modus ponens *)
+
+
+(* Prove the non-dependent hypothesis of a hypothesis that is a implication and specialize it *)
+Tactic Notation "spec_assert" hyp(H) :=
+  let H' := fresh in
+  match type of H with
+  | ?A -> _ =>
+    assert A as H'; [ | specialize (H H'); clear H']
+  end.
+
+Tactic Notation "spec_assert" hyp(H) "as" simple_intropattern(p) :=
+  let H' := fresh in
+  match type of H with
+  | ?A -> _ =>
+    assert A as H'; [ | specialize (H H') as p; clear H']
+  end.
+
+Tactic Notation "spec_assert" hyp(H) "by" tactic(T) :=
+  let H' := fresh in
+  match type of H with
+  | ?A -> _ =>
+    assert A as H' by T; specialize (H H'); clear H'
+  end.
+
+
+Tactic Notation "spec_assert" hyp(H) "as" simple_intropattern(p) "by" tactic(T) :=
+  let H' := fresh in
+  match type of H with
+  | ?A -> _ =>
+    assert A as H' by T; specialize (H H') as p; clear H'
+  end.
+
+
+
+(** ** Some debug tactics *)
+
+Ltac print_goal :=
+  match goal with
+  | [ |- ?H ] => idtac H
+  end.
+
+Ltac print_goal_cbn :=
+  match goal with
+  | [ |- ?H ] =>
+    let H' := eval cbn in H in idtac H'
+  end.
+
+Ltac print_type e := first [ let x := type of e in idtac x | idtac "Untyped:" e ].
+
+
+From Undecidability.Shared.Libs.PSL Require Export AutoIndTac.

--- a/theories/Shared/Libs/PSL/Vectors/Fin.v
+++ b/theories/Shared/Libs/PSL/Vectors/Fin.v
@@ -1,0 +1,50 @@
+(** * Tactics for [Fin.t] *)
+
+(* Author: Maximilian Wuttke *)
+
+
+From Undecidability.Shared.Libs.PSL Require Import Base.
+Require Import Coq.Vectors.Fin.
+
+
+Lemma fin_destruct_S (n : nat) (i : Fin.t (S n)) :
+  { i' | i = Fin.FS i' } + { i = Fin.F1 }.
+Proof.
+  refine (match i in (Fin.t n')
+          with
+          | Fin.F1 => _
+          | Fin.FS i' => _
+          end); eauto.
+  (*
+  refine (match i as i0 in (Fin.t n') return
+                match n' with
+                | O => fun _ : Fin.t 0 => unit
+                | S n'' => fun i0 : Fin.t (S n'') => { i' | i0 = Fin.FS i' } + { i0 = Fin0}
+                end i0
+          with
+          | Fin.F1 => _
+          | Fin.FS i' => _
+          end); eauto.
+   *)
+Defined.
+
+Lemma fin_destruct_O (i : Fin.t 0) : Empty_set.
+Proof. refine (match i with end). Defined.
+
+Ltac destruct_fin i :=
+  match type of i with
+  | Fin.t (S ?n) =>
+    let i' := fresh i in
+    pose proof fin_destruct_S i as [ (i'&->) | -> ];
+    [ destruct_fin i'
+    | idtac]
+  | Fin.t O =>
+    pose proof fin_destruct_O i as []
+  end.
+
+Goal True.
+  assert (i : Fin.t 4) by repeat constructor.
+  enough (i = i) by tauto.
+  destruct_fin i.
+  all: reflexivity.
+Qed.

--- a/theories/Shared/Libs/PSL/Vectors/FinNotation.v
+++ b/theories/Shared/Libs/PSL/Vectors/FinNotation.v
@@ -1,0 +1,128 @@
+(** * Notations for [Fin.t] *)
+(* Author: Maximilian Wuttke *)
+
+
+From Undecidability.Shared.Libs.PSL Require Import Fin.
+
+Notation "'Fin0'"  := (Fin.F1).
+Notation "'Fin1'"  := (Fin.FS Fin0).
+Notation "'Fin2'"  := (Fin.FS Fin1).
+Notation "'Fin3'"  := (Fin.FS Fin2).
+Notation "'Fin4'"  := (Fin.FS Fin3).
+Notation "'Fin5'"  := (Fin.FS Fin4).
+Notation "'Fin6'"  := (Fin.FS Fin5).
+Notation "'Fin7'"  := (Fin.FS Fin6).
+Notation "'Fin8'"  := (Fin.FS Fin7).
+Notation "'Fin9'"  := (Fin.FS Fin8).
+Notation "'Fin10'" := (Fin.FS Fin9).
+Notation "'Fin11'" := (Fin.FS Fin10).
+Notation "'Fin12'" := (Fin.FS Fin11).
+Notation "'Fin13'" := (Fin.FS Fin12).
+Notation "'Fin14'" := (Fin.FS Fin13).
+Notation "'Fin15'" := (Fin.FS Fin14).
+Notation "'Fin16'" := (Fin.FS Fin15).
+Notation "'Fin17'" := (Fin.FS Fin16).
+Notation "'Fin18'" := (Fin.FS Fin17).
+Notation "'Fin19'" := (Fin.FS Fin18).
+Notation "'Fin20'" := (Fin.FS Fin19).
+Notation "'Fin21'" := (Fin.FS Fin20).
+Notation "'Fin22'" := (Fin.FS Fin21).
+Notation "'Fin23'" := (Fin.FS Fin22).
+Notation "'Fin24'" := (Fin.FS Fin23).
+Notation "'Fin25'" := (Fin.FS Fin24).
+Notation "'Fin26'" := (Fin.FS Fin25).
+Notation "'Fin27'" := (Fin.FS Fin26).
+Notation "'Fin28'" := (Fin.FS Fin27).
+Notation "'Fin29'" := (Fin.FS Fin28).
+Notation "'Fin30'" := (Fin.FS Fin29).
+Notation "'Fin31'" := (Fin.FS Fin30).
+Notation "'Fin32'" := (Fin.FS Fin31).
+Notation "'Fin33'" := (Fin.FS Fin32).
+Notation "'Fin34'" := (Fin.FS Fin33).
+Notation "'Fin35'" := (Fin.FS Fin34).
+Notation "'Fin36'" := (Fin.FS Fin35).
+Notation "'Fin37'" := (Fin.FS Fin36).
+Notation "'Fin38'" := (Fin.FS Fin37).
+Notation "'Fin39'" := (Fin.FS Fin38).
+Notation "'Fin40'" := (Fin.FS Fin39).
+Notation "'Fin41'" := (Fin.FS Fin40).
+Notation "'Fin42'" := (Fin.FS Fin41).
+Notation "'Fin43'" := (Fin.FS Fin42).
+Notation "'Fin44'" := (Fin.FS Fin43).
+Notation "'Fin45'" := (Fin.FS Fin44).
+Notation "'Fin46'" := (Fin.FS Fin45).
+Notation "'Fin47'" := (Fin.FS Fin46).
+Notation "'Fin48'" := (Fin.FS Fin47).
+Notation "'Fin49'" := (Fin.FS Fin48).
+Notation "'Fin50'" := (Fin.FS Fin49).
+Notation "'Fin51'" := (Fin.FS Fin50).
+Notation "'Fin52'" := (Fin.FS Fin51).
+Notation "'Fin53'" := (Fin.FS Fin52).
+Notation "'Fin54'" := (Fin.FS Fin53).
+Notation "'Fin55'" := (Fin.FS Fin54).
+Notation "'Fin56'" := (Fin.FS Fin55).
+Notation "'Fin57'" := (Fin.FS Fin56).
+Notation "'Fin58'" := (Fin.FS Fin57).
+Notation "'Fin59'" := (Fin.FS Fin58).
+Notation "'Fin60'" := (Fin.FS Fin59).
+Notation "'Fin61'" := (Fin.FS Fin60).
+Notation "'Fin62'" := (Fin.FS Fin61).
+Notation "'Fin63'" := (Fin.FS Fin62).
+Notation "'Fin64'" := (Fin.FS Fin63).
+Notation "'Fin65'" := (Fin.FS Fin64).
+Notation "'Fin66'" := (Fin.FS Fin65).
+Notation "'Fin67'" := (Fin.FS Fin66).
+Notation "'Fin68'" := (Fin.FS Fin67).
+Notation "'Fin69'" := (Fin.FS Fin68).
+Notation "'Fin70'" := (Fin.FS Fin69).
+Notation "'Fin71'" := (Fin.FS Fin70).
+Notation "'Fin72'" := (Fin.FS Fin71).
+Notation "'Fin73'" := (Fin.FS Fin72).
+Notation "'Fin74'" := (Fin.FS Fin73).
+Notation "'Fin75'" := (Fin.FS Fin74).
+Notation "'Fin76'" := (Fin.FS Fin75).
+Notation "'Fin77'" := (Fin.FS Fin76).
+Notation "'Fin78'" := (Fin.FS Fin77).
+Notation "'Fin79'" := (Fin.FS Fin78).
+Notation "'Fin80'" := (Fin.FS Fin79).
+Notation "'Fin81'" := (Fin.FS Fin80).
+Notation "'Fin82'" := (Fin.FS Fin81).
+Notation "'Fin83'" := (Fin.FS Fin82).
+Notation "'Fin84'" := (Fin.FS Fin83).
+Notation "'Fin85'" := (Fin.FS Fin84).
+Notation "'Fin86'" := (Fin.FS Fin85).
+Notation "'Fin87'" := (Fin.FS Fin86).
+Notation "'Fin88'" := (Fin.FS Fin87).
+Notation "'Fin89'" := (Fin.FS Fin88).
+Notation "'Fin90'" := (Fin.FS Fin89).
+Notation "'Fin91'" := (Fin.FS Fin90).
+Notation "'Fin92'" := (Fin.FS Fin91).
+Notation "'Fin93'" := (Fin.FS Fin92).
+Notation "'Fin94'" := (Fin.FS Fin93).
+Notation "'Fin95'" := (Fin.FS Fin94).
+Notation "'Fin96'" := (Fin.FS Fin95).
+Notation "'Fin97'" := (Fin.FS Fin96).
+Notation "'Fin98'" := (Fin.FS Fin97).
+Notation "'Fin99'" := (Fin.FS Fin98).
+
+(* Generate arbitrary big Fin.t's *)
+
+Ltac getFin i :=
+  match i with
+  | 0 =>
+    eapply Fin.F1
+  | S ?i' =>
+    eapply Fin.FS;
+    ltac:(getFin i')
+  end.
+
+(*
+Section Test.
+  Compute ltac:(getFin 4) : Fin.t 100.
+  Compute ltac:(getFin 8) : Fin.t 100.
+  Compute ltac:(getFin 15) : Fin.t 100.
+  Compute ltac:(getFin 16) : Fin.t 100.
+  Compute ltac:(getFin 23) : Fin.t 100.
+  Compute ltac:(getFin 42) : Fin.t 100.
+End Test.
+*)

--- a/theories/Shared/Libs/PSL/Vectors/VectorDupfree.v
+++ b/theories/Shared/Libs/PSL/Vectors/VectorDupfree.v
@@ -1,0 +1,209 @@
+(** * Dupfree vector *)
+(* Author: Maximilian Wuttke *)
+
+From Undecidability.Shared.Libs.PSL Require Import Prelim.
+From Undecidability.Shared.Libs.PSL Require Import Tactics.Tactics.
+From Undecidability.Shared.Libs.PSL Require Import Vectors.Vectors.
+From Undecidability.Shared.Libs.PSL Require Import FiniteTypes.FinTypes.
+From Undecidability.Shared.Libs.PSL Require Lists.Dupfree.
+Require Import Coq.Vectors.Vector.
+
+Open Scope vector_scope.
+Import VectorNotations2.
+
+
+Inductive dupfree X : forall n, Vector.t X n -> Prop :=
+  dupfreeVN :
+    dupfree (@Vector.nil X)
+| dupfreeVC n (x : X) (V : Vector.t X n) :
+    ~ Vector.In x V -> dupfree V -> dupfree (x ::: V).
+
+
+Ltac vector_dupfree :=
+  match goal with
+  | [ |- dupfree (Vector.nil _) ] =>
+    constructor
+  | [ |- dupfree (?a ::: ?bs)] =>
+    constructor; [vector_not_in | vector_dupfree]
+  end.
+
+Goal dupfree [| 4; 8; 15; 16; 23; 42 |].
+Proof. vector_dupfree. Qed.
+
+Goal dupfree [| Fin.F1 (n := 1) |].
+Proof. vector_dupfree. Qed.
+
+(*
+(* This also works, but needs a bit to comile *)
+From Undecidability.Shared.Libs.PSL Require Import Vectors.FinNotation.
+Goal dupfree ([| Fin4; Fin8; Fin15; Fin16; Fin23; Fin42 |] : Vector.t (Fin.t 43) _).
+Proof. vector_dupfree. Qed.
+*)
+
+Lemma dupfree_cons (X : Type) (n : nat) (x : X) (xs : Vector.t X n) :
+  dupfree (x ::: xs) -> dupfree xs /\ ~ In x xs.
+Proof.
+  intros H1. inv H1. now existT_eq'.
+Qed.
+
+Lemma dupfree_replace (X : Type) (n : nat) (xs : Vector.t X n) (x : X) :
+  dupfree xs -> ~ In x xs -> forall i, dupfree (replace  xs i x).
+Proof.
+  revert x. induction xs; intros; cbn.
+  - inv i.
+  - dependent destruct i; cbn.
+    + constructor; auto.
+      * intros H1. contradict H0. now econstructor.
+      * inv H. existT_eq'. assumption.
+    + apply dupfree_cons in H as (H&H').
+      assert (~In x xs).
+      {
+        intros H1. contradict H0. now constructor.
+      }
+      specialize (IHxs x H H1 p). constructor.
+      * intros [ -> | H2] % In_replace. contradict H0. constructor. tauto.
+      * tauto.
+Qed.
+
+
+Lemma dupfree_tabulate_injective (X : Type) (n : nat) (f : Fin.t n -> X) :
+  (forall x y, f x = f y -> x = y) ->
+  dupfree (tabulate f).
+Proof.
+  intros H. revert f H. induction n; intros; cbn.
+  - constructor.
+  - constructor.
+    + intros (x & H2 % H) % in_tabulate. congruence.
+    + eapply IHn. now intros x y -> % H % Fin.FS_inj.
+Qed.
+
+Lemma dupfree_map_injective (X Y : Type) (n : nat) (f : X -> Y) (V : Vector.t X n) :
+  (forall x y, f x = f y -> x = y) ->
+  dupfree V ->
+  dupfree (map f V).
+Proof.
+  intros HInj. induction 1.
+  - cbn. constructor.
+  - cbn. constructor; auto. now intros (? & -> % HInj & ?) % vect_in_map_iff.
+Qed.
+
+Import VecToListCoercion.
+
+Lemma tolist_dupfree (X : Type) (n : nat) (xs : Vector.t X n) :
+  dupfree xs -> Dupfree.dupfree xs.
+Proof.
+  induction 1.
+  - cbn. constructor.
+  - cbn. constructor; auto. intros H1. contradict H. now apply tolist_In.
+Qed.
+
+Section Count.
+  Variable (X : eqType).
+
+  Definition count (n : nat) (x : X) (xs : t X n) :=
+    fold_right (fun y c => if Dec (x = y) then S c else c) xs 0.
+
+  Lemma count0_notIn (n : nat) (x : X) (xs : t X n) :
+    count x xs = 0 -> ~ In x xs.
+  Proof.
+    revert x. induction xs; intros; cbn in *.
+    - vector_not_in.
+    - intros H1. decide (x=h); try congruence.
+      apply In_cons in H1 as [-> | H1]; try tauto.
+      eapply IHxs; eauto.
+  Qed.
+
+  Lemma count0_notIn' (n : nat) (x : X) (xs : t X n) :
+    ~ In x xs -> count x xs = 0.
+  Proof.
+    induction xs; intros; cbn in *.
+    - reflexivity.
+    - decide (x = h) as [ -> | D ].
+      + contradict H. constructor.
+      + apply IHxs. intros H2. contradict H. now constructor.
+  Qed.
+
+  Lemma countDupfree (n : nat) (xs : t X n) :
+    (forall x : X, In x xs -> count x xs = 1) <-> dupfree xs.
+  Proof.
+    split; intros H.
+    {
+      induction xs; cbn -[count] in *.
+      - constructor.
+      - constructor.
+        + intros H2. specialize (H h ltac:(now constructor)). cbn in H.
+          decide (h = h); try tauto. inv H.
+          contradict H2. now eapply count0_notIn.
+        + apply IHxs. intros x Hx. specialize (H x ltac:(now constructor)).
+          cbn in H. decide (x = h); inv H; auto. rewrite H1.
+          contradict Hx. now eapply count0_notIn.
+    }
+    {
+      induction H as [ | n x' xs HIn HDup IH ]; intros; cbn in *.
+      - inv H.
+      - decide (x = x') as [ -> | D].
+        + f_equal. exact (count0_notIn' HIn).
+        + apply (IH x). now apply In_cons in H as [ -> | H].
+    }
+  Qed.
+
+
+(* (* Test *)
+End Count.
+Compute let xs := [|1;2;3;4;5;6|] in
+        let x  := 2 in
+        let y  := 1 in
+        let i  := Fin.F1 in
+        Dec (x = y) + count x xs = Dec (x = xs[@i]) + count x (replace xs i y).
+*)
+
+  Lemma replace_nochange (n : nat) (xs : Vector.t X n) (p : Fin.t n) :
+    replace xs p xs[@p] = xs.
+  Proof.
+    eapply eq_nth_iff. intros ? ? <-.
+    decide (p = p1) as [ -> | D].
+    - now rewrite replace_nth.
+    - now rewrite replace_nth2.
+  Qed.
+  
+  Lemma count_replace (n : nat) (xs : t X n) (x y : X) (i : Fin.t n) :
+    bool2nat (Dec (x = y)) + count x xs = bool2nat (Dec (x = xs[@i])) + count x (replace xs i y).
+  Proof.
+    induction xs; intros; cbn -[nth count] in *.
+    - inv i.
+    - dependent destruct i; cbn -[nth count] in *.
+      + decide (x = y) as [ D | D ]; cbn -[nth count] in *; cbn -[bool2nat dec2bool count].
+        * rewrite <- D in *. decide (x = h) as [ -> | D2]; cbn [dec2bool bool2nat plus]; auto.
+          cbv [count]. cbn. rewrite D. decide (y = y); try tauto. decide (y = h); congruence.
+        * decide (x = h); subst; cbn [bool2nat dec2bool plus]; cbv [count]; try reflexivity.
+          -- cbn. decide (h = h); try tauto. decide (h = y); tauto.
+          -- cbn. decide (x = h); try tauto. decide (x = y); tauto.
+      + cbn. decide (x = y); cbn.
+        * decide (x = h); cbn; f_equal.
+          -- decide (x = xs[@p]); cbn; repeat f_equal; subst.
+             ++ symmetry. now apply replace_nochange.
+             ++ cbn in *. specialize (IHxs p). decide (h = xs[@p]); tauto.
+          -- decide (x = xs[@p]); cbn; repeat f_equal; subst.
+             ++ symmetry. now apply replace_nochange.
+             ++ cbn in *. specialize (IHxs p). decide (y = xs[@p]); tauto.
+        * decide (x = h); cbn; f_equal.
+          -- decide (x = xs[@p]); cbn; f_equal; subst.
+             ++ cbn in *. specialize (IHxs p). decide (xs[@p] = xs[@p]); cbn in *; try tauto.
+             ++ specialize (IHxs p). cbn in *. decide (h = xs[@p]); cbn in *; tauto.
+          -- decide (x = xs[@p]); cbn; auto.
+             ++ specialize (IHxs p). cbn in *. decide (x = xs[@p]); cbn in *; tauto.
+             ++ specialize (IHxs p). cbn in *. decide (x = xs[@p]); cbn in *; tauto.
+  Qed.
+  
+End Count.
+
+Lemma dupfree_nth_injective (X : Type) (n : nat) (xs : Vector.t X n) :
+  dupfree xs -> forall (i j : Fin.t n), xs[@i] = xs[@j] -> i = j.
+Proof.
+  induction 1; intros; cbn -[nth] in *.
+  - inv i.
+  - dependent destruct i; dependent destruct j; cbn -[nth] in *; auto.
+    + cbn in *. contradict H. eapply vect_nth_In; eauto.
+    + cbn in *. contradict H. eapply vect_nth_In; eauto.
+    + f_equal. now apply IHdupfree.
+Qed.

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -1,0 +1,420 @@
+(** * Addendum for Vectors ([Vector.t]) *)
+(* Author: Maximilian Wuttke *)
+
+
+From Undecidability.Shared.Libs.PSL Require Import Prelim Tactics.Tactics EqDec.
+From Coq.Vectors Require Import Fin Vector.
+From Undecidability.Shared.Libs.PSL Require Import Vectors.FinNotation.
+From Undecidability.Shared.Libs.PSL Require Export Vectors.Fin.
+
+
+(* Vector.nth should not reduce with simpl, except the index is given with a constructor *)
+Arguments Vector.nth {A} {m} (v') !p.
+Arguments Vector.map {A B} f {n} !v /.
+Arguments Vector.map2 {A B C} g {n} !v1 !v2 /.
+
+Tactic Notation "dependent" "destruct" constr(V) :=
+  match type of V with
+  | Vector.t ?Z (S ?n) =>
+    revert all except V;
+    pattern V; revert n V;
+    eapply caseS; intros
+  | Vector.t ?Z 0 =>
+    revert all except V;
+    pattern V; revert V;
+    eapply case0; intros
+  | Fin.t 0 => inv V
+  | Fin.t (S ?n) =>
+    let pos := V in
+    revert all except pos;
+    pattern pos; revert n pos;
+    eapply Fin.caseS; intros
+  | _ => fail "Wrong type"
+  end.
+
+Delimit Scope vector_scope with vector.
+Local Open Scope vector.
+
+Module VectorNotations2.
+
+Notation "[||]" := (nil _) : vector_scope.
+Notation "h ':::' t" := (cons _ h _ t) (at level 60, right associativity) : vector_scope.
+
+Notation " [| x |] " := (x ::: [||]) : vector_scope.
+Notation " [| x ; y ; .. ; z |] " := (cons _ x _ (cons _ y _ .. (cons _ z _ (nil _)) ..)) : vector_scope.
+Notation "v [@ p ]" := (nth v p) (at level 1, format "v [@ p ]") : vector_scope.
+
+End VectorNotations2.
+
+Import VectorNotations2.
+
+
+
+Ltac existT_eq :=
+  match goal with
+  | [ H: existT ?X1 ?Y1 ?Z1 = existT ?X2 ?Y2 ?Z2 |- _] =>
+    apply EqdepFacts.eq_sigT_iff_eq_dep in H; inv H
+  end.
+
+Ltac existT_eq' :=
+  match goal with
+  | [ H: existT ?X1 ?Y1 ?Z1 = existT ?X2 ?Y2 ?Z2 |- _] =>
+    apply EqdepFacts.eq_sigT_iff_eq_dep in H; induction H
+  end.
+
+
+Lemma vect_map_injective X Y n (f : X -> Y) (v1 v2 : Vector.t X n) :
+  (forall x y, f x = f y -> x = y) ->
+  map f v1 = map f v2 -> v1 = v2.
+Proof.
+  intros Inj Eq.
+  induction n; cbn in *.
+  - dependent destruct v1. dependent destruct v2; reflexivity.
+  - dependent destruct v1. dependent destruct v2. cbn in *.
+    eapply cons_inj in Eq as (-> % Inj &?). f_equal. now apply IHn.
+Qed.
+
+
+
+Lemma replace_nth X n (v : Vector.t X n) i (x : X) :
+  (Vector.replace v i x) [@i] = x.
+Proof.
+  induction i; dependent destruct v; cbn; auto.
+Qed.
+
+Lemma replace_nth2 X n (v : Vector.t X n) i j (x : X) :
+  i <> j -> (Vector.replace v i x) [@j] = v[@j].
+Proof.
+  revert v. pattern i, j. revert n i j.
+  eapply Fin.rect2; intros; try congruence.
+  - revert f H. pattern v. revert n v.
+    eapply Vector.caseS. 
+    cbn. reflexivity.
+  - revert f H. pattern v. revert n v.
+    eapply Vector.caseS. 
+    cbn. reflexivity.
+  - revert g f H H0. pattern v. revert n v.
+    eapply Vector.caseS. firstorder congruence.
+Qed.
+
+Lemma destruct_vector_nil (X : Type) :
+  forall v : Vector.t X 0, v = [||].
+Proof.
+  now apply case0.
+Qed.
+
+Lemma destruct_vector_cons (X : Type) (n : nat) :
+  forall v : Vector.t X (S n), { h : X & { v' : Vector.t X n | v = h ::: v' }}.
+Proof.
+  revert n. apply caseS. eauto.
+Qed.
+
+
+Lemma In_nil (X : Type) (x : X) :
+  ~ In x [||].
+Proof. intros H. inv H. Qed.
+
+Lemma In_cons (X : Type) (n : nat) (x y : X) (xs : Vector.t X n) :
+  In y (x ::: xs) -> x = y \/ In y xs.
+Proof.
+  intros H. inv H; existT_eq'; tauto.
+Qed.
+
+Ltac destruct_vector_in :=
+  lazymatch goal with
+  | [ H: Vector.In _ [||] |- _ ] => solve [exfalso;simple apply In_nil in H;exact H]
+  | [ H: Vector.In _ (?x ::: _) |- _ ] => simple apply In_cons in H as [H| H] ; try (is_var x;move H at bottom;subst x) 
+  end.
+
+(*
+Goal ~ Vector.In 10 [|1;2;4|].
+Proof.
+  intros H. repeat destruct_vector_in; congruence.
+Qed.
+*)
+
+
+Section In_Dec.
+  Variable X : Type.
+  Hypothesis X_dec : eq_dec X.
+
+  Fixpoint in_dec (n : nat) (x : X) (xs : Vector.t X n) { struct xs } : bool :=
+    match xs with
+    | [||] => false
+    | y ::: xs' => if Dec (x = y) then true else in_dec x xs'
+    end.
+
+  Lemma in_dec_correct (n : nat) (x : X) (xs : Vector.t X n) :
+    in_dec x xs = true <-> In x xs.
+  Proof.
+    split; intros.
+    {
+      induction xs; cbn in *.
+      - congruence.
+      - decide (x = h) as [ -> | D].
+        + constructor.
+        + constructor. now apply IHxs.
+    }
+    {
+      induction H; cbn.
+      - have (x = x).
+      - decide (x = x0).
+        + reflexivity.
+        + apply IHIn.
+    }
+  Qed.
+
+  Global Instance In_dec (n : nat) (x : X) (xs : Vector.t X n) : dec (In x xs).
+  Proof. eapply dec_transfer. eapply in_dec_correct. auto. Defined.
+
+End In_Dec.
+
+  
+
+(* Destruct a vector of known size *)
+Ltac destruct_vector :=
+  repeat match goal with
+         | [ v : Vector.t ?X 0 |- _ ] =>
+           let H  := fresh "Hvect" in
+           pose proof (@destruct_vector_nil X v) as H;
+           subst v
+         | [ v : Vector.t ?X (S ?n) |- _ ] =>
+           let h  := fresh "h" in
+           let v' := fresh "v'" in
+           let H  := fresh "Hvect" in
+           pose proof (@destruct_vector_cons X n v) as (h&v'&H);
+           subst v; rename v' into v
+         end.
+
+
+
+Section In_nth.
+  Variable (A : Type) (n : nat).
+
+  Lemma vect_nth_In (v : Vector.t A n) (i : Fin.t n) (x : A) :
+    Vector.nth v i = x -> Vector.In x v.
+  Proof.
+    induction n; cbn in *.
+    - inv i.
+    - dependent destruct v. dependent destruct i; cbn in *; subst; econstructor; eauto.
+  Qed.
+
+  Lemma vect_nth_In' (v : Vector.t A n) (x : A) :
+    Vector.In x v -> exists i : Fin.t n, Vector.nth v i = x.
+  Proof.
+    induction n; cbn in *.
+    - inversion 1.
+    - dependent destruct v. destruct_vector_in.
+      + exists Fin.F1. auto.
+      + specialize (IHn0 _ H) as (i&<-). exists (Fin.FS i). auto.
+  Qed.
+
+End In_nth.
+
+
+
+Section tabulate_vec.
+  Variable X : Type.
+
+  Fixpoint tabulate (n : nat) (f : Fin.t n -> X) {struct n} : Vector.t X n.
+  Proof.
+    destruct n.
+    - apply Vector.nil.
+    - apply Vector.cons.
+      + apply f, Fin.F1.
+      + apply tabulate. intros m. apply f, Fin.FS, m.
+  Defined.
+
+  Lemma nth_tabulate n (f : Fin.t n -> X) (m : Fin.t n) :
+    Vector.nth (tabulate f) m = f m.
+  Proof.
+    induction m.
+    - cbn. reflexivity.
+    - cbn. rewrite IHm. reflexivity.
+  Qed.
+
+  Lemma in_tabulate n (f : Fin.t n -> X) (x : X) :
+    In x (tabulate (n := n) f) <-> exists i : Fin.t n, x = f i.
+  Proof.
+    split.
+    {
+      revert f x. induction n; intros f x H.
+      - cbn in *. inv H.
+      - cbn in *. apply In_cons in H as [ <- | H ].
+        + eauto.
+        + specialize (IHn (fun m => f (Fin.FS m)) _ H) as (i&IH). eauto.
+    }
+    {
+      intros (i&Hi). induction i; cbn in *; subst; econstructor; eauto.
+    }
+  Qed.
+
+End tabulate_vec.
+
+(*
+Lemma vec_replace_nth X x n (t : Vector.t X n) (i : Fin.t n) :
+  x = Vector.nth (Vector.replace t i x) i.
+Proof.
+  induction i; dependent destruct t; simpl; auto.
+Qed.
+
+Lemma vec_replace_nth_nochange X x n (t : Vector.t X n) (i j : Fin.t n) :
+  Fin.to_nat i <> Fin.to_nat j -> Vector.nth t i = Vector.nth (Vector.replace t j x) i.
+Proof.
+  revert j. induction i; dependent destruct t; dependent destruct j; simpl; try tauto.
+  apply IHi. contradict H. cbn. now rewrite !H.
+Qed.
+ *)
+
+Instance Vector_eq_dec n A: eq_dec A -> eq_dec (Vector.t A n).
+Proof.
+  intros H x y. eapply VectorEq.eq_dec with (A_beq := fun x y => proj1_sig (Sumbool.bool_of_sumbool (H x y))).
+  intros ? ?. destruct (Sumbool.bool_of_sumbool).
+  cbn.  destruct x1;intuition.
+Defined.
+
+Instance Fin_eq_dec n : eq_dec (Fin.t n).
+Proof.
+  intros; hnf.
+  destruct (Fin.eqb x y) eqn:E.
+  - left. now eapply Fin.eqb_eq.
+  - right. intros H. eapply Fin.eqb_eq in H. congruence.
+Defined.
+
+
+Lemma vect_in_map (X Y : Type) (n : nat) (f : X -> Y) (V : Vector.t X n) (x : X) :
+  In x V -> In (f x) (map f V).
+Proof. induction 1; cbn; constructor; auto. Qed.
+
+Lemma vect_in_map_iff (X Y : Type) (n : nat) (f : X -> Y) (V : Vector.t X n) (y : Y) :
+  In y (map f V) <-> (exists x : X, f x = y /\ In x V).
+Proof.
+  split.
+  - intros H. induction V; cbn in *.
+    + inv H.
+    + apply In_cons in H as [ <- | H].
+      * exists h. split; auto. now constructor 1.
+      * specialize (IHV H) as (x&Hx1&Hx2). exists x. split; auto. now constructor 2.
+  - intros (x&<-&H). now apply vect_in_map.
+Qed.
+
+
+Lemma In_replace (X : Type) (n : nat) (xs : Vector.t X n) (i : Fin.t n) (x y : X) :
+  In y (replace xs i x) -> (x = y \/ In y xs).
+Proof.
+  revert i x y. induction xs; intros; cbn in *.
+  - inv i.
+  - dependent destruct i; cbn in *; apply In_cons in H as [-> | H]; auto; try now (right; constructor).
+    specialize (IHxs _ _ _ H) as [-> | IH]; [ now left | right; now constructor ].
+Qed.
+
+Lemma In_replace' (X : Type) (n : nat) (xs : Vector.t X n) (i : Fin.t n) (x y : X) :
+  In y (replace xs i x) -> x = y \/ exists j, i <> j /\ xs[@j] = y.
+Proof.
+  revert i x y. induction xs; intros; cbn -[nth] in *.
+  - inv i.
+  - dependent destruct i; cbn -[nth] in *.
+    + apply In_cons in H as [->|H].
+      * tauto.
+      * apply vect_nth_In' in H as (j&H). right. exists (Fin.FS j). split. discriminate. cbn. assumption.
+    + apply In_cons in H as [->|H].
+      * right. exists Fin.F1. split. discriminate. cbn. reflexivity.
+      * specialize (IHxs _ _ _ H) as [-> | (j&IH1&IH2)]; [ tauto | ].
+        right. exists (Fin.FS j). split. now intros -> % Fin.FS_inj. cbn. assumption.
+Qed.
+
+
+
+
+(** Tactic for simplifying a hypothesis of the form [In x v] *)
+
+
+Ltac simpl_vector_inv :=
+  repeat match goal with
+         | [ H : [||] = (_ ::: _) |- _ ] => solve [discriminate H]
+         | [ H : (_ ::: _) = [||]  |- _ ] => solve [discriminate H]
+         | [ H : Fin.F1 = Fin.FS _ |- _] => solve [discriminate H]
+         | [ H : Fin.FS _ = Fin.F1 |- _] => solve [discriminate H]
+         | [ H : Fin.FS ?i = Fin.FS ?j |- _] =>
+           simple apply Fin.FS_inj in H;
+           first [is_var i;move H at bottom;subst i | is_var j;move H at bottom;subst j | idtac]
+         end.
+
+
+Ltac simpl_vector_in :=
+  repeat
+    match goal with
+    | _ => first
+            [ progress destruct_vector_in
+            | progress simpl_vector_inv
+            | progress auto
+            | congruence
+            ]
+    | [ H : Vector.In _ (Vector.map _ _) |- _] =>
+      let x := fresh "x" in
+      eapply vect_in_map_iff in H as (x&<-&H)
+    | [ H : Vector.In _ (Vector.map _ _) |- _] =>
+      let x := fresh "x" in
+      let H' := fresh H in
+      eapply vect_in_map_iff in H as (x&H&H')
+    | [ H : Vector.In _ (tabulate _) |- _ ] =>
+      let i := fresh "i" in
+      apply in_tabulate in H as (i&->)
+    | [ H : Vector.In _ (tabulate _) |- _ ] =>
+      let i := fresh "i" in
+      let H := fresh "H" in
+      apply in_tabulate in H as (i&H)
+    end.
+
+Ltac vector_not_in :=
+  let H := fresh "H" in
+  intros H; simpl_vector_in.
+
+Goal Vector.In (Fin.F1 (n := 10)) [|Fin1; Fin2; Fin3 |] -> False.
+Proof. intros H. simpl_vector_in. Qed.
+  
+Goal Vector.In (Fin.F1 (n := 10)) (map (Fin.FS) [|Fin0; Fin1; Fin2|]) -> False.
+Proof. intros H. simpl_vector_in. Qed.
+
+
+
+(** Conversion between vectors and lists *)
+Module VecToListCoercion.
+  Coercion Vector.to_list : Vector.t >-> list.
+End VecToListCoercion.
+
+Import VecToListCoercion.
+
+Lemma tolist_In (X : Type) (n : nat) (xs : Vector.t X n) (x : X) :
+  Vector.In x xs <-> List.In x xs.
+Proof.
+  split; intros H.
+  - induction H; cbn; auto.
+  - induction xs; cbn in *; auto. destruct H as [-> | H]; econstructor; eauto.
+Qed.
+
+Arguments Vector.eqb {_}  _ {_ _}.
+
+Lemma vector_eqb_spec X n eqb:
+  (forall (x1 x2 : X) , reflect (x1 = x2) (eqb x1 x2))
+  -> forall x y , reflect (x=y) (Vector.eqb (n:=n) eqb x y).
+Proof with try (constructor;congruence).
+  intros Hf x y.
+  apply iff_reflect. symmetry. apply Vector.eqb_eq. symmetry. apply reflect_iff. eauto.
+Qed. 
+
+Lemma vector_to_list_inj (X : Type) (n : nat) (xs ys : Vector.t X n) :
+  Vector.to_list xs = Vector.to_list ys -> xs = ys.
+Proof.
+  revert ys. induction xs as [ | x n xs IH]; intros; cbn in *.
+  - destruct_vector. reflexivity.
+  - destruct_vector. cbn in *. inv H. f_equal. auto.
+Qed.
+
+Lemma vector_to_list_length (X : Type) (n : nat) (xs : Vector.t X n) :
+  length(Vector.to_list xs) = n. 
+Proof.
+  induction xs as [ | x n xs IH]. 
+  - now cbn. 
+  - change (S (length xs) = S n). congruence.
+Qed. 

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -37,11 +37,12 @@ Local Open Scope vector.
 
 Module VectorNotations2.
 
-Notation "[||]" := (nil _) : vector_scope.
+Notation "[ | | ]" := (nil _) (format "[ |  | ]"): vector_scope.
 Notation "h ':::' t" := (cons _ h _ t) (at level 60, right associativity) : vector_scope.
 
-Notation " [| x |] " := (x ::: [||]) : vector_scope.
-Notation " [| x ; y ; .. ; z |] " := (cons _ x _ (cons _ y _ .. (cons _ z _ (nil _)) ..)) : vector_scope.
+Notation "[ | x | ]" := (x ::: [| |]) : vector_scope.
+Notation "[ | x ; y ; .. ; z | ] " := (cons _ x _ (cons _ y _ .. (cons _ z _ (nil _)) ..))
+   (format "[ | x ;  y ;  .. ;  z | ] ") : vector_scope.
 Notation "v [@ p ]" := (nth v p) (at level 1, format "v [@ p ]") : vector_scope.
 
 End VectorNotations2.
@@ -98,7 +99,7 @@ Proof.
 Qed.
 
 Lemma destruct_vector_nil (X : Type) :
-  forall v : Vector.t X 0, v = [||].
+  forall v : Vector.t X 0, v = [| |].
 Proof.
   now apply case0.
 Qed.
@@ -111,7 +112,7 @@ Qed.
 
 
 Lemma In_nil (X : Type) (x : X) :
-  ~ In x [||].
+  ~ In x [| |].
 Proof. intros H. inv H. Qed.
 
 Lemma In_cons (X : Type) (n : nat) (x y : X) (xs : Vector.t X n) :
@@ -122,7 +123,7 @@ Qed.
 
 Ltac destruct_vector_in :=
   lazymatch goal with
-  | [ H: Vector.In _ [||] |- _ ] => solve [exfalso;simple apply In_nil in H;exact H]
+  | [ H: Vector.In _ [| |] |- _ ] => solve [exfalso;simple apply In_nil in H;exact H]
   | [ H: Vector.In _ (?x ::: _) |- _ ] => simple apply In_cons in H as [H| H] ; try (is_var x;move H at bottom;subst x) 
   end.
 
@@ -140,7 +141,7 @@ Section In_Dec.
 
   Fixpoint in_dec (n : nat) (x : X) (xs : Vector.t X n) { struct xs } : bool :=
     match xs with
-    | [||] => false
+    | [| |] => false
     | y ::: xs' => if Dec (x = y) then true else in_dec x xs'
     end.
 
@@ -331,8 +332,8 @@ Qed.
 
 Ltac simpl_vector_inv :=
   repeat match goal with
-         | [ H : [||] = (_ ::: _) |- _ ] => solve [discriminate H]
-         | [ H : (_ ::: _) = [||]  |- _ ] => solve [discriminate H]
+         | [ H : [| |] = (_ ::: _) |- _ ] => solve [discriminate H]
+         | [ H : (_ ::: _) = [| |]  |- _ ] => solve [discriminate H]
          | [ H : Fin.F1 = Fin.FS _ |- _] => solve [discriminate H]
          | [ H : Fin.FS _ = Fin.F1 |- _] => solve [discriminate H]
          | [ H : Fin.FS ?i = Fin.FS ?j |- _] =>

--- a/theories/StackMachines/Reductions/HaltSBTM_to_HaltBSM.v
+++ b/theories/StackMachines/Reductions/HaltSBTM_to_HaltBSM.v
@@ -1,6 +1,6 @@
 Require Import Undecidability.TM.SBTM.
 
-Require Import PslBase.Vectors.FinNotation PslBase.Vectors.Vectors PslBase.EqDec.
+Require Import Undecidability.Shared.Libs.PSL.Vectors.FinNotation Undecidability.Shared.Libs.PSL.Vectors.Vectors Undecidability.Shared.Libs.PSL.EqDec.
 
 Require Import List Arith Lia Bool.
 

--- a/theories/TM/Code/BinNumbers/EncodeBinNumbers.v
+++ b/theories/TM/Code/BinNumbers/EncodeBinNumbers.v
@@ -2,7 +2,7 @@
 
 From Undecidability Require Import TM.Util.Prelim Code.
 From Undecidability Require Import ArithPrelim.
-From PslBase Require Export Bijection.
+From Undecidability.Shared.Libs.PSL Require Export Bijection.
 Require Export BinNums. (* Warning: There also is a constructor called [N] for the type [move] *)
 
 

--- a/theories/TM/Code/Code.v
+++ b/theories/TM/Code/Code.v
@@ -1,6 +1,6 @@
 From Undecidability Require Import TM.Util.Prelim.
 Require Import Coq.Lists.List.
-Require Import PslBase.Bijection. (* [injective] *)
+Require Import Undecidability.Shared.Libs.PSL.Bijection. (* [injective] *)
 
 
 (** * Codable Class **)

--- a/theories/TM/Combinators/StateWhile.v
+++ b/theories/TM/Combinators/StateWhile.v
@@ -1,5 +1,5 @@
 From Undecidability Require Export TM.Util.TM_facts.
-Require Import PslBase.FiniteTypes.DepPairs EqdepFacts.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.DepPairs EqdepFacts.
 
 Section StateWhile.
 

--- a/theories/TM/Combinators/Switch.v
+++ b/theories/TM/Combinators/Switch.v
@@ -1,5 +1,5 @@
 From Undecidability Require Export TM.Util.TM_facts.
-Require Import PslBase.FiniteTypes.DepPairs EqdepFacts.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.DepPairs EqdepFacts.
 
 (** * Switch Combinator *)
 

--- a/theories/TM/Combinators/While.v
+++ b/theories/TM/Combinators/While.v
@@ -1,5 +1,5 @@
 From Undecidability Require Export TM.Util.TM_facts.
-Require Import PslBase.FiniteTypes.DepPairs EqdepFacts.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.DepPairs EqdepFacts.
 
 Section While.
 

--- a/theories/TM/Compound/TMTac.v
+++ b/theories/TM/Compound/TMTac.v
@@ -75,8 +75,8 @@ Ltac TMSimp1_old T :=
   try T;
   repeat
   lazymatch goal with
-  | [ H : _ ::: _ = [||]  |- _ ] => inv H
-  | [ H : [||] = _ ::: _ |- _ ] => inv H
+  | [ H : _ ::: _ = [| |]  |- _ ] => inv H
+  | [ H : [| |] = _ ::: _ |- _ ] => inv H
   | [ H : _ ::: _ = _ ::: _ |- _ ] => apply VectorSpec.cons_inj in H
 
   | [ H : _ ::  _ = []  |- _ ] => inv H
@@ -158,8 +158,8 @@ Ltac TMSimp1 T :=
   repeat
   lazymatch goal with
   | [ x : unit |- _ ] => destruct x
-  | [ H : _ ::: _ = [||]  |- _ ] => discriminate H
-  | [ H : [||] = _ ::: _ |- _ ] => discriminate H
+  | [ H : _ ::: _ = [| |]  |- _ ] => discriminate H
+  | [ H : [| |] = _ ::: _ |- _ ] => discriminate H
   | [ H : _ ::: _ = _ ::: _ |- _ ] => apply VectorSpec.cons_inj in H
 
   | [ H : _ ::  _ = []  |- _ ] => discriminate H

--- a/theories/TM/Reductions/HaltTM_1_to_HaltSBTM.v
+++ b/theories/TM/Reductions/HaltTM_1_to_HaltSBTM.v
@@ -1,7 +1,7 @@
 From Undecidability Require TM.TM TM.SBTM.
 Require Import Undecidability.Shared.FinTypeEquiv.
 (* Require Import Undecidability.L.Functions.FinTypeLookup. *)
-Require Import PslBase.FiniteTypes.FinTypes PslBase.Vectors.Vectors.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 Require Undecidability.TM.Util.TM_facts.
 Import VectorNotations2.
 Local Open Scope vector.

--- a/theories/TM/Single/StepTM.v
+++ b/theories/TM/Single/StepTM.v
@@ -281,7 +281,7 @@ Fixpoint map_vect_list (X Y : Type) (f : X -> Y -> X) (n : nat) (vs : Vector.t Y
   | nil => nil
   | x :: ls' =>
     match vs with
-    | [||] => ls
+    | [| |] => ls
     | y ::: vs' =>
       f x y :: map_vect_list f vs' ls'
     end
@@ -1234,7 +1234,7 @@ Section ToSingleTape.
 
     Definition ReadCurrentSymbols_steps (n : nat) (T : tapes sig n) :=
       match T with
-      | [||] => ReadCurrentSymbols_Loop_steps_nil
+      | [| |] => ReadCurrentSymbols_Loop_steps_nil
       | tp ::: T' => 2 + ReadCurrentSymbols_Loop_steps_cons (vector_to_list T') tp
       end.
 

--- a/theories/TM/TM.v
+++ b/theories/TM/TM.v
@@ -1,6 +1,6 @@
 (** * Definition of Multi-Tape Turing Machines *)
 
-Require Import PslBase.FiniteTypes.FinTypes.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
 Require Import Vector List.
 
 Unset Implicit Arguments.
@@ -99,7 +99,7 @@ Section Fix_Alphabet.
       Lemma finType_equiv (X : finType) :
          {n & {f : X -> Fin.t n & { g : Fin.t n -> X | (forall x, g (f x) = x) /\ forall i, f (g i) = i }}}.
 
-      in PslBase.FiniteTypes.FinTypesEquiv.
+      in Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypesEquiv.
 
    *)
   

--- a/theories/TM/Univ/LookupAssociativeListTM.v
+++ b/theories/TM/Univ/LookupAssociativeListTM.v
@@ -1,4 +1,4 @@
-Require Import PslBase.Bijection. (* [injective] *)
+Require Import Undecidability.Shared.Libs.PSL.Bijection. (* [injective] *)
 From Undecidability Require Import ProgrammingTools.
 From Undecidability Require Import TM.Code.CompareValue.
 From Undecidability Require Import TM.Code.CasePair TM.Code.CaseList.

--- a/theories/TM/Univ/StepTM.v
+++ b/theories/TM/Univ/StepTM.v
@@ -758,7 +758,7 @@ Section Univ.
         exists 0. eexists. cbn. unfold haltConf. cbn. rewrite E. repeat split; eauto.
       - modpon HStar. destruct (halt q) eqn:E; auto. destruct (step (mk_mconfig q [|tp|])) as [q' tp'] eqn:E2. modpon HStar.
         modpon HLastStep.
-        { instantiate (1:=[|_;_;_|]). cbn. intros i. specialize(HStar2 i). destruct_fin i; cbn; auto. }
+        { instantiate (1:=[| _;_;_|]). cbn. intros i. specialize(HStar2 i). destruct_fin i; cbn; auto. }
         destruct HLastStep as (k&oconf&HLastStep); modpon HLastStep.
         exists (S k). eexists. cbn. unfold haltConf. cbn. rewrite !E, !E2. repeat split; eauto.
         rewrite <- HLastStep. unfold loopM. f_equal. clear_all. destruct_tapes; auto.
@@ -804,12 +804,12 @@ Section Univ.
       - modpon HStep.
         { unfold containsTrans, containsTrans_size in *. contains_ext. }
         { unfold containsState, containsState_size in *. contains_ext. }
-        { instantiate (1 := [|_;_;_|]). intros i. specialize (HRight i). destruct_fin i; cbn; auto. }
+        { instantiate (1 := [| _;_;_|]). intros i. specialize (HRight i). destruct_fin i; cbn; auto. }
         destruct (halt q) eqn:E; auto; modpon HStep. destruct k'; cbn in Hk; auto. rewrite E in Hk. auto.
       - modpon HStep.
         { unfold containsTrans, containsTrans_size in *. contains_ext. }
         { unfold containsState, containsState_size in *. contains_ext. }
-        { instantiate (1 := [|_;_;_|]). intros i. specialize (HRight i). destruct_fin i; cbn; auto. }
+        { instantiate (1 := [| _;_;_|]). intros i. specialize (HRight i). destruct_fin i; cbn; auto. }
         destruct (halt q) eqn:E; auto.
         unfold step, current_chars in HStep. cbn in *. destruct (trans (q, [|current tp|])) as [q'' acts] eqn:E'; modpon HStep. simpl_vector in HStep. cbn in *.
         pose proof destruct_vector1 acts as (act&->); cbn in *.

--- a/theories/TM/Univ/StepTM.v
+++ b/theories/TM/Univ/StepTM.v
@@ -1,5 +1,5 @@
 From Undecidability Require Import TM.Code.ProgrammingTools.
-Require Import PslBase.Bijection. (* [injective] *)
+Require Import Undecidability.Shared.Libs.PSL.Bijection. (* [injective] *)
 
 
 From Undecidability Require Import Basic.Duo.

--- a/theories/TM/Util/Prelim.v
+++ b/theories/TM/Util/Prelim.v
@@ -2,12 +2,12 @@
 
 (** This file imports all shared libraries and defines [loop], lemmas about [loop], and some auxiliay functions. *)
 
-Require Export PslBase.FiniteTypes.FinTypes PslBase.FiniteTypes.BasicFinTypes PslBase.FiniteTypes.CompoundFinTypes PslBase.FiniteTypes.VectorFin.
-Require Export PslBase.Vectors.FinNotation.
-Require Export PslBase.Retracts.
-Require Export PslBase.Inhabited.
-Require Export PslBase.Base.
-Require Export PslBase.Vectors.Vectors PslBase.Vectors.VectorDupfree.
+Require Export Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes Undecidability.Shared.Libs.PSL.FiniteTypes.BasicFinTypes Undecidability.Shared.Libs.PSL.FiniteTypes.CompoundFinTypes Undecidability.Shared.Libs.PSL.FiniteTypes.VectorFin.
+Require Export Undecidability.Shared.Libs.PSL.Vectors.FinNotation.
+Require Export Undecidability.Shared.Libs.PSL.Retracts.
+Require Export Undecidability.Shared.Libs.PSL.Inhabited.
+Require Export Undecidability.Shared.Libs.PSL.Base.
+Require Export Undecidability.Shared.Libs.PSL.Vectors.Vectors Undecidability.Shared.Libs.PSL.Vectors.VectorDupfree.
 
 Require Export smpl.Smpl Lia.
 

--- a/theories/TM/Util/Relations.v
+++ b/theories/TM/Util/Relations.v
@@ -1,5 +1,5 @@
-Require Import PslBase.Base PslBase.FiniteTypes Undecidability.TM.Util.Prelim.
-Require Import PslBase.Vectors.Vectors.
+Require Import Undecidability.Shared.Libs.PSL.Base Undecidability.Shared.Libs.PSL.FiniteTypes Undecidability.TM.Util.Prelim.
+Require Import Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 
 (** * Relations *)
 

--- a/theories/TM/Util/TM_facts.v
+++ b/theories/TM/Util/TM_facts.v
@@ -3,7 +3,7 @@
 (** Definitions of tapes and (unlabelled) multi-tape Turing machines from Asperti, Riciotti "A formalization of multi-tape Turing machines" (2015) and the accompanying Matita code. *)
 
 From Undecidability Require Export TM.Util.Prelim TM.Util.Relations.
-Require Import PslBase.Vectors.Vectors.
+Require Import Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 Require Export Undecidability.TM.TM.
        
 Section Fix_Sigma.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -69,6 +69,41 @@ Shared/Libs/DLW/Code/compiler.v
 Shared/Libs/DLW/Code/compiler_correction.v
 
 
+Shared/Libs/PSL/Base.v
+
+Shared/Libs/PSL/Tactics/Tactics.v
+Shared/Libs/PSL/Tactics/AutoIndTac.v
+Shared/Libs/PSL/Prelim.v
+Shared/Libs/PSL/EqDec.v
+Shared/Libs/PSL/Numbers.v
+Shared/Libs/PSL/Bijection.v
+Shared/Libs/PSL/Retracts.v
+Shared/Libs/PSL/Inhabited.v
+Shared/Libs/PSL/FCI.v
+
+Shared/Libs/PSL/Lists/BaseLists.v
+Shared/Libs/PSL/Lists/Cardinality.v
+Shared/Libs/PSL/Lists/Dupfree.v
+Shared/Libs/PSL/Lists/Filter.v
+Shared/Libs/PSL/Lists/Position.v
+Shared/Libs/PSL/Lists/Power.v
+Shared/Libs/PSL/Lists/Removal.v
+
+Shared/Libs/PSL/Vectors/Fin.v
+Shared/Libs/PSL/Vectors/Vectors.v
+Shared/Libs/PSL/Vectors/FinNotation.v
+Shared/Libs/PSL/Vectors/VectorDupfree.v
+
+Shared/Libs/PSL/FiniteTypes.v
+Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
+Shared/Libs/PSL/FiniteTypes/FinTypes.v
+Shared/Libs/PSL/FiniteTypes/BasicFinTypes.v
+Shared/Libs/PSL/FiniteTypes/CompoundFinTypes.v
+Shared/Libs/PSL/FiniteTypes/FiniteFunction.v
+Shared/Libs/PSL/FiniteTypes/Cardinality.v
+Shared/Libs/PSL/FiniteTypes/DepPairs.v
+Shared/Libs/PSL/FiniteTypes/Arbitrary.v
+Shared/Libs/PSL/FiniteTypes/VectorFin.v
 
 # Abstract L simulator as Turing Machine
 L/AbstractMachines/TM_LHeapInterpreter/Alphabets.v


### PR DESCRIPTION
Removed external dependency on PslBase by including it in theories/Shared/Libs/PSL.
Notably, PslBase is only used in `L`, `TM`, and `HaltSBTM_to_HaltBSM`, so this should not be of any concern for people except maybe @yforster .

This simplifies installation and makes the addition of the psl-opam-repository not necessary (unless one installs the Undecidability library itself via opam).

I also fixed that the Vector notation: "[| ... |]" does not interfere with destruct patterns "destruct x as [|]" anymore

The following things _would_ also nice-to-have, and easier to do now that PslBase is included:
-Some files from Shared and Shared/Libs/PSL are very similar due to historic reasons, and one might can tidy this up.
-On the other hand, the files in "toplevel" of shared are probably meant to never be used again, and only there for other code to work?
-Remove Shared/Prelim.v dependencies to make Andrej more happy
-Libs/PSL declares several hints in core, which changes the behaviour of the tactic "now" and annoys me sometimes

This includes https://github.com/uds-psl/base-library/pull/8, which speeds up Undec-Lib  builds a tiny bit although they now compile a few more files.
