### PR TITLE
Improvements to L framework

### DIFF
--- a/theories/L/Complexity/ResourceMeasures.v
+++ b/theories/L/Complexity/ResourceMeasures.v
@@ -47,7 +47,7 @@ Module Leftmost.
     intros s t R u ? <-. revert s t R u.
     induction k;cbn in *;intros ? ? R ?. congruence. destruct R as [s' [R1 R2]].
     exists (app s' u). firstorder.
-  Defined.
+  Qed.
 
   Instance pow_step_lm_congR k:
     Proper (eq ==>(pow step_lm k) ==> (pow step_lm k)) (fun s t => app (lam s) t).
@@ -55,7 +55,7 @@ Module Leftmost.
     intros s ? <- t u R. revert s t u R.
     induction k;cbn in *;intros ? ? ? R. congruence. destruct R as [t' [R1 R2]].
     exists (app (lam s) t'). firstorder.
-  Defined.
+  Qed.
 
   Instance step_lm_step: subrelation step_lm step.
   Proof.
@@ -84,7 +84,7 @@ Module Leftmost.
     -apply redWithMaxSizeR. cbn in *. lia. 
     -eapply redWithMaxSizeC. now eauto using step_lm. apply IHR. reflexivity.
      subst m m'. cbn -[plus]. repeat eapply Nat.max_case_strong;lia.
-  Defined.
+  Qed.
 
 
   Lemma step_lm_evaluatesIn s s' t k: s ≻lm s' -> timeBS k s' t -> timeBS (S k) s t.
@@ -273,7 +273,6 @@ Proof.
   destruct t'. 1,2:(now exfalso;destruct H2 as [? []]).
   eapply HR. 1-6:try (eapply timeBS_evalIn); eauto.
   eapply timeBS_evalIn in H'. inv H'.
-  Search evalIn eq. 
   apply timeBS_evalIn in H5. apply timeBS_evalIn in H6. apply timeBS_evalIn in H8.
   do 3 lazymatch goal with
   | H : ?s ⇓(_) _ , H' : ?s ⇓(_) _ |- _ =>

--- a/theories/L/Complexity/UpToCNary.v
+++ b/theories/L/Complexity/UpToCNary.v
@@ -1,10 +1,8 @@
-From Undecidability Require Export UpToC.
+From Undecidability.L.Complexity Require Export UpToC GenericNary.
 
 Require Import smpl.Smpl.
 From Coq Require Import Setoid.
 From Coq Require Import CRelationClasses CMorphisms.
-From Undecidability Require Export UpToC.
-From Undecidability Require Export GenericNary.
 From Undecidability.Shared.Libs.PSL Require FinTypes.
 
 Local Set Universe Polymorphism. 

--- a/theories/L/Computability/Acceptability.v
+++ b/theories/L/Computability/Acceptability.v
@@ -51,7 +51,7 @@ Proof.
   (* todo: nicer way?*)
   assert (R':(lam(
       (Por ((ext app) (ext u) ((ext (term_enc)) 0)))
-      ((ext app) (ext v) ((ext (term_enc)) 0))) (ext t)) >* t'). subst t'. Lsimpl.
+      ((ext app) (ext v) ((ext (term_enc)) 0))) (ext t)) >* t'). subst t'. now Lsimpl.
   rewrite R'. subst t'.
   split. intros [A|B].
   -destruct (Por_correct_1a (v (enc t)) A) as [s [R ls]]. exists s. split;try Lproc. eassumption.
@@ -74,7 +74,8 @@ Proof.
       split; intros H; destruct dec_u_M; try tauto. 
       * destruct H0 as [u_true ?]. eexists;split;[|eexists;reflexivity]. redSteps. rewrite u_true. destruct x. now Lsimpl. tauto.
       * destruct H0. destruct x. tauto. 
-        assert ((lam ((((u #0) I) (lam Omega)) I)) (enc t) == Omega). clear H. LsimplRed. rewrite H0. Lrewrite. now Lsimpl. destruct H as [H [? []]]. subst H. rewrite H2 in H3. 
+        assert ((lam ((((u #0) I) (lam Omega)) I)) (enc t) == Omega). clear H. LsimplRed. rewrite H0. Lrewrite.
+        now Lsimpl_old. destruct H as [H [? []]]. subst H. rewrite H2 in H3. 
         destruct (Omega_diverges H3).
 Qed.
 

--- a/theories/L/Computability/Decidability.v
+++ b/theories/L/Computability/Decidability.v
@@ -17,14 +17,16 @@ Definition conj (P : term -> Prop) (Q : term -> Prop) := fun t => P t /\ Q t.
 Definition disj (P : term -> Prop) (Q : term -> Prop) := fun t => P t \/ Q t.
 
 (* * Deciders for complement, conj and disj of ldec predicates *)
-Definition tcompl (u : term) : term := Eval cbn in λ x, !!(ext negb) (!!u x).
+Definition tcompl (u : term) : term := Eval cbn in convert (λ x, !!(ext negb) (!!u x)).
 
-Definition tconj (u v : term) : term := Eval cbn in λ x, !!(ext andb) (!!u x) (!!v x).
+Definition tconj (u v : term) : term := Eval cbn in convert (λ x, !!(ext andb) (!!u x) (!!v x)).
 
-Definition tdisj (u v : term) : term := Eval cbn in λ x, !!(ext orb) (!!u x) (!!v x). 
+Definition tdisj (u v : term) : term := Eval cbn in convert (λ x, !!(ext orb) (!!u x) (!!v x)). 
 
 Hint Unfold tcompl tconj tdisj : Lrewrite.
+Hint Opaque tcompl tconj tdisj : Lrewrite.
 Hint Unfold tcompl tconj tdisj : LProc.
+Hint Opaque tcompl tconj tdisj : LProc.
 
 (* * L-decidable predicates are closed under complement, conj and disj *)
 
@@ -33,7 +35,7 @@ Proof.
   intros [u [[cls_u lam_u] H]]. exists (tcompl u). unfold tcompl. split. Lproc. 
   intros s. destruct (H s) as [b [A Ps]];exists (negb b).
   split.
-  -Lsimpl. rewrite A. Lsimpl.
+  -Lsimpl. rewrite A. now Lsimpl.
   -destruct b;simpl; intuition.
 Qed.
 
@@ -43,7 +45,7 @@ Proof.
   exists (tconj u v). unfold tconj. split. Lproc. 
   intros s.  destruct (decP s) as [b  [Hu Ps]], (decQ s) as [b' [Hv Qs]];exists (andb b b').
   split.
-  -Lsimpl. rewrite Hu,Hv. Lsimpl.
+  -Lsimpl. rewrite Hu,Hv. now Lsimpl.
   -destruct b,b';simpl;unfold conj;intuition.   
 Qed.
 
@@ -53,7 +55,7 @@ Proof.
   exists (tdisj u v). unfold tdisj. split. Lproc. 
   intros s.  destruct (decP s) as [b  [Hu Ps]], (decQ s) as [b' [Hv Qs]];exists (orb b b').
   split.
-  -Lsimpl. rewrite Hu,Hv. Lsimpl.
+  -Lsimpl. rewrite Hu,Hv. now Lsimpl.
   -destruct b,b';simpl;unfold disj;intuition.
 Qed.
 

--- a/theories/L/Computability/Fixpoints.v
+++ b/theories/L/Computability/Fixpoints.v
@@ -22,12 +22,12 @@ Proof.
   exists t. split;[subst t A;Lproc|].
   symmetry. change (enc t) with (ext t).
   unfold t. unfold A at 1.
-  redSteps. Lsimpl.
+  redSteps. now Lsimpl.
 Qed.
 
 Goal exists t, closed t /\ t == (enc t).
 Proof.
   destruct (SecondFixedPoint) with ( s := I) as [t [cls_t A]]. Lproc.
   exists t.
-  split. Lproc. rewrite <- A at 1. clear A. unfold I. Lsimpl.
+  split. Lproc. rewrite <- A at 1. clear A. unfold I. now Lsimpl.
 Qed.

--- a/theories/L/Computability/MuRec.v
+++ b/theories/L/Computability/MuRec.v
@@ -16,7 +16,7 @@ Qed.
 
 Section hoas.
   Import HOAS_Notations.
-  Definition mu' := Eval cbn -[enc] in rho (λ mu P n, (P n) (!!K n) (λ Sn, mu P Sn) (!!(ext S) n)).
+  Definition mu' := Eval cbn -[enc] in rho (convert (λ mu P n, (P n) (!!K n) (λ Sn, mu P Sn) (!!(ext S) n))).
 End hoas.
 
 Import L_Notations.
@@ -29,7 +29,7 @@ Hint Resolve mu'_proc : LProc.
 
 Lemma mu'_n_false n: P (ext n)  == ext false -> mu' P (ext n) >* mu' P (ext (S n)).
 Proof.
-  intros R. apply equiv_lambda in R;[|Lproc]. recStep mu'. unfold K. Lsimpl. 
+  intros R. apply equiv_lambda in R;[|Lproc]. recStep mu'. unfold K. now Lsimpl. 
 Qed.
 
 Lemma mu'_0_false n: (forall n', n' < n -> P (ext n')  == ext false) -> mu' P (ext 0) >* mu' P (ext n).
@@ -43,7 +43,7 @@ Qed.
 
 Lemma mu'_n_true (n:nat): P (ext n)  == ext true -> mu' P (ext n) == ext n.
 Proof.
-  intros R. recStep mu'. Lsimpl. rewrite R. unfold K.  Lsimpl.
+  intros R. recStep mu'. Lsimpl. rewrite R. unfold K. now Lsimpl.
 Qed.
 
 (* TODO: mu' sound*)
@@ -71,7 +71,7 @@ Lemma mu'_complete n0 : P (ext n0) == ext true
                         -> mu' P (ext 0) == ext n0.
 Proof.
   intros. rewrite mu'_0_false with (n:=n0);try tauto.
-  -recStep mu'. Lsimpl. rewrite H. unfold K. Lsimpl. 
+  -recStep mu'. Lsimpl. rewrite H. unfold K. now Lsimpl. 
 Qed.
 
 (* the mu combinator:*)

--- a/theories/L/Computability/Por.v
+++ b/theories/L/Computability/Por.v
@@ -3,7 +3,7 @@ From Undecidability.L.Tactics Require Import Lbeta_nonrefl.
 (* * Definition of parallel or *)
 
 Section hoas. Import HOAS_Notations.
-Definition Por :term := Eval simpl in (λ s t , (λ n0,  !!(ext doesHaltIn) s n0 ) (!!mu (λ n ,!!(ext orb) (!!(ext doesHaltIn) s n) (!!(ext doesHaltIn) t n)))) .
+Definition Por :term := Eval simpl in [L_HOAS λ s t , (λ n0,  !!(ext doesHaltIn) s n0 ) (!!mu (λ n ,!!(ext orb) (!!(ext doesHaltIn) s n) (!!(ext doesHaltIn) t n)))] .
 End hoas.
 
 Lemma Por_proc : proc Por.
@@ -21,8 +21,8 @@ Proof.
   apply seval_eva in H. edestruct mu_complete with (n:=n) (P:=(lam ((ext orb) ((ext doesHaltIn) (ext s) 0) ((ext doesHaltIn) (ext t) 0)))) as [v R].
   -Lproc.
   -eexists;now Lsimpl.
-  -Lsimpl. edestruct (doesHaltIn s n) eqn:eq;unfold doesHaltIn in eq;rewrite H in eq. 2:congruence. Lsimpl.
-  -eapply Seval.eval_converges. unfold Por. Lsimpl. rewrite R. Lsimpl.
+  -Lsimpl. edestruct (doesHaltIn s n) eqn:eq;unfold doesHaltIn in eq;rewrite H in eq. 2:congruence. reflexivity.
+  -eapply Seval.eval_converges. unfold Por. Lsimpl_old. rewrite R. Lsimpl. Lreflexivity.
 Qed.
 
 Lemma Por_correct_1b (s t:term) : converges t -> converges (Por (ext s) (ext t)).
@@ -31,8 +31,8 @@ Proof.
   apply seval_eva in H. edestruct mu_complete with (n:=n) (P:=lam ( (ext orb) ((ext doesHaltIn) (ext s) 0) ((ext doesHaltIn) (ext t) 0))) as [v R].
   -Lproc.
   -eexists;now Lsimpl.
-  -Lsimpl.  edestruct (doesHaltIn t n) eqn:eq;unfold doesHaltIn in eq;rewrite H in eq. 2:congruence. edestruct doesHaltIn;Lsimpl.
-  -eapply Seval.eval_converges. unfold Por. Lsimpl. rewrite R. Lsimpl.
+  -Lsimpl.  edestruct (doesHaltIn t n) eqn:eq;unfold doesHaltIn in eq;rewrite H in eq. 2:congruence. edestruct doesHaltIn;reflexivity.
+  -eapply Seval.eval_converges. unfold Por. Lsimpl_old. rewrite R. Lsimpl. Lreflexivity.
 Qed.
 
 Lemma Por_correct_1 s t : converges s \/ converges t -> converges (Por (ext s) (ext t)).
@@ -48,7 +48,7 @@ Proof.
   apply app_converges in C as [_ [v' [C lv']]].
   assert (C':=C).
   apply mu_sound in C as [n [eq [R' H]]];try Lproc.
-  -exists (doesHaltIn s n). subst. unfold Por. Lsimpl. rewrite C'. Lsimpl. 
+  -exists (doesHaltIn s n). subst. unfold Por. Lsimpl_old. rewrite C'. now Lsimpl. 
   -eexists. now Lsimpl.
 Qed.
 

--- a/theories/L/Computability/Rice.v
+++ b/theories/L/Computability/Rice.v
@@ -54,8 +54,8 @@ Proof with eauto; try now intuition.
   transitivity (pi u vs /\ proc s).
   { 
     split; intros [R cls_s];(split;[|Lproc]).
-    -revert R. eapply converges_proper. symmetry. subst v. Lsimpl.
-    -revert R. eapply converges_proper. subst v. Lsimpl.
+    -revert R. eapply converges_proper. symmetry. subst v. now Lsimpl.
+    -revert R. eapply converges_proper. subst v. now Lsimpl.
   }
 
   transitivity (M vs /\ proc s).
@@ -67,7 +67,7 @@ Proof with eauto; try now intuition.
       intros [w [Hw lw]]. 
       assert (forall t, pi vs t <-> pi t2 t). {
         intros t. eapply converges_proper.
-        assert (closed w). eapply (equiv_lambda lw) in Hw. eapply closed_star. exact Hw. Lproc. subst vs. Lsimpl. rewrite Hw. Lsimpl. 
+        assert (closed w). eapply (equiv_lambda lw) in Hw. eapply closed_star. exact Hw. Lproc. subst vs. Lsimpl_old. rewrite Hw. now Lsimpl. 
       }
       eapply nMt2. eapply M_cl_equiv; eassumption.
     - intros [npi_s_s cls_s]; intuition.
@@ -75,7 +75,7 @@ Proof with eauto; try now intuition.
         intros t; split; intros H'.
         - exfalso. destruct H' as [w [Hw lw]]. inv lw. eapply Omega_diverges. rewrite <- Hw. symmetry. clear Hw. now redStep.
         - exfalso. eapply npi_s_s.
-          assert (A: converges (lam ( t2 (enc t)) (s (enc s)))). revert H'. eapply converges_proper. symmetry. unfold vs. Lsimpl.
+          assert (A: converges (lam ( t2 (enc t)) (s (enc s)))). revert H'. eapply converges_proper. symmetry. unfold vs. now Lsimpl_old.
           eapply app_converges in A. firstorder.
       }
                                                        subst vs.
@@ -111,8 +111,8 @@ Proof.
   transitivity (pi u vs /\ proc s).
   {
     split; intros [R cls_s];(split;[|Lproc]).
-    -revert R. eapply converges_proper. symmetry. subst v. Lsimpl.
-    -revert R. eapply converges_proper. subst v. Lsimpl.
+    -revert R. eapply converges_proper. symmetry. subst v. now Lsimpl.
+    -revert R. eapply converges_proper. subst v. now Lsimpl.
   }
 
   transitivity (~ M vs /\ proc s).
@@ -126,7 +126,7 @@ Proof.
       intros [w [Hw lw]]. 
       assert (forall t, pi t1 t <-> pi vs t). {
         intros t. symmetry. assert (closed w). eapply closed_star. eapply equiv_lambda;eauto. Lproc.  eapply converges_proper.
-        transitivity (lam ( t1 (enc t)) (s (enc s))). unfold vs. Lsimpl. rewrite Hw. Lsimpl.
+        transitivity (lam ( t1 (enc t)) (s (enc s))). unfold vs. now Lsimpl_old. rewrite Hw. now Lsimpl.
       }
       eapply Mvs. eapply M_cl_equiv;try subst vs; try Lproc; try eassumption.
     - intros [npi_s_s cls_s]; intuition.
@@ -134,7 +134,7 @@ Proof.
         intros t; split; intros A.
         - exfalso. destruct A as [w [Hw lw]]. inv lw. eapply Omega_diverges. rewrite <- Hw. symmetry. clear Hw. now LsimplRed.
         - exfalso. eapply npi_s_s.
-          assert (B: converges (lam ( t1 (enc t)) (s (enc s)))). revert A. eapply converges_proper. symmetry. unfold vs. Lsimpl.
+          assert (B: converges (lam ( t1 (enc t)) (s (enc s)))). revert A. eapply converges_proper. symmetry. unfold vs. Lsimpl_old.
           eapply app_converges in B. firstorder.
       }
       eapply nMLO.

--- a/theories/L/Computability/Synthetic.v
+++ b/theories/L/Computability/Synthetic.v
@@ -40,7 +40,7 @@ Section L_enum_rec.
   Import HOAS_Notations.
 
   Lemma proc_test (x : X) :
-    proc (λ y, !!(ext test) !!(enc x) y).
+    proc [L_HOAS λ y, !!(ext test) !!(enc x) y].
   Proof.
     cbn. Lproc.
   Qed.
@@ -48,23 +48,23 @@ Section L_enum_rec.
   Lemma L_enumerable_recognisable :
     L_recognisable' p.
   Proof.
-    exists (λ x, !!mu (λ y, !!(ext test) x y)).
+    exists [L_HOAS λ x, !!mu (λ y, !!(ext test) x y)].
     intros. split; intros.
     - eapply H_f in H0 as [n H0].
       edestruct (mu_complete (proc_test x)) with (n := n).
-      + intros. exists (test x n0). cbn. Lsimpl.
-      + cbn. Lsimpl. unfold test. rewrite H0. Lsimpl. destruct (H_d x x); intuition.
+      + intros. exists (test x n0). cbn. now Lsimpl.
+      + cbn. Lsimpl. unfold test. rewrite H0. destruct (H_d x x); intuition.
       + exists (ext x0). split; try Lproc.
         cbn. Lsimpl. now rewrite H1.
     - destruct H0 as (v & ? & ?).
       edestruct (mu_sound (proc_test x)) with (v := v) as (n & ? & ? & _).
-      + intros. exists (test x n). cbn. Lsimpl.
+      + intros. exists (test x n). cbn. now Lsimpl.
       + Lproc.
-      + rewrite <- H0. symmetry. cbn. Lsimpl.
+      + rewrite <- H0. symmetry. cbn. now Lsimpl.
       + subst. eapply H_f. exists n.
-        assert ((λ y, !! (ext test) !! (enc x) y) !!(ext n) == ext (test x n)).
-        cbn. Lsimpl. cbn in *. rewrite H2 in *.
-        eapply unique_normal_forms in H3; try Lproc.
+        assert ([L_HOAS (λ y, !! (ext test) !! (enc x) y) !!(ext n)] == ext (test x n)).
+        cbn. now Lsimpl. cbn in *. rewrite H2 in *.
+        eapply unique_normal_forms in H3;[|Lproc..].
         eapply inj_enc in H3.
         unfold test in H3. destruct (f n); inv H3.
         destruct (H_d x x0); firstorder congruence.
@@ -236,14 +236,14 @@ Proof.
   intros (f & [c_f] & H_f).
   exists (lam (mu (lam (ext f 1 0)))).
   intros. 
-  assert (((lam (mu (lam ((ext f 1) 0)))) (enc x)) >* mu (lam (ext f (enc x) 0))) by Lsimpl.
+  assert (((lam (mu (lam ((ext f 1) 0)))) (enc x)) >* mu (lam (ext f (enc x) 0))) by now Lsimpl.
   rewrite H0. rewrite mu_spec.
   - rewrite H_f. split; intros [n]; exists n.
     Lsimpl. now rewrite H1.
     eapply enc_extinj.
-    now assert ((lam (((ext f) (enc x)) 0)) (ext n) == enc (f x n)) as <- by Lsimpl.
+    now assert ((lam (((ext f) (enc x)) 0)) (ext n) == enc (f x n)) as <- by now Lsimpl.
   - Lproc.
-  - intros. exists (f x n). Lsimpl.
+  - intros. exists (f x n). now Lsimpl.
 Qed.    
 
 Lemma L_recognisable_halt {X} `{registered X} (p : X -> Prop) :

--- a/theories/L/Datatypes/LNat.v
+++ b/theories/L/Datatypes/LNat.v
@@ -14,13 +14,13 @@ Instance termT_S : computableTime' S (fun _ _ => (1,tt)).
 Proof.
   extract constructor.
   solverec.
-Defined.
+Qed.
 
 Instance termT_pred : computableTime' pred (fun _ _ => (5,tt)).
 Proof.
   extract.
   solverec.
-Defined.
+Qed.
 
 Definition c__add := 11. 
 Definition c__add1 := 5.
@@ -30,7 +30,7 @@ Proof.
   extract.
   fold add. solverec. 
   all: unfold add_time, c__add1, c__add; solverec. 
-Defined.
+Qed.
 
 Definition c__mult1 := 5.
 Definition c__mult := c__add + c__add1 + 10.
@@ -39,7 +39,7 @@ Instance termT_mult : computableTime' mult (fun x xT => (c__mult1,(fun y yT => (
 Proof.
   extract. solverec. 
   all: unfold mult_time, c__mult1, c__mult, add_time, c__add1, c__add; solverec. 
-Defined.
+Qed.
 
 Definition c__sub1 := 5.
 Definition c__sub := 14. 
@@ -48,7 +48,7 @@ Instance term_sub : computableTime' Nat.sub (fun n _ => (c__sub1,fun m _ => (sub
 Proof.
   extract. solverec.
   all: unfold sub_time, c__sub1, c__sub; solverec. 
-Defined.
+Qed.
 
 Definition c__leb := 14.
 Definition c__leb2 := 5. 
@@ -57,7 +57,7 @@ Instance termT_leb : computableTime' leb (fun x xT => (c__leb2,(fun y yT => (leb
 Proof.
   extract.
   solverec. all: unfold leb_time, c__leb, c__leb2; solverec. 
-Defined.
+Qed.
 
 Definition c__ltb := c__leb2 + 4.
 Definition ltb_time (a b : nat) := leb_time (S a) b + c__ltb. 
@@ -82,7 +82,7 @@ Proof.
   [c]:exact 5.
   all:unfold c;try lia.
 Qed.
-(*Defined.*)
+(*Qed.*)
 
 Definition c__min1 := 5.
 Definition c__min2 := 15. 
@@ -91,7 +91,7 @@ Instance termT_nat_min : computableTime' Nat.min (fun x _ => (c__min1, fun y _ =
 Proof. 
   extract. solverec. 
   all: unfold min_time, c__min1, c__min2; solverec. 
-Defined. 
+Qed. 
 
 Definition c__max1 := 5.
 Definition c__max2 := 15. 
@@ -100,7 +100,7 @@ Instance termT_nat_max : computableTime' Nat.max (fun x _ => (c__max1, fun y _ =
 Proof. 
   extract. solverec. 
   all: unfold max_time, c__max1, c__max2; solverec. 
-Defined. 
+Qed. 
 
 Definition c__pow1 := 5.
 Definition c__pow2 := 10 + c__mult1.
@@ -113,7 +113,7 @@ Instance termT_pow:
 Proof.
   extract. fold Nat.pow. solverec. 
   all: unfold pow_time, c__pow1, c__pow2; solverec. 
-Defined.
+Qed.
 
 
 Definition c__divmod := 20.
@@ -122,7 +122,7 @@ Instance termT_divmod :
   computableTime' divmod (fun (x : nat) _ => (5, fun (y : nat) _ => (5, fun (q : nat) _ => (1, fun (u : nat) _ => (divmod_time x, tt))))). 
 Proof. 
   extract. solverec. all: unfold divmod_time, c__divmod; solverec. 
-Defined. 
+Qed. 
 
 Definition c__modulo := 21 + c__sub1. 
 Definition modulo_time (x :nat) (y : nat) := divmod_time x + c__sub * y + c__modulo.
@@ -132,7 +132,7 @@ Proof.
   extract. solverec. 
   - unfold modulo_time, c__modulo; solverec. 
   - unfold sub_time. rewrite Nat.le_min_l. unfold modulo_time, c__modulo. solverec. 
-Defined. 
+Qed. 
 
 (* now some more encoding-related properties:*)
 
@@ -193,4 +193,4 @@ Qed.
 (*   extract. *)
 (*   eexists (fun x xT => (x*9+7,tt)). *)
 (*   abstract (repeat (cbn;intros;intuition;try destruct _;try ring_simplify)). *)
-(* Defined. *)
+(* Qed. *)

--- a/theories/L/Datatypes/LOptions.v
+++ b/theories/L/Datatypes/LOptions.v
@@ -73,7 +73,7 @@ Section int.
                                                                                           | _,_ => 8 end,tt)))). cbn.
   Proof.
     extract. solverec.
-  Defined.
+  Qed.
 
   Global Instance eqbOption f `{eqbClass (X:=X) f}:
     eqbClass (option_eqb f).

--- a/theories/L/Datatypes/LProd.v
+++ b/theories/L/Datatypes/LProd.v
@@ -22,17 +22,17 @@ Section Fix_XY.
   Global Instance term_pair : computableTime' (@pair X Y) (fun _ _ => (1,fun _ _ => (1,tt))).
   Proof.
     extract constructor. solverec. 
-  Defined.
+  Qed.
 
   Global Instance term_fst : computableTime' (@fst X Y) (fun _ _ => (5,tt)).
   Proof.
     extract. solverec.
-  Defined.
+  Qed.
 
   Global Instance term_snd : computableTime' (@snd X Y) (fun _ _ => (5,tt)).
   Proof.
     extract. solverec.
-  Defined.
+  Qed.
 
   Definition prod_eqb f g (a b: X*Y):=
     let (x1,y1):= a in
@@ -84,13 +84,13 @@ Section Fix_XY.
                                            k2 +fst (eqT2' (snd y) tt)) + 14, tt))))).
   Proof.
     extract. solverec. 
-  Defined.
+  Qed.
 
   Global Instance term_prod_eqb_notime :
     computable prod_eqb.
   Proof.
     extract. 
-  Defined. *)
+  Qed. *)
 
   
   Lemma size_prod (w:X*Y):

--- a/theories/L/Datatypes/LTerm.v
+++ b/theories/L/Datatypes/LTerm.v
@@ -10,17 +10,17 @@ Hint Resolve term_enc_correct : Lrewrite.
 Instance term_var : computableTime' var (fun n _ => (1, tt)).
 Proof.
   extract constructor. solverec.
-Defined.
+Qed.
 
 Instance term_app : computableTime' L.app (fun s1 _ => (1, (fun s2 _ => (1, tt)))).
 Proof.
   extract constructor. solverec.
-Defined.
+Qed.
 
 Instance term_lam : computableTime' lam (fun s _ => (1, tt)).
 Proof.
   extract constructor. solverec.
-Defined.
+Qed.
 
 
 Definition c__termsize := c__natsizeS + 7. 

--- a/theories/L/Datatypes/List/List_eqb.v
+++ b/theories/L/Datatypes/List/List_eqb.v
@@ -85,7 +85,7 @@ Section int.
   Proof.
     extract.
     solverec.                                                                                             
-  Defined.
+  Qed.
 
   Definition list_eqbTime_leq (eqbT: timeComplexity (X -> X -> bool)) (A B:list X) k:
     (forall a b, callTime2 eqbT a b <= k)

--- a/theories/L/Datatypes/List/List_extra.v
+++ b/theories/L/Datatypes/List/List_extra.v
@@ -30,7 +30,7 @@ Instance term_seq : computableTime' seq (fun start _ => (5, fun len _ => (seq_ti
 Proof. 
   extract. solverec. 
   all: unfold seq_time, c__seq; solverec. 
-Defined. 
+Qed. 
 
 (* prodLists *)
 Section fixprodLists. 
@@ -51,6 +51,6 @@ Section fixprodLists.
     extract. solverec. 
     all: unfold prodLists_time, c__prodLists1, c__prodLists2; solverec. 
     rewrite map_length, map_time_const. leq_crossout. 
-  Defined. 
+  Qed. 
 End fixprodLists. 
 

--- a/theories/L/Datatypes/List/List_fold.v
+++ b/theories/L/Datatypes/List/List_fold.v
@@ -16,7 +16,7 @@ Section forallb.
     extract.
     solverec. 
     all: unfold forallb_time, c__forallb; solverec. 
-  Defined. 
+  Qed. 
 
   Lemma forallb_time_eq f (l:list X):
     forallb_time f l = sumn (map f l) + length l * c__forallb + c__forallb.

--- a/theories/L/Functions/Encoding.v
+++ b/theories/L/Functions/Encoding.v
@@ -1,5 +1,5 @@
 From Undecidability.L.Tactics Require Import LTactics.
-From Undecidability.L.Datatypes Require Import LNat LTerm LProd Lists.
+From Undecidability.L.Datatypes Require Import LNat LTerm LBool LProd List.List_enc LOptions.
 
 (* ** Extracted encoding of natural numbers *)
 

--- a/theories/L/Functions/Eval.v
+++ b/theories/L/Functions/Eval.v
@@ -18,7 +18,7 @@ Qed.
 
 Section hoas. Import HOAS_Notations.
 Definition Eval :term := Eval cbn in
-      (λ u, !!(ext eva) 
+      convert(λ u, !!(ext eva) 
               (!!mu (λ n, !!(ext doesHaltIn) u n)) u !!I !!I).
 End hoas.
 
@@ -35,22 +35,27 @@ Proof.
    apply mu_sound in R as [n [ eq [R _]]];try Lproc.
    +subst w. LsimplHypo. Lrewrite in H. Lrewrite in R. apply enc_extinj in R. unfold doesHaltIn in R. destruct (eva n) eqn:eq. 
     *exists n,t. split. Lsimpl. now rewrite eq. split. apply unique_normal_forms;[Lproc..|].
-       rewrite <- H. unfold I. clear H. Lsimpl. eapply eva_lam. eauto. 
+       rewrite <- H. unfold I. clear H. now Lsimpl. eapply eva_lam. eauto. 
     *congruence. 
    +intros. eexists. Lsimpl. reflexivity.
   -intros [n [v' [H [eq lv']]]]. subst v. Lrewrite in H. Lsimpl. 
     apply enc_extinj in H. destruct mu_complete with (P:=(lam ((ext doesHaltIn) (ext s) 0))) (n:=n);try Lproc.
    +intros n0. destruct (eva n0 s) eqn:eq;eexists; Lsimpl;reflexivity.
-   + Lsimpl. unfold doesHaltIn. rewrite H. Lsimpl.
-   +rewrite H0. Lsimpl. apply mu_sound in H0. destruct H0 as [n' [eq [R _]]]. apply inj_enc in eq. subst. LsimplHypo. Lrewrite in R. apply enc_extinj in R. unfold doesHaltIn in R. destruct (eva n' s) eqn:eq. Lsimpl. apply eva_equiv in H. assert (lambda t) by now apply eva_lam in eq. apply eva_equiv in eq. rewrite H in eq. unfold I. apply unique_normal_forms in eq;try Lproc. subst. Lsimpl. congruence. Lproc.
+   + Lsimpl. unfold doesHaltIn. rewrite H. reflexivity.
+   +rewrite H0. Lsimpl. apply mu_sound in H0. 2,4:Lproc.
+    * destruct H0 as [n' [eq [R _]]]. apply inj_enc in eq. subst. LsimplHypo.
+      Lrewrite in R. apply enc_extinj in R. unfold doesHaltIn in R. destruct (eva n' s) eqn:eq. 2:congruence.
+      Lsimpl. apply eva_equiv in H. assert (lambda t) by now apply eva_lam in eq. apply eva_equiv in eq. rewrite H in eq. unfold I.
+      apply unique_normal_forms in eq;[|Lproc..]. subst. reflexivity.
     *intros n0. eexists; Lsimpl. reflexivity.
-     *Lproc.
 Qed.
 
 Lemma seval_Eval n (s t:term): seval n s t -> Eval (ext s) == (ext t).
 Proof.
   intros. apply seval_eva in H. 
-  rewrite Eval_correct;try Lproc.  exists n,t. repeat split. Lsimpl. rewrite H. symmetry; Lsimpl. apply eva_lam in H. Lproc.
+  rewrite Eval_correct;try Lproc.  exists n,t. repeat split.
+  -Lsimpl. rewrite H. reflexivity.
+  -apply eva_lam in H. Lproc.
 Qed.
 
 Lemma eval_Eval s t : eval s t -> Eval (ext s) == (ext t).

--- a/theories/L/Functions/UnboundIteration.v
+++ b/theories/L/Functions/UnboundIteration.v
@@ -12,7 +12,7 @@ Section uiter.
   Context `{computableTime' f fT}.
 
   Import HOAS_Notations.
-  Definition uiter := Eval cbn -[enc] in rho (λ uiter x, !!(extT f) x (λ x' _ , uiter x') (λ y _ , y) !!I).
+  Definition uiter := Eval cbn -[enc] in rho [L_HOAS (λ uiter x, !!(extT f) x (λ x' _ , uiter x') (λ y _ , y) !!I)].
   
   Lemma uiter_proc : proc uiter.
   Proof. unfold uiter. Lproc. Qed.
@@ -37,8 +37,8 @@ Section uiter.
     2,3:reflexivity.
     2:{
       destruct (f x) eqn:eqfx.
-      -Intern.recStepUnnamed. Lrewrite_new. rewrite eqfx. Lrewrite_new. eapply IHn. eauto.
-      -inv Heq. Intern.recStepUnnamed. Lrewrite_new. rewrite eqfx. Lrewrite_new. Lreflexivity.
+      -Intern.recStepNew P. Lsimpl. rewrite eqfx. Lsimpl. eapply IHn. eauto.
+      -inv Heq. Intern.recStepNew P. Lsimpl. rewrite eqfx. Lsimpl. Lreflexivity.
     }
     destruct (f x).
     all:solverec.
@@ -48,9 +48,9 @@ Section uiter.
   Lemma uiter_total_instanceTime {Z} `{registered Z} (f':  Z -> Y) (preprocess : Z -> X) preprocessT (fuel : Z -> nat)
     `{computableTime' preprocess preprocessT} :
     (forall x, loopSum (fuel x) f (preprocess x) = Some (f' x)) ->
-    computesTime (TyArr _ _) f' (λ x, !!uiter !!(L.app (extT preprocess) x)) (fun z _ => (1 + fst (preprocessT z tt) + uiterTime (fuel z) (preprocess z),tt)).
+    computesTime (TyArr _ _) f' (convert (λ x, !!uiter (!!(extT preprocess) x))) (fun z _ => (1 + fst (preprocessT z tt) + uiterTime (fuel z) (preprocess z),tt)).
   Proof.
-    cbn [convert TH].
+    cbn [convert TH "-"].
     intros total.
     eapply computesTimeTyArr_helper with (time:=(fun x _ => _)).
     { unfold uiter. now Lproc. }
@@ -61,6 +61,7 @@ Section uiter.
     2:{ eapply evalLe_trans with (t := (L.app uiter (enc (preprocess z)))).
         -now Lsimpl.
         -eapply uiter_sound. apply total. }
+    cbn.
     lia.
   Qed.
     

--- a/theories/L/Functions/Unenc.v
+++ b/theories/L/Functions/Unenc.v
@@ -1,6 +1,0 @@
-From Undecidability.L Require Import Functions.Encoding Datatypes.LOptions Datatypes.LNat.
-
-Instance term_nat_unenc : computable nat_unenc.
-Proof.
-   extract.
-Defined.

--- a/theories/L/TM/TMEncoding.v
+++ b/theories/L/TM/TMEncoding.v
@@ -2,13 +2,11 @@ From Undecidability.L.Tactics Require Import LTactics GenEncode.
 From Undecidability.L.Datatypes Require Import LNat Lists LProd LFinType LVector.
 From Undecidability.L Require Import Functions.EqBool.
 
-From Undecidability Require Import TM.Util.VectorPrelim.
+From Undecidability.TM.Util Require Import VectorPrelim TM_facts.
 
-
-
-From Undecidability Require Import TM.Util.VectorPrelim.
-From Undecidability Require Import TM.Util.TM_facts.
 Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
+From Undecidability.TM Require PrettyBounds.SizeBounds.
+
 
 Import L_Notations.
 
@@ -150,7 +148,7 @@ End fix_sig.
 
 Hint Resolve tape_enc_correct : Lrewrite.
 
-From Undecidability Require Import PrettyBounds.SizeBounds.
+Import PrettyBounds.SizeBounds.
 
 Lemma sizeOfTape_by_size {sig} `{registered sig} (t:(tape sig)) :
   sizeOfTape t <= size (enc t).

--- a/theories/L/TM/TMinL.v
+++ b/theories/L/TM/TMinL.v
@@ -5,7 +5,7 @@ From Undecidability.L Require Export TM.TMEncoding.
 From Undecidability.L Require Import TM.TapeFuns.
 
 
-From Undecidability Require Import TM.Util.TM_facts.
+From Undecidability.TM Require Import TM_facts.
 
 Local Notation L := TM.Lmove.
 Local Notation R := TM.Rmove.
@@ -143,12 +143,12 @@ Section loopM.
       + exists (ext x). split. eauto. Lproc.
     - destruct H as (v & ? & ?). edestruct mu_sound as (k & ? & ? & _).
       + eapply term_test.
-      + intros. eexists. now Lsimpl.
+      + intros. eexists. now Lsimpl_old.
       + eassumption.
       + eauto.
       + subst.
         assert ((ext (fun k : nat => LOptions.isSome (loopM cfg k))) (ext k) ==
-                ext (LOptions.isSome (loopM cfg k))) by Lsimpl.
+                ext (LOptions.isSome (loopM cfg k))) by now Lsimpl.
         rewrite H1 in H2. clear H1.
         eapply unique_normal_forms in H2; try Lproc. eapply inj_enc in H2.
         destruct (loopM cfg k) eqn:E.

--- a/theories/L/TM/TapeFuns.v
+++ b/theories/L/TM/TapeFuns.v
@@ -3,7 +3,7 @@ From Undecidability.L.Datatypes Require Import LNat Lists LProd LFinType LVector
 From Undecidability.L Require Import TM.TMEncoding.
 
 
-From Undecidability Require Import TM.Util.TM_facts.
+From Undecidability.TM Require Import Util.TM_facts.
 From Undecidability.Shared.Libs.PSL Require Import FinTypes Vectors.
 
 

--- a/theories/L/Tactics/ComputableTactics.v
+++ b/theories/L/Tactics/ComputableTactics.v
@@ -66,10 +66,7 @@ Ltac recStepInit P:=
    end.
 
 
-Ltac recStepUnnamed :=
-  match goal with
-    [ P := rho _ |- ?G ] => recStepInit P
-  end.
+Ltac recStepNew P := recStepInit P.
 
 
 Ltac destructRefine :=
@@ -95,9 +92,6 @@ Ltac destructRefine :=
       let eq := fresh "eq" in destruct x eqn:eq
     end
   end.
-
-Ltac extractCorrectCrush :=
-  repeat(repeat destructRefine;Lsimpl).
 
 Ltac shelveIfUnsolved msg:= first[let n:= numgoals in guard n=0|
                                   match goal with
@@ -186,7 +180,7 @@ Ltac cstep' extractSimp:=
           (once lazymatch n with
            |  S ?n =>
               eexists;
-              eapply computesExpStep;[try recStep P;extractSimp idtac;shelveIfUnsolved "pos5"|Lproc;shelveIfUnsolved "pos6"|];
+              eapply computesExpStep;[try recStep P;extractSimp;shelveIfUnsolved "pos5"|Lproc;shelveIfUnsolved "pos6"|];
               (*simple notypeclasses refine (_:computes (_ ~> _) _ _ (fun x xInt xNorm => (_,_)));try exact tt;shelve_unifiable;*)
               let x := fresh "x" in  
               let xInt := fresh x "Int" in
@@ -213,7 +207,7 @@ Ltac cstep' extractSimp:=
               end in
           loop recArg;
           eexists;
-          (split;[try recStep P;extractSimp idtac;shelveIfUnsolved "pos7"|]))
+          (split;[try recStepNew P;extractSimp;shelveIfUnsolved "pos7"|]))
 
     (* a non-recursive function *)
     | _=>
@@ -230,7 +224,7 @@ Ltac cstep' extractSimp:=
                 clear xInt xInts;assert (xInt:True) by constructor; assert (xInts:True) by constructor
       | _ => idtac
       end;
-      eexists;split;[extractSimp idtac;shelveIfUnsolved "pos2" | intros vProc]
+      eexists;split;[extractSimp;shelveIfUnsolved "pos2" | intros vProc]
     end
 
   | |- computes (TyB _) _ ?t=> has_no_evar t;apply computesTyB
@@ -262,7 +256,7 @@ Ltac cstep' extractSimp:=
               let xT := fresh x "T" in
               let xInts := fresh x "Ints" in
               (refine (computesTimeExpStep (fT:=fun x xT => _) _ _ _ _) ;
-               [|try recStepUnnamed;extractSimp idtac;shelveIfUnsolved "pos8"|Lproc;shelveIfUnsolved "pos9"|]);
+               [|try recStepNew P;extractSimp;shelveIfUnsolved "pos8"|Lproc;shelveIfUnsolved "pos9"|]);
               [try reflexivity;is_assumed_add|];clean_assumed;
               (*simple notypeclasses refine (_:computes (_ ~> _) _ _ (fun x xInt xNorm => (_,_)));try exact tt;shelve_unifiable;*) 
               intros x xInt xT; intro_to_assumed x;intro_to_assumed xT;intro xInts;
@@ -298,7 +292,7 @@ Ltac cstep' extractSimp:=
                      once lazymatch goal with
                        |- evalLe ?k _ _ =>
                        refine (le_evalLe_proper _ eq_refl eq_refl _);[refine (proj1 H);shelve|apply proj2 in H;lock H];
-                       try recStepUnnamed;extractSimp idtac;shelveIfUnsolved "pos10"
+                       try recStepNew P;extractSimp;shelveIfUnsolved "pos10"
                      end
                     |apply proj2 in H;lock H])
              | S ?n' => loop n'
@@ -323,7 +317,7 @@ Ltac cstep' extractSimp:=
                 clear xInt xInts;assert (xInt:True) by constructor; assert (xInts:True) by constructor
       | _ => idtac
       end;
-      eexists;split;[extractSimp idtac;shelveIfUnsolved "pos4"| intros vProc]
+      eexists;split;[extractSimp;shelveIfUnsolved "pos4"| intros vProc]
     end
   (* complexity: *)
 
@@ -351,20 +345,23 @@ Tactic Notation "progress'" tactic(t) :=
     end
   end.
 
-Ltac extractCorrectCrush_new :=
-   Lrewrite_new;
-  repeat (progress (repeat Intern.destructRefine);Lrewrite_new);
+Ltac extractCorrectCrush :=
+  idtac;
+   try Lsimpl;try Lreflexivity;
+   try repeat' (repeat' Intern.destructRefine;Lsimpl;try Lreflexivity);
   try Lreflexivity.
 
-Ltac cstep := cstep' ltac:(fun _ => 
-                               once lazymatch goal with
-                                 |- eval _ _ => extractCorrectCrush_new
-                               | |- evalLe _ _ _ => extractCorrectCrush_new
-                               | |- evalIn _ _ _ => Lsimpl;fail "evalIn does not support full Lrewrite and should only occur when simplifying rho/recursion"
-                               | |- ?G => idtac "cstep found unexpected" G 
-                               end;try (idtac;[idtac "could not simplify some occuring term, shelved instead"];shelve)).
+Ltac extractSimple := 
+  lazymatch goal with
+    |- eval _ _ => extractCorrectCrush
+  | |- evalLe _ _ _ => extractCorrectCrush
+  | |- evalIn _ _ _ => Lsimpl_old;fail "evalIn does not support full Lrewrite and should only occur when simplifying rho/recursion"
+  | |- ?G => idtac "cstep found unexpected" G 
+  end;try (idtac;[idtac "could not simplify some occuring term, shelved instead"];shelve).
 
-                           Ltac computable_match:=
+Ltac cstep := cstep' extractSimple.
+
+Ltac computable_match:=
   intros;
   once lazymatch goal with
   | |- ?R ?lhs ?rhs =>
@@ -376,7 +373,7 @@ Ltac cstep := cstep' ltac:(fun _ =>
       cbn -[enc];
       repeat change encf with (@enc _ reg);
       fold_encs;
-      Lsimpl
+      Lsimpl_old
     end
   end.
 
@@ -401,12 +398,12 @@ Ltac computable_prepare t :=
 Ltac computable_using_noProof Lter:=
   once lazymatch goal with
   | [ |- computable ?t ] =>
-    eexists Lter;unfold Lter;
+    eexists Lter;unfold Lter;try clear Lter;
     let t' := eval hnf in t in
         let h := visibleHead t' in
         try unfold h;computable_prepare t;infer_instances
   | [ |- computableTime ?t _] =>
-    eexists Lter;unfold Lter;
+    eexists Lter;unfold Lter;try clear Lter;
     let t' := (eval hnf in t) in
     let h := visibleHead t' in
     try unfold h; computable_prepare t; infer_instancesT
@@ -464,6 +461,7 @@ Tactic Notation "computable" "infer" :=
   end.
 
 Tactic Notation "extract" :=
+  unshelve
     let term := fresh "used_term" in
     extractAs term;computable using term.
 
@@ -620,7 +618,7 @@ Lemma cast_computableTime X Y `{registered Y} (cast : X -> Y) (Hc : injective ca
 Proof.
   cbn.
   pose (t:=lam 0).
-  computable using t. solverec.
+  computable using t. solverec. Unshelve.
 Defined.
 
 

--- a/theories/L/Tactics/GenEncode.v
+++ b/theories/L/Tactics/GenEncode.v
@@ -4,7 +4,7 @@ Require Import String List.
 Export String.StringSyntax.
 
 Import MonadNotation.
-Open Scope string_scope.
+Local Open Scope string_scope.
 
 (* *** Generation of encoding functions *)
 
@@ -73,6 +73,8 @@ Definition tmGenEncode (n : ident) (A : Type) : TemplateMonad unit :=
   m <- tmMatchCorrect A;;
   n4 <- tmEval cbv (n ++ "_correct") ;;
   (Core.tmBind (tmMatchCorrect A) (fun m => tmLemma n4 m ;; ret tt)).
+
+Arguments tmGenEncode _%string _%type.
 
 (*
 Definition tmGenEncode' (n : ident) (A : Type) :=

--- a/theories/L/Tactics/Lbeta.v
+++ b/theories/L/Tactics/Lbeta.v
@@ -123,7 +123,7 @@ Ltac simplify_L' n:=
       pose (phi := Reflection.liftPhi vars);
       let pp := fresh "pp" in
       let cs := fresh "cs" in
-      assert (pp:Reflection.Proc phi) by (ProcPhi vars;shelve);
+      assert (pp:Reflection.Proc phi) by (ProcPhi vars);
       assert (cs :Reflection.rClosed phi s') by (simple apply Reflection.rClosed_decb_correct;[exact pp|vm_cast_no_check (@eq_refl bool true) ]);
       let R := fresh "R" in
       assert (R:= Reflection.rStandardizeUsePow n pp cs);
@@ -173,7 +173,7 @@ Ltac Lbeta' n :=
     | |- ?G => fail "Not supported for LSimpl (or other failed):" G 
     end;
     once lazymatch goal with
-      |- ?rel s _ => fail "No Progress (progress in indexes are not currently noticed...)"
+      |- ?rel s _ => fail "No Progress in beta' in " rel s "(progress in indexes are not currently noticed...)"
     | |- _ => idtac
     (* don;t change evars if you did not make progress!*)
     end

--- a/theories/L/Tactics/Lproc.v
+++ b/theories/L/Tactics/Lproc.v
@@ -27,44 +27,51 @@ Ltac fLproc :=intros;
               | [ |- closed ?s ] => vm_compute; reflexivity || fail "Prooving 'closed " s " ' by computation failed. It is either not a fixed term, some used identifier is opaque or the goal does not hold"
               end.
 
-Ltac Lproc' :=
+
+
+Ltac Lproc' :=idtac;
   once lazymatch goal with
+  | |- bound _ (L.app _ _) => refine (dclApp _ _)
+  | |- bound _ (L.lam _) => refine (dcllam _)
+  | |- bound ?y (L.var ?x) => exact (dclvar (proj1 (Nat.ltb_lt x y) eq_refl))
   | |- lambda (match ?c with _ => _ end) => destruct c
-  | |- lambda (@enc ?t ?H ?x) => exact (proc_lambda (@proc_enc t H x))
-  | |- lambda (@ext ?X ?tt ?x ?H) => exact (proc_lambda (@proc_ext X tt x H))
-  | |- lambda (@extT ?X ?tt ?x _ ?H) => exact (proc_lambda (@proc_extT X tt x _ H))
+  | |- lambda (@enc ?t ?H ?x) => exact_no_check (proc_lambda (@proc_enc t H x))
+  | |- lambda (@ext ?X ?tt ?x ?H) => exact_no_check (proc_lambda (@proc_ext X tt x H))
+  | |- lambda (@extT ?X ?tt ?x ?f ?H) => exact_no_check (proc_lambda (@proc_extT X tt x f H))
+  | |- lambda (app _ _) => fail
   (*| |- lambda (@ext_ext ?X ?x ?H) => exact (proc_lambda (@proc_extT X tt x _))*)
   | |- lambda _ => (simple apply proc_lambda;(trivial with nocore LProc || tauto)) || tauto || (eexists;reflexivity)
-  | |- rClosed ?phi _ => solve [simple apply rClosed_decb_correct;[assumption|vm_compute;reflexivity]]
-  | |- L_facts.closed _ => refine (proj2 (closed_dcl _) _)
+  | |- rClosed ?phi _ => solve [simple apply rClosed_decb_correct;[assumption|reflexivity]]
+  | |- L_facts.closed ?s => refine (proj2 (closed_dcl s) _)
   | |- bound _  (match ?c with _ => _ end) => destruct c
-  | |- bound _ (L.var _) => solve [constructor;lia]
-  | |- bound _ (L.app _ _) => constructor
-  | |- bound _ (L.lam _) => constructor
   | |- bound _ (rho ?s) => simple apply rho_dcls
   | |- bound ?k (@ext ?X ?tt ?x ?H) =>
-    exact (closed_dcl_x k (proc_closed (@proc_ext X tt x H)))
-            | |- bound ?k (@extT ?X ?tt ?x _ ?H) =>
-    exact (closed_dcl_x k (proc_closed (@proc_extT X tt x _ H)))
+    exact_no_check (closed_dcl_x k (proc_closed (@proc_ext X tt x H)))
+  | |- bound ?k (@extT ?X ?tt ?x ?f ?H) =>
+    exact_no_check (closed_dcl_x k (proc_closed (@proc_extT X tt x f H)))
   (*| |- bound ?k (@extT ?X ?tt ?x ?H) =>
       exact (closed_dcl_x k (proc_closed (@extT_proc X tt x H)))*)
   | |- bound ?k (@enc ?t ?H ?x) =>
-    exact (closed_dcl_x k (proc_closed (@proc_enc t H x)))
-  | |- bound _ ?s => refine (closed_dcl_x _ _); (trivial with LProc || (apply proc_closed;trivial with LProc || tauto) || tauto )
+    exact_no_check (closed_dcl_x k (proc_closed (@proc_enc t H x)))
+  | |- bound ?k ?s => (refine (@closed_dcl_x k s _); (trivial with LProc || (apply proc_closed;trivial with LProc || tauto) || tauto ))
   | |- ?s => idtac s;fail 1000
   end.
 
 
 (* early abort for speed!*)
 
-Ltac Lproc :=
-  repeat once lazymatch goal with
+Ltac Lproc := (* match goal with |- ?G => idtac G end ;time "Lproc"( *)
+  lazymatch goal with
   | |- proc (app _ _) => fail
-  | |- proc _ => split;[|solve [Lproc]]
+  | |- proc (@enc ?t ?H ?x) => exact_no_check (@proc_enc t H x)
+  | |- proc (@ext ?X ?tt ?x ?H) => exact_no_check (@proc_ext X tt x H)
+  | |- proc (@extT ?X ?tt ?x ?f ?H) => exact_no_check (@proc_extT X tt x f H)
+
+  | |- proc _ => refine (conj _ _);[|solve [Lproc]];Lproc
                                     
-  | |- closed _ => solve [repeat Lproc']
+  | |- closed _ => solve [repeat' Lproc']
                      
   | |- lambda (app _ _) => fail
-  | |- lambda _ => repeat Lproc'
-  | s := _ |- ?p ?s => unfold s
+  | |- lambda _ => repeat' Lproc'
+  | s := ?t |- ?p ?s => change (p t);Lproc
          end.

--- a/theories/L/Tactics/Lrewrite.v
+++ b/theories/L/Tactics/Lrewrite.v
@@ -44,24 +44,36 @@ Qed.
 
 
 Ltac find_Lrewrite_lemma :=
-  match goal with
-    |- ?R ?s _ => has_no_evar s;solve [eauto 20 with Lrewrite nocore|eassumption]
+  once lazymatch goal with
+    | |- ?R (lam _) => fail
+    | |- ?R (enc _) => fail
+    | |- ?R (extT (ty:=TyB _) _) => fail
+    | |- ?R (ext (ty:=TyB _) _) => fail
+    | |- ?R ?s _ => has_no_evar s;solve [eauto 20 with Lrewrite nocore]
   end.
+
+Create HintDb Lrewrite discriminated.
+Hint Constants Opaque : Lrewrite.
+Hint Variables Opaque : Lrewrite.
 
 Hint Extern 0 (proc _) => solve [Lproc] : Lrewrite.
 Hint Extern 0 (lambda _) => solve [Lproc] : Lrewrite.
 Hint Extern 0 (closed _) => solve [Lproc] : Lrewrite.
 
-Hint Extern 0 (_ >(<= _ ) _) => eapply pow_redLe_subrelation : Lrewrite.
-Hint Extern 0 (_ >* _) => eapply redLe_star_subrelation : Lrewrite.
-Hint Extern 0 (_ >* _) => eapply eval_star_subrelation : Lrewrite.
+Lemma pow_redLe_subrelation' i s t : pow step i s t -> redLe i s t.
+Proof. apply pow_redLe_subrelation. Qed. (* for performance, without [subrelation] in type*)
+
+
+Hint Extern 0 (_ >(<= _ ) _) => simple eapply pow_redLe_subrelation' : Lrewrite.
+Hint Extern 0 (_ >* _) => simple eapply redLe_star_subrelation : Lrewrite.
+Hint Extern 0 (_ >* _) => simple eapply eval_star_subrelation : Lrewrite.
 
 (* replace int by intT if possible*)
 
 Ltac Ltransitivity :=
   once lazymatch goal with
-  | |- _ >(<= _ ) _ => eapply redLe_trans
-  | |- _ >* _ => eapply star_trans
+  | |- _ >(<= _ ) _ => refine (redLe_trans _ _);[shelve.. | | ]
+  | |- _ >* _ => refine (star_trans _ _);[shelve.. | | ]
   | |- _ >(_) _ => eapply pow_add with (R:=step)
   | |- ?t => fail "not supported by Ltransitivity:" t
   end.
@@ -80,7 +92,7 @@ Ltac useFixHypo :=
     |- ?s >* ?t =>
     has_no_evar s;
     let IH := fresh "IH" in
-    unshelve epose (IH:=_);[|(notypeclasses refine (_:{v:term & computesExp _ _ s v}));solve [eauto]|];
+    unshelve epose (IH:=_);[|(notypeclasses refine (_:{v:term & computesExp _ _ s v}));solve [once auto with nocore]|];
     let v := constr:(projT1 IH) in
     assert (IHR := fst (projT2 IH));
     let IHInts := constr:( snd (projT2 IH)) in
@@ -91,7 +103,8 @@ Ltac useFixHypo :=
   | |- ?s >(<= ?i ) ?t=>
     has_no_evar s;
     let IH := fresh "IH" in
-    unshelve epose (IH:=_);[|(notypeclasses refine (_:{v:term & computesTimeExp _ _ s _ v _}));solve [eauto]|];
+    unshelve epose (IH:=_);[|(notypeclasses refine (_:{v:term & computesTimeExp _ _ s _ v _}));solve [once auto with nocore]|];
+    (* (let t := type of IH in idtac "Used IH:" t); *)
     let v := constr:(projT1 IH) in
     assert (IHR := fst (projT2 IH));
     let IHInts := constr:( snd (projT2 IH)) in
@@ -140,7 +153,7 @@ Ltac LrewriteTime_solveGoals :=
   | |- _ >* _ => reflexivity (* TO DEBUG: use idtac here*)
   end.
 
-Ltac Lrewrite_old tt:=
+Ltac Lrewrite' :=
   once lazymatch goal with
     |- ?rel ?s _ =>
     once lazymatch goal with             
@@ -157,18 +170,20 @@ Ltac Lrewrite_old tt:=
   | |- _ => idtac
   end.
 
-Ltac Lrewrite_wrapper k:=
-  once lazymatch goal with
-  | |- _ >(<= _) _ => k idtac
-  | |- _ ⇓(<= _) _ => try (eapply evalLe_trans;[progress (Lrewrite_wrapper k);Lreflexivity|])
-  | |- _ ⇓( _) _ => idtac "Lrewrite_prepare does not support s ⇓(k) y, only s ⇓(<=k) t)" (*try (eapply evalIn_trans;[progress Lrewrite_prepare;Lreflexivity|])*)
-  | |- _ >(_) _ => idtac "Lrewrite_prepare does not support s >(k) y, only s >(<=k) t)"
-  | |- _ >* _ => k idtac(* Lrewrite_prepare_old *)
-  | |- eval _ _ => try (eapply eval_helper;[progress (Lrewrite_wrapper k);Lreflexivity|])
-  | |- _ == _ => try (progress (eapply Lrewrite_equiv_helper;[try (Lrewrite_wrapper k);reflexivity..|]))
-  end.
+Tactic Notation "Lrewrite_wrapper" tactic(k):=
+once lazymatch goal with
+| |- _ >(<= _) _ => k
+| |- _ ⇓(<= _) _ => (eapply evalLe_trans;[k;Lreflexivity|])
+| |- _ ⇓( _) _ => idtac "Lrewrite_prepare does not support s ⇓(k) y, only s ⇓(<=k) t)" (*try (eapply evalIn_trans;[progress Lrewrite_prepare;Lreflexivity|])*)
+| |- _ >(_) _ => idtac "Lrewrite_prepare does not support s >(k) y, only s >(<=k) t)"
+| |- _ >* _ => k (* Lrewrite_prepare_old *)
+| |- eval _ _ => (eapply eval_helper;[k;Lreflexivity|])
+| |- _ == _ => progress ((eapply Lrewrite_equiv_helper;[try (* inefficient, but needed if only one side does progress *)k;reflexivity..|]))
+end.
 
-Ltac Lrewrite := Lrewrite_wrapper Lrewrite_old.
+(* does work on coq variables that are not abstactions *)
+Ltac Lrewrite := Lrewrite_wrapper Lrewrite'.
+
 
 
 Lemma Lrewrite_in_helper s t s' t' :
@@ -184,23 +199,27 @@ Tactic Notation "Lrewrite" "in" hyp(_H) :=
     | _ >* _ => idtac "not supported yet"
   end.
 
-  Lemma ext_rel_helper X `(H:registered X) (x:X) (inst : computable x) (R: term -> term -> Prop) u:
-    R (enc x) u -> R (@ext _ _ _ inst) u.
-  Proof.
-    now rewrite ext_is_enc.
-  Qed.
+Lemma ext_rel_helper X `(H:registered X) (x:X) (inst : computable x) (R: term -> term -> Prop) u:
+  R (enc x) u -> R (@ext _ _ _ inst) u.
+Proof.
+  now rewrite ext_is_enc.
+Qed.
 
-  Lemma extT_rel_helper X `(H:registered X) (x:X) xT (inst : computableTime x xT) (R: term -> term -> Prop) u:
-    R (enc x) u -> R (@extT _ _ _ _ inst) u.
-  Proof.
-    now rewrite extT_is_enc.
-  Qed.
+Lemma extT_rel_helper X `(H:registered X) (x:X) xT (inst : computableTime x xT) (R: term -> term -> Prop) u:
+  R (enc x) u -> R (@extT _ _ _ _ inst) u.
+Proof.
+  now rewrite extT_is_enc.
+Qed.
     
 
-(* version of Lrewrite that the verification of the extraction uses*)
-Ltac Lrewrite_new' :=
+(* version of Lrewrite that des the beta-steps as well *)
+Ltac LrewriteSimpl_old':=
+  idtac;
+  (* time "LrewriteSimpl'" *) (
   once lazymatch goal with
-    |- ?R ?s _  => has_no_evar s
+  | |- _ (@ext _ (@TyB _ ?reg) _ _) _ => eapply ext_rel_helper (* for backwards-compability, if used on term with hole*)
+  | |- _ (@extT _ (@TyB _ ?reg) _ _ _) _ => eapply extT_rel_helper (* for backwards-compability, if used on term with hole*)
+  | |- ?R ?s _  => has_no_evar s(* ;idtac "head" s *)
   end;
   once lazymatch goal with
   | |- ?R (L.app _ _) _ =>
@@ -208,20 +227,20 @@ Ltac Lrewrite_new' :=
     (once lazymatch R with
      |  star step => refine (pow_app_helper _ _ _)
      | redLe _ => refine (redLe_app_helper _ _ _)
-     end);[Lrewrite_new'..| ];
+     end);[LrewriteSimpl_old';Lreflexivity..| ];
 
     (* then reduce here/above *)
     once lazymatch goal with
          (* beta-reduce here & recurse down again (if argument abstraction)*)
-         | |- ?R (L.app (lam _) ?t) _ =>                      
+         | |- _ (L.app (lam _) ?t) _ =>                      
            let valt := fresh "valt" in
            assert (valt:proc t) by Lproc;
-           Lbeta;
+           Lbeta; (*;
            once lazymatch goal with
-             |- ?R (L.app (lam _) t) _ => fail "could not reduce"
+             |- _ (L.app (lam _) t) _ => fail "could not reduce"
            | |- _ => idtac
-           end;
-           clear valt;Lrewrite_new'
+           end; *)
+           clear valt;LrewriteSimpl_old'
          | |- _ =>
 
            let appTimeHelper tt:=
@@ -253,16 +272,219 @@ Ltac Lrewrite_new' :=
          end
   | |- _ => idtac
   end;
-  repeat (Ltransitivity;[find_Lrewrite_lemma|Ltransitivity;[Lrewrite_new' |]]);
+  try repeat' (Ltransitivity;[find_Lrewrite_lemma|LrewriteSimpl_old']);
   try (once (Ltransitivity;[useFixHypo|]));
   (* clean up goal*)
   once lazymatch goal with
-  | |- ?R (@ext _ (@TyB _ ?reg) _ _) _ => eapply ext_rel_helper
-  | |- ?R (@extT _ (@TyB _ ?reg) _ _ _) _ => eapply extT_rel_helper                  
+  | |- _ (@ext _ (@TyB _ ?reg) _ _) _ => eapply ext_rel_helper
+  | |- _ (@extT _ (@TyB _ ?reg) _ _ _) _ => eapply extT_rel_helper                  
   | |- _ => idtac
-  end;
-  (Lreflexivity).
+  end).
 
-Ltac Lrewrite_new :=
-  Lrewrite_wrapper ltac:(fun _ => Lrewrite_new').
+Lemma LrewriteTime_helper_index:
+forall [s t : term] [i i' : nat], i = i' -> s >(<=i) t -> s >(<=i') t.
+Proof. intros. now subst. Qed.
 
+  
+Lemma redLe_app_helperL s s' t u i j:
+s >(<= i) s' -> app s' t >(<=j) u -> app s t >(<=i+j) u.
+Proof. intros ? H'. eapply redLe_app_helper in H'. 2:eassumption. 2:Lreflexivity. now rewrite Nat.add_0_r in H'. Qed. 
+
+Lemma redLe_app_helperR s t t' u i j:
+t >(<= i) t' -> app s t' >(<=j) u -> app s t >(<=i+j) u.
+Proof. intros ? H'. eapply redLe_app_helper in H'. 3:eassumption. 2:Lreflexivity. eassumption. Qed.
+
+Lemma pow_app_helperL s s' t u:
+s >* s' -> app s' t >* u -> app s t >* u.
+Proof. now intros -> -> . Qed.
+
+Lemma pow_app_helperR s t t' u:
+t >* t' -> app s t' >* u -> app s t >* u.
+Proof. now intros -> -> . Qed.
+
+
+Ltac LrewriteSimpl_appL R:=
+  lazymatch R with
+  | star step => refine (pow_app_helperL _ _)
+  | redLe _ => refine (redLe_app_helperL _ _)
+  end.
+
+Ltac LrewriteSimpl_appR R:=
+lazymatch R with
+| star step => refine (pow_app_helperR _ _)
+| redLe _ => refine (redLe_app_helperR _ _)
+end.
+
+
+Ltac appTimeHelper tt:=
+ (* As we might build n using the projection on an on-ty-fly constructed computableTime-instance, we mustavoid it to depend on the proof that the time function is correct*)
+  (once lazymatch goal with
+  | |- app (@extT _ (_ ~> _ ) _ _ ?fInts) (@extT _ _ _ _ ?xInts) >(<= _ ) _
+    => Ltransitivity;[refine (LrewriteTime_helper_index _ (extTApp fInts xInts));[unfold evalTime;reflexivity]| ]
+    end ).
+
+
+Ltac isValue s:=
+  lazymatch s with
+  | lam _ => idtac
+  | app _ _ => fail
+  | @ext _ _ _ _ => idtac
+  | @extT _ _ _ _ _ => idtac
+  | @enc _ _ _ => idtac
+  | I => idtac
+  | ?P => tryif (is_var P;lazymatch eval unfold P in P with rho _ => idtac end) then idtac
+          else
+          lazymatch goal with
+          | H : proc s |- _  => idtac
+          | H : lambda s |- _ => idtac
+          | _ => (* idtac "noFastValue, default to true" s; *)idtac
+          end
+  end.
+
+(* version of Lrewrite that des the beta-steps as well *)
+(* clears the flag iff head is not applied to values *)
+Ltac LrewriteSimpl'' canReduceFlag :=
+  idtac;
+  (* time "LrewriteSimpl'" *) 
+  once lazymatch goal with
+  | |- _ (@ext _ (@TyB _ ?reg) _ _) _ => refine (ext_rel_helper _ _) (* for backwards-compability, if used on term with hole*)
+  | |- _ (@extT _ (@TyB _ ?reg) _ _ _) _ => refine (extT_rel_helper _ _) (* for backwards-compability, if used on term with hole*)
+  | |- ?R ?s _  => has_no_evar s;(* idtac "recurse to" s; *)
+
+  repeat' (idtac;
+    lazymatch goal with
+    | |- _ (lam _) _ => fail
+    | |- _ (enc _) _ => fail
+      
+    (* use correctness lemmatas of int here*)  
+    | |- L.app (@ext _ (_ ~> _ ) _ _) (ext _) >* _ => Ltransitivity;[apply extApp|]
+    | |- L.app (@ext _ (_ ~> _ ) _ ?ints) (@enc _ ?reg ?x) >* ?v =>
+      change (app (@ext _ _ _ ints) (@ext _ _ _ (reg_is_ext reg x)) >* v);
+      Ltransitivity;[refine (extApp _ _)|]
+    | |- L.app (@extT _ (_ ~> _ ) _ _ ?fInts) (@extT _ _ _ _ ?xInts) >(<= _ ) _ => appTimeHelper tt
+    | |- L.app (@extT _ (_ ~> _ ) _ _ ?ints) (@enc _ ?reg ?x) >(<= ?k ) ?v =>
+      change (L.app (@extT _ _ _ _ ints) (@extT _ _ _ _ (reg_is_extT reg x)) >(<= k) v);appTimeHelper tt  
+
+    (* clean up goal *)
+    | |- _ (@ext _ (@TyB _ ?reg) _ _) _ => refine (ext_rel_helper _ _)
+    | |- _ (@extT _ (@TyB _ ?reg) _ _ _) _ => refine (extT_rel_helper _ _)  
+
+      (* last reduce recursively, and then try to apply rewrite lemmas o Lbeta *)
+    | |- ?R (L.app _ _) _ =>
+      (* idtac "at app0"; *)
+      let progressFlag := fresh in
+      let recCanReduceFlag := fresh  in
+      let tmp := fresh in
+      assert (progressFlag:=tt);
+      assert (tmp:=tt);
+      assert (recCanReduceFlag:=tt);
+      try (LrewriteSimpl_appR R;[solve [LrewriteSimpl'' tmp;Lreflexivity]|(* idtac"didR"; *)try clear progressFlag]);
+      try clear tmp; (*we don't care for RHS*)
+      try (LrewriteSimpl_appL R;[solve [LrewriteSimpl'' canReduceFlag;Lreflexivity]|(* idtac"didL"; *)try clear progressFlag]);
+      (* idtac "at app"; *)
+      lazymatch goal with
+      | |- ?R (L.app ?s ?t) _ =>
+        (* idtac "still app" s t; *)
+        let maybeBeta _ := lazymatch s with lam _ => Lbeta end in
+        try (maybeBeta ();try clear progressFlag);
+        tryif (tryif is_var recCanReduceFlag then isValue t else fail)
+          then
+            try (
+              Ltransitivity;[solve [find_Lrewrite_lemma|useFixHypo]|];
+              try clear progressFlag (* we did something *);
+
+              (* We mus re-evaluate if we produce an assumption where s rewrite could apply*)
+              try (clear canReduceFlag;pose (canReduceFlag:=tt))
+            )
+          else clear canReduceFlag
+      end;
+      (* fail if no progress *)
+      tryif is_var progressFlag then (* lazymatch goal with |- ?H => idtac "leaving behind" H end; *)fail else idtac
+(*     | |- ?H => fail 1000 "unexpected goal" H  *)  
+    | |- ?H => (* idtac "fallback" H; *)Ltransitivity;[solve[find_Lrewrite_lemma]|]  
+    end)
+  end.
+
+
+
+  
+Ltac LrewriteSimpl' := let flag := fresh in assert (flag:=tt);
+  (tryif Lbeta then try LrewriteSimpl'' flag else LrewriteSimpl'' flag);try clear flag.
+
+
+Ltac LrewriteSimpl := Lrewrite_wrapper ltac:(idtac;LrewriteSimpl').
+
+
+  
+  (*
+  From Ltac2 Require Import Ltac2.
+  Ltac2 rec lrewriteSimpl' () :=
+    (* time "LrewriteSimpl'" *)
+    lazy_match! goal with
+    | [ |- _ (@ext _ (@TyB _ ?reg) _ _) _ ] => eapply ext_rel_helper (* for backwards-compability, if used on term with hole*)
+    | [ |- _ (@extT _ (@TyB _ ?reg) _ _ _) _] => eapply extT_rel_helper (* for backwards-compability, if used on term with hole*)
+    | [ |- ?rel ?s _ ] => ltac1:(has_no_evar &s) (* ;idtac "head" s *)
+    end ;
+    lazy_match! goal with 
+    | [ |- ?rel (L.app _ _) _] => 
+      (* first reduce recursively *)
+      (lazy_match! rel with
+       |  star step => ltac1:(refine (pow_app_helper _ _ _))
+       | redLe _ => ltac1:(refine (redLe_app_helper _ _ _))
+       end)  > [lrewriteSimpl' ();ltac1:(Lreflexivity)..| ]  ;
+  
+      (* then reduce here/above *)
+      lazy_match! goal with
+           (* beta-reduce here & recurse down again (if argument abstraction)*)
+         | [ |- _ (L.app (lam _) ?t) _ ] =>              
+             let valt := Fresh.in_goal @H in
+             assert (valt:proc t) by ltac1:(Lproc);
+             ltac1:(Lbeta);
+             lazy_match! goal with
+               [ |- _ (L.app (lam _) t) _] => Control.backtrack_tactic_failure "could not reduce" 
+             | [ |- _] => ()
+             end; 
+             Std.clear [valt];(lrewriteSimpl' ()) 
+           | [ |- _] =>
+  
+             let appTimeHelper _:=
+                  (lazy_match! goal with
+                  | [ |- app (@extT _ (_ ~> _ ) _ _ ?fInts) (@extT _ _ _ _ ?xInts) >(<= _ ) _ ]
+                    => let rr := Fresh.in_goal @R in 
+                      specialize (extTApp &fInts &xInts) as rr;
+                      lazy_match! Constr.type &rr with
+                        (* As we might build n using the projection on an on-ty-fly constructed computableTime-instance, we mustavoid it to depend on the proof that the time function is correct*)
+                        | ?s >(<= ?n) ?t =>
+                          let n' := Std.eval_unfold [(reference:(&evalTime), Std.AllOccurrences)] &n in
+                              change (&s >(<= &n') t) in rr
+                      end;
+                      ltac1:(Ltransitivity)> [exact &rr|]
+                 end) in
+  
+             (* use correctness lemmates of int here*)
+             lazy_match! goal with                
+             | [ |- L.app (@ext _ (_ ~> _ ) _ _) (ext _) >* _] => ltac1:(Ltransitivity) > [apply extApp|]
+             | [ |- L.app (@ext _ (_ ~> _ ) _ ?ints) (@enc _ ?reg ?x) >* ?v ]=>
+               change (app (@ext _ _ _ &ints) (@ext _ _ _ (reg_is_ext &reg &x)) >* &v);
+               ltac1:(Ltransitivity) > [apply extApp|]
+  
+             | [ |- L.app (@extT _ (_ ~> _ ) _ _ ?fInts) (@extT _ _ _ _ ?xInts) >(<= _ ) _ ]=> appTimeHelper ()
+             | [ |- L.app (@extT _ (_ ~> _ ) _ _ ?ints) (@enc _ ?reg ?x) >(<= ?k ) ?v ]=>
+               change (L.app (@extT _ _ _ _ &ints) (@extT _ _ _ _ (reg_is_extT &reg &x)) >(<= &k) &v);appTimeHelper ()                                                            
+             | [ |- _ ]=> ()
+              
+             end 
+           end
+    | [|- _] => ()
+    end;
+    let rec loop () :=  ltac1:(Ltransitivity)> [ltac1:(find_Lrewrite_lemma)|lrewriteSimpl' ()];try (loop ()) in
+    try (loop ()) ;
+    try ((ltac1:(Ltransitivity) > [ltac1:(useFixHypo)|]));
+    (* clean up goal*)
+    lazy_match! goal with
+    | [ |- _ (@ext _ (@TyB _ ?reg) _ _) _] => eapply ext_rel_helper
+    | [ |- _ (@extT _ (@TyB _ ?reg) _ _ _) _] => eapply extT_rel_helper                  
+    | [ |- _ ]=> ()
+    end.
+
+  Ltac LrewriteSimpl' ::= ltac2:(lrewriteSimpl' ()). *)

--- a/theories/L/Tactics/Lsimpl.v
+++ b/theories/L/Tactics/Lsimpl.v
@@ -16,11 +16,11 @@ Ltac Lsimpl' :=
   end.
 
 Ltac Lreduce :=
-  repeat progress (try Lrewrite;try Lbeta). 
+  repeat progress ( (Lrewrite;try Lbeta) || Lbeta). 
            
 
 (*Lsimpl that uses correctnes lemmas*)
-Ltac Lsimpl :=intros(*;repeat foldLocalInts*);
+Ltac Lsimpl_old :=intros;
   once lazymatch goal with
   | |- _ >(<= _ ) _ => Lreduce;try Lreflexivity
   | |- _ ⇓(_ ) _ => repeat progress Lbeta;try Lreflexivity
@@ -31,6 +31,13 @@ Ltac Lsimpl :=intros(*;repeat foldLocalInts*);
   (*| |- _ >* _  => repeat Lsimpl';try reflexivity'
   | |- eval _ _  => repeat Lsimpl';try reflexivity'*)
   | |- _ == _  => repeat Lsimpl';try reflexivity'
+  end.
+
+
+Ltac Lsimpl :=
+  lazymatch goal with
+  | |- _ >( _ ) _ => Lsimpl_old
+  | |- _ => LrewriteSimpl
   end.
 
 Ltac LsimplHypo := standardizeHypo 100.
@@ -60,9 +67,10 @@ Tactic Notation "redStep" "in" hyp(h) := redStep in h at 1.
 
 (* register needed lemmas:*)
 
+
 Lemma rho_correct s t : proc s -> lambda t -> rho s t >* s (rho s) t.
 Proof.
-  intros. unfold rho,r. redStep at 1. apply star_trans_l. Lsimpl.
+  intros. unfold rho,r. redStep at 1. apply star_trans_l. now Lsimpl. 
 Qed.
 
 Lemma rho_correctPow s t : proc s -> lambda t -> rho s t >(3) s (rho s) t.
@@ -72,7 +80,7 @@ Proof.
   cbn. closedRewrite. apply pow_step_congL;[|reflexivity]. now Lbeta.  
 Qed.
 
-Hint Resolve rho_correct : Lrewrite.
+(* Hint Resolve rho_correct : Lrewrite. *)
 
 
 Lemma rho_inj s t: rho s = rho t -> s = t.

--- a/theories/L/Tactics/mixedTactics.v
+++ b/theories/L/Tactics/mixedTactics.v
@@ -27,3 +27,6 @@ Require Export ZArith.
 Ltac leq_crossout :=
        try zify;try apply Zle_0_minus_le; ring_simplify;
        repeat eapply Z.add_nonneg_nonneg;try now (repeat eapply Z.mul_nonneg_nonneg;easy).
+
+Tactic Notation (at level 3) "repeat'" tactic3(t) :=
+  let rec loop := (once t);try loop in loop.

--- a/theories/L/Util/L_facts.v
+++ b/theories/L/Util/L_facts.v
@@ -13,6 +13,16 @@ Hint Constructors ARS.star : cbv.
 Notation "'#' v" := (var v) (at level 1).
 (* Notation "(λ  s )" := (lam s) (right associativity, at level 0).  *)
 
+Module L_Notations_app.
+  Coercion app : term >-> Funclass. 
+End L_Notations_app.
+
+Module L_Notations.
+
+  Coercion var : nat >-> term.
+  Export L_Notations_app.
+End L_Notations.
+
 Instance term_eq_dec : eq_dec term.
 Proof.
   intros s t; unfold dec; repeat decide equality.
@@ -34,31 +44,22 @@ Fixpoint TH n s :=
   | hter t => t
   end.
 
+
 (* TODO: should not be a coercion *)
 Definition convert := TH 0.
-Coercion convert : hoas >-> term.
-
-Module L_Notations_app.
-  Coercion app : term >-> Funclass. 
-End L_Notations_app.
-
-Module L_Notations.
-
-  Coercion var : nat >-> term.
-  Export L_Notations_app.
-End L_Notations.
 
 Module HOAS_Notations.
 
   Coercion hv : nat >-> hoas.
   Coercion ha : hoas >-> Funclass.
+  Notation "'!!' s" := (hter s) (at level 0).
+
+  Notation "[ 'L_HOAS' p ]" := (convert p) (at level 0, format  "[ 'L_HOAS'  p ]").
 
   Notation "'λ' x .. y , p" := (hl (fun x => .. (hl (fun y => p)) ..))
     (at level 100, x binder, right associativity,
      format "'[' 'λ'  '/  ' x  ..  y ,  '/  ' p ']'").
-
-  (* Coercion hter : term >-> hoas. *)
-
+     
 End HOAS_Notations.
 
 (* Use Eval simpl in (term) when defining an term using convert.
@@ -70,22 +71,20 @@ Also: remember to give the type of combinators explicitly becuase we want to use
 
 Arguments convert /.
 
-Notation "'!!' s" := (hter s) (at level 0).
 
 (* Important terms *)
 
 (* Import L_Notations. *)
 Import HOAS_Notations.
 
-Definition r : term := Eval simpl in λ r f, f (λ x , r r f x). 
-Definition R : term := app r r.
+Definition r := Eval simpl in [L_HOAS λ r f, f (λ x , r r f x) ]. 
+Definition R := app r r.
+Definition rho (s : term)  := Eval simpl in [L_HOAS λ x, !!r !!r !!s x]. 
 
-Definition rho (s : term) : term := Eval simpl in λ x, !!r !!r !!s x. 
+Definition I := Eval simpl in [L_HOAS λ x, x].
+Definition K := Eval simpl in [L_HOAS λ x y, x].
 
-Definition I : term := Eval simpl in λ x, x.
-Definition K : term := Eval simpl in λ x y, x.
-
-Definition omega : term := Eval simpl in λ x , x x.
+Definition omega : term := Eval simpl in [L_HOAS λ x , x x].
 Definition Omega : term := app omega omega.
 
 (*  Substitution *)

--- a/theories/Shared/Libs/PSL/Lists/BaseLists.v
+++ b/theories/Shared/Libs/PSL/Lists/BaseLists.v
@@ -1,6 +1,6 @@
 From Undecidability.Shared.Libs.PSL Require Export Prelim EqDec.
 
-Export ListNotations.
+Export List.ListNotations.
 Notation "x 'el' A" := (In x A) (at level 70).
 Notation "A <<= B" := (incl A B) (at level 70).
 Notation "| A |" := (length A) (at level 65).

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -516,9 +516,7 @@ Proof.
   rewrite vector_rev_to_list,List.rev_involutive. easy.
 Qed.
 
-About eq_refl.
 Require Import Equations.Type.DepElim.
-About eq_refl.
 
 Local Arguments Fin.of_nat_lt _ {_} _.
 

--- a/theories/Shared/ListAutomation.v
+++ b/theories/Shared/ListAutomation.v
@@ -1,5 +1,5 @@
 Require Export List Undecidability.Shared.Dec Undecidability.Shared.FilterFacts.
-Export ListNotations.
+Export List.ListNotations.
 
 Module ListAutomationNotations.
 

--- a/theories/TM/Basic/Basic.v
+++ b/theories/TM/Basic/Basic.v
@@ -1,1 +1,1 @@
-From Undecidability Require Export TM.Basic.Null TM.Basic.Mono TM.Basic.Duo.
+From Undecidability.TM.Basic Require Export Null Mono Duo.

--- a/theories/TM/Basic/Duo.v
+++ b/theories/TM/Basic/Duo.v
@@ -1,6 +1,6 @@
 (* * Primitive Two-tape machines *)
 
-From Undecidability Require Import TM.Util.TM_facts.
+From Undecidability.TM Require Import Util.TM_facts.
 
 
 (* ** Read two symbols *)

--- a/theories/TM/Basic/Mono.v
+++ b/theories/TM/Basic/Mono.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.Util.TM_facts.
+From Undecidability.TM Require Import Util.TM_facts.
 
 (* * Basic 1-Tape Machines *)
 

--- a/theories/TM/Basic/Null.v
+++ b/theories/TM/Basic/Null.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.Util.Prelim TM.Util.TM_facts.
+From Undecidability.TM Require Import Util.Prelim Util.TM_facts.
 
 (* * 0-tape Turing machine that does nothing. *)
 

--- a/theories/TM/Code/BinNumbers/NTM.v
+++ b/theories/TM/Code/BinNumbers/NTM.v
@@ -1,6 +1,6 @@
 (* * Machines on [N] (binary natural numbers) *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import BinNumbers.EncodeBinNumbers.
 From Undecidability Require Import Code.CaseSum. (* [CaseOption] *)
 

--- a/theories/TM/Code/BinNumbers/PosAddTM.v
+++ b/theories/TM/Code/BinNumbers/PosAddTM.v
@@ -1,6 +1,6 @@
 (* ** Addition for [positive] numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import BinNumbers.EncodeBinNumbers.
 From Undecidability Require Import BinNumbers.PosDefinitions.
 From Undecidability Require Import BinNumbers.PosPointers.

--- a/theories/TM/Code/BinNumbers/PosCompareTM.v
+++ b/theories/TM/Code/BinNumbers/PosCompareTM.v
@@ -1,6 +1,6 @@
 (* * Machine for comparing two [positive] binary numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import EncodeBinNumbers PosDefinitions PosPointers PosHelperMachines.
 
 (* Declare discreteness of [comparison] *)

--- a/theories/TM/Code/BinNumbers/PosDefinitions.v
+++ b/theories/TM/Code/BinNumbers/PosDefinitions.v
@@ -1,6 +1,6 @@
-From Undecidability Require Import ProgrammingTools.
-From Undecidability Require Import EncodeBinNumbers.
-From Undecidability Require Export ArithPrelim. (* [nia] etc. *)
+From Undecidability.TM Require Import ProgrammingTools.
+From Undecidability.TM Require Import EncodeBinNumbers.
+From Undecidability.TM Require Export ArithPrelim. (* [nia] etc. *)
 From Coq Require Export BinPos.
 
 (* Compute 42. (* default number notation is still for [nat] *) *)

--- a/theories/TM/Code/BinNumbers/PosHelperMachines.v
+++ b/theories/TM/Code/BinNumbers/PosHelperMachines.v
@@ -1,6 +1,6 @@
 (* ** Helper Machines for positive numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import EncodeBinNumbers PosDefinitions PosPointers.
 From Undecidability Require Import TM.Basic.Duo.
 

--- a/theories/TM/Code/BinNumbers/PosIncrementTM.v
+++ b/theories/TM/Code/BinNumbers/PosIncrementTM.v
@@ -1,6 +1,6 @@
 (* ** Increment *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import EncodeBinNumbers PosDefinitions PosPointers PosHelperMachines.
 
 (* In the loop, we assume that we are at a certain bit. We stop if we reached the HSB *)

--- a/theories/TM/Code/BinNumbers/PosMultTM.v
+++ b/theories/TM/Code/BinNumbers/PosMultTM.v
@@ -1,6 +1,6 @@
 (* * Multiplication of [positive] numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import BinNumbers.EncodeBinNumbers.
 From Undecidability Require Import BinNumbers.PosDefinitions.
 From Undecidability Require Import BinNumbers.PosPointers.

--- a/theories/TM/Code/BinNumbers/PosPointers.v
+++ b/theories/TM/Code/BinNumbers/PosPointers.v
@@ -1,6 +1,6 @@
 (* * Pointer bookkeeping for machines using (positive) binary numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import BinNumbers.EncodeBinNumbers.
 From Undecidability Require Import BinNumbers.PosDefinitions.
 

--- a/theories/TM/Code/BinNumbers/PosShiftTM.v
+++ b/theories/TM/Code/BinNumbers/PosShiftTM.v
@@ -1,6 +1,6 @@
 (* * Machines for shifting [positive] binary numbers *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import EncodeBinNumbers.
 From Undecidability Require Import PosDefinitions.
 From Undecidability Require Import PosPointers.

--- a/theories/TM/Code/CaseBool.v
+++ b/theories/TM/Code/CaseBool.v
@@ -1,6 +1,6 @@
 (* * Constructors and Deconstructors for Bool *)
 
-From Undecidability Require Import ProgrammingTools Code.
+From Undecidability.TM Require Import ProgrammingTools Code.
 
 Section CaseBool.
 
@@ -53,7 +53,7 @@ Ltac smpl_TM_CaseBool :=
 Smpl Add smpl_TM_CaseBool : TM_Correct.
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Definition CaseBool_size (_ : bool) : Vector.t (nat->nat) 1 :=
    [|plus 2|].

--- a/theories/TM/Code/CaseFin.v
+++ b/theories/TM/Code/CaseFin.v
@@ -1,6 +1,6 @@
 (* * Constructors and Deconstructors for Finite Types *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 
 Section CaseFin.
 
@@ -54,7 +54,7 @@ Ltac smpl_TM_CaseFin :=
 
 Smpl Add smpl_TM_CaseFin : TM_Correct.
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Section CaseFin.
 

--- a/theories/TM/Code/CaseList.v
+++ b/theories/TM/Code/CaseList.v
@@ -1,6 +1,6 @@
 (* * Constructor and Deconstructor Machines for Lists *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 
 
 Local Arguments plus : simpl never. Local Arguments mult : simpl never.
@@ -516,7 +516,7 @@ Smpl Add smpl_TM_CaseList : TM_Correct.
 
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Section CaseList.
 

--- a/theories/TM/Code/CaseNat.v
+++ b/theories/TM/Code/CaseNat.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.Code.ProgrammingTools.
+From Undecidability.TM.Code Require Import ProgrammingTools.
 
 (* * Constructor and Deconstructor Machines for Natural Numbers *)
 
@@ -119,7 +119,7 @@ Ltac smpl_TM_CaseNat :=
 
 Smpl Add smpl_TM_CaseNat : TM_Correct.
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Lemma Constr_O_SpecT_size (ss : Vector.t nat 1) :
   TripleT (≃≃(([], withSpace  [|Void |] ss))) Constr_O_steps Constr_O (fun _ => ≃≃(([], withSpace  [|Contains _ 0|] (appSize [|Constr_O_size|] ss)))).

--- a/theories/TM/Code/CasePair.v
+++ b/theories/TM/Code/CasePair.v
@@ -1,6 +1,6 @@
 (* * Constructors and Deconstructors for Pair Types *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 
 (* TODO: ~> base *)
 Lemma pair_eq (A B : Type) (a1 a2 : A) (b1 b2 : B) :
@@ -319,7 +319,7 @@ Ltac smpl_TM_CasePair :=
 Smpl Add smpl_TM_CasePair : TM_Correct.
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 Section CasePair.
 
   Variable (X Y : Type) (sigX sigY : finType) (codX : codable sigX X) (codY : codable sigY Y).

--- a/theories/TM/Code/CaseSum.v
+++ b/theories/TM/Code/CaseSum.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 
 (* * Constructor and Deconstructor Machines for Sum Types and Option Types *)
 
@@ -312,7 +312,7 @@ Ltac smpl_TM_CaseOption :=
 Smpl Add smpl_TM_CaseOption : TM_Correct.
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Section CaseSum.
   Variable (X Y : Type) (sigX sigY : finType) (codX : codable sigX X) (codY : codable sigY Y).

--- a/theories/TM/Code/ChangeAlphabet.v
+++ b/theories/TM/Code/ChangeAlphabet.v
@@ -1,5 +1,5 @@
-From Undecidability Require Import TM.Util.Prelim TM.Code.CodeTM.
-From Undecidability Require Import TM.Lifting.LiftAlphabet.
+From Undecidability.TM Require Import Util.Prelim Code.CodeTM.
+From Undecidability.TM Require Import Lifting.LiftAlphabet.
 
 
 (* * Alphabet-lift for "programmed" Turing Machines *)

--- a/theories/TM/Code/CodeTM.v
+++ b/theories/TM/Code/CodeTM.v
@@ -1,6 +1,6 @@
-From Undecidability Require Export TM.Util.Prelim TM.Util.TM_facts TM.Code.Code.
-From Undecidability Require Export TM.Lifting.Lifting.
-From Undecidability Require Export TM.Combinators.Combinators.
+From Undecidability.TM Require Export Util.Prelim Util.TM_facts Code.Code.
+From Undecidability.TM Require Export Lifting.Lifting.
+From Undecidability.TM Require Export Combinators.Combinators.
 
 (* * Value-Containing *)
 

--- a/theories/TM/Code/CompareValue.v
+++ b/theories/TM/Code/CompareValue.v
@@ -204,7 +204,7 @@ Section CompareValues_steps_comp.
 End CompareValues_steps_comp.
 *)
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Section CompareValues.
 

--- a/theories/TM/Code/Copy.v
+++ b/theories/TM/Code/Copy.v
@@ -3,7 +3,7 @@
 From Coq Require Import FunInd.
 
 From Undecidability Require Import TM.Code.CodeTM.
-From Undecidability Require Export TM.Compound.CopySymbols TM.Compound.MoveToSymbol.
+From Undecidability.TM.Compound Require Export CopySymbols MoveToSymbol.
 
 From Undecidability Require Import TM.Basic.Mono.
 From Undecidability Require Import TM.Combinators.Combinators.
@@ -654,7 +654,7 @@ Smpl Add smpl_TM_Copy : TM_Correct.
 
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 (* We give all rule variants here, because automation is forbidden for these machines *)
 

--- a/theories/TM/Code/List/App.v
+++ b/theories/TM/Code/List/App.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import CaseNat CaseList CaseSum. (* [TM.Code.CaseSum] contains [Constr_Some] and [Constr_None]. *)
 From Undecidability.TM Require Hoare.
 

--- a/theories/TM/Code/List/Concat_Repeat.v
+++ b/theories/TM/Code/List/Concat_Repeat.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import CaseNat CaseList List.App.
 
 From Undecidability.L.Complexity Require Import UpToCNary.

--- a/theories/TM/Code/List/Cons_constant.v
+++ b/theories/TM/Code/List/Cons_constant.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import CaseList WriteString Hoare. 
 
 Module Cons_constant.

--- a/theories/TM/Code/List/Length.v
+++ b/theories/TM/Code/List/Length.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import CaseNat CaseList CaseSum. (* [TM.Code.CaseSum] contains [Constr_Some] and [Constr_None]. *)
 
 Local Arguments skipn { A } !n !l.

--- a/theories/TM/Code/List/Rev.v
+++ b/theories/TM/Code/List/Rev.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import CaseNat CaseList CaseSum Hoare. (* [TM.Code.CaseSum] contains [Constr_Some] and [Constr_None]. *)
 
 

--- a/theories/TM/Code/NatSub.v
+++ b/theories/TM/Code/NatSub.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.Code.ProgrammingTools.
+From Undecidability.TM.Code Require Import ProgrammingTools.
 From Undecidability Require Import TM.Code.CaseNat.
 
 (* Minus x y computes x - y and returns whether x >= y (e.g., if the subtraction did not need to truncate) *)

--- a/theories/TM/Code/NatTM.v
+++ b/theories/TM/Code/NatTM.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import TM.Code.ProgrammingTools.
+From Undecidability.TM.Code Require Import ProgrammingTools.
 From Undecidability Require Import TM.Code.CaseNat.
 
 

--- a/theories/TM/Code/WriteValue.v
+++ b/theories/TM/Code/WriteValue.v
@@ -78,7 +78,7 @@ Ltac smpl_TM_WriteValue :=
 Smpl Add smpl_TM_WriteValue : TM_Correct.
 
 
-From Undecidability Require Import HoareLogic HoareRegister HoareTactics.
+From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister HoareTactics.
 
 Section WriteValue.
 

--- a/theories/TM/Combinators/Combinators.v
+++ b/theories/TM/Combinators/Combinators.v
@@ -1,7 +1,7 @@
 (* * Combinators *)
 
-(* Export Modules for Combinators *)
-From Undecidability Require Export Switch If SequentialComposition StateWhile While Mirror.
+(* * Export Modules for Combinators *)
+From Undecidability.TM.Combinators Require Export Switch If SequentialComposition StateWhile While Mirror.
 
 (* ** Simple Combinators *)
 

--- a/theories/TM/Combinators/If.v
+++ b/theories/TM/Combinators/If.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import Switch.
+From Undecidability.TM Require Import Util.TM_facts Switch.
 
 Section If.
 

--- a/theories/TM/Combinators/SequentialComposition.v
+++ b/theories/TM/Combinators/SequentialComposition.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import Switch.
+From Undecidability.TM Require Import Util.TM_facts Switch.
 
 Section Composition.
   

--- a/theories/TM/Combinators/Switch.v
+++ b/theories/TM/Combinators/Switch.v
@@ -1,4 +1,4 @@
-From Undecidability Require Export TM.Util.TM_facts.
+From Undecidability Require Import TM.Util.TM_facts.
 Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.DepPairs EqdepFacts.
 
 (* * Switch Combinator *)

--- a/theories/TM/Combinators/While.v
+++ b/theories/TM/Combinators/While.v
@@ -1,4 +1,4 @@
-From Undecidability Require Export TM.Util.TM_facts.
+From Undecidability Require Import TM.Util.TM_facts.
 Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.DepPairs EqdepFacts.
 
 Section While.

--- a/theories/TM/Hoare/Hoare.v
+++ b/theories/TM/Hoare/Hoare.v
@@ -1,11 +1,11 @@
 (* * A New Logic  for the specification of Turing Machines, Based on Hoare Logic *)
 
-From Undecidability Require Export TM.Hoare.HoareLogic. (* Abstract definition of Hoare triples *)
-From Undecidability Require Export TM.Hoare.HoareCombinators. (* Rules for the combinators *)
-From Undecidability Require Export TM.Hoare.HoareRegister. (* Definition of a specification language for Register machines; rules for lifts *)
-From Undecidability Require Export TM.Hoare.HoareTactics TM.Hoare.HoareTacticsView. (* Verification step tactics *)
-From Undecidability Require Export TM.Hoare.HoareStdLib. (* Hoare rules for standard machine *)
-From Undecidability Require Export TM.Hoare.HoareLegacy. (* generating Legacy Lemmas for Realise/Terminates *)
+From Undecidability.TM.Hoare Require Export HoareLogic. (** Abstract definition of Hoare triples *)
+From Undecidability.TM.Hoare Require Export HoareCombinators. (** Rules for the combinators *)
+From Undecidability.TM.Hoare Require Export HoareRegister. (** Definition of a specification language for Register machines; rules for lifts *)
+From Undecidability.TM.Hoare Require Export HoareTactics HoareTacticsView. (** Verification step tactics *)
+From Undecidability.TM.Hoare Require Export HoareStdLib. (** Hoare rules for standard machine *)
+From Undecidability.TM.Hoare Require Export HoareLegacy. (** generating Legacy Lemmas for Realise/Terminates *)
 
 
 (* TODO:

--- a/theories/TM/Hoare/HoareCombinators.v
+++ b/theories/TM/Hoare/HoareCombinators.v
@@ -1,7 +1,7 @@
 (* ** Some Hoare Rules *)
 
 From Undecidability Require Import TMTac TM.Util.Prelim.
-From Undecidability Require Export TM.Compound.Multi TM.Combinators.Combinators.
+From Undecidability.TM Require Export Compound.Multi Combinators.Combinators.
 From Undecidability.TM.Hoare Require Import HoareLogic HoareRegister.
 
 (* *** Nop *)

--- a/theories/TM/Hoare/HoareExamples.v
+++ b/theories/TM/Hoare/HoareExamples.v
@@ -1,6 +1,6 @@
 (* ** Examples *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import Hoare.HoareLogic Hoare.HoareCombinators Hoare.HoareRegister Hoare.HoareTactics Hoare.HoareTacticsView.
 From Undecidability Require Import CaseNat.
 

--- a/theories/TM/Hoare/HoareMult.v
+++ b/theories/TM/Hoare/HoareMult.v
@@ -1,6 +1,6 @@
 (* ** Multiplication *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import Hoare.Hoare.
 
 From Undecidability Require Import CaseNat.

--- a/theories/TM/Hoare/HoareTacticsView.v
+++ b/theories/TM/Hoare/HoareTacticsView.v
@@ -4,7 +4,7 @@ Arguments abbreviate {A} {x}.
   
   (* The concept of abbreviations is taken from  VST*)
 
-  Tactic Notation "abbreviate" constr(y) "as"  ident(x)  :=
+Tactic Notation "abbreviate" constr(y) "as"  ident(x)  :=
   (first [ is_var y
           |  let x' := fresh x in pose (x':= @abbreviate _ y);
               change y with x']).

--- a/theories/TM/L/CaseCom.v
+++ b/theories/TM/L/CaseCom.v
@@ -1,6 +1,6 @@
 (* * Constructors and Deconstructors for Comens *)
 
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import TM.Code.CaseNat TM.Code.CaseSum TM.Code.CaseFin LM_heap_def .
 From Undecidability.TM.L Require Import Alphabets.
 

--- a/theories/TM/L/CompilerBoolFuns/ClosedLAdmissible.v
+++ b/theories/TM/L/CompilerBoolFuns/ClosedLAdmissible.v
@@ -118,13 +118,13 @@ Proof.
   - cbn. specialize (Htot (Vector.nil _)). cbn in Htot. 
     eapply logical; clear o.
     + intros o Hl. pose proof Hl as [y ->] % Htot. eapply eval_Eval in Hl. rewrite Hl.
-      split. 2: Lproc. Lsimpl. rewrite decode_correct. Lsimpl.
+      split. 2: Lproc. Lsimpl. rewrite decode_correct. now Lsimpl.
     + intros Hrev o Heval. 
       match type of Heval with L_facts.eval ?l _ => assert (Hc : converges l) by eauto end.
       eapply app_converges in Hc as [[[_ Hc]%app_converges _] % app_converges _].
       eapply Eval_converges in Hc as [o' [Hc Hl]]. rewrite Hc. 
-      enough (o = o'). subst. econstructor; eauto. Lsimpl. eapply eval_unique.
-      eapply Heval. eapply Hrev. rewrite Hc. split; eauto. Lsimpl.
+      enough (o = o'). subst. now econstructor; eauto. eapply eval_unique.
+      eapply Heval. eapply Hrev. rewrite Hc. split; eauto. reflexivity.
   - cbn -[apply_to tabulate many_vars]. rewrite !apply_to_cons. specialize (IHv (s (enc h))). rewrite <- IHv.
     + unfold apply_encs_to. cbn -[many_vars]. rewrite many_vars_S. cbn. eapply equiv_eval_equiv. etransitivity. eapply apply_to_equiv'. eapply beta_red. Lproc. reflexivity.
       rewrite subst_many_lam. cbn [subst]. replace (n + 0) with n by lia.
@@ -139,7 +139,7 @@ Proof.
       fold (@apply_encs_to (enc (s (enc h))) n). fold (apply_encs_to (ext L.app (enc s) (ext (@enc X _) n)) n).
       rewrite subst_apply_encs_to. cbn. repeat (rewrite subst_closed; [ | now Lproc]). rewrite Nat.eqb_refl.
       rewrite !many_subst_apply_encs_to.
-      * rewrite equiv_fold_left. reflexivity. Lsimpl.
+      * rewrite equiv_fold_left. reflexivity. now Lsimpl.
       * Lproc.
       * clear. induction v; cbn; intros ? Hi. inversion Hi. inv Hi. Lproc. eapply IHv. eapply Eqdep_dec.inj_pair2_eq_dec in H2. subst. eauto. eapply nat_eq_dec. 
       * Lproc.

--- a/theories/TM/L/CompilerBoolFuns/Compiler_nat_facts.v
+++ b/theories/TM/L/CompilerBoolFuns/Compiler_nat_facts.v
@@ -49,8 +49,8 @@ n >= k ->
 subst (gen_list (X := X) (many_vars k)) n u = gen_list (X := X) (many_vars k).
 Proof.
 induction k in n |- *; rewrite ?many_vars_S; cbn.
-- rewrite subst_closed; Lproc. reflexivity.
-- intros Hn. rewrite subst_closed; Lproc. destruct (Nat.eqb_spec k n); try lia.
+- rewrite subst_closed. 2:Lproc. reflexivity.
+- intros Hn. rewrite subst_closed. 2: Lproc. destruct (Nat.eqb_spec k n); try lia.
   rewrite IHk. reflexivity. lia.
 Qed.
 
@@ -58,11 +58,11 @@ Lemma gen_list_spec {k} {X} {Hr : registered X} (v' : Vector.t X k) :
 many_subst (gen_list (X := X) (many_vars k)) 0 (Vector.map enc v') == enc v'.
 Proof.
 induction v'; cbn - [many_vars].
-- Lsimpl.
+- Lsimpl_old.
 - rewrite many_vars_S. cbn. rewrite Nat.eqb_refl.
   rewrite subst_closed; [ | now Lproc ]. rewrite subst_gen_list; try lia.
-  rewrite many_subst_app. rewrite many_subst_closed; Lproc. rewrite IHv'.
-  unfold enc at 2. cbn. Lsimpl.
+  rewrite many_subst_app. rewrite many_subst_closed. 2:Lproc. rewrite IHv'.
+  unfold enc at 2. cbn. now Lsimpl.
 Qed.
 
 Definition validate (l : list (list bool)) := forallb (forallb (fun x => x)) l.
@@ -166,7 +166,7 @@ Proof.
         eapply Hs in HR. eapply eval_iff in HR. rewrite eval_iff.
         rewrite HEQ. Lsimpl. change (encNatL m') with (enc m') in HR. change (encBoolsL) with (@enc (list bool) _).
         rewrite validate_spec'.
-        rewrite !Vector.map_map. erewrite Vector.map_ext. 2:intros; now rewrite repeat_length. Lsimpl.
+        rewrite !Vector.map_map. erewrite Vector.map_ext. 2:intros; now rewrite repeat_length. Lsimpl_old.
       + rewrite eval_iff. rewrite HEQ. erewrite equiv_eval_equiv. 2:{ Lsimpl. reflexivity. }
         intros Heval. change (encNatL) with (@enc nat _) in *. change (encBoolsL) with (@enc (list bool) _) in *.
         match type of Heval with L_facts.eval ?l _ => assert (Hc : converges l) by eauto end.
@@ -178,7 +178,7 @@ Proof.
           erewrite equiv_eval_equiv in Heval. 2:{ clear Heval.  Lsimpl. reflexivity. }  eapply validate_spec in E as [v' ->].
           eexists v'.
           assert (m = repeat true m') as ->. { eapply encBoolsL_inj. change (encBoolsL) with (@enc (list bool) _).
-          eapply unique_normal_forms; Lproc. now destruct Heval as [-> _]. } 
+          eapply unique_normal_forms;[Lproc..|]. now destruct Heval as [-> _]. } 
           exists m'. repeat split.  eapply Hs.
           rewrite !Vector.map_map in *. erewrite Vector.map_ext in *. 2:intros; now rewrite repeat_length. 2: reflexivity.
           now eapply eval_iff.
@@ -194,9 +194,10 @@ Proof.
       * clear HEQ. erewrite equiv_eval_equiv in Heval. 2:{ clear Heval. Lsimpl. reflexivity. } eapply validate_spec in E as [v' ->].
         rewrite !Vector.map_map in *. erewrite Vector.map_ext in *. 2:intros; now rewrite repeat_length.
         exists (repeat true m'). destruct Heval as [Heval ?].
-        eapply unique_normal_forms; Lproc. now rewrite Heval.
+        eapply unique_normal_forms;[Lproc..|]. now rewrite Heval.
       * erewrite equiv_eval_equiv in Heval. 2:{ clear Heval. rewrite Hc'. eapply beta_red. Lproc. rewrite subst_closed. 2:Lproc. reflexivity. } 
         now eapply Omega_diverge in Heval.
+      Unshelve. 
 Qed.
 
 Lemma TM_bool_computable_to_TM_computable k (R : Vector.t nat k -> nat -> Prop) : 

--- a/theories/TM/Lifting/Lifting.v
+++ b/theories/TM/Lifting/Lifting.v
@@ -1,1 +1,1 @@
-From Undecidability Require Export LiftTapes LiftAlphabet.
+From Undecidability.TM.Lifting Require Export LiftTapes LiftAlphabet.

--- a/theories/TM/PrettyBounds/MaxList.v
+++ b/theories/TM/PrettyBounds/MaxList.v
@@ -1,6 +1,6 @@
 (* * Maximum element in a list *)
 
-From Undecidability Require Export TM.Util.Prelim TM.Util.ArithPrelim.
+From Undecidability.TM.Util Require Export Prelim ArithPrelim.
 
 (* ** Basic lemmas about upper bounds *)
 

--- a/theories/TM/Reductions/Arbitrary_to_Binary.v
+++ b/theories/TM/Reductions/Arbitrary_to_Binary.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import ArithPrelim.
 Require Import Undecidability.Shared.FinTypeEquiv Undecidability.Shared.FinTypeForallExists.
 

--- a/theories/TM/Single/EncodeTapes.v
+++ b/theories/TM/Single/EncodeTapes.v
@@ -1,6 +1,6 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 
-From Undecidability Require Export PrettyBounds.SizeBounds.
+From Undecidability.TM.PrettyBounds Require Export SizeBounds.
 
 From Undecidability Require Import TM.Util.VectorPrelim.
 

--- a/theories/TM/Single/StepTM.v
+++ b/theories/TM/Single/StepTM.v
@@ -1,5 +1,5 @@
 (* From Undecidability Require Import Combinators.Combinators Multi Basic.Mono TMTac. *)
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import ArithPrelim.
 From Undecidability Require Import TM.Compound.Shift.
 From Undecidability Require Import TM.Util.VectorPrelim.

--- a/theories/TM/Univ/LookupAssociativeListTM.v
+++ b/theories/TM/Univ/LookupAssociativeListTM.v
@@ -1,5 +1,5 @@
 Require Import Undecidability.Shared.Libs.PSL.Bijection. (* [injective] *)
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import TM.Code.CompareValue.
 From Undecidability Require Import TM.Code.CasePair TM.Code.CaseList.
 From Undecidability.TM.Hoare Require Import Hoare HoareLegacy.

--- a/theories/TM/Univ/LowLevel.v
+++ b/theories/TM/Univ/LowLevel.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 Require Import Undecidability.Shared.Libs.PSL.Bijection. (* [injective] *)
 
 From Undecidability Require Import Basic.Duo.

--- a/theories/TM/Univ/Univ.v
+++ b/theories/TM/Univ/Univ.v
@@ -1,4 +1,4 @@
-From Undecidability Require Import ProgrammingTools.
+From Undecidability.TM Require Import ProgrammingTools.
 From Undecidability Require Import Hoare.Hoare HoareLegacy.
 From Undecidability Require Import Univ.LookupAssociativeListTM.
 

--- a/theories/TM/Util/TM_facts.v
+++ b/theories/TM/Util/TM_facts.v
@@ -2,7 +2,7 @@
 
 (* Definitions of tapes and (unlabelled) multi-tape Turing machines from Asperti, Riciotti "A formalization of multi-tape Turing machines" (2015) and the accompanying Matita code. *)
 
-From Undecidability Require Export TM.Util.Prelim TM.Util.Relations.
+From Undecidability.TM.Util Require Export Prelim Relations.
 Require Import Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 Require Export Undecidability.TM.TM.
        

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -494,7 +494,6 @@ L/Functions/LoopSum.v
 L/Functions/UnboundIteration.v
 L/Functions/FinTypeLookup.v
 L/Functions/EnumInt.v
-L/Functions/Unenc.v
 L/Functions/Ackermann.v
 
 L/TM/TMEncoding.v


### PR DESCRIPTION
-Cleaned up Require Exports
-Removed `Defined` where `Qed` sufficed
-improved extraction runtime by reimplementing Lrewrite and therefore changing Lsimpl.
-removed clash between L hoas syntax and app-coercion by making `convert` from HOAS to L exlicit (syntax `[L_HOAS someTerm]`)