### PR TITLE
change Fixpoint to Definition ... := fix to avoid a warning

### DIFF
--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -23,7 +23,8 @@ Set Implicit Arguments.
 
 (* Fixpoint instead of Definition because of better unfolding properties *)
 
-Fixpoint de_bruijn_ext {X} (ν : nat -> X) x n { struct n } :=
+Definition de_bruijn_ext {X} (ν : nat -> X) x :=
+  fix dbe n :=
   match n with
     | 0   => x
     | S n => ν n

--- a/theories/MinskyMachines/MMenv/env.v
+++ b/theories/MinskyMachines/MMenv/env.v
@@ -13,7 +13,8 @@ From Undecidability.Shared.Libs.DLW.Utils
 Set Implicit Arguments.
 
 Reserved Notation " e '⇢' x " (at level 58).
-Reserved Notation " e [ v / x ] " (at level 57, v at level 0, x at level 0, left associativity).
+Reserved Notation " e [ v / x ] " (at level 57, v at level 0, x at level 0, 
+                                   left associativity, format "e [ v / x ]").
 Reserved Notation " e ⦃  x '⇠' v ⦄ " (at level 57, v at level 0, x at level 0, left associativity).
 
 Section env.

--- a/theories/TRAKHTENBROT/notations.v
+++ b/theories/TRAKHTENBROT/notations.v
@@ -20,7 +20,8 @@ Set Implicit Arguments.
 
 (* Fixpoint instead of Definition because of better unfolding properties *)
 
-Fixpoint de_bruijn_ext {X} (ν : nat -> X) x n { struct n } :=
+Definition de_bruijn_ext {X} (ν : nat -> X) x := 
+  fix dbe n :=
   match n with
     | 0   => x
     | S n => ν n


### PR DESCRIPTION
Removes two kinds of _harmless_ warnings:

- `Coq` complaining about `Fixpoint` definitions that make no recursive sub-calls. `Fixpoint`s are somewhat natively better behaved wrt the `simpl` tactic. Solution is to replace by anonymous fixpoints, ie `Fixpoint foo ... := ...` is replaced with `Definition foo := fix foo ... := ...`;
- a component access notation `_ [ _ / _ ]` which what declared twice, once with the default (or absent) `format` directive, and a second time with a specific `format` directive to avoid unnecessary blank spaces, hence the warning.

The component access notation is declared as `Reserved Notation` in `Shared/Libs/DLW/Vec/vec.v` where it covers the case of `pos n` indexed vectors but also in `MinskyMachines/MMenv/env.v` where it covers `X -> Y` where `X` is a discrete type.  
