### PR TITLE
Improvements in the proof of Trakhtenbrot

### DIFF
--- a/theories/Shared/Libs/DLW/Utils/fin_dec.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_dec.v
@@ -10,9 +10,19 @@
 Require Import List Arith Lia.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import fin_base.
+  Require Import utils_decidable fin_base.
 
 Set Implicit Arguments.
+
+Theorem finite_t_find_dec X (P : X -> Prop) 
+           (Pdec : forall x, { P x } + { ~ P x }) 
+           (HQ : finite_t X) :
+           { x | P x } + { forall x, ~ P x }.
+Proof.
+  destruct HQ as (l & Hl). 
+  destruct list_choose_dep with (P := P) (Q := fun x => ~ P x) (l := l)
+    as [ (? & ? & ?) | ]; eauto.
+Qed.
 
 Theorem exists_dec_fin_t X (P Q : X -> Prop) 
            (Pdec : forall x, { P x } + { ~ P x }) 

--- a/theories/Shared/Libs/DLW/Utils/fin_upto.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_upto.v
@@ -12,9 +12,9 @@ Require Import List Arith Nat Lia Relations Bool.
 From Undecidability.Shared.Libs.DLW.Utils 
   Require Import utils_tac utils_list fin_base.
 
-Infix "∈" := In (at level 70, no associativity).
-Infix "⊆" := incl (at level 70, no associativity).
-Notation "P ≅ Q" := ((P -> Q) * (Q -> P))%type (at level 70, no associativity).
+Local Infix "∈" := In (at level 70, no associativity).
+Local Infix "⊆" := incl (at level 70, no associativity).
+Local Notation "P ≅ Q" := ((P -> Q) * (Q -> P))%type (at level 70, no associativity).
 
 Set Implicit Arguments.
 

--- a/theories/Shared/Libs/DLW/Utils/php.v
+++ b/theories/Shared/Libs/DLW/Utils/php.v
@@ -131,6 +131,13 @@ Section pigeon_list.
   Proof. inversion 1; subst; auto. Qed.
 
   Definition list_has_dup_cons_inv := list_hd_cons_inv.
+
+  Fact list_has_dup_cons_iff x l : list_has_dup (x::l) <-> In x l \/ list_has_dup l.
+  Proof.
+    split.
+    + apply list_hd_cons_inv.
+    + intros []; [ constructor 1 | constructor 2 ]; auto.
+  Qed.
   
   Fact list_has_dup_app_left l m : list_has_dup m -> list_has_dup (l++m).
   Proof. induction l; simpl; auto; constructor 2; auto. Qed.
@@ -158,6 +165,9 @@ Section pigeon_list.
         - apply in_list_hd0; right; auto.
         - do 2 apply in_list_hd1; auto.
   Qed.
+
+  Fact list_has_dup_swap x y l : list_has_dup (x::y::l) -> list_has_dup (y::x::l).
+  Proof. apply perm_list_has_dup; constructor. Qed.
 
   Fact list_has_dup_app_inv l m : list_has_dup (l++m) -> list_has_dup l 
                                                       \/ list_has_dup m 

--- a/theories/Shared/Libs/DLW/Utils/seteq.v
+++ b/theories/Shared/Libs/DLW/Utils/seteq.v
@@ -20,43 +20,48 @@
 Require Import Arith Lia List Permutation.
 
 From Undecidability.Shared.Libs.DLW.Utils 
-  Require Import php.
+  Require Import utils_tac php.
 
 From Undecidability.Shared.Libs.DLW.Wf 
   Require Import measure_ind.
 
 Set Implicit Arguments.
 
-Reserved Notation "x ≡ y" (at level 70, no associativity).
-Reserved Notation "x ⊆ y" (at level 70, no associativity).
+Local Reserved Notation "x ≡ y" (at level 70, no associativity).
+Local Reserved Notation "x ⪼ y" (at level 70, no associativity).
 
-Local Infix "~p" := (@Permutation _) (at level 70, no associativity).
+Local Notation lhd := list_has_dup.
+Local Infix "~p" := Permutation (at level 70, no associativity).
+Local Notation "⌊ l ⌋" := (length l) (at level 1, format "⌊ l ⌋").
 
-Section seteq.
+Local Infix "∈" := In (at level 70, no associativity).
+Local Infix "⊆" := incl (at level 70, no associativity).
+Local Infix "≃ₛ" := (fun l p => l ⊆ p /\ p ⊆ l) (at level 70, no associativity).
 
-  Variable X : Type.
+Section incl_extra.
 
-  (* When viewed as sets, the lists are equivalent,
-      ie closed under perm + contraction + RST *)
+  Variable (X : Type).
 
-  Inductive seteq : list X -> list X -> Prop :=
-    | seteq_nil   : nil ≡ nil
-    | seteq_skip  : forall x l m, l ≡ m -> x::l ≡ x::m
-    | seteq_swap  : forall x y l, x::y::l ≡ y::x::l
-    | seteq_dup   : forall x l, x::x::l ≡ x::l
-    | seteq_sym   : forall l m, l ≡ m -> m ≡ l 
-    | seteq_trans : forall l m k, l ≡ m -> m ≡ k -> l ≡ k
-  where "l ≡ m" := (seteq l m).
+  Implicit Type (l : list X).
 
-  Hint Constructors seteq : core.
+  Hint Resolve incl_refl incl_tl incl_cons incl_nil_l : core.
 
-  Fact perm_seteq l m : l ~p m -> l ≡ m.
-  Proof. induction 1; eauto. Qed.
+  Fact lequiv_refl l : l ≃ₛ l.
+  Proof. split; auto. Qed.
 
-  Notation "l ⊆ m" := (incl l m).
+  Fact lequiv_sym l m : l ≃ₛ m -> m ≃ₛ l.
+  Proof. simpl; tauto. Qed.
 
-  Fact incl_cons_mono (x : X) l m : l ⊆ m -> x::l ⊆ x::m.
-  Proof. intros ? ? [ -> | ]; simpl; auto. Qed.
+  Fact lequiv_trans l m k : l ≃ₛ m -> m ≃ₛ k -> l ≃ₛ k.
+  Proof. intros [] []; split; apply incl_tran with m; auto. Qed.
+
+  Fact incl_cons_simpl x l m : l ⊆ m -> x::l ⊆ x::m.
+  Proof. intros; apply incl_cons; simpl; auto. Qed.
+
+  Fact incl_tail_simpl x l : l ⊆ x::l.
+  Proof. auto. Qed.
+
+  Hint Resolve incl_cons_simpl incl_tail_simpl : core.
 
   Fact incl_swap (x y : X) l : x::y::l ⊆ y::x::l.
   Proof. intros ? [ -> | [ -> | ] ]; simpl; auto. Qed.
@@ -64,76 +69,257 @@ Section seteq.
   Fact incl_cntr (x : X) l : x::x::l ⊆ x::l.
   Proof. intros ? [ -> | [ -> | ] ]; simpl; auto. Qed.
 
-  Hint Resolve incl_refl incl_cons_mono incl_swap incl_cntr incl_tl : core.
+  Fact lequiv_swap x y l : x::y::l ≃ₛ y::x::l.
+  Proof. split; apply incl_cons; simpl; auto. Qed.
 
-  Fact seqeq_incl l m : l ≡ m -> l ⊆ m /\ m ⊆ l.
+  Fact lequiv_app_comm l m : l++m ≃ₛ m++l.
+  Proof. split; intros ?; rewrite !in_app_iff; tauto. Qed.
+
+  Fact incl_cons_l_inv l m x : x::m ⊆ l -> x ∈ l /\ m ⊆ l.
   Proof.
-    induction 1 as [ | x l m H [] | x y l | x l 
-                   | l m H []
-                   | l m k H1 IH1 H2 IH2 ]; auto.
-    split; apply incl_tran with m; tauto.
+    intros H; split.
+    + apply H; simpl; auto.
+    + apply incl_tran with (2 := H); simpl; auto.
   Qed.
 
-  Lemma list_has_dup_seteq l : list_has_dup l -> exists m, m ≡ l /\ length m < length l.
+  Hint Resolve perm_skip Permutation_cons_app : core.
+
+  Fact incl_app_r_inv l m p : m ⊆ l++p -> exists m1 m2, m ~p m1++m2 /\ m1 ⊆ l /\ m2 ⊆ p.
+  Proof.
+    induction m as [ | x m IHm ].
+    + exists nil, nil; auto.
+    + intros H; apply incl_cons_l_inv in H as (H1 & H2).
+      destruct (IHm H2) as (m1 & m2 & H3 & H4 & H5).
+      apply in_app_or in H1 as [].
+      * exists (x::m1), m2; simpl; auto.
+      * exists m1, (x::m2); simpl; auto.
+  Qed.
+  
+  Fact incl_cons_r_inv x l m : 
+         m ⊆ x::l -> exists m1 m2, m ~p m1 ++ m2 /\ Forall (eq x) m1 /\ m2 ⊆ l.
+  Proof.
+    intros H.
+    apply (@incl_app_r_inv (x::nil) _ l) in H as (m1 & m2 & H1 & H2 & H3).
+    exists m1, m2; msplit 2; auto.
+    rewrite Forall_forall.
+    intros a Ha; apply H2 in Ha; destruct Ha as [ | [] ]; auto.
+  Qed.
+
+  Fact incl_right_cons_choose x l m : m ⊆ x::l -> x ∈ m \/ m ⊆ l.
+  Proof.
+    intros H; apply incl_cons_r_inv in H
+      as ([ | y m1] & m2 & H1 & H2 & H3).
+    + right.
+      intros u H; apply H3; revert H.
+      apply Permutation_in; auto.
+    + left.
+      apply Permutation_in with (1 := Permutation_sym H1).
+      rewrite Forall_forall in H2.
+      rewrite (H2 y); left; auto.
+  Qed.
+
+  Fact incl_left_right_cons x l y m : 
+          x::l ⊆ y::m  -> y = x /\ y ∈ l 
+                       \/ y = x /\ l ⊆ m
+                       \/ x ∈ m /\ l ⊆ y::m.
+  Proof.
+    intros H; apply incl_cons_l_inv in H
+      as [ [|] H2 ]; auto.
+    apply incl_right_cons_choose in H2; tauto.
+  Qed.
+
+  Fact perm_incl_left m1 m2 l: m1 ~p m2 -> m2 ⊆ l -> m1 ⊆ l.
+  Proof. intros H1 H2 ? H; apply H2; revert H; apply Permutation_in; auto. Qed.
+
+  Fact perm_incl_right m l1 l2: l1 ~p l2 -> m ⊆ l1 -> m ⊆ l2.
+  Proof. intros H1 H2 ? ?; apply Permutation_in with (1 := H1), H2; auto. Qed.
+  
+End incl_extra.
+
+Section seteq.
+
+  Variable X : Type.
+
+  Implicit Types l : list X.
+
+  Inductive list_contract : list X -> list X -> Prop :=
+    | lc_nil      : nil ⪼  nil
+    | lc_skip     : forall x l m, l ⪼ m -> x::l ⪼ x::m
+    | lc_swap     : forall x y l, x::y::l ⪼ y::x::l
+    | lc_cntr     : forall x l, x::x::l ⪼ x::l
+    | lc_trans    : forall l m k, l ⪼ m -> m ⪼ k -> l ⪼ k
+  where "l ⪼ m" := (list_contract l m).
+
+  Hint Constructors list_contract : core.
+
+  Fact perm_lc l m : l ~p m -> l ⪼ m.
+  Proof. induction 1; eauto. Qed.
+
+  Fact lc_length l m : l ⪼ m -> ⌊m⌋ <= ⌊l⌋.
+  Proof. induction 1; simpl; lia. Qed.
+
+  Fact lc_nil_inv_l l : nil ⪼ l -> l = nil.
+  Proof.
+    intros H; apply lc_length in H.
+    destruct l; simpl in *; auto; lia.
+  Qed.
+
+  Hint Resolve perm_swap perm_trans : core.
+
+  Fact lc_length_perm l m : l ⪼ m -> ⌊m⌋ < ⌊l⌋ \/ l ~p m.
+  Proof.
+    induction 1 as [ | ? ? ? ? [] | | 
+      | ? ? ? ? [] ? [] ]; simpl; eauto;
+      repeat match goal with
+        | H: _ ⪼ _ |- _ => apply lc_length in H
+      end; lia.
+  Qed.
+
+  Fact lc_refl l : l ⪼ l.
+  Proof. apply perm_lc; auto. Qed.
+
+  (* When viewed as sets, the lists are equivalent,
+      ie closed under perm + contraction + RST *)
+
+  Inductive list_seteq : list X -> list X -> Prop :=
+    | lseq_nil   : nil ≡ nil
+    | lseq_skip  : forall x l m, l ≡ m -> x::l ≡ x::m
+    | lseq_swap  : forall x y l, x::y::l ≡ y::x::l
+    | lseq_dup   : forall x l, x::x::l ≡ x::l
+    | lseq_sym   : forall l m, l ≡ m -> m ≡ l 
+    | lseq_trans : forall l m k, l ≡ m -> m ≡ k -> l ≡ k
+  where "l ≡ m" := (list_seteq l m).
+
+  Hint Constructors list_seteq : core.
+
+  Fact lc_lseq l m : l ⪼ m -> l ≡ m.
+  Proof. induction 1; eauto. Qed.
+
+  Hint Resolve perm_lc lc_lseq : core.
+
+  Fact perm_lseq l m : l ~p m -> l ≡ m.
+  Proof. auto. Qed.
+
+  Hint Resolve incl_refl incl_cons_simpl incl_swap incl_cntr incl_tl incl_tran : core.
+
+  Fact lseq_lequiv l m : l ≡ m -> l ≃ₛ m.
+  Proof.
+    induction 1 as [ | ? ? ? ? [] | | 
+                   | ? ? ? []
+                   | ? ? ? ? [] ? [] ]; eauto.
+  Qed.
+ 
+  Hint Resolve lseq_lequiv : core.
+
+  Fact lc_lequiv l m : l ⪼ m -> l ≃ₛ m.
+  Proof. intro; apply lseq_lequiv; auto. Qed.
+
+  Hint Resolve incl_l_nil : core.
+
+  Fact lc_nil_inv_r l : l ⪼ nil -> l = nil.
+  Proof. intros H; apply lc_lequiv in H as []; auto. Qed.
+ 
+  Hint Resolve list_has_dup_swap in_eq in_cons in_list_hd0 in_list_hd1 : core.
+
+  Notation lhd_cons_iff := list_has_dup_cons_iff.
+
+  Fact lc_lhd l m : l ⪼ m -> lhd m -> lhd l.
+  Proof.
+    induction 1 as [ | x l m H IH | | | ]; eauto.
+    rewrite !lhd_cons_iff; intros []; auto.
+    apply lc_lequiv in H as []; auto.
+  Qed.
+
+  Fact lseq_incl l m : l ≡ m -> l ⊆ m.
+  Proof. intro; apply lseq_lequiv; auto. Qed.
+
+  (* A list with a dup is contractible in a smaller one *) 
+
+  Lemma lhd_lc l : lhd l -> exists m, l ⪼ m /\ ⌊m⌋ < ⌊l⌋.
   Proof.
     induction 1 as [ l x H | l x H (m & H1 & H2) ].
-    + induction l as [ | y l IHl ].
-      * exfalso; destruct H.
-      * destruct H as [ -> | H ].
-        - exists (x::l); simpl; split; auto; lia.
-        - destruct (IHl H) as (m & H1 & H2).
-          exists (y::m); simpl in *; split; try lia.
-          apply seteq_trans with (y::x::l); auto.
-    + exists (x::m); simpl; split; auto; lia.
+    + apply in_split in H as (l1 & l2 & ->).
+      exists (l1++x::l2); split; simpl; try lia.
+      apply lc_trans with (x::x::l1++l2).
+      * apply perm_lc, perm_skip, Permutation_sym,
+              Permutation_cons_app; auto.
+      * apply lc_trans with (1 := lc_cntr _ _), perm_lc,
+              Permutation_cons_app; auto.
+    + exists (x::m); split; simpl; auto; lia.
   Qed.
 
-  (* The proof by induction on |l|+|m| for l ⊆ m and m ⊆ l
+  Hint Resolve lc_lseq : core.
 
-      Three cases:
+  Lemma lhd_lseq l : lhd l -> exists m, l ≡ m /\ ⌊m⌋ < ⌊l⌋.
+  Proof. intro H; apply lhd_lc in H as (? & ? & ?); eauto. Qed.
 
-      (1) m has dup    (2) l ~p m      (3) l has dup
+  Hint Constructors list_contract : core.
 
-      For (2) If l ~p m then it is trivial
+  Hint Resolve lc_refl lc_lhd : core.
 
-      Otherwise (1 or 3), if eg l has dup then l ≡ l' for a shorter l' 
-      we deduce l' ⊆ m and m ⊆ l' by seqeq_incl
-      and apply the induction hypothesis to (l',m)
-
-    *)
-
-  Lemma incl_seteq l m : l ⊆ m -> m ⊆ l -> l ≡ m.
+  Lemma lequiv_php_choose l m : l ≃ₛ m -> l ~p m \/ lhd l \/ lhd m.
   Proof.
-    induction on l m as IH with measure (length l + length m).
-    intros H1 H2.
-    destruct (le_lt_dec (length l) (length m)) as [ H3 | H3 ];
-      [ destruct length_le_and_incl_implies_dup_or_perm with (1 := H3)
-        as [ H4 | H4 ]; auto | ].
-    + destruct list_has_dup_seteq with (1 := H4) as (m' & H5 & H6).
-      apply seteq_trans with m'; auto.
-      apply seqeq_incl in H5; destruct H5.
-      apply IH; try lia; apply incl_tran with m; auto.
-    + apply seteq_sym, perm_seteq; auto.
-    + generalize (finite_php_dup H3 H1); intros H4.
-      destruct list_has_dup_seteq with (1 := H4) as (m' & H5 & H6).
-      apply seteq_trans with m'; auto.
-      apply seqeq_incl in H5; destruct H5.
-      apply IH; try lia; apply incl_tran with l; auto.
+    intros [ I1 I2 ].
+    destruct (le_lt_dec ⌊m⌋ ⌊l⌋) as [ H1 | H1 ].
+    + apply length_le_and_incl_implies_dup_or_perm in H1; tauto.
+    + apply finite_php_dup in H1; tauto.
   Qed.
 
-  Hint Resolve seqeq_incl incl_seteq : core.
+  (* if l and m are equivalent, either
+     1) l ~p m in which case l is contractible into m
+     2) lhd l hence l is contracted into a smaller one and recursion
+     3) lhd m hence m is contracted into a smaller one and recursion
+   *)
+
+  Hint Resolve lequiv_trans : core.
+
+  Lemma lequiv_lc l m : l ≃ₛ m -> exists c, l ⪼ c /\ m ⪼ c.
+  Proof.
+    induction on l m as IH with measure (⌊l⌋+⌊m⌋); intros H1.
+    destruct (lequiv_php_choose H1) as [ H2 | [ H2 | H2 ] ]; eauto.
+    + apply lhd_lc in H2 as (c & ? & ?).
+      destruct (IH c m) as (d & ? & ?); eauto; lia.
+    + apply lhd_lc in H2 as (c & ? & ?).
+      destruct (IH l c) as (d & ? & ?); eauto; lia.
+  Qed.
+
+  Lemma lequiv_lseq l m : l ≃ₛ m -> l ≡ m.
+  Proof. intros H; apply lequiv_lc in H as (c & []); eauto. Qed.
+
+  Hint Resolve lequiv_lseq : core.
 
   (* seteq is equivalent to bi-inclusion *)
 
-  Theorem seteq_bi_incl l m : l ≡ m <-> l ⊆ m /\ m ⊆ l.
-  Proof. split; auto; intros []; auto. Qed.
+  Theorem lseq_lequiv_iff l m : l ≡ m <-> l ≃ₛ m.
+  Proof. split; auto. Qed.
+
+  (* A nice induction principle for list bi-inclusion *)
+
+  Section lequiv_ind.
+
+    Variables (P : list X -> list X -> Prop)
+              (HP0 : P nil nil)
+              (HP1 : forall x l m, l ≃ₛ m -> P l m -> P (x::l) (x::m))
+              (HP2 : forall x y l, P (x::y::l) (y::x::l))
+              (HP3 : forall x l, P (x::x::l) (x::l))
+              (HP4 : forall l m, l ≃ₛ m -> P l m -> P m l)
+              (HP5 : forall l m k, l ≃ₛ m -> P l m -> m ≃ₛ k -> P m k -> P l k).
+
+    Theorem lequiv_ind l m : l ≃ₛ m -> P l m.
+    Proof. rewrite <- lseq_lequiv_iff; induction 1; eauto. Qed.
+
+  End lequiv_ind.
+
+  Lemma lequiv_lhd_or_contract l m : l ≃ₛ m -> lhd m \/ l ⪼  m.
+  Proof.
+    simpl; intros H.
+    destruct lequiv_lc with (1 := H) as (d & H1 & H2).
+    apply lc_length_perm in H2 as [ H2 | H2 ].
+    + apply finite_php_dup in H2; auto.
+      apply lc_lseq, lseq_lequiv in H1.
+      apply incl_tran with l; tauto.
+    + right; apply lc_trans with (1 := H1).
+      apply perm_lc, Permutation_sym; auto.
+  Qed.
 
 End seteq.
-
-Local Infix "≡" := seteq.
-Local Infix "⊆" := incl.
-
-(*
-Print seteq.
-Check seteq_bi_incl.
-Print Assumptions seteq_bi_incl.
-*)

--- a/theories/Shared/Libs/DLW/Wf/wf_finite.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_finite.v
@@ -31,21 +31,21 @@ Section wf_strict_order_list.
   Fact chain_trans n x y : chain R n x y -> n = 0 /\ x = y \/ R x y.
   Proof. induction 1 as [ | ? ? ? ? ? ? [ [] | ] ]; subst; eauto. Qed.
 
-  Corollary chain_irrefl n x : n = 0 \/ ~ chain R n x x.
+  Corollary chain_irrefl n x :~ chain R (S n) x x.
   Proof.
-    destruct n as [ | n ]; auto; right; intros H.
-    destruct (chain_trans H) as [ (? & _) | H1 ]; try easy.
-    revert H1; apply Rirrefl.
+    intros H.
+    apply chain_trans in H as [ (? & _) | H ]; try easy.
+    revert H; apply Rirrefl.
   Qed.
+
+  (* Assume a list over approximating the domain of R *)
 
   Variable (m : list X) (Hm : forall x y, R x y -> x ∊ m).
 
-  Fact chain_list_incl l x y : chain_list R l x y -> l = nil \/ l ⊆ m.
-  Proof.
-    induction 1 as [ x | x l y z H1 H2 IH2 ]; simpl; auto; right.
-    apply incl_cons; eauto.
-    destruct IH2; auto; subst; intros _ [].
-  Qed.
+  Hint Resolve incl_nil_l incl_cons : core.
+
+  Fact chain_list_incl l x y : chain_list R l x y -> l ⊆ m.
+  Proof. induction 1; simpl; eauto. Qed.
 
   (* Any chain of length above length m contains a duplicated
       value (by the PHP) hence a non nil sub-chain with identical 
@@ -65,22 +65,18 @@ Section wf_strict_order_list.
       apply chain_list_app_inv in H1 as (p & H4 & H1).
       apply chain_list_cons_inv in H1 as (<- & _ & _ & _).
       apply chain_list_chain in H4.
-      destruct (chain_irrefl (S (length u)) z)
-        as [ | [] ]; try easy.
+      destruct (@chain_irrefl (length u) z).
       constructor 2 with k; auto.
-    + apply chain_list_incl in H1 as [ -> | H1 ].
-      * simpl in *; lia.
-      * apply finite_php_dup with (2 := H1); lia.
+    + apply chain_list_incl in H1.
+      apply finite_php_dup with (2 := H1); lia.
   Qed.
 
   (* Since chains have bounded length, we get WF *)
 
+  Hint Resolve chain_bounded : core.
+
   Theorem wf_strict_order_list : well_founded R.
-  Proof.
-    apply wf_chains.
-    intros x; exists (length m). 
-    intros ? ?; apply chain_bounded.
-  Qed.
+  Proof. apply wf_chains; eauto. Qed.
 
 End wf_strict_order_list.
 

--- a/theories/Shared/Libs/DLW/Wf/wf_finite.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_finite.v
@@ -17,6 +17,9 @@ From Undecidability.Shared.Libs.DLW.Wf
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊆" := incl (at level 70, no associativity).
+
 Section wf_strict_order_list.
 
   Variable (X : Type) (R : X -> X -> Prop).
@@ -26,27 +29,22 @@ Section wf_strict_order_list.
   Implicit Type l : list X.
 
   Fact chain_trans n x y : chain R n x y -> n = 0 /\ x = y \/ R x y.
-  Proof.
-    induction 1 as [ x | n x y z H1 H2 IH2 ]; auto.
-    destruct IH2 as [ [] | ]; subst; right; auto.
-    apply Rtrans with (1 := H1); auto.
-  Qed.
+  Proof. induction 1 as [ | ? ? ? ? ? ? [ [] | ] ]; subst; eauto. Qed.
 
   Corollary chain_irrefl n x : n = 0 \/ ~ chain R n x x.
   Proof.
     destruct n as [ | n ]; auto; right; intros H.
-    destruct (chain_trans H) as [ (? & _) | H1 ]; try discriminate.
+    destruct (chain_trans H) as [ (? & _) | H1 ]; try easy.
     revert H1; apply Rirrefl.
   Qed.
 
-  Variable (m : list X) (Hm : forall x y, R x y -> In x m).
+  Variable (m : list X) (Hm : forall x y, R x y -> x ∊ m).
 
-  Fact chain_list_incl l x y : chain_list R l x y -> l = nil \/ incl l m.
+  Fact chain_list_incl l x y : chain_list R l x y -> l = nil \/ l ⊆ m.
   Proof.
     induction 1 as [ x | x l y z H1 H2 IH2 ]; simpl; auto; right.
-    apply incl_cons.
-    + apply Hm with (1 := H1); auto.
-    + destruct IH2; auto; subst l; intros _ [].
+    apply incl_cons; eauto.
+    destruct IH2; auto; subst; intros _ [].
   Qed.
 
   (* Any chain of length above length m contains a duplicated
@@ -61,23 +59,17 @@ Section wf_strict_order_list.
       as (ll & H1 & H2).
     cut (list_has_dup ll).
     + intros H3.
-      apply list_has_dup_equiv in H3.
-      destruct H3 as (z & l & u & r & ->).
-      apply chain_list_app_inv in H1.
-      destruct H1 as (a & _ & H1).
-      apply chain_list_cons_inv in H1.
-      destruct H1 as (<- & k & H3 & H1).
-      apply chain_list_app_inv in H1.
-      destruct H1 as (p & H4 & H1).
-      apply chain_list_cons_inv in H1.
-      destruct H1 as (<- & _ & _ & _).
+      apply list_has_dup_equiv in H3 as (z & l & u & r & ->).
+      apply chain_list_app_inv in H1 as (a & _ & H1).
+      apply chain_list_cons_inv in H1 as (<- & k & H3 & H1).
+      apply chain_list_app_inv in H1 as (p & H4 & H1).
+      apply chain_list_cons_inv in H1 as (<- & _ & _ & _).
       apply chain_list_chain in H4.
       destruct (chain_irrefl (S (length u)) z)
-        as [ | [] ]; try discriminate.
+        as [ | [] ]; try easy.
       constructor 2 with k; auto.
-    + apply chain_list_incl in H1.
-      destruct H1 as [ -> | H1 ].
-      * subst; simpl in C; lia.
+    + apply chain_list_incl in H1 as [ -> | H1 ].
+      * simpl in *; lia.
       * apply finite_php_dup with (2 := H1); lia.
   Qed.
 
@@ -94,7 +86,7 @@ End wf_strict_order_list.
 
 Section wf_strict_order_finite.
 
-  Variable (X : Type) (HX : exists l, forall x : X, In x l) 
+  Variable (X : Type) (HX : exists l, forall x : X, x ∊ l) 
            (R : X -> X -> Prop)
            (Rirrefl : forall x, ~ R x x)
            (Rtrans : forall x y z, R x y -> R y z -> R x z).

--- a/theories/TRAKHTENBROT/Sig0.v
+++ b/theories/TRAKHTENBROT/Sig0.v
@@ -74,9 +74,9 @@ Section Σ_Σ0.
                (A : fol_form Σ)
                (HA : fol_sem M phi A).
 
-    Local Lemma Σ_Σ0_soundness : fo_form_fin_dec_SAT_in (Σ_Σ0 A) unit.
+    Local Lemma Σ_Σ0_soundness : fo_form_fin_dec_SAT (Σ_Σ0 A).
     Proof.
-      exists M', finite_t_unit.
+      exists unit, M', finite_t_unit.
       exists. { intros r v; simpl; apply Mdec. }
       exists (fun _ => tt).
       revert HA; apply Σ_Σ0_sound.
@@ -86,7 +86,7 @@ Section Σ_Σ0.
 
   Section completeness.
 
-    Variable (M' : fo_model Σ0 unit).
+    Variable (X : Type) (M' : fo_model Σ0 X).
   
     Let M : fo_model Σ unit.
     Proof.
@@ -102,21 +102,21 @@ Section Σ_Σ0.
       + simpl; tauto.
       + apply fol_bin_sem_ext; auto.
       + simpl; split.
-        * intros (x & Hx); exists tt; revert Hx; apply HA.
+        * intros (x & Hx); exists (ψ 0); revert Hx; apply HA.
         * intros (x & Hx); exists (φ 0); revert Hx; apply HA.
       + simpl; split.
         * intros H x; generalize (H (φ 0)); apply HA.
-        * intros H x; generalize (H tt); apply HA.
+        * intros H x; generalize (H (ψ 0)); apply HA.
     Qed.
 
     Hypothesis (M'dec : fo_model_dec M')
-               (psi : nat -> unit)
+               (psi : nat -> X)
                (A : fol_form Σ)
                (HA : fol_sem M' psi (Σ_Σ0 A)).
 
-    Local Lemma Σ_Σ0_completeness : fo_form_fin_dec_SAT_in A unit.
+    Local Lemma Σ_Σ0_completeness : fo_form_fin_dec_SAT A.
     Proof.
-      exists M, finite_t_unit.
+      exists unit, M, finite_t_unit.
       exists. { intros r v; simpl; apply M'dec. }
       exists (fun _ => tt).
       revert HA; apply Σ_Σ0_complete.
@@ -124,13 +124,13 @@ Section Σ_Σ0.
 
   End completeness.
 
-  Theorem Σ_Σ0_correct A : fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT_in (Σ_Σ0 A) unit.
+  Theorem Σ_Σ0_correct A : fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT (Σ_Σ0 A).
   Proof.
     split.
     + intros (X & M & _ & G2 & phi & G3).
       apply Σ_Σ0_soundness with X M phi; auto.
-    + intros (M & _ & G2 & phi & G3).
-      exists unit; apply Σ_Σ0_completeness with M phi; auto.
+    + intros (X & M & _ & G2 & phi & G3).
+      apply Σ_Σ0_completeness with X M phi; auto.
   Qed.
 
 End Σ_Σ0.

--- a/theories/TRAKHTENBROT/Sig0.v
+++ b/theories/TRAKHTENBROT/Sig0.v
@@ -62,8 +62,8 @@ Section Σ_Σ0.
         intros v; vec nil v; auto.
       + apply fol_bin_sem_ext; auto.
       + simpl; split.
-        * intros (x & Hx); exists tt; revert Hx; apply HA.
-        * intros (x & Hx); exists (φ 0); revert Hx; apply HA.
+        * intros (? & H); exists tt; revert H; apply HA.
+        * intros (? & H); exists (φ 0); revert H; apply HA.
       + simpl; split.
         * intros H x; generalize (H (φ 0)); apply HA.
         * intros H x; generalize (H tt); apply HA.
@@ -102,8 +102,8 @@ Section Σ_Σ0.
       + simpl; tauto.
       + apply fol_bin_sem_ext; auto.
       + simpl; split.
-        * intros (x & Hx); exists (ψ 0); revert Hx; apply HA.
-        * intros (x & Hx); exists (φ 0); revert Hx; apply HA.
+        * intros (? & H); exists (ψ 0); revert H; apply HA.
+        * intros (? & H); exists (φ 0); revert H; apply HA.
       + simpl; split.
         * intros H x; generalize (H (φ 0)); apply HA.
         * intros H x; generalize (H (ψ 0)); apply HA.

--- a/theories/TRAKHTENBROT/Sig0.v
+++ b/theories/TRAKHTENBROT/Sig0.v
@@ -57,7 +57,7 @@ Section Σ_Σ0.
     Proof.
       revert φ ψ; induction A as [ | r v | b A HA B HB | [] A HA ]; intros φ ψ.
       + simpl; tauto.
-      + simpl; apply fol_equiv_ext; f_equal.
+      + simpl; fol equiv.
         revert v; rewrite (HΣ r); unfold eq_rect_r; simpl.
         intros v; vec nil v; auto.
       + apply fol_bin_sem_ext; auto.

--- a/theories/TRAKHTENBROT/Sig1.v
+++ b/theories/TRAKHTENBROT/Sig1.v
@@ -37,6 +37,8 @@ Section Σ1_model.
   Defined.
 
   Variable (X : Type) (M : fo_model ΣP1 X) (HX : finite_t X) (Mdec : fo_model_dec M).
+
+  (* We simulate X with a model over bool^n -> bool *)
  
   Let f p (x : X) := if Mdec (r := p) (x##ø) then true else false.
 
@@ -62,7 +64,7 @@ Section Σ1_model.
   Let Kf x : K (vec_set_pos (fun p => f p x)) = true.
   Proof. 
     apply HK; exists x; intros; rew vec. 
-  Qed. 
+  Qed.
 
   Let M' : fo_model ΣP1 (sig (fun v => K v = true)).
   Proof.
@@ -72,7 +74,7 @@ Section Σ1_model.
       exact (vec_pos (proj1_sig (vec_head v)) p = true).
   Defined.
 
-  Let R : @fo_simulation ΣP1 (nil) (pos_list n) _ M _ M'.
+  Let R : @fo_simulation ΣP1 nil (pos_list n) _ M _ M'.
   Proof.
     exists (fun x v => forall p, f p x = vec_pos (proj1_sig v) p).
     + intros s; destruct (HV s).
@@ -122,11 +124,11 @@ End Σ1_model.
     a model over base type X which is a decidable subtype of bool^n
     where n bound the number of unary predicates *)
 
-Theorem ΣP1_model_bounded n V (A : fol_form (ΣP1 V n)) :
+Theorem Monadic_model_bounded n V (A : fol_form (ΣP1 V n)) :
            (V -> False)
         -> fo_form_fin_dec_SAT A
-        -> exists (Q : vec bool n -> bool),
-                  fo_form_fin_dec_SAT_in A (sig (fun v => Q v = true)).
+        -> exists (b : vec bool n -> bool),
+                  fo_form_fin_dec_SAT_in A (sig (fun v => b v = true)).
 Proof.
   intros HV (X & M & H1 & H2 & phi & H3).
   destruct bounded_model with (1 := HV) (4 := H3)
@@ -161,7 +163,7 @@ Proof.
     destruct H as (P & HP).
     exists { v | P v = true }; auto.
   + right; intros (X & HX).
-    apply H, ΣP1_model_bounded; auto; exists X; auto.
+    apply H, Monadic_model_bounded; auto; exists X; auto.
 Qed.
 
     

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -501,8 +501,6 @@ Section Σfull_mon_rem.
 
 End Σfull_mon_rem.
 
-Check Σfull_mon_red'_correct.
-
 Section Σ11_reduction.
 
   (* We can lower the hypotheses now by computing m from A *)

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -20,9 +20,14 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
+
 (* * Removal of function symbols from full monadic signatures *)
 
-Fixpoint find_non_empty_word X (l : list (list X)) : { s & { w | In (s::w) l } } + { concat l = nil }.
+Fixpoint find_non_empty_word X (l : list (list X)) : 
+           { s & { w | s::w ∊ l } } 
+         + { concat l = nil }.
 Proof.
   destruct l as [ | [ | s w ] l ].
   + right; auto.
@@ -65,7 +70,7 @@ Section fot_word_var.
   Proof.
     induction t as [ | s v IH ]; simpl in *; auto; f_equal.
     generalize (IH pos0); clear IH; vec split v with t; vec nil v; clear v; simpl.
-    intro; f_equal; auto.
+    intros; f_equal; auto.
   Qed.
 
   Fact fot_word_eq w i : fot_word (fot_word_var w i) = w.
@@ -121,16 +126,18 @@ Section Σfull_mon_rem.
 
   Notation X := (pos n).
 
+  (* Bounded lists *)
+
   Let Yw := { w : list X | length w < S m }.
 
   Let YwY_fin : finite_t (Yw*Y).
   Proof. 
     apply finite_t_prod; auto. 
-    apply finite_t_list, finite_t_pos. 
+    apply finite_t_list, finite_t_pos.
   Qed.
 
   Let lwY := proj1_sig YwY_fin.
-  Let HlwY p : In p lwY.
+  Let HlwY p : p ∊ lwY.
   Proof. apply (proj2_sig YwY_fin). Qed.
 
   (* The new signature is not finite (list X !!)
@@ -140,16 +147,46 @@ Section Σfull_mon_rem.
   Notation Σ := (Σ11 X Y).
   Notation Σ' := (Σ11 X (list X*Y + Y)).
 
+  Let f s v := @in_fot _ (ar_syms Σ') s v##ø.
+  Let P r v : fol_form Σ' := @fol_atom Σ' (inr r) v.
+  Let Q w r v : fol_form Σ' :=  @fol_atom Σ' (inl (w,r)) v.
+
+  Arguments f : clear implicits.
+  Arguments P : clear implicits.
+  Arguments Q : clear implicits.
+
+  (* An atomic formula of Σ as the form r(s1(...(sn(x))))
+     and we encode it as the monadic Q_([sn;...;s1],r) (x) 
+
+     To ensure correctness, we have to add the non-simply 
+     monadic equations:
+     
+                  P_r x <-> Q_(nil,r) x 
+         and Q_(s::w,r) <-> Q_(w,r) (s x)
+
+     In these, there is still Q_* (s x) which is not
+     simply monodic. Later, we skolemize those equations
+     to get rid of the compound term (s x)
+
+     Notice that we have to bound n above to ensure that 
+     those equations are finitely many
+   *)
+
   Fixpoint Σfull_mon_rec (A : fol_form Σ) : fol_form Σ' :=
     match A with
       | ⊥              => ⊥
       | fol_atom r v   => 
-        let w := fot_word (vec_head v) in
-        let i := fot_var  (vec_head v) 
-        in  @fol_atom Σ' (inl (rev w,r)) (£i##ø)
+        let t := vec_head v in
+        let w := fot_word t in
+        let x := fot_var  t 
+        in  Q (rev w) r (£x##ø)
       | fol_bin b A B => fol_bin b (Σfull_mon_rec A) (Σfull_mon_rec B)
       | fol_quant q A => fol_quant q (Σfull_mon_rec A)
     end.
+
+  (* The reduction function does not map to a signature void of
+     functions to simplify the above expression. However, the
+     obtained formula is void of any function symbols *)
 
   Fact Σfull_mon_rec_syms A : fol_syms (Σfull_mon_rec A) = nil.
   Proof.
@@ -158,31 +195,29 @@ Section Σfull_mon_rem.
     simpl; rewrite HA, HB; auto.
   Qed.
 
-  Variable (A : fol_form Σ) (HwA : forall w, In w (Σ11_words A) -> length w < S m).
+  Variable (A : fol_form Σ) (HwA : forall w, w ∊ Σ11_words A -> length w < S m).
 
-  (* Equations P_r(£0) <-> Q_(nil,r) (£0) 
+  (* Equations P_r (£0) <-> Q_(nil,r) (£0) 
            and Q_(s::w,r) (£0) <-> Q_(w,r) (s(£0)) *)
 
-  Let Eq (p : Yw * Y) := 
-    let (w,r) := p  in
+  Let Eq (p : Yw * Y) : fol_form Σ' :=
+    let v := £0##ø in 
+    let (w,r) := p in
     let (w,_) := w in
     match w with
-      | nil   => @fol_atom Σ' (inl (nil,r)) (£0##ø)
-               ↔ @fol_atom Σ' (inr r) (£0##ø)
-      | s::w' => @fol_atom Σ' (inl (w',r)) (@in_fot _ (ar_syms Σ') s (£0##ø)##ø)
-               ↔ @fol_atom Σ' (inl (w,r)) (£0##ø)
+      | nil   => Q nil r v ↔ P r v
+      | s::w' => Q w' r (f s v) ↔ Q w r v
     end.
 
-  (* The previous equation but skolemized by s(£0) <-> £(s) *) 
+  (* The previous equations but skolemized by s(£0) <-> £(s) *) 
 
   Let Eq' (p : Yw * Y) := 
+    let m := £n##ø  in
     let (w,r) := p  in
-    let (w,_) := w in
+    let (w,_) := w  in
     match w with
-      | nil   => @fol_atom Σ' (inl (nil,r)) (£n##ø)
-               ↔ @fol_atom Σ' (inr r) (£n##ø)
-      | s::w' => @fol_atom Σ' (inl (w',r)) (£(pos2nat s)##ø)
-               ↔ @fol_atom Σ' (inl (w,r)) (£n##ø)
+      | nil   => Q nil r m ↔ P r m
+      | s::w' => Q w' r (£(pos2nat s)##ø) ↔ Q w r m
     end.
 
   (* We first deals with the non-skolemized reduction *)
@@ -192,17 +227,19 @@ Section Σfull_mon_rem.
 
   Variable (K : Type).
 
-  Let Fixpoint f (M : fo_model Σ K) w x :=
+  (* Interpretation of a list of functions mapped on a value *)
+
+  Let Fixpoint g (M : fo_model Σ K) w x :=
     match w with
       | nil  => x
-      | s::w => f M w (fom_syms M s (x##ø))
+      | s::w => g M w (fom_syms M s (x##ø))
     end.
 
-  Let f_app M w1 w2 x : f M (w1++w2) x = f M w2 (f M w1 x).
+  Let g_app M w1 w2 x : g M (w1++w2) x = g M w2 (g M w1 x).
   Proof. revert x; induction w1; simpl; auto. Qed.
 
-  Let f_snoc M w s x : f M (w++s::nil) x = fom_syms M s (f M w x##ø).
-  Proof. rewrite f_app; auto. Qed.
+  Let g_snoc M w s x : g M (w++s::nil) x = fom_syms M s (g M w x##ø).
+  Proof. rewrite g_app; auto. Qed.
 
   Section soundness.
 
@@ -213,7 +250,7 @@ Section Σfull_mon_rem.
       split.
       + exact (fom_syms M).
       + intros [ (w,r) | r ]; simpl in r |- *.
-        * exact (fun v  => fom_rels M r (f M w (vec_head v)##ø)).
+        * exact (fun v  => fom_rels M r (g M w (vec_head v)##ø)).
         * exact (fom_rels M r).
     Defined.
 
@@ -230,7 +267,7 @@ Section Σfull_mon_rem.
         * simpl; apply fol_equiv_ext; do 2 f_equal.
           generalize (fot_word t) (fot_var t); clear t HA; intros w.
           induction w as [ | s w IHw ]; simpl; auto; intros i.
-          rewrite f_snoc; simpl; do 2 f_equal; auto.
+          rewrite g_snoc; simpl; do 2 f_equal; auto.
         * f_equal; symmetry; apply fot_word_var_eq.
       + simpl; apply fol_bin_sem_ext.
         * apply HB; intros ? ?; apply HA, in_app_iff; auto.
@@ -279,10 +316,10 @@ Section Σfull_mon_rem.
       Hypothesis HM2' : forall r x, fom_rels M' (inr r) (x##ø)
                                 <-> fom_rels M' (inl (nil,r)) (x##ø).
 
-      Let Hf φ w i : f M (rev w) (φ i) = fo_term_sem M φ (fot_word_var w i).
+      Let Hf φ w i : g M (rev w) (φ i) = fo_term_sem M φ (fot_word_var w i).
       Proof.
         induction w; simpl; auto.
-        rewrite f_snoc; simpl in *; rewrite IHw; auto.
+        rewrite g_snoc; simpl in *; rewrite IHw; auto.
       Qed.
 
       Fact Σfull_mon_rec_complete φ : 
@@ -349,7 +386,7 @@ Section Σfull_mon_rem.
       apply Σfull_mon_rem_complete with M' phi; auto.
   Qed.
 
-  (* Now we skolemize the right part and show correctness *)
+  (* Now we skolemize the right part (equations) and show correctness *)
 
   Definition Σfull_mon_red' : fol_form Σ' :=
     Σfull_mon_rec A ⟑ ∀ fol_mquant fol_ex n (fol_lconj (map Eq' lwY)).
@@ -363,11 +400,11 @@ Section Σfull_mon_rem.
     intros x; specialize (H2 x).
     rewrite fol_sem_mexists.
     exists (vec_set_pos (fun p => fom_syms M p (x##ø))).
-    rewrite fol_sem_lconj; intros g; rewrite in_map_iff.
-    intros (c & <- & Hg).
+    rewrite fol_sem_lconj; intros ?; rewrite in_map_iff.
+    intros (c & <- & H).
     rewrite fol_sem_lconj in H2.
-    specialize (H2 (Eq c) (in_map _ _ _ Hg)).
-    clear Hg; revert H2.
+    specialize (H2 (Eq c) (in_map _ _ _ H)).
+    clear H; revert H2.
     destruct c as (([ | s w ],?),r); simpl.
     + rewrite env_vlift_fix1 with (k := 0); simpl; auto.
     + rewrite env_vlift_fix1 with (k := 0).
@@ -384,7 +421,7 @@ Section Σfull_mon_rem.
 
     Let R x (v : vec _ n) := fol_sem M (env_vlift x·φ v) (fol_lconj (map Eq' lwY)).
 
-    Let Rreif : { f : K -> vec K n | forall x, R x (f x) }.
+    Let Rreif : { r : K -> vec K n | forall x, R x (r x) }.
     Proof.
       apply finite_t_dec_choice.
       + apply finite_t_vec; auto.
@@ -394,15 +431,15 @@ Section Σfull_mon_rem.
         rewrite fol_sem_mexists; auto.
     Qed.
 
-    Let g := proj1_sig Rreif.
-    Let Hg x : fol_sem M (env_vlift x·φ (g x)) (fol_lconj (map Eq' lwY)).
+    Let r := proj1_sig Rreif.
+    Let Hg x : fol_sem M (env_vlift x·φ (r x)) (fol_lconj (map Eq' lwY)).
     Proof. apply (proj2_sig Rreif). Qed.
 
     Let M' : fo_model Σ' K.
     Proof.
       split.
       + simpl; intros p v.
-        exact (vec_pos (g (vec_head v)) p).
+        exact (vec_pos (r (vec_head v)) p).
       + exact (fom_rels M).
     Defined.
 
@@ -422,7 +459,7 @@ Section Σfull_mon_rem.
         intros (c & <- & Hc).
         specialize (Hg (Eq' c) (in_map _ _ _ Hc)).
         revert Hg.
-        destruct c as (([|s w]&?),r); simpl.
+        destruct c as (([|s w]&?),?); simpl.
         * rewrite env_vlift_fix1 with (k := 0); simpl; auto.
         * rewrite env_vlift_fix1 with (k := 0).
           rewrite env_vlift_fix0; simpl; rew vec.
@@ -464,15 +501,17 @@ Section Σfull_mon_rem.
 
 End Σfull_mon_rem.
 
+Check Σfull_mon_red'_correct.
+
 Section Σ11_reduction.
 
-  (* We can lower the hypotheses now bu computing m from A *)
+  (* We can lower the hypotheses now by computing m from A *)
 
   Variable (n : nat) (Y : Type) (HY : finite_t Y) (A : fol_form (Σ11 (pos n) Y)) (K : Type).
 
   Let m := lmax (map (@length _) (Σ11_words A)).
 
-  Let Hm w : In w (Σ11_words A) -> length w < S m.
+  Let Hm w : w ∊ Σ11_words A -> length w < S m.
   Proof.
     intros Hw; apply le_n_S, lmax_prop, in_map_iff.
     exists w; auto.
@@ -492,9 +531,9 @@ End Σ11_reduction.
 
 Section Σ11_Σ1.
 
-  Variable (n : nat) (Y : Type) (HY : finite_t Y) (A : fol_form (Σ11 (pos n) Y)).
+  Variable (n : nat) (P : Type) (HY : finite_t P) (A : fol_form (Σ11 (pos n) P)).
 
-  Theorem Σ11_Σ1_reduction : { B : fol_form (Σ11 Empty_set (list (pos n)*Y + Y)) 
+  Theorem Σ11_Σ1_reduction : { B : fol_form (Σ11 Empty_set (list (pos n)*P + P)) 
                                  | fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT B }.
   Proof.
     destruct Σ_no_sym_correct with (A := Σ11_red HY A) as (B & HB).

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -172,7 +172,7 @@ Section Σfull_mon_rem.
      those equations are finitely many
    *)
 
-  Fixpoint Σfull_mon_rec (A : fol_form Σ) : fol_form Σ' :=
+  Local Fixpoint encode (A : fol_form Σ) : fol_form Σ' :=
     match A with
       | ⊥              => ⊥
       | fol_atom r v   => 
@@ -180,9 +180,11 @@ Section Σfull_mon_rem.
         let w := fot_word t in
         let x := fot_var  t 
         in  Q (rev w) r (£x##ø)
-      | fol_bin b A B => fol_bin b (Σfull_mon_rec A) (Σfull_mon_rec B)
-      | fol_quant q A => fol_quant q (Σfull_mon_rec A)
+      | fol_bin b A B => fol_bin b (encode A) (encode B)
+      | fol_quant q A => fol_quant q (encode A)
     end.
+
+  Notation Σfull_mon_rec := encode.
 
   (* The reduction function does not map to a signature void of
      functions to simplify the above expression. However, the
@@ -507,9 +509,11 @@ Section Σ11_reduction.
 
   Variable (n : nat) (Y : Type) (HY : finite_t Y) (A : fol_form (Σ11 (pos n) Y)) (K : Type).
 
-  Let m := lmax (map (@length _) (Σ11_words A)).
+  Local Definition max_depth := lmax (map (@length _) (Σ11_words A)).
 
-  Let Hm w : w ∊ Σ11_words A -> length w < S m.
+  Notation m := max_depth.
+
+  Let Hmd w : w ∊ Σ11_words A -> length w < S m.
   Proof.
     intros Hw; apply le_n_S, lmax_prop, in_map_iff.
     exists w; auto.

--- a/theories/TRAKHTENBROT/Sig_discernable.v
+++ b/theories/TRAKHTENBROT/Sig_discernable.v
@@ -1,0 +1,407 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia Max Bool.
+
+From Undecidability.Synthetic
+  Require Import Definitions ReducibilityFacts
+                 InformativeDefinitions InformativeReducibilityFacts.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_list utils_decidable finite.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
+
+From Undecidability.TRAKHTENBROT
+  Require Import notations utils decidable discernable
+                 fol_ops fo_sig fo_terms fo_logic fo_sat 
+                 Sig1_1 red_utils.
+
+Set Implicit Arguments.
+
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
+Local Notation ø := vec_nil.
+
+Local Infix "≢" := discernable (at level 70, no associativity).
+Local Infix "≡" := undiscernable (at level 70, no associativity).
+
+Section FSAT_equiv_discernable_rels.
+
+  Variable Σ : fo_signature.
+
+  Local Definition test K := @fol_atom Σ K (vec_set_pos (fun _ => £0)).
+
+  Variables (P Q : rels Σ).
+
+  Section model.
+
+    Variable (f : rels Σ -> bool) (HP : f P = true) (HQ : f Q = false).
+
+    Let M : fo_model Σ bool.
+    Proof.
+      split.
+      + intros; exact true. 
+      + intros r _; exact (f r = true).
+    Defined.
+
+    Local Fact discernable_rels_FSAT : FSAT Σ (test P ⟑ (test Q ⤑ ⊥)).
+    Proof.
+      exists bool, M; msplit 2.
+      + apply finite_t_bool.
+      + intros r v; simpl; apply bool_dec.
+      + exists (fun _ => true); simpl.
+        now rewrite HP, HQ.
+    Qed.
+
+  End model.
+
+  Theorem FSAT_equiv_discernable_rels : FSAT Σ (test P ⟑ (test Q ⤑ ⊥)) <-> P ≢ Q.
+  Proof.
+    rewrite discernable_equiv1.
+    split.
+    + intros (D & M & H1 & H2 & rho & H3 & H4).
+      exists (fun K => if @H2 K (vec_set_pos (fun _ => rho 0)) then true else false).
+      simpl in H3, H4 |- *.
+      rewrite vec_map_set_pos in H3, H4.
+      do 2 match goal with 
+        |- context[if ?c then _ else _] => destruct c 
+      end; auto; tauto.
+    + intros (f & H1 & H2).
+      apply discernable_rels_FSAT with f; auto.
+  Qed.
+
+End FSAT_equiv_discernable_rels.
+
+Section FSAT_equiv_discernable_syms.
+  
+  Variables (Σ : fo_signature) (P : rels Σ) (HP : ar_rels Σ P = 1).
+
+  Let termt (p : syms Σ) : fo_term (ar_syms Σ) := in_fot p (vec_set_pos (fun _ => in_var 0)).
+
+  Local Definition testt (p : syms Σ) : fol_form Σ := fol_atom P (cast (termt p##ø) (eq_sym HP)).
+
+  Variables (p q : syms Σ).
+
+  Section model.
+
+    Variable (f : syms Σ -> bool) (Hp : f p = true) (Hq : f q = false).
+
+    Let M : fo_model Σ bool.
+    Proof.
+      split.
+      + intros s _; exact (f s). 
+      + intros r; simpl; intros v. 
+        exact (match v with vec_nil => True | h##_ => h = true end).
+    Defined.
+
+    Local Fact discernable_syms_FSAT : FSAT Σ (testt p ⟑ (testt q ⤑ ⊥)).
+    Proof.
+      exists bool, M; msplit 2.
+      + apply finite_t_bool.
+      + intros r v; simpl.
+        destruct v; try tauto.
+        apply bool_dec.
+      + exists (fun _ => true); simpl.
+        rewrite HP; simpl.
+        now rewrite Hp, Hq.
+    Qed.
+
+  End model.
+
+  Theorem FSAT_equiv_discernable_syms : FSAT Σ (testt p ⟑ (testt q ⤑ ⊥)) <-> p ≢ q.
+  Proof.
+    rewrite discernable_equiv1.
+    split.
+    + intros (D & M & H1 & H2 & rho & H3 & H4).
+      simpl in H3, H4 |- *.
+      exists (fun k => if H2 P (vec_map (fo_term_sem M rho)
+          (cast (termt k ## ø) (eq_sym HP))) then true else false).
+      do 2 match goal with 
+        |- context[if ?c then _ else _] => destruct c 
+      end; auto; tauto.
+    + intros (f & H1 & H2).
+      apply discernable_syms_FSAT with f; auto.
+  Qed.
+
+End FSAT_equiv_discernable_syms.
+
+Section FSAT_DEC_implies_discernable_rels.
+
+  (* For any signature, FSAT decidability implies 
+     decidable discernability of rels *)
+
+  Variable Σ : fo_signature.
+
+  Hypothesis HXY : forall A, decidable (FSAT Σ A).
+
+  Theorem FSAT_dec_implies_discernable_rels_dec (P Q : rels Σ) : decidable (discernable P Q).
+  Proof.
+    destruct (HXY (test _ P ⟑ (test _ Q ⤑ ⊥))) as [ H | H ].
+    + left; revert H; apply FSAT_equiv_discernable_rels.
+    + right; contradict H; revert H; apply FSAT_equiv_discernable_rels.
+  Qed.
+
+End FSAT_DEC_implies_discernable_rels.
+
+Section FSAT_DEC_implies_discernable_syms.
+
+  (* For any signature with a unary relation, 
+     FSAT decidability implies decidable discernability of syms *)
+
+  Variables (Σ : fo_signature) (P : rels Σ) (HP : ar_rels Σ P = 1).
+
+  Hypothesis HXY : forall A, decidable (FSAT Σ A).
+
+  Theorem FSAT_dec_implies_discernable_syms_dec (f g : syms Σ) : decidable (discernable f g).
+  Proof.
+    destruct (HXY (testt _ _ HP f ⟑ (testt _ _ HP g ⤑ ⊥))) as [ H | H ].
+    + left; revert H; apply FSAT_equiv_discernable_syms.
+    + right; contradict H; revert H; apply FSAT_equiv_discernable_syms.
+  Qed.
+
+End FSAT_DEC_implies_discernable_syms.
+
+Section discrete_projection.
+
+  Variable (X Y : Type) (HY : discrete Y) (f : X -> Y) (l : list X).
+
+  Fact find_discrete_projection y : { x | x ∊ l /\ f x = y } + (forall x, x ∊ l -> f x <> y).
+  Proof.
+    destruct list_choose_dep 
+      with (P := fun x => f x = y) (Q := fun x => f x <> y) (l := l)
+    as [ (? & ? & ?) | ]; eauto.
+    intros; apply HY.
+  Qed.
+
+End discrete_projection.
+
+Section discriminable_implies_FSAT_DEC.
+
+  Variable (X Y : Type) 
+           (lX : list X) (HlX : discriminable_list lX)
+           (lY : list Y) (HlY : discriminable_list lY).
+
+  Let DX := projT1 HlX.
+
+  Let DX_discr : discrete DX.   Proof. apply (projT2 HlX). Qed.
+  Let DX_fin : finite_t DX.     Proof. apply (projT2 (projT2 HlX)). Qed.
+
+  Let f : X -> DX := proj1_sig (projT2 (projT2 (projT2 HlX))).
+  Let Hf u v : u ∊ lX -> v ∊ lX -> u ≡ v <-> f u = f v.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlX)))). Qed.
+
+  Let DY := projT1 HlY.
+
+  Let DY_discr : discrete DY.   Proof. apply (projT2 HlY). Qed.
+  Let DY_fin : finite_t DY.     Proof. apply (projT2 (projT2 HlY)). Qed.
+
+  Let g : Y -> DY := proj1_sig (projT2 (projT2 (projT2 HlY))).
+  Let Hg u v : u ∊ lY -> v ∊ lY -> u ≡ v <-> g u = g v.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlY)))). Qed.
+
+  Let fromX d : { x | x ∊ lX /\ f x = d } + (forall x, x ∊ lX -> f x <> d).
+  Proof. now apply find_discrete_projection. Qed.
+
+  Let fromY d : { y | y ∊ lY /\ g y = d } + (forall y, y ∊ lY -> g y <> d).
+  Proof. now apply find_discrete_projection. Qed.
+
+  Fixpoint fot_discriminable_discrete (t : fo_term (fun _ : X => 1)) : fo_term (fun _ : DX => 1) :=
+    match t with
+      | in_var n => in_var n
+      | in_fot s v => in_fot (f s) ((fot_discriminable_discrete (vec_pos v pos0))##ø)
+    end.
+
+  Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 DX DY) :=
+    match A with
+      | ⊥              => ⊥
+      | fol_atom r v   => @fol_atom (Σ11 DX DY) (g r) (vec_map fot_discriminable_discrete v)
+      | fol_bin b A B => fol_bin b (Σdiscriminable_discrete A) (Σdiscriminable_discrete B)
+      | fol_quant q A => fol_quant q (Σdiscriminable_discrete A)
+    end.
+
+  Section sound.
+
+    Variable (K : Type).
+
+    Variable (M : fo_model (Σ11 X Y) K) (HM : fo_model_dec M) (Kdiscr : discrete K).
+
+    Let M' : fo_model (Σ11 DX DY) K.
+    Proof.
+      split.
+      + intros s.
+        destruct (fromX s) as [ (x & Hx1 & Hx2) | C ].
+        * apply (fom_syms M x).
+        * apply vec_head.
+      + intros r.
+        destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
+        * apply (fom_rels M y).
+        * exact (fun _ => True).
+    Defined.
+
+    Let M'_dec : fo_model_dec M'.
+    Proof.
+      intros r v; simpl.
+      destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
+      + apply HM.
+      + tauto.
+    Qed.
+
+    Let term_equal (t : fo_term (fun _ : X => 1)) φ : 
+             fo_term_syms t ⊑ lX
+          -> fo_term_sem M' φ (fot_discriminable_discrete t)
+           = fo_term_sem M φ t.
+    Proof.
+      induction t as [ n | s v IH ]; simpl; intros Ht; auto.
+      destruct (fromX (f s)) as [ (x & Hx1 & Hx2) | C ].
+      2: destruct (C s); auto.
+      revert IH Ht; vec split v with a; vec nil v; intros IH Ht.
+      simpl in Ht |- *.
+      rewrite <- app_nil_end in Ht.
+      specialize (IH pos0); simpl in IH.
+      assert (undiscernable x s) as Hxs by (apply Hf; auto).
+      rewrite IH.
+      2: apply incl_tran with (2 := Ht); intro; simpl; tauto.
+      apply undiscernable_discrete with (f := fun u => fom_syms M u (fo_term_sem M φ a ## ø)); auto.
+    Qed.
+
+    Let form_equiv (A : fol_form (Σ11 X Y)) φ :
+          fol_syms A ⊑ lX
+       -> fol_rels A ⊑ lY
+       -> fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; intros G1 G2; try tauto. 
+      + destruct (fromY (g r)) as [ (y & Hy1 & Hy2) | C ].
+        2: destruct (C r); auto.
+        apply Hg in Hy2; auto.
+        apply undiscernable_Prop_dec 
+          with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy2.
+        2: intro; apply HM.
+        rewrite <- Hy2.
+        fol equiv.
+        rewrite vec_map_map.
+        clear Hy2.
+        revert G1; vec split v with a; vec nil v; simpl; rewrite <- app_nil_end; intros G1.
+        f_equal; apply term_equal; auto.
+      + apply fol_bin_sem_ext; auto.
+        * eapply HA, incl_tran; eauto.
+        * eapply HB, incl_tran; eauto.
+      + destruct q; fol equiv; auto.
+    Qed.
+
+    Hypothesis Kfin : finite_t K.
+    Variables (φ : nat -> K) 
+              (A : fol_form (Σ11 X Y))
+              (HA1 : fol_syms A ⊑ lX) 
+              (HA2 : fol_rels A ⊑ lY)
+              (HA : fol_sem M φ A).
+
+    Local Fact Σdiscriminable_discrete_sound : FSAT _ (Σdiscriminable_discrete A).
+    Proof.
+      exists K, M', Kfin, M'_dec, φ.
+      now apply form_equiv.
+    Qed.
+
+  End sound.
+
+  Section complete.
+
+    Variable (K : Type).
+
+    Variable (M : fo_model (Σ11 DX DY) K) (HM : fo_model_dec M).
+
+    Let M' : fo_model (Σ11 X Y) K.
+    Proof.
+      split.
+      + exact (fun s => fom_syms M (f s)).
+      + exact (fun r => fom_rels M (g r)).
+    Defined.
+
+    Let M'_dec : fo_model_dec M'.
+    Proof.
+      intros r v; simpl.
+      apply HM.
+    Qed.
+
+    Let term_equal t φ : fo_term_sem M φ (fot_discriminable_discrete t)
+                       = fo_term_sem M' φ t.
+    Proof.
+      induction t as [ n | s v IH ]; simpl; auto.
+      specialize (IH pos0); revert IH.
+      vec split v with a; vec nil v; simpl; intros ->; auto.
+    Qed.
+
+    Let form_equiv A φ : fol_sem M φ (Σdiscriminable_discrete A) <-> fol_sem M' φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto.
+      + rewrite vec_map_map; fol equiv.
+        vec split v with a; vec nil v; simpl; f_equal; auto.
+      + apply fol_bin_sem_ext; auto.
+      + destruct q; fol equiv; auto.
+    Qed.
+
+    Hypothesis Kfin : finite_t K.
+    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ (Σdiscriminable_discrete A)).
+
+    Local Fact Σdiscriminable_discrete_complete : FSAT _ A.
+    Proof.
+      exists K, M', Kfin, M'_dec, φ.
+      now apply form_equiv.
+    Qed.
+
+  End complete.
+
+  Theorem Σdiscriminable_discrete_correct (A : fol_form (Σ11 X Y)) :
+          fol_syms A ⊑ lX
+       -> fol_rels A ⊑ lY
+       -> { DX : _ & 
+          { DY : _ & 
+          { _ : discrete DX &
+          { _ : discrete DY & 
+          { _ : finite_t DX &
+          { _ : finite_t DY &
+          { B : fol_form (Σ11 DX DY) | FSAT _ A <-> FSAT _ B } } } } } } }. 
+  Proof.
+    intros HX HY.
+    exists DX, DY.
+    do 4 (exists; [ auto | ]).
+    exists (Σdiscriminable_discrete A).
+    split.
+    + rewrite fo_form_fin_dec_SAT_discr_equiv.
+      intros (K & H0 & M & H1 & H2 & phi & H3).
+      apply Σdiscriminable_discrete_sound with K M phi; auto.
+    + intros (K & M & H1 & H2 & phi & H3).
+      apply Σdiscriminable_discrete_complete with K M phi; auto.
+  Qed.
+
+End discriminable_implies_FSAT_DEC.
+
+Theorem Sig_discernable_dec_to_discrete X Y :
+           (forall u v : X, decidable (u ≢ v))
+        -> (forall u v : Y, decidable (u ≢ v))
+        -> forall A : fol_form (Σ11 X Y), 
+           { DX : _ 
+         & { DY : _ 
+         & { _ : discrete DX
+         & { _ : discrete DY
+         & { _ : finite_t DX
+         & { _ : finite_t DY
+         & { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 DX DY) B } } } } } } }.
+Proof.
+  intros HX HY A.
+  generalize (discernable_discriminable_list HX (fol_syms A))
+             (discernable_discriminable_list HY (fol_rels A)); intros HlX HlY.
+  destruct (Σdiscriminable_discrete_correct HlX HlY A)
+    as (DX & DY & ? & ? & ? & ? & B & HB).
+  1,2: apply incl_refl.
+  exists DX, DY.
+  do 4 (exists; [ auto | ]).
+  exists B; auto.
+Qed.

--- a/theories/TRAKHTENBROT/Sig_noeq.v
+++ b/theories/TRAKHTENBROT/Sig_noeq.v
@@ -21,6 +21,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Notation ø := vec_nil.
+
 (* * FSATEQ reduces to FSAT *)
 
 (* 1/ A is satisfiable in a fin/dec/interpreted model iff 

--- a/theories/TRAKHTENBROT/Sig_noeq.v
+++ b/theories/TRAKHTENBROT/Sig_noeq.v
@@ -21,6 +21,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
 Local Notation ø := vec_nil.
 
 (* * FSATEQ reduces to FSAT *)
@@ -54,7 +56,7 @@ Local Notation ø := vec_nil.
 Section remove_interpreted_symbol.
 
   Variables (Σ : fo_signature) (ls : list (syms Σ)) (lr : list (rels Σ))
-            (e : rels Σ) (H_ae : ar_rels _ e = 2) (He : In e lr). 
+            (e : rels Σ) (H_ae : ar_rels _ e = 2) (He : e ∊ lr). 
 
   Notation 𝕋 := (fol_term Σ).
   Notation 𝔽 := (fol_form Σ).
@@ -99,8 +101,8 @@ Section remove_interpreted_symbol.
     Hint Resolve finite_t_pos : core.
 
     Variable (A : 𝔽) 
-             (HA1 : incl (fol_syms A) ls) 
-             (HA2 : incl (fol_rels A) lr).
+             (HA1 : fol_syms A ⊑ ls) 
+             (HA2 : fol_rels A ⊑ lr).
 
     Theorem Σ_noeq_complete : 
                fo_form_fin_dec_SAT (Σ_noeq A)

--- a/theories/TRAKHTENBROT/Sig_noeq.v
+++ b/theories/TRAKHTENBROT/Sig_noeq.v
@@ -105,8 +105,8 @@ Section remove_interpreted_symbol.
             -> fo_form_fin_dec_eq_SAT e H_ae A.
     Proof.
       intros (X & M & H1 & H2 & phi & H5 & H3).
-      apply fol_sem_congruence in H5.
-      destruct H5 as ((H4 & H5) & (H6 & H8 & H7)).
+      apply fol_sem_congruence in H5
+        as ((H4 & H5) & (H6 & H8 & H7)).
       set (R x y := fom_rels M e (cast (x ## y ## ø) (eq_sym H_ae))).
       destruct H1 as (lX & HlX).
       destruct decidable_EQUIV_fin_quotient with (l := lX) (R := R)

--- a/theories/TRAKHTENBROT/Sign_Sig2.v
+++ b/theories/TRAKHTENBROT/Sign_Sig2.v
@@ -24,6 +24,9 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
+
 (* * From Σ=(ø;{R^n}) to Σ=(ø;{R^2}) *)
 
 Local Notation ø := vec_nil.
@@ -39,13 +42,17 @@ Section Sign_Sig2_encoding.
   Infix "≈" := Σ2_equiv.
   Infix "⊆" := Σ2_incl.
 
+  Notation "t ∋ ⦉ v ⦊" := (Σ2_is_tuple_in t v) (at level 70, format "t  ∋  ⦉ v ⦊").
+
   (* We bound quantification inside hf-set l ∈ p and r ∈ p represent a set 
      of ordered triples corresponding to M3 *)
+
+  Arguments Σrel_var {k}.
 
   Fixpoint Σn_Σ2 (d r : nat) (A : fol_form Σn) : fol_form Σ2 :=
     match A with
       | ⊥             => ⊥
-      | fol_atom _  v => Σ2_is_tuple_in r (vec_map (@Σrel_var _) v)
+      | fol_atom _  v => r ∋ ⦉vec_map Σrel_var v⦊
       | fol_bin b A B => fol_bin b (Σn_Σ2 d r A) (Σn_Σ2 d r B)
       | fol_quant fol_fa A  => ∀ 0 ∈ (S d) ⤑ Σn_Σ2 (S d) (S r) A
       | fol_quant fol_ex A  => ∃ 0 ∈ (S d) ⟑ Σn_Σ2 (S d) (S r) A
@@ -54,9 +61,7 @@ Section Sign_Sig2_encoding.
   Variable (X : Type) (M2 : fo_model Σ2 X).
   Variable (Y : Type) (Mn : fo_model Σn Y).
 
-  Let mem a b := fom_rels M2 tt (a##b##ø).
-
-  Infix "∈m" := mem (at level 59, no associativity).
+  Notation "a ∈ₘ b" := (fom_rels M2 tt (a##b##ø)) (at level 59, no associativity).
   Notation P := (fun v => fom_rels Mn tt v).
 
   Variable R : Y -> X -> Prop.
@@ -72,10 +77,11 @@ Section Sign_Sig2_encoding.
 
     *)
 
-  Let HR1 (d r : X) := forall y, exists x, x ∈m d /\ R y x.
-  Let HR2 (d r : X) := forall x, x ∈m d -> exists y, R y x.
-  Let HR3 (d r : X) := forall v w, (forall p, R (vec_pos v p) (vec_pos w p))
-         -> P v <-> mb_is_tuple_in mem r w.
+  Let HR1 (d r : X) := forall y, exists x, x ∈ₘ d /\ R y x.
+  Let HR2 (d r : X) := forall x, x ∈ₘ d -> exists y, R y x.
+  Let HR3 (d r : X) := forall v w, 
+            (forall p, R (vec_pos v p) (vec_pos w p))
+         -> P v <-> mb_is_tuple_in (fun a b => a ∈ₘ b) r w.
 
   Notation "⟪ A ⟫" := (fun ψ => fol_sem M2 ψ A).
   Notation "⟪ A ⟫'" := (fun φ => fol_sem Mn φ A) (at level 1, format "⟪ A ⟫'").
@@ -86,7 +92,7 @@ Section Sign_Sig2_encoding.
             HR1 (ψ d) (ψ r) 
          -> HR2 (ψ d) (ψ r) 
          -> HR3 (ψ d) (ψ r)
-        -> (forall x, In x (fol_vars A) -> R (φ x) (ψ x))
+        -> (forall x, x ∊ fol_vars A -> R (φ x) (ψ x))
         -> ⟪ A ⟫' φ <-> ⟪Σn_Σ2 d r A⟫ ψ.
   Proof.
     revert d r φ ψ.
@@ -146,17 +152,11 @@ Section Sign_Sig2_encoding.
      that could be quantified existentially over if needed *)
 
   (* The FO set-theoretic axioms we need to add are somewhat minimal:
-         - ∈ must be extensional (of course, this is a set-theoretic model)
-         - ordered n-tuples encoded in the usual way should exists for elements ∈ l 
-         - l should not be the empty set 
-         - and free variables of A (lifted twice) should be interpreted in l
+         - d should be non empty 
+         - and free variables of A (lifted twice) should be interpreted in d
    *)
 
-  Definition Σn_Σ2_enc := 
-                Σ2_extensional 
-              ⟑ Σ2_non_empty d
-              ⟑ Σ2_list_in d (fol_vars B) 
-              ⟑ Σn_Σ2 d r B.
+  Definition Σn_Σ2_enc := Σ2_non_empty d ⟑ Σ2_list_in d (fol_vars B) ⟑ Σn_Σ2 d r B.
 
 End Sign_Sig2_encoding.
 
@@ -216,11 +216,11 @@ Section SAT2_SATn.
     Local Lemma SAT2_to_SATn : exists Y, fo_form_fin_dec_SAT_in A Y.
     Proof.
       exists (sig P).
-      destruct HA as (H1 & H2 & H3 & H4).
+      destruct HA as ( H2 & H3 & H4).
       rewrite Σ2_non_empty_spec in H2.
       rewrite Σ2_list_in_spec in H3.
       revert H3 H4; set (B := A⦃fun v : nat => in_var (2 + v)⦄); intros H3 H4.
-      assert (H5 : forall n, In n (fol_vars B) -> P (ψ n)).
+      assert (H5 : forall n, n ∊ fol_vars B -> P (ψ n)).
       { intros; apply HP0, H3; auto. }
       destruct H2 as (x0 & H0).
       generalize H0; intros H2.
@@ -267,7 +267,7 @@ Section SATn_SAT2.
   (* This is the hard implication. From a model of A, 
       build a model of Σn_Σ2_enc A in hereditary finite sets *)
 
-  Section nested.
+  Section The_HFS_model.
 
     Variables (A : fol_form (Σrel n))
               (X : Type) (Mn : fo_model (Σrel n) X)
@@ -282,33 +282,30 @@ Section SATn_SAT2.
     Local Lemma SATn_to_SAT2 : exists Y, fo_form_fin_dec_SAT_in (@Σn_Σ2_enc n A) Y.
     Proof.
       destruct reln_hfs with (R := fom_rels Mn tt)
-        as (Y & H1 & H2 & mem & H3 & l & r & i & s & H4 & H5 & H6 & H7 & H8 & H9 & H10); auto.
-      exists Y, (bin_rel_Σ2 mem), H1, (bin_rel_Σ2_dec _ H3), 
-        (fun n => match n with 
-           | 0 => l
-           | 1 => r
-           | S (S n) => i (φ n)
-         end).
-      unfold Σn_Σ2_enc; msplit 3; auto.
+        as (Y & H1 & mem & H3 & d & r & i & s & H6 & H7 & H9); auto.
+      exists Y, (bin_rel_Σ2 mem), H1, (bin_rel_Σ2_dec _ H3), d·r·(fun n => i (φ n)).
+      unfold Σn_Σ2_enc; msplit 2; auto.
       + exists (i (φ 0)); simpl; rew fot; simpl; auto.
       + apply Σ2_list_in_spec.
-        intros n'; simpl.
+        intros ?; simpl.
         rewrite fol_vars_map, in_map_iff.
-        intros (m & <- & ?); auto.
-      + rewrite <- Σn_Σ2_correct with (Mn := Mn) (R := fun x y => y = i x) 
-            (φ := fun n => match n with 0 => φ 0 | 1 => φ 1 | S (S n) => φ n end); auto.
+        intros (? & <- & ?); simpl; auto.
+      + rewrite <- Σn_Σ2_correct 
+          with (Mn := Mn) 
+               (R := fun x y => y = i x) 
+               (φ := (φ 0)·(φ 1)·φ); auto.
         * rewrite fol_sem_subst.
           revert HA; apply fol_sem_ext.
           intros; simpl; rew fot; auto.
         * intros x; exists (i x); split; auto; apply H6.
-        * intros v w E; rewrite H9.
+        * intros ? ? ?; rewrite H9.
           apply fol_equiv_ext; f_equal.
           apply vec_pos_ext; intro; rew vec.
-        * intros n'; rewrite fol_vars_map, in_map_iff.
-          intros (m & <- & Hm); simpl; auto.
+        * intros ?; rewrite fol_vars_map, in_map_iff.
+          intros (? & <- & ?); simpl; auto.
     Qed.
 
-  End nested.
+  End The_HFS_model.
 
   Theorem SATn_SAT2 A : fo_form_fin_discr_dec_SAT A
                      -> fo_form_fin_dec_SAT (@Σn_Σ2_enc n A).

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -190,46 +190,79 @@ Section FSAT_DEC_implies_discriminable.
 
 End FSAT_DEC_implies_discriminable.
 
+Section discrete_projection.
+
+  Variable (X Y : Type) (HY : discrete Y) (f : X -> Y) (l : list X).
+
+  Fact find_discrete_projection y : { x | In x l /\ f x = y } + (forall x, In x l -> f x <> y).
+  Proof.
+    destruct list_choose_dep 
+      with (P := fun x => f x = y) (Q := fun x => f x <> y) (l := l)
+    as [ (? & ? & ?) | ]; eauto.
+    intros; apply HY.
+  Qed.
+
+End discrete_projection.
+
+Local Notation ø := vec_nil.
+
 Section discriminable_implies_FSAT_DEC.
 
-  Variable (X Y : Type) (l : list Y) (Hl : pdiscriminable l).
+  Variable (X Y : Type) 
+           (lX : list X) (HlX : pdiscriminable lX)
+           (lY : list Y) (HlY : pdiscriminable lY).
 
-  Let D := projT1 Hl.
+  Let DX := projT1 HlX.
 
-  Let Ddiscr : discrete D.   Proof. apply (projT2 Hl). Qed.
-  Let Dfin : finite_t D.     Proof. apply (projT2 (projT2 Hl)). Qed.
+  Let DX_discr : discrete DX.   Proof. apply (projT2 HlX). Qed.
+  Let DX_fin : finite_t DX.     Proof. apply (projT2 (projT2 HlX)). Qed.
 
-  Let f : Y -> D := proj1_sig (projT2 (projT2 (projT2 Hl))).
-  Let Hf x y : In x l -> In y l -> undiscernable x y <-> f x = f y.
-  Proof. apply (proj2_sig (projT2 (projT2 (projT2 Hl)))). Qed.
+  Let f : X -> DX := proj1_sig (projT2 (projT2 (projT2 HlX))).
+  Let Hf u v : In u lX -> In v lX -> undiscernable u v <-> f u = f v.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlX)))). Qed.
 
-  Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 X D) :=
+  Let DY := projT1 HlY.
+
+  Let DY_discr : discrete DY.   Proof. apply (projT2 HlY). Qed.
+  Let DY_fin : finite_t DY.     Proof. apply (projT2 (projT2 HlY)). Qed.
+
+  Let g : Y -> DY := proj1_sig (projT2 (projT2 (projT2 HlY))).
+  Let Hg u v : In u lY -> In v lY -> undiscernable u v <-> g u = g v.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlY)))). Qed.
+
+  Let fromX d : { x | In x lX /\ f x = d } + (forall x, In x lX -> f x <> d).
+  Proof. now apply find_discrete_projection. Qed.
+
+  Let fromY d : { y | In y lY /\ g y = d } + (forall y, In y lY -> g y <> d).
+  Proof. now apply find_discrete_projection. Qed.
+
+  Fixpoint fot_discriminable_discrete (t : fo_term (fun _ : X => 1)) : fo_term (fun _ : DX => 1) :=
+    match t with
+      | in_var n => in_var n
+      | in_fot s v => in_fot (f s) ((fot_discriminable_discrete (vec_pos v pos0))##ø)
+    end.
+
+  Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 DX DY) :=
     match A with
       | ⊥              => ⊥
-      | fol_atom r v   => @fol_atom (Σ11 X D) (f r) v
+      | fol_atom r v   => @fol_atom (Σ11 DX DY) (g r) (vec_map fot_discriminable_discrete v)
       | fol_bin b A B => fol_bin b (Σdiscriminable_discrete A) (Σdiscriminable_discrete B)
       | fol_quant q A => fol_quant q (Σdiscriminable_discrete A)
     end.
-
-  Let fromY d : { y | In y l /\ f y = d } + (forall y, In y l -> f y <> d).
-  Proof.
-    clear Hf.
-    red in Hl.
-    destruct list_choose_dep with (P := fun y => f y = d) (Q := fun y => f y <> d) (l := l)
-    as [ (? & ? & ?) | ]; eauto.
-    intros; apply Ddiscr.
-  Qed.
 
   Section sound.
 
     Variable (K : Type).
 
-    Variable (M : fo_model (Σ11 X Y) K) (HM : fo_model_dec M).
+    Variable (M : fo_model (Σ11 X Y) K) (HM : fo_model_dec M) (Kdiscr : discrete K).
 
-    Let M' : fo_model (Σ11 X D) K.
+    Let M' : fo_model (Σ11 DX DY) K.
     Proof.
       split.
-      + exact (fom_syms M).
+      + intros s.
+        destruct (fromX s) as [ (x & Hx1 & Hx2) | C ].
+        * apply (fom_syms M x).
+        * apply vec_head.
       + intros r.
         destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
         * apply (fom_rels M y).
@@ -244,18 +277,42 @@ Section discriminable_implies_FSAT_DEC.
       + tauto.
     Qed.
 
-    Let equiv (A : fol_form (Σ11 X Y)) φ : 
-          incl (fol_rels A) l -> fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
+    Let term_equal (t : fo_term (fun _ : X => 1)) φ : 
+             incl (fo_term_syms t) lX
+          -> fo_term_sem M' φ (fot_discriminable_discrete t)
+           = fo_term_sem M φ t.
     Proof.
-      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; intros G; try tauto. 
-      + destruct (fromY (f r)) as [ (y & Hy1 & Hy2) | C ].
+      induction t as [ n | s v IH ]; simpl; intros Ht; auto.
+      destruct (fromX (f s)) as [ (x & Hx1 & Hx2) | C ].
+      2: destruct (C s); auto.
+      revert IH Ht; vec split v with a; vec nil v; intros IH Ht.
+      simpl in Ht |- *.
+      rewrite <- app_nil_end in Ht.
+      specialize (IH pos0); simpl in IH.
+      assert (undiscernable x s) as Hxs by (apply Hf; auto).
+      rewrite IH.
+      2: apply incl_tran with (2 := Ht); intro; simpl; tauto.
+      apply undiscernable_discrete with (f := fun u => fom_syms M u (fo_term_sem M φ a ## ø)); auto.
+    Qed.
+
+    Let form_equiv (A : fol_form (Σ11 X Y)) φ :
+          incl (fol_syms A) lX
+       -> incl (fol_rels A) lY
+       -> fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; intros G1 G2; try tauto. 
+      + destruct (fromY (g r)) as [ (y & Hy1 & Hy2) | C ].
         2: destruct (C r); auto.
-        apply Hf in Hy2; auto.
+        apply Hg in Hy2; auto.
         apply undiscernable_Prop_dec 
           with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy2.
         2: intro; apply HM.
         rewrite <- Hy2.
         fol equiv.
+        rewrite vec_map_map.
+        clear Hy2.
+        revert G1; vec split v with a; vec nil v; simpl; rewrite <- app_nil_end; intros G1.
+        f_equal; apply term_equal; auto.
       + apply fol_bin_sem_ext; auto.
         * eapply HA, incl_tran; eauto.
         * eapply HB, incl_tran; eauto.
@@ -263,12 +320,16 @@ Section discriminable_implies_FSAT_DEC.
     Qed.
 
     Hypothesis Kfin : finite_t K.
-    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ A) (HA' : incl (fol_rels A) l).
+    Variables (φ : nat -> K) 
+              (A : fol_form (Σ11 X Y))
+              (HA1 : incl (fol_syms A) lX) 
+              (HA2 : incl (fol_rels A) lY)
+              (HA : fol_sem M φ A).
 
     Local Fact Σdiscriminable_discrete_sound : FSAT _ (Σdiscriminable_discrete A).
     Proof.
       exists K, M', Kfin, M'_dec, φ.
-      now apply equiv.
+      now apply form_equiv.
     Qed.
 
   End sound.
@@ -277,14 +338,13 @@ Section discriminable_implies_FSAT_DEC.
 
     Variable (K : Type).
 
-    Variable (M : fo_model (Σ11 X D) K) (HM : fo_model_dec M).
+    Variable (M : fo_model (Σ11 DX DY) K) (HM : fo_model_dec M).
 
     Let M' : fo_model (Σ11 X Y) K.
     Proof.
       split.
-      + exact (fom_syms M).
-      + intros r.
-        apply (fom_rels M (f r)).
+      + exact (fun s => fom_syms M (f s)).
+      + exact (fun r => fom_rels M (g r)).
     Defined.
 
     Let M'_dec : fo_model_dec M'.
@@ -293,9 +353,19 @@ Section discriminable_implies_FSAT_DEC.
       apply HM.
     Qed.
 
-    Let equiv A φ : fol_sem M φ (Σdiscriminable_discrete A) <-> fol_sem M' φ A.
+    Let term_equal t φ : fo_term_sem M φ (fot_discriminable_discrete t)
+                       = fo_term_sem M' φ t.
     Proof.
-      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto. 
+      induction t as [ n | s v IH ]; simpl; auto.
+      specialize (IH pos0); revert IH.
+      vec split v with a; vec nil v; simpl; intros ->; auto.
+    Qed.
+
+    Let form_equiv A φ : fol_sem M φ (Σdiscriminable_discrete A) <-> fol_sem M' φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto.
+      + rewrite vec_map_map; fol equiv.
+        vec split v with a; vec nil v; simpl; f_equal; auto.
       + apply fol_bin_sem_ext; auto.
       + destruct q; fol equiv; auto.
     Qed.
@@ -306,17 +376,19 @@ Section discriminable_implies_FSAT_DEC.
     Local Fact Σdiscriminable_discrete_complete : FSAT _ A.
     Proof.
       exists K, M', Kfin, M'_dec, φ.
-      now apply equiv.
+      now apply form_equiv.
     Qed.
 
   End complete.
 
   Theorem Σdiscriminable_discrete_correct (A : fol_form (Σ11 X Y)) :
-          incl (fol_rels A) l 
+          incl (fol_syms A) lX
+       -> incl (fol_rels A) lY
        -> FSAT _ A <-> FSAT _ (Σdiscriminable_discrete A).
   Proof.
-    split.
-    + intros (K & M & H1 & H2 & phi & H3).
+    intros HX HY; split.
+    + rewrite fo_form_fin_dec_SAT_discr_equiv.
+      intros (K & H0 & M & H1 & H2 & phi & H3).
       apply Σdiscriminable_discrete_sound with K M phi; auto.
     + intros (K & M & H1 & H2 & phi & H3).
       apply Σdiscriminable_discrete_complete with K M phi; auto.
@@ -325,59 +397,65 @@ Section discriminable_implies_FSAT_DEC.
 End discriminable_implies_FSAT_DEC.
 
 Theorem Σdiscernable_dec_to_discrete X Y :
-           (X -> False)
-        -> (forall x y : Y, decidable (discernable x y))
+           (forall u v : X, decidable (discernable u v))
+        -> (forall u v : Y, decidable (discernable u v))
         -> forall A : fol_form (Σ11 X Y), 
-           { D : _ 
-         & { _ : discrete D 
-         & { _ : finite_t D 
-         & { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 X D)  B } } } }.
+           { DX : _ 
+         & { DY : _ 
+         & { _ : discrete DX
+         & { _ : discrete DY 
+         & { _ : finite_t DX
+         & { _ : finite_t DY 
+         & { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 DX DY)  B } } } } } } }.
 Proof.
   intros HX HY A.
-  generalize (fsubset_discernable_discriminable HY (fol_rels A)); intros Hl.
-  generalize (Σdiscriminable_discrete_correct Hl A); revert Hl.
-  intros (D & H1 & H2 & f & H3) H4.
+  generalize (fsubset_discernable_discriminable HX (fol_syms A))
+             (fsubset_discernable_discriminable HY (fol_rels A)); intros HlX HlY.
+  generalize (Σdiscriminable_discrete_correct HlX HlY A); revert HlX HlY.
+  intros (DX & HX1 & HX2 & f & HX3) (DY & HY1 & HY2 & g & HY3) H4.
   simpl in H4.
-  exists D, H1, H2.
-  match type of H4 with _ -> _ <-> FSAT _ ?b => exists b end.
-  apply H4, incl_refl.
+  exists DX, DY.
+  do 4 (exists; [ auto | ]).
+  match type of H4 with _ -> _ -> _ <-> FSAT _ ?b => exists b end.
+  apply H4; apply incl_refl.
 Qed.
 
-Theorem Σ1_discernable_dec_FSAT V X : 
-          (V -> False) 
-       -> (forall x y : X, decidable (discernable x y))
-       -> forall A, decidable (FSAT (Σ11 V X) A).
+Theorem Σ11_discernable_dec_FSAT X Y : 
+          (forall u v : X, decidable (discernable u v))
+       -> (forall u v : Y, decidable (discernable u v))
+       -> forall A, decidable (FSAT (Σ11 X Y) A).
 Proof.
   intros H0 H1 A.
-  destruct (Σdiscernable_dec_to_discrete H0 H1 A) as (D & D1 & D2 & B & HB); auto.
+  destruct (Σdiscernable_dec_to_discrete H0 H1 A) 
+    as (DX & DY & ? & ? & ? & ? & B & HB); auto.
   destruct FSAT_FULL_MONADIC_DEC with (A := B); simpl; auto.
-  + intros x; destruct (H0 x).
   + left; tauto.
   + right; tauto.
 Qed. 
 
-(* For a purely monadic signature Σ, i.e.:
-     - without functions 
-     - of uniform arity 1
+(* For a monadic signature Σ of uniform arity 1
+   over type X of funs and Y of rels
 
-   FSAT is decidable iff X has decidable discernability 
+   FSAT is decidable iff both X and Y have decidable discernability 
+
+   one needs at least one rel to discern funs ?
 *)
 
-Theorem Σ1_discernable_dec_FSAT_equiv V X :
-           (V -> False) 
-        ->  (forall x y : X, decidable (discernable x y))
-          ≋ ((forall A, decidable (FSAT (Σ11 V X) A))).
+Theorem Σ11_discernable_dec_FSAT_equiv X Y :
+            ( (forall u v : X, decidable (discernable u v))
+            * (forall u v : Y, decidable (discernable u v)) )
+          ≋ ((forall A, decidable (FSAT (Σ11 X Y) A))).
 Proof.
-  intros H.
   split.
-  + apply Σ1_discernable_dec_FSAT; auto.
-  + intros H1.
-    intros P Q.
-    generalize (H1 (test _ P ⟑ (test _ Q ⤑ ⊥))).
-    intros [ H2 | H2 ]; [ left | right ]; 
-      now rewrite FSAT_equiv_discernable in H2.
-Qed.
+  + intros (? & ?); apply Σ11_discernable_dec_FSAT; auto.
+  + intros H1; split.
+    * admit.
+    * intros P Q.
+      generalize (H1 (test _ P ⟑ (test _ Q ⤑ ⊥))).
+      intros [ H2 | H2 ]; [ left | right ]; 
+        now rewrite FSAT_equiv_discernable in H2.
+Admitted.
 
-Check Σ1_discernable_dec_FSAT_equiv.
+Check Σ11_discernable_dec_FSAT_equiv.
 
 

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -25,7 +25,7 @@ From Undecidability.TRAKHTENBROT
                  fo_sat fo_sat_dec
 
                  red_utils 
-                 Sig1 Sig1_1 red_dec.
+                 Sig1 Sig1_1 Sig0 red_dec.
 
 Set Implicit Arguments.
 
@@ -432,6 +432,55 @@ Proof.
   + left; tauto.
   + right; tauto.
 Qed. 
+
+Section FSAT_FULL_MONADIC_discernable.
+
+  Variable (Σ : fo_signature) 
+           (H1 : forall u v : syms Σ, decidable (discernable u v))
+           (H2 : forall u v : rels Σ, decidable (discernable u v))
+           (H3 : forall s, ar_syms Σ s <= 1)
+           (H4 : forall r, ar_rels Σ r <= 1).
+
+  Theorem FSAT_FULL_MONADIC_discernable A : decidable (FSAT Σ A).
+  Proof.
+    destruct (FSAT_FULL_MONADIC_FSAT_11 _ H3 H4) as (f & Hf).
+    destruct (Σ11_discernable_dec_FSAT H1 H2 (f A)) as [ H | H ].
+    + left; apply Hf; auto.
+    + right; contradict H; apply Hf; auto.
+  Qed.
+
+End FSAT_FULL_MONADIC_discernable.
+
+Section FSAT_PROP_ONLY_discernable.
+
+  Variable (Σ : fo_signature)
+           (H1 : forall u v : rels Σ, decidable (discernable u v))
+           (H2 : forall r, ar_rels Σ r = 0).
+
+  Theorem FSAT_PROP_ONLY_discernable A : decidable (FSAT Σ A).
+  Proof.
+    assert (H: decidable (FSAT _ (Σ_Σ0 A))).
+    { apply FSAT_FULL_MONADIC_discernable; simpl; auto; intros []. }
+    destruct H as [ H | H ].
+    + left; apply Σ_Σ0_correct; auto.
+    + right; contradict H; revert H; apply Σ_Σ0_correct; auto.
+  Qed.
+
+End FSAT_PROP_ONLY_discernable.
+
+Theorem FULL_MONADIC_disernable (Σ : fo_signature) :
+          { _ : forall u v : syms Σ, decidable (discernable u v) &
+          { _ : forall u v : rels Σ, decidable (discernable u v)
+              | (forall s, ar_syms Σ s <= 1)
+             /\ (forall r, ar_rels Σ r <= 1) } }
+        + { _ : forall u v : rels Σ, decidable (discernable u v)
+              | forall r, ar_rels Σ r = 0 }
+       -> forall A, decidable (FSAT Σ A).
+Proof.
+  intros [ (H1 & H2 & H3 & H4) | (H1 & H2) ].
+  + apply FSAT_FULL_MONADIC_discernable; auto.
+  + apply FSAT_PROP_ONLY_discernable; auto.
+Qed.
 
 (* For a monadic signature Σ of uniform arity 1
    over type X of funs and Y of rels

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -85,6 +85,9 @@ Section discernable.
     destruct (d (f x) (f y)) as [ | ]; auto.
   Qed.
 
+  Fact discrete_undiscernable_implies_equal x y : discrete X -> undiscernable x y -> x = y.
+  Proof. intro; now apply undiscernable_discrete with (f := fun x => x). Qed.
+
   Fact undiscernable_Prop_dec x y : undiscernable x y -> forall P, (forall x, decidable (P x)) -> P x <-> P y.
   Proof.
     intros H P HP.
@@ -245,7 +248,7 @@ Section FSAT_DEC_implies_discernable_rels.
 
   Hypothesis HXY : forall A, decidable (FSAT Σ A).
 
-  Theorem FSAT_dec_FIN_implies_discernable_rels_dec (P Q : rels Σ) : decidable (discernable P Q).
+  Theorem FSAT_dec_implies_discernable_rels_dec (P Q : rels Σ) : decidable (discernable P Q).
   Proof.
     destruct (HXY (test _ P ⟑ (test _ Q ⤑ ⊥))) as [ H | H ].
     + left; revert H; apply FSAT_equiv_discernable_rels.
@@ -263,7 +266,7 @@ Section FSAT_DEC_implies_discernable_syms.
 
   Hypothesis HXY : forall A, decidable (FSAT Σ A).
 
-  Theorem FSAT_dec_FIN_implies_discernable_syms_dec (f g : syms Σ) : decidable (discernable f g).
+  Theorem FSAT_dec_implies_discernable_syms_dec (f g : syms Σ) : decidable (discernable f g).
   Proof.
     destruct (HXY (testt _ _ HP f ⟑ (testt _ _ HP g ⤑ ⊥))) as [ H | H ].
     + left; revert H; apply FSAT_equiv_discernable_syms.
@@ -589,8 +592,8 @@ Proof.
   split.
   + intros (? & ?); apply FSAT_FULL_MONADIC_discernable; auto.
   + intros H3; split.
-    * apply FSAT_dec_FIN_implies_discernable_syms_dec with r; auto.
-    * apply FSAT_dec_FIN_implies_discernable_rels_dec; auto.
+    * apply FSAT_dec_implies_discernable_syms_dec with r; auto.
+    * apply FSAT_dec_implies_discernable_rels_dec; auto.
 Qed.
 
 (* For a signature with only constant relations (arity 0),
@@ -606,6 +609,6 @@ Proof.
   + intros H1.
     assert (forall A, decidable (FSAT (Σ0 Σ) A)) as H2.
     { revert H1; apply ireduction_decidable, FSAT_x0_FSAT_PROP; auto. }
-    exact (FSAT_dec_FIN_implies_discernable_rels_dec H2).
+    exact (FSAT_dec_implies_discernable_rels_dec H2).
 Qed. 
 

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -1,0 +1,351 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia Max Bool.
+
+From Undecidability.Synthetic
+  Require Import Definitions ReducibilityFacts
+                 InformativeDefinitions InformativeReducibilityFacts.
+
+From Undecidability.Shared.Libs.DLW.Utils
+  Require Import utils_tac utils_list utils_nat finite fin_quotient fin_dec.
+
+From Undecidability.Shared.Libs.DLW.Vec 
+  Require Import pos vec.
+
+From Undecidability.TRAKHTENBROT
+  Require Import notations utils decidable
+                 fol_ops fo_sig fo_terms fo_logic
+                 fo_sat fo_sat_dec
+
+                 red_utils 
+                 Sig1 Sig1_1 red_dec.
+
+Set Implicit Arguments.
+
+Section discernable.
+
+  Variable (X : Type).
+
+  Definition discernable x y := exists f : X -> bool, f x <> f y.
+
+  Definition undiscernable x y := forall f : X -> bool, f x = f y.
+
+  Fact discernable_equiv1 x y : discernable x y <-> exists f, f x = true /\ f y = false.
+  Proof.
+    split.
+    + intros (f & Hf).
+      case_eq (f x); intros Hx.
+      * exists f; split; auto.
+        now rewrite Hx in Hf; destruct (f y).
+      * exists (fun x => negb (f x)).
+        rewrite Hx in *; split; auto.
+        now destruct (f y).
+    + intros (f & E1 & E2); exists f.
+      now rewrite E1, E2.
+  Qed.
+
+  Fact discernable_undiscernable x y : discernable x y -> undiscernable x y -> False.
+  Proof. intros (f & Hf) H; apply Hf, H. Qed.
+
+  Fact undiscernable_refl x : undiscernable x x.
+  Proof. red; auto. Qed.
+
+  Fact undiscernable_sym x y : undiscernable x y -> undiscernable y x.
+  Proof. red; auto. Qed.
+
+  Fact undiscernable_trans x y z : undiscernable x y -> undiscernable y z -> undiscernable x z.
+  Proof. unfold undiscernable; eauto. Qed.
+
+  Fact undiscernable_discrete D (f : X -> D) x y : discrete D -> undiscernable x y -> f x = f y.
+  Proof.
+    intros d H.
+    set (g z := if d (f x) (f z) then true else false).
+    specialize (H g); unfold g in H.
+    destruct (d (f x) (f x)) as [ _ | [] ]; auto.
+    destruct (d (f x) (f y)) as [ | ]; auto.
+  Qed.
+
+  Fact undiscernable_Prop_dec x y : undiscernable x y -> forall P, (forall x, decidable (P x)) -> P x <-> P y.
+  Proof.
+    intros H P HP.
+    set (f x := if HP x then true else false).
+    specialize (H f); unfold f in H.
+    destruct (HP x); destruct (HP y); try tauto; easy.
+  Qed.
+
+  (* undiscernable is equivalent to a equilaty after mapping on some datatype *)
+
+  Definition discriminable := 
+    { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
+             | forall x y, undiscernable x y <-> f x = f y } } } }.
+
+  Hypothesis (H2 : forall x y, decidable (discernable x y)).
+
+  Let H3 x y : decidable (undiscernable x y).
+  Proof.
+    destruct (H2 x y) as [ H | H ].
+    + right; red; apply discernable_undiscernable; auto.
+    + left; intros f.
+      destruct (bool_dec (f x) (f y)) as [ | C ]; auto.
+      destruct H; exists f; auto.
+  Qed.
+
+  Hypothesis (H1 : finite_t X).
+
+  Hint Resolve undiscernable_refl undiscernable_sym undiscernable_trans : core.
+
+  Theorem finite_t_discernable_discriminable : discriminable. 
+  Proof.
+    destruct H1 as (l & Hl).
+    destruct decidable_EQUIV_fin_quotient with (l := l) (R := undiscernable)
+      as [ n cls repr E1 E2 ]; eauto.
+    exists (pos n), (@pos_eq_dec n), (finite_t_pos n), cls; auto.
+  Qed.
+
+End discernable.
+
+Section FSAT_equiv_discernable.
+
+  Variables (X Y : Type).
+
+  Notation Σ := (Σ11 X Y).
+  Notation ø := vec_nil.
+
+  Local Definition test K := @fol_atom Σ K (£0##ø).
+
+  Variables (P Q : rels Σ).
+
+  Section model.
+
+    Variable (f : Y -> bool) (HP : f P = true) (HQ : f Q = false).
+
+    Let M : fo_model Σ bool.
+    Proof.
+      split.
+      + intros; exact true. 
+      + intros r _; exact (f r = true).
+    Defined.
+
+    Local Fact discernable_FSAT : FSAT Σ (test P ⟑ (test Q ⤑ ⊥)).
+    Proof.
+      exists bool, M; msplit 2.
+      + apply finite_t_bool.
+      + intros r v; simpl; apply bool_dec.
+      + exists (fun _ => true); simpl.
+        now rewrite HP, HQ.
+    Qed.
+
+  End model.
+
+  Theorem FSAT_equiv_discernable : FSAT Σ (test P ⟑ (test Q ⤑ ⊥))
+                    <-> discernable P Q.
+  Proof.
+    rewrite discernable_equiv1.
+    split.
+    + intros (D & M & H1 & H2 & rho & H3 & H4).
+      exists (fun K => if @H2 K (rho 0##ø) then true else false).
+      simpl in H3, H4.
+      destruct (H2 P (rho 0##ø)); destruct (H2 Q (rho 0##ø)); tauto.
+    + intros (f & H1 & H2).
+      apply discernable_FSAT with f; auto.
+  Qed.
+
+End FSAT_equiv_discernable.
+
+Section FSAT_DEC_implies_discriminable.
+
+  Variables (X Y : Type).
+
+  Notation Σ := (Σ11 X Y).
+
+  Hypothesis HY : finite_t Y.
+  Hypothesis HXY : forall A, decidable (FSAT Σ A).
+
+  Theorem FSAT_DEC_FIN_implies_discriminable : discriminable Y.
+  Proof.
+    apply finite_t_discernable_discriminable; auto.
+    intros P Q.
+    destruct (HXY (test _ P ⟑ (test _ Q ⤑ ⊥))) as [ H | H ].
+    + left; revert H; apply FSAT_equiv_discernable.
+    + right; contradict H; revert H; apply FSAT_equiv_discernable.
+  Qed.
+
+End FSAT_DEC_implies_discriminable.
+
+Section discriminable_implies_FSAT_DEC.
+
+  Variable (X Y : Type) (HY : discriminable Y) (Yfin : finite_t Y).
+
+  Let D := projT1 HY.
+
+  Let Ddiscr : discrete D.   Proof. apply (projT2 HY). Qed.
+  Let Dfin : finite_t D.     Proof. apply (projT2 (projT2 HY)). Qed.
+
+  Let f : Y -> D := proj1_sig (projT2 (projT2 (projT2 HY))).
+  Let Hf x y : undiscernable x y <-> f x = f y.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HY)))). Qed.
+
+  Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 X D) :=
+    match A with
+      | ⊥              => ⊥
+      | fol_atom r v   => @fol_atom (Σ11 X D) (f r) v
+      | fol_bin b A B => fol_bin b (Σdiscriminable_discrete A) (Σdiscriminable_discrete B)
+      | fol_quant q A => fol_quant q (Σdiscriminable_discrete A)
+    end.
+
+  Let fromY d : { y | f y = d } + (forall y, f y <> d).
+  Proof.
+    clear Hf.
+    red in HY.
+    destruct finite_t_find_dec with (P := fun y => f y = d); auto.
+    intros; apply Ddiscr.
+  Qed.
+
+  Section sound.
+
+    Variable (K : Type).
+
+    Variable (M : fo_model (Σ11 X Y) K) (HM : fo_model_dec M).
+
+    Let M' : fo_model (Σ11 X D) K.
+    Proof.
+      split.
+      + exact (fom_syms M).
+      + intros r.
+        destruct (fromY r) as [ (y & Hy) | C ].
+        * apply (fom_rels M y).
+        * exact (fun _ => True).
+    Defined.
+
+    Let M'_dec : fo_model_dec M'.
+    Proof.
+      intros r v; simpl.
+      destruct (fromY r) as [ (y & Hy) | C ].
+      + apply HM.
+      + tauto.
+    Qed.
+
+    Let equiv A φ : fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto. 
+      + destruct (fromY (f r)) as [ (y & Hy) | C ].
+        2: destruct (C r); auto.
+        apply Hf in Hy.
+        apply undiscernable_Prop_dec 
+          with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy.
+        2: intro; apply HM.
+        rewrite <- Hy.
+        fol equiv.
+      + apply fol_bin_sem_ext; auto.
+      + destruct q; fol equiv; auto.
+    Qed.
+
+    Hypothesis Kfin : finite_t K.
+    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ A).
+
+    Local Fact Σdiscriminable_discrete_sound : FSAT _ (Σdiscriminable_discrete A).
+    Proof.
+      exists K, M', Kfin, M'_dec, φ.
+      now apply equiv.
+    Qed.
+
+  End sound.
+
+  Section complete.
+
+    Variable (K : Type).
+
+    Variable (M : fo_model (Σ11 X D) K) (HM : fo_model_dec M).
+
+    Let M' : fo_model (Σ11 X Y) K.
+    Proof.
+      split.
+      + exact (fom_syms M).
+      + intros r.
+        apply (fom_rels M (f r)).
+    Defined.
+
+    Let M'_dec : fo_model_dec M'.
+    Proof.
+      intros r v; simpl.
+      apply HM.
+    Qed.
+
+    Let equiv A φ : fol_sem M φ (Σdiscriminable_discrete A) <-> fol_sem M' φ A.
+    Proof.
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto. 
+      + apply fol_bin_sem_ext; auto.
+      + destruct q; fol equiv; auto.
+    Qed.
+
+    Hypothesis Kfin : finite_t K.
+    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ (Σdiscriminable_discrete A)).
+
+    Local Fact Σdiscriminable_discrete_complete : FSAT _ A.
+    Proof.
+      exists K, M', Kfin, M'_dec, φ.
+      now apply equiv.
+    Qed.
+
+  End complete.
+
+  Theorem Σdiscriminable_discrete_correct A : FSAT _ A <-> FSAT _ (Σdiscriminable_discrete A).
+  Proof.
+    split.
+    + intros (K & M & H1 & H2 & phi & H3).
+      apply Σdiscriminable_discrete_sound with K M phi; auto.
+    + intros (K & M & H1 & H2 & phi & H3).
+      apply Σdiscriminable_discrete_complete with K M phi; auto.
+  Qed.
+
+  Theorem Σdiscriminable_to_discrete : 
+           { D : _ & { _ : discrete D & { _ : finite_t D &
+           forall A, { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 X D)  B } } } }.
+  Proof.
+    exists D, Ddiscr, Dfin.
+    intros A; exists (Σdiscriminable_discrete A).
+    apply Σdiscriminable_discrete_correct.
+  Qed.
+
+End discriminable_implies_FSAT_DEC.
+
+Theorem Σ1_discriminable_FSAT V X : 
+          (V -> False) 
+       -> finite_t X
+       -> discriminable X -> forall A, decidable (FSAT (Σ11 V X) A).
+Proof.
+  intros H0 H1 H2.
+  destruct (Σdiscriminable_to_discrete V H2) as (D & D1 & D2 & H); auto.
+  intros A.
+  destruct (H A) as (B & HB).
+  destruct FSAT_FULL_MONADIC_DEC with (A := B); auto.
+  + intros x; destruct (H0 x).
+  + left; tauto.
+  + right; tauto.
+Qed. 
+
+(* For a signature Σ:
+     - without functions 
+     - with finitely many relations in type X
+     - of uniform arity 1
+
+   FSAT is decidable iff X is discriminable *)
+
+Theorem Σ1_discriminable_FSAT_equiv V X :
+        (V -> False) -> finite_t X ->
+                        (discriminable X -> forall A, decidable (FSAT (Σ11 V X) A))
+                      * ((forall A, decidable (FSAT (Σ11 V X) A)) -> discriminable X).
+Proof.
+  split.
+  + apply Σ1_discriminable_FSAT; auto.
+  + apply FSAT_DEC_FIN_implies_discriminable; auto.
+Qed.
+  
+

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -14,7 +14,7 @@ From Undecidability.Synthetic
                  InformativeDefinitions InformativeReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import utils_tac utils_list utils_nat finite fin_quotient fin_dec.
+  Require Import utils_tac utils_list utils_nat finite fin_quotient fin_dec utils_decidable.
 
 From Undecidability.Shared.Libs.DLW.Vec 
   Require Import pos vec.
@@ -80,12 +80,6 @@ Section discernable.
     destruct (HP x); destruct (HP y); try tauto; easy.
   Qed.
 
-  (* undiscernable is equivalent to a equilaty after mapping on some datatype *)
-
-  Definition discriminable := 
-    { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
-             | forall x y, undiscernable x y <-> f x = f y } } } }.
-
   Hypothesis (H2 : forall x y, decidable (discernable x y)).
 
   Let H3 x y : decidable (undiscernable x y).
@@ -97,16 +91,34 @@ Section discernable.
       destruct H; exists f; auto.
   Qed.
 
-  Hypothesis (H1 : finite_t X).
+  (* undiscernable is equivalent to a equality after mapping on some finite datatype *)
+
+  Definition pdiscriminable l := 
+    { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
+             | forall x y, In x l -> In y l -> undiscernable x y <-> f x = f y } } } }.
+
+  Definition discriminable := 
+    { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
+             | forall x y, undiscernable x y <-> f x = f y } } } }.
 
   Hint Resolve undiscernable_refl undiscernable_sym undiscernable_trans : core.
+
+  Theorem fsubset_discernable_discriminable l : pdiscriminable l. 
+  Proof.
+    apply DEC_PER_list_proj_finite_discrete with (l := l) (R := undiscernable).
+    + split; eauto.
+    + red; apply H3.
+    + intros; auto.
+  Qed.
+
+  Hypothesis (H1 : finite_t X).
 
   Theorem finite_t_discernable_discriminable : discriminable. 
   Proof.
     destruct H1 as (l & Hl).
-    destruct decidable_EQUIV_fin_quotient with (l := l) (R := undiscernable)
-      as [ n cls repr E1 E2 ]; eauto.
-    exists (pos n), (@pos_eq_dec n), (finite_t_pos n), cls; auto.
+    destruct fsubset_discernable_discriminable with l
+      as (D & D1 & D2 & f & Hf).
+    exists D, D1, D2, f; intros; eauto.
   Qed.
 
 End discernable.
@@ -165,12 +177,11 @@ Section FSAT_DEC_implies_discriminable.
 
   Notation Σ := (Σ11 X Y).
 
-  Hypothesis HY : finite_t Y.
   Hypothesis HXY : forall A, decidable (FSAT Σ A).
 
-  Theorem FSAT_DEC_FIN_implies_discriminable : discriminable Y.
+  Theorem FSAT_DEC_FIN_implies_discriminable (l : list Y) : pdiscriminable l.
   Proof.
-    apply finite_t_discernable_discriminable; auto.
+    apply fsubset_discernable_discriminable; auto.
     intros P Q.
     destruct (HXY (test _ P ⟑ (test _ Q ⤑ ⊥))) as [ H | H ].
     + left; revert H; apply FSAT_equiv_discernable.
@@ -181,16 +192,16 @@ End FSAT_DEC_implies_discriminable.
 
 Section discriminable_implies_FSAT_DEC.
 
-  Variable (X Y : Type) (HY : discriminable Y) (Yfin : finite_t Y).
+  Variable (X Y : Type) (l : list Y) (Hl : pdiscriminable l).
 
-  Let D := projT1 HY.
+  Let D := projT1 Hl.
 
-  Let Ddiscr : discrete D.   Proof. apply (projT2 HY). Qed.
-  Let Dfin : finite_t D.     Proof. apply (projT2 (projT2 HY)). Qed.
+  Let Ddiscr : discrete D.   Proof. apply (projT2 Hl). Qed.
+  Let Dfin : finite_t D.     Proof. apply (projT2 (projT2 Hl)). Qed.
 
-  Let f : Y -> D := proj1_sig (projT2 (projT2 (projT2 HY))).
-  Let Hf x y : undiscernable x y <-> f x = f y.
-  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HY)))). Qed.
+  Let f : Y -> D := proj1_sig (projT2 (projT2 (projT2 Hl))).
+  Let Hf x y : In x l -> In y l -> undiscernable x y <-> f x = f y.
+  Proof. apply (proj2_sig (projT2 (projT2 (projT2 Hl)))). Qed.
 
   Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 X D) :=
     match A with
@@ -200,11 +211,12 @@ Section discriminable_implies_FSAT_DEC.
       | fol_quant q A => fol_quant q (Σdiscriminable_discrete A)
     end.
 
-  Let fromY d : { y | f y = d } + (forall y, f y <> d).
+  Let fromY d : { y | In y l /\ f y = d } + (forall y, In y l -> f y <> d).
   Proof.
     clear Hf.
-    red in HY.
-    destruct finite_t_find_dec with (P := fun y => f y = d); auto.
+    red in Hl.
+    destruct list_choose_dep with (P := fun y => f y = d) (Q := fun y => f y <> d) (l := l)
+    as [ (? & ? & ?) | ]; eauto.
     intros; apply Ddiscr.
   Qed.
 
@@ -219,7 +231,7 @@ Section discriminable_implies_FSAT_DEC.
       split.
       + exact (fom_syms M).
       + intros r.
-        destruct (fromY r) as [ (y & Hy) | C ].
+        destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
         * apply (fom_rels M y).
         * exact (fun _ => True).
     Defined.
@@ -227,28 +239,31 @@ Section discriminable_implies_FSAT_DEC.
     Let M'_dec : fo_model_dec M'.
     Proof.
       intros r v; simpl.
-      destruct (fromY r) as [ (y & Hy) | C ].
+      destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
       + apply HM.
       + tauto.
     Qed.
 
-    Let equiv A φ : fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
+    Let equiv (A : fol_form (Σ11 X Y)) φ : 
+          incl (fol_rels A) l -> fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
     Proof.
-      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto. 
-      + destruct (fromY (f r)) as [ (y & Hy) | C ].
+      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; intros G; try tauto. 
+      + destruct (fromY (f r)) as [ (y & Hy1 & Hy2) | C ].
         2: destruct (C r); auto.
-        apply Hf in Hy.
+        apply Hf in Hy2; auto.
         apply undiscernable_Prop_dec 
-          with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy.
+          with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy2.
         2: intro; apply HM.
-        rewrite <- Hy.
+        rewrite <- Hy2.
         fol equiv.
       + apply fol_bin_sem_ext; auto.
+        * eapply HA, incl_tran; eauto.
+        * eapply HB, incl_tran; eauto.
       + destruct q; fol equiv; auto.
     Qed.
 
     Hypothesis Kfin : finite_t K.
-    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ A).
+    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ A) (HA' : incl (fol_rels A) l).
 
     Local Fact Σdiscriminable_discrete_sound : FSAT _ (Σdiscriminable_discrete A).
     Proof.
@@ -296,7 +311,9 @@ Section discriminable_implies_FSAT_DEC.
 
   End complete.
 
-  Theorem Σdiscriminable_discrete_correct A : FSAT _ A <-> FSAT _ (Σdiscriminable_discrete A).
+  Theorem Σdiscriminable_discrete_correct (A : fol_form (Σ11 X Y)) :
+          incl (fol_rels A) l 
+       -> FSAT _ A <-> FSAT _ (Σdiscriminable_discrete A).
   Proof.
     split.
     + intros (K & M & H1 & H2 & phi & H3).
@@ -305,47 +322,62 @@ Section discriminable_implies_FSAT_DEC.
       apply Σdiscriminable_discrete_complete with K M phi; auto.
   Qed.
 
-  Theorem Σdiscriminable_to_discrete : 
-           { D : _ & { _ : discrete D & { _ : finite_t D &
-           forall A, { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 X D)  B } } } }.
-  Proof.
-    exists D, Ddiscr, Dfin.
-    intros A; exists (Σdiscriminable_discrete A).
-    apply Σdiscriminable_discrete_correct.
-  Qed.
-
 End discriminable_implies_FSAT_DEC.
 
-Theorem Σ1_discriminable_FSAT V X : 
-          (V -> False) 
-       -> finite_t X
-       -> discriminable X -> forall A, decidable (FSAT (Σ11 V X) A).
+Theorem Σdiscernable_dec_to_discrete X Y :
+           (X -> False)
+        -> (forall x y : Y, decidable (discernable x y))
+        -> forall A : fol_form (Σ11 X Y), 
+           { D : _ 
+         & { _ : discrete D 
+         & { _ : finite_t D 
+         & { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 X D)  B } } } }.
 Proof.
-  intros H0 H1 H2.
-  destruct (Σdiscriminable_to_discrete V H2) as (D & D1 & D2 & H); auto.
-  intros A.
-  destruct (H A) as (B & HB).
-  destruct FSAT_FULL_MONADIC_DEC with (A := B); auto.
+  intros HX HY A.
+  generalize (fsubset_discernable_discriminable HY (fol_rels A)); intros Hl.
+  generalize (Σdiscriminable_discrete_correct Hl A); revert Hl.
+  intros (D & H1 & H2 & f & H3) H4.
+  simpl in H4.
+  exists D, H1, H2.
+  match type of H4 with _ -> _ <-> FSAT _ ?b => exists b end.
+  apply H4, incl_refl.
+Qed.
+
+Theorem Σ1_discernable_dec_FSAT V X : 
+          (V -> False) 
+       -> (forall x y : X, decidable (discernable x y))
+       -> forall A, decidable (FSAT (Σ11 V X) A).
+Proof.
+  intros H0 H1 A.
+  destruct (Σdiscernable_dec_to_discrete H0 H1 A) as (D & D1 & D2 & B & HB); auto.
+  destruct FSAT_FULL_MONADIC_DEC with (A := B); simpl; auto.
   + intros x; destruct (H0 x).
   + left; tauto.
   + right; tauto.
 Qed. 
 
-(* For a signature Σ:
+(* For a purely monadic signature Σ, i.e.:
      - without functions 
-     - with finitely many relations in type X
      - of uniform arity 1
 
-   FSAT is decidable iff X is discriminable *)
+   FSAT is decidable iff X has decidable discernability 
+*)
 
-Theorem Σ1_discriminable_FSAT_equiv V X :
-        (V -> False) -> finite_t X ->
-                        (discriminable X -> forall A, decidable (FSAT (Σ11 V X) A))
-                      * ((forall A, decidable (FSAT (Σ11 V X) A)) -> discriminable X).
+Theorem Σ1_discernable_dec_FSAT_equiv V X :
+           (V -> False) 
+        ->  (forall x y : X, decidable (discernable x y))
+          ≋ ((forall A, decidable (FSAT (Σ11 V X) A))).
 Proof.
+  intros H.
   split.
-  + apply Σ1_discriminable_FSAT; auto.
-  + apply FSAT_DEC_FIN_implies_discriminable; auto.
+  + apply Σ1_discernable_dec_FSAT; auto.
+  + intros H1.
+    intros P Q.
+    generalize (H1 (test _ P ⟑ (test _ Q ⤑ ⊥))).
+    intros [ H2 | H2 ]; [ left | right ]; 
+      now rewrite FSAT_equiv_discernable in H2.
 Qed.
-  
+
+Check Σ1_discernable_dec_FSAT_equiv.
+
 

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -7,31 +7,17 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Lia Max Bool.
-
-From Undecidability.Synthetic
-  Require Import Definitions ReducibilityFacts
-                 InformativeDefinitions InformativeReducibilityFacts.
+Require Import List Bool.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import utils_tac utils_list utils_nat finite fin_quotient fin_dec utils_decidable.
-
-From Undecidability.Shared.Libs.DLW.Vec 
-  Require Import pos vec.
+  Require Import utils_list finite fin_quotient fin_dec utils_decidable.
 
 From Undecidability.TRAKHTENBROT
-  Require Import notations utils decidable
-                 fol_ops fo_sig fo_terms fo_logic
-                 fo_sat fo_sat_dec
-
-                 red_utils 
-                 Sig1 Sig1_1 Sig0 red_dec.
+  Require Import notations utils decidable.
 
 Set Implicit Arguments.
 
 Local Infix "∊" := In (at level 70, no associativity).
-Local Infix "⊑" := incl (at level 70, no associativity). 
-Local Notation ø := vec_nil.
 
 Section discernable.
 
@@ -39,7 +25,9 @@ Section discernable.
 
   Definition discernable x y := exists f : X -> bool, f x <> f y.
 
-  Fact discernable_equiv1 x y : discernable x y <-> exists f, f x = true /\ f y = false.
+  Infix "≢" := discernable (at level 70, no associativity).
+
+  Fact discernable_equiv1 x y : x ≢ y <-> exists f, f x = true /\ f y = false.
   Proof.
     split.
     + intros (f & Hf).
@@ -55,10 +43,12 @@ Section discernable.
 
   Definition undiscernable x y := forall f : X -> bool, f x = f y.
 
-  Fact discernable_undiscernable x y : discernable x y -> undiscernable x y -> False.
+  Infix "≡" := undiscernable (at level 70, no associativity).
+
+  Fact discernable_undiscernable x y : x ≢ y -> x ≡ y -> False.
   Proof. intros (f & Hf) H; apply Hf, H. Qed.
 
-  Fact undiscernable_spec x y : undiscernable x y <-> ~ discernable x y.
+  Fact undiscernable_spec x y : x ≡ y <-> ~ x ≢ y.
   Proof.
     split.
     + intros H1 H2; revert H2 H1; apply discernable_undiscernable.
@@ -67,16 +57,16 @@ Section discernable.
       destruct H; exists f; auto.
   Qed.
 
-  Fact undiscernable_refl x : undiscernable x x.
+  Fact undiscernable_refl x : x ≡ x.
   Proof. red; auto. Qed.
 
-  Fact undiscernable_sym x y : undiscernable x y -> undiscernable y x.
+  Fact undiscernable_sym x y : x ≡ y -> y ≡ x.
   Proof. red; auto. Qed.
 
-  Fact undiscernable_trans x y z : undiscernable x y -> undiscernable y z -> undiscernable x z.
+  Fact undiscernable_trans x y z : x ≡ y -> y ≡ z -> x ≡ z.
   Proof. unfold undiscernable; eauto. Qed.
 
-  Fact undiscernable_discrete D (f : X -> D) x y : discrete D -> undiscernable x y -> f x = f y.
+  Fact undiscernable_discrete D (f : X -> D) x y : discrete D -> x ≡ y -> f x = f y.
   Proof.
     intros d H.
     set (g z := if d (f x) (f z) then true else false).
@@ -85,10 +75,10 @@ Section discernable.
     destruct (d (f x) (f y)) as [ | ]; auto.
   Qed.
 
-  Fact discrete_undiscernable_implies_equal x y : discrete X -> undiscernable x y -> x = y.
+  Fact discrete_undiscernable_implies_equal x y : discrete X -> x ≡ y -> x = y.
   Proof. intro; now apply undiscernable_discrete with (f := fun x => x). Qed.
 
-  Fact undiscernable_Prop_dec x y : undiscernable x y -> forall P, (forall x, decidable (P x)) -> P x <-> P y.
+  Fact undiscernable_Prop_dec x y : x ≡ y -> forall P, (forall x, decidable (P x)) -> P x <-> P y.
   Proof.
     intros H P HP.
     set (f x := if HP x then true else false).
@@ -96,16 +86,20 @@ Section discernable.
     destruct (HP x); destruct (HP y); try tauto; easy.
   Qed.
 
-  Hypothesis (H2 : forall x y, decidable (discernable x y)).
+  Hypothesis (H2 : forall x y, decidable (x ≢ y)).
 
-  Let H3 x y : decidable (undiscernable x y).
+  Fact discernable_dec_undiscernable_dec x y : decidable (x ≡ y).
   Proof.
     destruct (H2 x y); [ right | left ]; rewrite undiscernable_spec; tauto.
   Qed.
 
+  Hint Resolve discernable_dec_undiscernable_dec : core.
+
+  (* There is a simultaneously discerning function for a list l *)
+
   Definition discriminable_list l := 
     { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
-             | forall x y, In x l -> In y l -> undiscernable x y <-> f x = f y } } } }.
+             | forall x y, x ∊ l -> y ∊ l -> x ≡ y <-> f x = f y } } } }.
 
   Hint Resolve undiscernable_refl undiscernable_sym undiscernable_trans : core.
 
@@ -113,13 +107,15 @@ Section discernable.
   Proof.
     apply DEC_PER_list_proj_finite_discrete with (l := l) (R := undiscernable).
     + split; eauto.
-    + red; apply H3.
+    + red; apply discernable_dec_undiscernable_dec.
     + intros; auto.
   Qed.
 
+  (* There is a simultaneously discerning function for a type *)
+
   Definition discriminable_type := 
     { D & { _ : discrete D & { _ : finite_t D & { f : X -> D 
-             | forall x y, undiscernable x y <-> f x = f y } } } }.
+             | forall x y, x ≡ y <-> f x = f y } } } }.
 
   Hypothesis (H1 : finite_t X).
 
@@ -134,481 +130,4 @@ Section discernable.
   Qed.
 
 End discernable.
-
-Section FSAT_equiv_discernable_rels.
-
-  Variable Σ : fo_signature.
-
-  Local Definition test K := @fol_atom Σ K (vec_set_pos (fun _ => £0)).
-
-  Variables (P Q : rels Σ).
-
-  Section model.
-
-    Variable (f : rels Σ -> bool) (HP : f P = true) (HQ : f Q = false).
-
-    Let M : fo_model Σ bool.
-    Proof.
-      split.
-      + intros; exact true. 
-      + intros r _; exact (f r = true).
-    Defined.
-
-    Local Fact discernable_rels_FSAT : FSAT Σ (test P ⟑ (test Q ⤑ ⊥)).
-    Proof.
-      exists bool, M; msplit 2.
-      + apply finite_t_bool.
-      + intros r v; simpl; apply bool_dec.
-      + exists (fun _ => true); simpl.
-        now rewrite HP, HQ.
-    Qed.
-
-  End model.
-
-  Theorem FSAT_equiv_discernable_rels : 
-            FSAT Σ (test P ⟑ (test Q ⤑ ⊥))
-        <-> discernable P Q.
-  Proof.
-    rewrite discernable_equiv1.
-    split.
-    + intros (D & M & H1 & H2 & rho & H3 & H4).
-      exists (fun K => if @H2 K (vec_set_pos (fun _ => rho 0)) then true else false).
-      simpl in H3, H4 |- *.
-      rewrite vec_map_set_pos in H3, H4.
-      do 2 match goal with 
-        |- context[if ?c then _ else _] => destruct c 
-      end; auto; tauto.
-    + intros (f & H1 & H2).
-      apply discernable_rels_FSAT with f; auto.
-  Qed.
-
-End FSAT_equiv_discernable_rels.
-
-Section FSAT_equiv_discernable_syms.
-  
-  Variables (Σ : fo_signature) (P : rels Σ) (HP : ar_rels Σ P = 1).
-
-  Let termt (p : syms Σ) : fo_term (ar_syms Σ) := in_fot p (vec_set_pos (fun _ => in_var 0)).
-
-  Local Definition testt (p : syms Σ) : fol_form Σ := fol_atom P (cast (termt p##ø) (eq_sym HP)).
-
-  Variables (p q : syms Σ).
-
-  Section model.
-
-    Variable (f : syms Σ -> bool) (Hp : f p = true) (Hq : f q = false).
-
-    Let M : fo_model Σ bool.
-    Proof.
-      split.
-      + intros s _; exact (f s). 
-      + intros r; simpl; intros v. 
-        exact (match v with vec_nil => True | h##_ => h = true end).
-    Defined.
-
-    Local Fact discernable_syms_FSAT : FSAT Σ (testt p ⟑ (testt q ⤑ ⊥)).
-    Proof.
-      exists bool, M; msplit 2.
-      + apply finite_t_bool.
-      + intros r v; simpl.
-        destruct v; try tauto.
-        apply bool_dec.
-      + exists (fun _ => true); simpl.
-        rewrite HP; simpl.
-        now rewrite Hp, Hq.
-    Qed.
-
-  End model.
-
-  Theorem FSAT_equiv_discernable_syms : 
-            FSAT Σ (testt p ⟑ (testt q ⤑ ⊥))
-        <-> discernable p q.
-  Proof.
-    rewrite discernable_equiv1.
-    split.
-    + intros (D & M & H1 & H2 & rho & H3 & H4).
-      simpl in H3, H4 |- *.
-      exists (fun k => if H2 P (vec_map (fo_term_sem M rho)
-          (cast (termt k ## ø) (eq_sym HP))) then true else false).
-      do 2 match goal with 
-        |- context[if ?c then _ else _] => destruct c 
-      end; auto; tauto.
-    + intros (f & H1 & H2).
-      apply discernable_syms_FSAT with f; auto.
-  Qed.
-
-End FSAT_equiv_discernable_syms.
-
-Section FSAT_DEC_implies_discernable_rels.
-
-  (* For any signature, FSAT decidability implies 
-     decidable discernability of rels *)
-
-  Variable Σ : fo_signature.
-
-  Hypothesis HXY : forall A, decidable (FSAT Σ A).
-
-  Theorem FSAT_dec_implies_discernable_rels_dec (P Q : rels Σ) : decidable (discernable P Q).
-  Proof.
-    destruct (HXY (test _ P ⟑ (test _ Q ⤑ ⊥))) as [ H | H ].
-    + left; revert H; apply FSAT_equiv_discernable_rels.
-    + right; contradict H; revert H; apply FSAT_equiv_discernable_rels.
-  Qed.
-
-End FSAT_DEC_implies_discernable_rels.
-
-Section FSAT_DEC_implies_discernable_syms.
-
-  (* For any signature with a unary relation, 
-     FSAT decidability implies decidable discernability of syms *)
-
-  Variables (Σ : fo_signature) (P : rels Σ) (HP : ar_rels Σ P = 1).
-
-  Hypothesis HXY : forall A, decidable (FSAT Σ A).
-
-  Theorem FSAT_dec_implies_discernable_syms_dec (f g : syms Σ) : decidable (discernable f g).
-  Proof.
-    destruct (HXY (testt _ _ HP f ⟑ (testt _ _ HP g ⤑ ⊥))) as [ H | H ].
-    + left; revert H; apply FSAT_equiv_discernable_syms.
-    + right; contradict H; revert H; apply FSAT_equiv_discernable_syms.
-  Qed.
-
-End FSAT_DEC_implies_discernable_syms.
-
-Section discrete_projection.
-
-  Variable (X Y : Type) (HY : discrete Y) (f : X -> Y) (l : list X).
-
-  Fact find_discrete_projection y : { x | x ∊ l /\ f x = y } + (forall x, x ∊ l -> f x <> y).
-  Proof.
-    destruct list_choose_dep 
-      with (P := fun x => f x = y) (Q := fun x => f x <> y) (l := l)
-    as [ (? & ? & ?) | ]; eauto.
-    intros; apply HY.
-  Qed.
-
-End discrete_projection.
-
-Section discriminable_implies_FSAT_DEC.
-
-  Variable (X Y : Type) 
-           (lX : list X) (HlX : discriminable_list lX)
-           (lY : list Y) (HlY : discriminable_list lY).
-
-  Let DX := projT1 HlX.
-
-  Let DX_discr : discrete DX.   Proof. apply (projT2 HlX). Qed.
-  Let DX_fin : finite_t DX.     Proof. apply (projT2 (projT2 HlX)). Qed.
-
-  Let f : X -> DX := proj1_sig (projT2 (projT2 (projT2 HlX))).
-  Let Hf u v : u ∊ lX -> v ∊ lX -> undiscernable u v <-> f u = f v.
-  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlX)))). Qed.
-
-  Let DY := projT1 HlY.
-
-  Let DY_discr : discrete DY.   Proof. apply (projT2 HlY). Qed.
-  Let DY_fin : finite_t DY.     Proof. apply (projT2 (projT2 HlY)). Qed.
-
-  Let g : Y -> DY := proj1_sig (projT2 (projT2 (projT2 HlY))).
-  Let Hg u v : u ∊ lY -> v ∊ lY -> undiscernable u v <-> g u = g v.
-  Proof. apply (proj2_sig (projT2 (projT2 (projT2 HlY)))). Qed.
-
-  Let fromX d : { x | x ∊ lX /\ f x = d } + (forall x, x ∊ lX -> f x <> d).
-  Proof. now apply find_discrete_projection. Qed.
-
-  Let fromY d : { y | y ∊ lY /\ g y = d } + (forall y, y ∊ lY -> g y <> d).
-  Proof. now apply find_discrete_projection. Qed.
-
-  Fixpoint fot_discriminable_discrete (t : fo_term (fun _ : X => 1)) : fo_term (fun _ : DX => 1) :=
-    match t with
-      | in_var n => in_var n
-      | in_fot s v => in_fot (f s) ((fot_discriminable_discrete (vec_pos v pos0))##ø)
-    end.
-
-  Fixpoint Σdiscriminable_discrete (A : fol_form (Σ11 X Y)) : fol_form (Σ11 DX DY) :=
-    match A with
-      | ⊥              => ⊥
-      | fol_atom r v   => @fol_atom (Σ11 DX DY) (g r) (vec_map fot_discriminable_discrete v)
-      | fol_bin b A B => fol_bin b (Σdiscriminable_discrete A) (Σdiscriminable_discrete B)
-      | fol_quant q A => fol_quant q (Σdiscriminable_discrete A)
-    end.
-
-  Section sound.
-
-    Variable (K : Type).
-
-    Variable (M : fo_model (Σ11 X Y) K) (HM : fo_model_dec M) (Kdiscr : discrete K).
-
-    Let M' : fo_model (Σ11 DX DY) K.
-    Proof.
-      split.
-      + intros s.
-        destruct (fromX s) as [ (x & Hx1 & Hx2) | C ].
-        * apply (fom_syms M x).
-        * apply vec_head.
-      + intros r.
-        destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
-        * apply (fom_rels M y).
-        * exact (fun _ => True).
-    Defined.
-
-    Let M'_dec : fo_model_dec M'.
-    Proof.
-      intros r v; simpl.
-      destruct (fromY r) as [ (y & Hy1 & Hy2) | C ].
-      + apply HM.
-      + tauto.
-    Qed.
-
-    Let term_equal (t : fo_term (fun _ : X => 1)) φ : 
-             fo_term_syms t ⊑ lX
-          -> fo_term_sem M' φ (fot_discriminable_discrete t)
-           = fo_term_sem M φ t.
-    Proof.
-      induction t as [ n | s v IH ]; simpl; intros Ht; auto.
-      destruct (fromX (f s)) as [ (x & Hx1 & Hx2) | C ].
-      2: destruct (C s); auto.
-      revert IH Ht; vec split v with a; vec nil v; intros IH Ht.
-      simpl in Ht |- *.
-      rewrite <- app_nil_end in Ht.
-      specialize (IH pos0); simpl in IH.
-      assert (undiscernable x s) as Hxs by (apply Hf; auto).
-      rewrite IH.
-      2: apply incl_tran with (2 := Ht); intro; simpl; tauto.
-      apply undiscernable_discrete with (f := fun u => fom_syms M u (fo_term_sem M φ a ## ø)); auto.
-    Qed.
-
-    Let form_equiv (A : fol_form (Σ11 X Y)) φ :
-          fol_syms A ⊑ lX
-       -> fol_rels A ⊑ lY
-       -> fol_sem M' φ (Σdiscriminable_discrete A) <-> fol_sem M φ A.
-    Proof.
-      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; intros G1 G2; try tauto. 
-      + destruct (fromY (g r)) as [ (y & Hy1 & Hy2) | C ].
-        2: destruct (C r); auto.
-        apply Hg in Hy2; auto.
-        apply undiscernable_Prop_dec 
-          with (P := fun z => fom_rels M z (vec_map (fo_term_sem M φ) v)) in Hy2.
-        2: intro; apply HM.
-        rewrite <- Hy2.
-        fol equiv.
-        rewrite vec_map_map.
-        clear Hy2.
-        revert G1; vec split v with a; vec nil v; simpl; rewrite <- app_nil_end; intros G1.
-        f_equal; apply term_equal; auto.
-      + apply fol_bin_sem_ext; auto.
-        * eapply HA, incl_tran; eauto.
-        * eapply HB, incl_tran; eauto.
-      + destruct q; fol equiv; auto.
-    Qed.
-
-    Hypothesis Kfin : finite_t K.
-    Variables (φ : nat -> K) 
-              (A : fol_form (Σ11 X Y))
-              (HA1 : fol_syms A ⊑ lX) 
-              (HA2 : fol_rels A ⊑ lY)
-              (HA : fol_sem M φ A).
-
-    Local Fact Σdiscriminable_discrete_sound : FSAT _ (Σdiscriminable_discrete A).
-    Proof.
-      exists K, M', Kfin, M'_dec, φ.
-      now apply form_equiv.
-    Qed.
-
-  End sound.
-
-  Section complete.
-
-    Variable (K : Type).
-
-    Variable (M : fo_model (Σ11 DX DY) K) (HM : fo_model_dec M).
-
-    Let M' : fo_model (Σ11 X Y) K.
-    Proof.
-      split.
-      + exact (fun s => fom_syms M (f s)).
-      + exact (fun r => fom_rels M (g r)).
-    Defined.
-
-    Let M'_dec : fo_model_dec M'.
-    Proof.
-      intros r v; simpl.
-      apply HM.
-    Qed.
-
-    Let term_equal t φ : fo_term_sem M φ (fot_discriminable_discrete t)
-                       = fo_term_sem M' φ t.
-    Proof.
-      induction t as [ n | s v IH ]; simpl; auto.
-      specialize (IH pos0); revert IH.
-      vec split v with a; vec nil v; simpl; intros ->; auto.
-    Qed.
-
-    Let form_equiv A φ : fol_sem M φ (Σdiscriminable_discrete A) <-> fol_sem M' φ A.
-    Proof.
-      induction A as [ | r v | b A HA B HB | q A HA ] in φ |- *; simpl; try tauto.
-      + rewrite vec_map_map; fol equiv.
-        vec split v with a; vec nil v; simpl; f_equal; auto.
-      + apply fol_bin_sem_ext; auto.
-      + destruct q; fol equiv; auto.
-    Qed.
-
-    Hypothesis Kfin : finite_t K.
-    Variables (φ : nat -> K) (A : fol_form (Σ11 X Y)) (HA : fol_sem M φ (Σdiscriminable_discrete A)).
-
-    Local Fact Σdiscriminable_discrete_complete : FSAT _ A.
-    Proof.
-      exists K, M', Kfin, M'_dec, φ.
-      now apply form_equiv.
-    Qed.
-
-  End complete.
-
-  Theorem Σdiscriminable_discrete_correct (A : fol_form (Σ11 X Y)) :
-          fol_syms A ⊑ lX
-       -> fol_rels A ⊑ lY
-       -> { DX : _ & 
-          { DY : _ & 
-          { _ : discrete DX &
-          { _ : discrete DY & 
-          { _ : finite_t DX &
-          { _ : finite_t DY &
-          { B : fol_form (Σ11 DX DY) | FSAT _ A <-> FSAT _ B } } } } } } }. 
-  Proof.
-    intros HX HY.
-    exists DX, DY.
-    do 4 (exists; [ auto | ]).
-    exists (Σdiscriminable_discrete A).
-    split.
-    + rewrite fo_form_fin_dec_SAT_discr_equiv.
-      intros (K & H0 & M & H1 & H2 & phi & H3).
-      apply Σdiscriminable_discrete_sound with K M phi; auto.
-    + intros (K & M & H1 & H2 & phi & H3).
-      apply Σdiscriminable_discrete_complete with K M phi; auto.
-  Qed.
-
-End discriminable_implies_FSAT_DEC.
-
-Theorem Σdiscernable_dec_to_discrete X Y :
-           (forall u v : X, decidable (discernable u v))
-        -> (forall u v : Y, decidable (discernable u v))
-        -> forall A : fol_form (Σ11 X Y), 
-           { DX : _ 
-         & { DY : _ 
-         & { _ : discrete DX
-         & { _ : discrete DY
-         & { _ : finite_t DX
-         & { _ : finite_t DY
-         & { B | FSAT (Σ11 X Y) A <-> FSAT (Σ11 DX DY)  B } } } } } } }.
-Proof.
-  intros HX HY A.
-  generalize (discernable_discriminable_list HX (fol_syms A))
-             (discernable_discriminable_list HY (fol_rels A)); intros HlX HlY.
-  destruct (Σdiscriminable_discrete_correct HlX HlY A)
-    as (DX & DY & ? & ? & ? & ? & B & HB).
-  1,2: apply incl_refl.
-  exists DX, DY.
-  do 4 (exists; [ auto | ]).
-  exists B; auto.
-Qed.
-
-Theorem Σ11_discernable_dec_FSAT X Y : 
-          (forall u v : X, decidable (discernable u v))
-       -> (forall u v : Y, decidable (discernable u v))
-       -> forall A, decidable (FSAT (Σ11 X Y) A).
-Proof.
-  intros H0 H1 A.
-  destruct (Σdiscernable_dec_to_discrete H0 H1 A) 
-    as (DX & DY & ? & ? & ? & ? & B & HB); auto.
-  destruct FSAT_FULL_MONADIC_DEC with (A := B); simpl; auto.
-  + left; tauto.
-  + right; tauto.
-Qed. 
-
-Section FSAT_FULL_MONADIC_discernable.
-
-  Variable (Σ : fo_signature) 
-           (H1 : forall u v : syms Σ, decidable (discernable u v))
-           (H2 : forall u v : rels Σ, decidable (discernable u v))
-           (H3 : forall s, ar_syms Σ s <= 1)
-           (H4 : forall r, ar_rels Σ r <= 1).
-
-  Theorem FSAT_FULL_MONADIC_discernable A : decidable (FSAT Σ A).
-  Proof.
-    destruct (FSAT_FULL_MONADIC_FSAT_11 _ H3 H4) as (f & Hf).
-    destruct (Σ11_discernable_dec_FSAT H1 H2 (f A)) as [ H | H ].
-    + left; apply Hf; auto.
-    + right; contradict H; apply Hf; auto.
-  Qed.
-
-End FSAT_FULL_MONADIC_discernable.
-
-Section FSAT_PROP_ONLY_discernable.
-
-  Variable (Σ : fo_signature)
-           (H1 : forall u v : rels Σ, decidable (discernable u v))
-           (H2 : forall r, ar_rels Σ r = 0).
-
-  Theorem FSAT_PROP_ONLY_discernable A : decidable (FSAT Σ A).
-  Proof.
-    destruct (FSAT_PROP_FSAT_x0 _ H2) as (f & Hf).
-    destruct FSAT_FULL_MONADIC_discernable with (A := f A)
-      as [ H | H ]; auto.
-    + intros [].
-    + left; revert H; apply Hf; auto.
-    + right; contradict H; revert H; apply Hf; auto.
-  Qed.
-
-End FSAT_PROP_ONLY_discernable.
-
-Theorem FULL_MONADIC_discernable (Σ : fo_signature) :
-          { _ : forall u v : syms Σ, decidable (discernable u v) &
-          { _ : forall u v : rels Σ, decidable (discernable u v)
-              | (forall s, ar_syms Σ s <= 1)
-             /\ (forall r, ar_rels Σ r <= 1) } }
-        + { _ : forall u v : rels Σ, decidable (discernable u v)
-              | forall r, ar_rels Σ r = 0 }
-       -> forall A, decidable (FSAT Σ A).
-Proof.
-  intros [ (H1 & H2 & H3 & H4) | (H1 & H2) ].
-  + apply FSAT_FULL_MONADIC_discernable; auto.
-  + apply FSAT_PROP_ONLY_discernable; auto.
-Qed.
-
-(* For a monadic signature Σ (arity 0 or 1) with at least one unary relation,
-
-   FSAT is decidable iff both syms and rels have decidable discernability 
-*)
-
-Theorem FULL_MONADIC_discernable_dec_FSAT_dec_equiv Σ r : 
-            ar_rels Σ r = 1 
-         -> (forall s, ar_syms Σ s <= 1)
-         -> (forall r, ar_rels Σ r <= 1)
-         -> ( (forall u v : syms Σ, decidable (discernable u v))
-            * (forall u v : rels Σ, decidable (discernable u v)) )
-          ≋ forall A, decidable (FSAT Σ A).
-Proof.
-  intros Hr H1 H2.
-  split.
-  + intros (? & ?); apply FSAT_FULL_MONADIC_discernable; auto.
-  + intros H3; split.
-    * apply FSAT_dec_implies_discernable_syms_dec with r; auto.
-    * apply FSAT_dec_implies_discernable_rels_dec; auto.
-Qed.
-
-(* For a signature with only constant relations (arity 0),
-   FSAT is decidable iff relations have decidable discernability *) 
-
-Theorem MONADIC_PROP_discernable_dec_FSAT_dec_equiv (Σ : fo_signature) :
-            (forall r, @ar_rels Σ r = 0)
-        ->  (forall u v : rels Σ, decidable (discernable u v))
-          ≋  forall A, decidable (FSAT Σ A).
-Proof.
-  intros H; split.
-  + intros; apply FULL_MONADIC_discernable; eauto.
-  + intros H1.
-    assert (forall A, decidable (FSAT (Σ0 Σ) A)) as H2.
-    { revert H1; apply ireduction_decidable, FSAT_x0_FSAT_PROP; auto. }
-    exact (FSAT_dec_implies_discernable_rels_dec H2).
-Qed. 
 

--- a/theories/TRAKHTENBROT/discrete.v
+++ b/theories/TRAKHTENBROT/discrete.v
@@ -23,6 +23,13 @@ Set Implicit Arguments.
 Local Notation " e '#>' x " := (vec_pos e x).
 Local Notation " e [ v / x ] " := (vec_change e x v).
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity).
+
+Local Notation "M , r ⊨ A" := (fol_sem M r A) (at level 70, format "M , r  ⊨  A").
+
+Local Notation "f ∘ g" := (fun x => f (g x)) (at level 55, left associativity).
+
 Section discrete_quotient.
 
   (* We show the FO bisimilarity/indistinguishability ≡ is both
@@ -85,10 +92,9 @@ Section discrete_quotient.
       two free variables might be needed, see the remarks and counter-example 
       below *)
 
-  Definition fo_bisimilar X M x y := 
-         forall A φ, incl (fol_syms A) ls
-                  -> incl (fol_rels A) lr
-                  -> @fol_sem Σ X M x·φ A <-> fol_sem M y·φ A.
+  Definition fo_bisimilar X (M : fo_model Σ X) x y := 
+         forall φ, fol_syms φ ⊑ ls -> fol_rels φ ⊑ lr
+                -> forall ρ, M,x·ρ ⊨ φ <-> M,y·ρ ⊨ φ.
 
   (* Let us assume a finite and Boolean model m *)
 
@@ -97,18 +103,31 @@ Section discrete_quotient.
             (M : fo_model Σ X) 
             (dec : fo_model_dec M).
 
+  Infix "≐" := (fo_bisimilar M) (at level 70).
+
+  Fact fo_bisimilar_refl x : x ≐ x.
+  Proof. intro; tauto. Qed.
+
+  Fact fo_bisimilar_sym x y : x ≐ y -> y ≐ x.
+  Proof. unfold fo_bisimilar; intros H ? ? ? ?; rewrite H; auto; tauto. Qed.
+
+  Fact fo_bisimilar_trans x y z : x ≐ y -> y ≐ z -> x ≐ z.
+  Proof. unfold fo_bisimilar; intros H ? ? ? ? ?; rewrite H; auto. Qed.
+
   Implicit Type (R T : X -> X -> Prop).
 
   (* Construction of the greatest fixpoint of the following operator fom_op.
       Any prefixpoint R ⊆ fom_op R is a simulation for the model *)
 
-  Local Definition fom_op1 R x y := forall s, In s ls 
-                    -> forall (v : vec _ (ar_syms Σ s)) p, 
-                              R (fom_syms M s (v[x/p])) (fom_syms M s (v[y/p])).
+  Local Definition fom_op1 R x y := 
+          forall s, s ∊ ls 
+       -> forall (v : vec _ (ar_syms Σ s)) p, 
+                 R (fom_syms M s (v[x/p])) (fom_syms M s (v[y/p])).
 
-  Local Definition fom_op2 x y :=   forall s, In s lr 
-                    -> forall (v : vec _ (ar_rels Σ s)) p, 
-                              fom_rels M s (v[x/p]) <-> fom_rels M s (v[y/p]).
+  Local Definition fom_op2 x y := 
+          forall s, s ∊ lr 
+       -> forall (v : vec _ (ar_rels Σ s)) p, 
+                 fom_rels M s (v[x/p]) <-> fom_rels M s (v[y/p]).
 
   Local Definition fom_op R x y := fom_op1 R x y /\ fom_op2 x y.
   
@@ -157,75 +176,96 @@ Section discrete_quotient.
     + apply (H 0); auto.
   Qed.
 
-  (* Decidability, a bit more complicated but we have all the tools to do it
-     in an efficient way *)
+  Section fom_op_dec.
 
-  Let fom_op1_dec R : (forall x y, { R x y } + { ~ R x y })
-                   -> (forall x y, { fom_op1 R x y } + { ~ fom_op1 R x y }).
-  Proof.
-    unfold fom_op1.
-    intros HR x y.
-    apply forall_list_sem_dec; intros.
-    do 2 (apply (fol_quant_sem_dec fol_fa); auto; intros).
-  Qed.
+    (* fom_op is closed under strong decidability, 
+       a bit more complicated but we have all 
+       the tools to do it the easy way *)
 
-  Let fom_op2_dec : (forall x y, { fom_op2 x y } + { ~ fom_op2 x y }).
-  Proof.
-    unfold fom_op2.
-    intros x y.
-    apply forall_list_sem_dec; intros.
-    do 2 (apply (fol_quant_sem_dec fol_fa); auto; intros).
-    apply (fol_bin_sem_dec fol_conj); 
-      apply (fol_bin_sem_dec fol_imp); auto.
-  Qed.
+    Let fom_op1_dec R : 
+          (forall x y, { R x y } + { ~ R x y })
+       -> (forall x y, { fom_op1 R x y } + { ~ fom_op1 R x y }).
+    Proof.
+      unfold fom_op1.
+      intros HR x y.
+      apply forall_list_sem_dec; intros.
+      do 2 (apply (fol_quant_sem_dec fol_fa); auto; intros).
+    Qed.
 
-  Local Fact fom_op_dec R : (forall x y, { R x y } + { ~ R x y })
-                  -> (forall x y, { fom_op R x y } + { ~ fom_op R x y }).
-  Proof. intros; apply (fol_bin_sem_dec fol_conj); auto. Qed.
+    Let fom_op2_dec x y : { fom_op2 x y } + { ~ fom_op2 x y }.
+    Proof.
+      unfold fom_op2.
+      apply forall_list_sem_dec; intros.
+      do 2 (apply (fol_quant_sem_dec fol_fa); auto; intros).
+      apply (fol_bin_sem_dec fol_conj); 
+        apply (fol_bin_sem_dec fol_imp); auto.
+    Qed.
 
-  (* FO definability, also more complicated but we have all the
-     needed closure properties *)
+    Local Fact fom_op_dec R : 
+            (forall x y, { R x y } + { ~ R x y })
+         -> (forall x y, { fom_op R x y } + { ~ fom_op R x y }).
+    Proof. intros; apply (fol_bin_sem_dec fol_conj); auto. Qed.
 
-  Tactic Notation "solve" "with" "proj" constr(t) :=
-    apply fot_def_equiv with (f := fun φ => φ t); fol def; intros; rew vec.
+  End fom_op_dec.
 
-  Let fol_def_fom_op1 R : fol_definable ls lr M (fun ψ => R (ψ 0) (ψ 1))
-                       -> fol_definable ls lr M (fun ψ => fom_op1 R (ψ 0) (ψ 1)).
-  Proof.
-    intros H.
-    apply fol_def_list_fa; intros s Hs.
-    apply fol_def_vec_fa.
-    apply fol_def_finite_fa; auto; intro p.
-    apply fol_def_subst2; auto.
-    * apply fot_def_comp; auto; intro q.
-      destruct (pos_eq_dec p q); subst.
-      - solve with proj (ar_syms Σ s).
-      - solve with proj (pos2nat q).
-    * apply fot_def_comp; auto; intro q.
-      destruct (pos_eq_dec p q); subst.
-      - solve with proj (ar_syms Σ s+1).
-      - solve with proj (pos2nat q).
-  Qed.
+  Section fo_definability.
 
-  Let fol_def_fom_op2 : fol_definable ls lr M (fun ψ => fom_op2 (ψ 0) (ψ 1)).
-  Proof.
-    apply fol_def_list_fa; intros r Hr.
-    apply fol_def_vec_fa.
-    apply fol_def_finite_fa; auto; intro p.
-    apply fol_def_iff.
-    * apply fol_def_atom; auto; intro q.
-      destruct (pos_eq_dec p q); subst.
-      - solve with proj (ar_rels Σ r).
-      - solve with proj (pos2nat q).
-    * apply fol_def_atom; auto; intro q.
-      destruct (pos_eq_dec p q); subst.
-      - solve with proj (ar_rels Σ r+1).
-      - solve with proj (pos2nat q).
-  Qed.
+    (* fom_op is closed under FO definability, 
+       more complicated but we have all the
+       needed closure properties *)
 
-  Let fol_def_fom_op R : fol_definable ls lr M (fun ψ => R (ψ 0) (ψ 1))
-                      -> fol_definable ls lr M (fun ψ => fom_op R (ψ 0) (ψ 1)).
-  Proof. intro; apply fol_def_conj; auto. Qed.
+    Tactic Notation "solve" "with" "proj" constr(t) :=
+      apply fot_def_equiv with (f := fun φ => φ t); fol def; intros; rew vec.
+
+    Let fol_def_fom_op1 R : 
+           fol_definable ls lr M (fun ψ => R (ψ 0) (ψ 1))
+        -> fol_definable ls lr M (fun ψ => fom_op1 R (ψ 0) (ψ 1)).
+    Proof.
+      intros H.
+      apply fol_def_list_fa; intros s Hs.
+      apply fol_def_vec_fa.
+      apply fol_def_finite_fa; auto; intro p.
+      apply fol_def_subst2; auto.
+      * apply fot_def_comp; auto; intro q.
+        destruct (pos_eq_dec p q); subst.
+        - solve with proj (ar_syms Σ s).
+        - solve with proj (pos2nat q).
+      * apply fot_def_comp; auto; intro q.
+        destruct (pos_eq_dec p q); subst.
+        - solve with proj (ar_syms Σ s+1).
+        - solve with proj (pos2nat q).
+    Qed.
+
+    Let fol_def_fom_op2 : 
+           fol_definable ls lr M (fun ψ => fom_op2 (ψ 0) (ψ 1)).
+    Proof.
+      apply fol_def_list_fa; intros r Hr.
+      apply fol_def_vec_fa.
+      apply fol_def_finite_fa; auto; intro p.
+      apply fol_def_iff.
+      * apply fol_def_atom; auto; intro q.
+        destruct (pos_eq_dec p q); subst.
+        - solve with proj (ar_rels Σ r).
+        - solve with proj (pos2nat q).
+      * apply fol_def_atom; auto; intro q.
+        destruct (pos_eq_dec p q); subst.
+        - solve with proj (ar_rels Σ r+1).
+        - solve with proj (pos2nat q).
+    Qed.
+
+    Local Fact fol_def_fom_op R : 
+            fol_definable ls lr M (fun ψ => R (ψ 0) (ψ 1))
+         -> fol_definable ls lr M (fun ψ => fom_op R (ψ 0) (ψ 1)).
+    Proof. intro; apply fol_def_conj; auto. Qed.
+
+    Hint Resolve fol_def_fom_op : core. 
+
+    Local Fact fol_def_iter_fom_op R n :
+            fol_definable ls lr M (fun ψ => R (ψ 0) (ψ 1))
+         -> fol_definable ls lr M (fun ψ => iter fom_op R n (ψ 0) (ψ 1)).
+    Proof. revert R; induction n; simpl; auto. Qed.
+
+  End fo_definability.
 
   (* Now we build the greatest fixpoint fom_eq and show its properties
 
@@ -246,43 +286,51 @@ Section discrete_quotient.
   Hint Resolve fom_op_mono fom_op_id fom_op_sym fom_op_trans 
                fom_op_continuous fom_op_dec : core.
 
-  Let fom_eq_equiv : equiv _ fom_eq.
+  Local Fact fom_eq_equiv : equiv _ fom_eq.
   Proof. apply gfp_equiv; eauto. Qed.
 
-  Fact fom_eq_fix x y : fom_op fom_eq x y <-> x ≡ y.
+  Local Fact fom_eq_fix x y : fom_op fom_eq x y <-> x ≡ y.
   Proof. apply gfp_fix; eauto. Qed.
 
-  Fact fom_eq_incl R : (forall x y, R x y -> fom_op R x y)
-                    -> (forall x y, R x y -> x ≡ y).
+  Local Fact fom_eq_incl R : 
+           (forall x y, R x y -> fom_op R x y)
+        -> (forall x y, R x y -> x ≡ y).
   Proof. apply gfp_greatest; eauto. Qed.
 
   (* We build the greatest bisimulation which is an equivalence 
       and a fixpoint for the above operator *) 
 
-  Fact fom_eq_refl x : x ≡ x.
-  Proof. apply (proj1 fom_eq_equiv). Qed.
-
-  Fact fom_eq_sym x y : x ≡ y -> y ≡ x.
-  Proof. apply fom_eq_equiv. Qed.
-
-  Fact fom_eq_trans x y z : x ≡ y -> y ≡ z -> x ≡ z.
-  Proof. apply fom_eq_equiv. Qed.
+  Local Fact fom_eq_refl x : x ≡ x.                         Proof. apply (proj1 fom_eq_equiv). Qed.
+  Local Fact fom_eq_sym x y : x ≡ y -> y ≡ x.               Proof. apply fom_eq_equiv. Qed.
+  Local Fact fom_eq_trans x y z : x ≡ y -> y ≡ z -> x ≡ z.  Proof. apply fom_eq_equiv. Qed.
 
   (* It is a congruence wrt to the model *)
 
-  Fact fom_eq_syms x y s v p : In s ls -> x ≡ y -> fom_syms M s (v[x/p]) ≡ fom_syms M s (v[y/p]).
+  Local Fact fom_eq_syms x y s v p : 
+          s ∊ ls -> x ≡ y -> fom_syms M s (v[x/p]) ≡ fom_syms M s (v[y/p]).
   Proof. intros; apply fom_eq_fix; auto. Qed. 
     
-  Fact fom_eq_rels x y s v p : In s lr -> x ≡ y -> fom_rels M s (v[x/p]) <-> fom_rels M s (v[y/p]).
+  Local Fact fom_eq_rels x y s v p : 
+          s ∊ lr -> x ≡ y -> fom_rels M s (v[x/p]) <-> fom_rels M s (v[y/p]).
   Proof. intros; apply fom_eq_fix; auto. Qed.
 
   Hint Resolve fom_eq_refl fom_eq_sym fom_eq_trans fom_eq_syms fom_eq_rels : core.
 
-  Theorem fom_eq_syms_full s v w : In s ls -> (forall p, v#>p ≡ w#>p) -> fom_syms M s v ≡ fom_syms M s w.
+  Local Theorem fom_eq_syms_full s v w : 
+          s ∊ ls -> (forall p, v#>p ≡ w#>p) -> fom_syms M s v ≡ fom_syms M s w.
   Proof. intro; apply map_vec_pos_equiv; eauto. Qed.
 
-  Theorem fom_eq_rels_full s v w : In s lr -> (forall p, v#>p ≡ w#>p) -> fom_rels M s v <-> fom_rels M s w.
+  Local Theorem fom_eq_rels_full s v w : 
+          s ∊ lr -> (forall p, v#>p ≡ w#>p) -> fom_rels M s v <-> fom_rels M s w.
   Proof. intro; apply map_vec_pos_equiv; eauto; tauto. Qed.
+
+  (* And because the signature is finite (ie the symbols and relations) 
+                  the model M is finite and composed of decidable relations 
+
+      We do have a decidable equivalence here *) 
+
+  Local Fact fom_eq_dec x y : { x ≡ y } + { ~ x ≡ y }.
+  Proof. apply gfp_decidable; eauto. Qed.
 
   Section fol_characterization.
 
@@ -298,11 +346,10 @@ Section discrete_quotient.
     Let f : fo_simulation ls lr M M.
     Proof. exists fom_eq; auto; intros a; exists a; auto. Defined.
 
-    Let fom_eq_fol_charac1 A phi psi : 
-            (forall n, In n (fol_vars A) -> phi n ≡ psi n)
-         -> incl (fol_syms A) ls
-         -> incl (fol_rels A) lr
-         -> fol_sem M phi A <-> fol_sem M psi A.
+    Let fom_eq_fol_charac1 φ : 
+            fol_syms φ ⊑ ls
+         -> fol_rels φ ⊑ lr
+         -> forall ρ δ, (forall n, n ∊ fol_vars φ -> ρ n ≡ δ n) -> M,ρ ⊨ φ <-> M,δ ⊨ φ.
     Proof. intros; apply fo_model_simulation with (R := f); auto. Qed.
 
     (* By fom_eq_form_sem above, we know there is a FO formula
@@ -324,18 +371,17 @@ Section discrete_quotient.
 
       *)
 
-    Local Fact fom_eq_fo_bisimilar x y : x ≡ y -> fo_bisimilar M x y.
+    Let fom_eq_fo_bisimilar x y : x ≡ y -> x ≐ y.
     Proof.
-      intros H A phi.
-      apply fom_eq_fol_charac1.
-      intros [ | n ] _; simpl; auto.
+      intros ? ? ? ? ?; apply fom_eq_fol_charac1; auto.
+      intros [] _; simpl; auto.
     Qed.
 
-    Local Fact fo_bisimilar_fom_eq x y : fo_bisimilar M x y -> x ≡ y.
+    Let fo_bisimilar_fom_eq x y : x ≐ y -> x ≡ y.
     Proof.
       revert x y; apply gfp_greatest; eauto.
       intros x y H; split.
-      * intros s Hs v p A phi H1 H2.
+      * intros s Hs v p A H1 H2 phi.
         destruct (fot_vec_env Σ p) as (w & Hw1 & Hw2).
         set (B := fol_subst (fun n => 
                match n with
@@ -375,9 +421,8 @@ Section discrete_quotient.
         - unfold B; simpl; intros ? [ <- | [] ]; auto.
     Qed.
 
-    Theorem fom_eq_fol_characterization x y : 
-            x ≡ y <-> fo_bisimilar M x y.
-     Proof.
+    Theorem fom_eq_fol_characterization x y : x ≡ y <-> x ≐ y.
+    Proof.
       split.
       + apply fom_eq_fo_bisimilar.
       + apply fo_bisimilar_fom_eq.
@@ -385,21 +430,17 @@ Section discrete_quotient.
 
   End fol_characterization.
 
-  (* And because the signature is finite (ie the symbols and relations) 
-                  the model M is finite and composed of decidable relations 
-
-      We do have a decidable equivalence here *) 
-
-  Fact fom_eq_dec : forall x y, { x ≡ y } + { ~ x ≡ y }.
-  Proof. apply gfp_decidable; eauto. Qed.
+  (** R is an equivalence relation and a congruence for the interpretations
+      of all the symbols in ls and lr *)
 
   Definition fo_congruence_upto R := 
-                 ( (equivalence _ R)
-                 * (forall s v w, In s ls -> (forall p, R (v#>p) (w#>p)) -> R (fom_syms M s v) (fom_syms M s w))
-                 * (forall r v w, In r lr -> (forall p, R (v#>p) (w#>p)) -> fom_rels M r v <-> fom_rels M r w) )%type.
+      ( (equivalence _ R)
+    * (forall s v w, s ∊ ls -> (forall p, R (v#>p) (w#>p)) -> R (fom_syms M s v) (fom_syms M s w))
+    * (forall r v w, r ∊ lr -> (forall p, R (v#>p) (w#>p)) -> fom_rels M r v <-> fom_rels M r w) )%type.
 
-  Theorem fo_bisimilar_dec_congr : fo_congruence_upto (@fo_bisimilar X M)
-                                 * (forall x y, decidable (fo_bisimilar M x y)).
+  Theorem fo_bisimilar_dec_congr : 
+            fo_congruence_upto (fun x y => x ≐ y)
+         * (forall x y, decidable (x ≐ y)).
   Proof.
     split; [ split; [ split | ] | ].
     + split; red; [ intros ? | intros ? ? ? | intros ? ?]; rewrite <- !fom_eq_fol_characterization; auto.
@@ -412,74 +453,18 @@ Section discrete_quotient.
       destruct (fom_eq_dec x y); [ left | right ]; rewrite <- fom_eq_fol_characterization; auto.
   Qed.
 
-  (* But we have a much stronger statement: fom_eq is first order definable 
-      which follows from the fact that X/M is finite *)
+  Section build_the_discrete_model.
 
-  Theorem fom_eq_finite : { n | forall x y, x ≡ y <-> iter fom_op (fun _ _ => True) n x y }.
-  Proof. apply gfp_finite_t; eauto. Qed.
-
-  Theorem fom_eq_fol_def : fol_definable ls lr M (fun φ => φ 0 ≡ φ 1).
-  Proof.
-    destruct fom_eq_finite as (n & Hn).
-    apply fol_def_equiv with (R := fun φ => iter fom_op (fun _ _ : X => True) n (φ 0) (φ 1)).
-    + intro; rewrite <- Hn; tauto.
-    + clear Hn; induction n as [ | n IHn ].
-      * simpl; fol def.
-      * rewrite iter_S; auto.
-  Qed.
-
-  Section fom_eq_form.
-
-    (* We build a single FO formula with two variables A[.,.] 
-        such that x ≡ y <-> A(x,y)  *)
-
-    Let A := proj1_sig fom_eq_fol_def.
-
-    (* Let use remove unused variables by mapping them to £0 *) 
-    
-    Definition fom_eq_form := fol_subst (fun n => match n with 0 => £1 | _ => £0 end) A.
-
-    Fact fom_eq_form_sem φ x y : fol_sem M y·x·φ fom_eq_form <-> x ≡ y.
-    Proof.
-      unfold fom_eq_form; rewrite fol_sem_subst.
-      apply (proj2_sig fom_eq_fol_def).
-    Qed.
-
-    Fact fom_eq_form_vars : incl (fol_vars fom_eq_form) (0::1::nil).
-    Proof.
-      unfold fom_eq_form; rewrite fol_vars_subst.
-      intros n; rewrite in_flat_map; intros (? & _ & H).
-      revert x H; intros [ | [] ]; simpl; tauto.
-    Qed.
-
-    Fact fom_eq_form_syms : incl (fol_syms fom_eq_form) ls.
-    Proof.
-      unfold fom_eq_form; red.
-      apply Forall_forall, fol_syms_subst.
-      + intros [ | []]; rew fot; auto.
-      + apply Forall_forall, (proj2_sig fom_eq_fol_def).
-    Qed.
-
-    Fact fom_eq_form_rels : incl (fol_rels fom_eq_form) lr.
-    Proof.
-      unfold fom_eq_form; rewrite fol_rels_subst.
-      apply (proj2_sig fom_eq_fol_def).
-    Qed.
-
-  End fom_eq_form.
-
-  Hint Resolve fom_eq_form_vars fom_eq_form_syms fom_eq_form_rels fom_eq_dec : core.
-
-  (* And now we can build a discrete model with this decidable 
+    (* And now we can build a discrete model with this decidable 
       equivalence. There is a fo_projection from M to Md where
       Md is a Boolean model based on the ground type pos n.
 
-    *)
-
-  Section build_the_model.
+     *)
 
     Let l := proj1_sig fin.
-    Let Hl : forall x, In x l := proj2_sig fin.
+    Let Hl : forall x, x ∊ l := proj2_sig fin.
+
+    Hint Resolve fom_eq_dec : core.
 
     Let Q : fin_quotient fom_eq.
     Proof. apply decidable_EQUIV_fin_quotient with (l := l); eauto. Qed.
@@ -497,7 +482,7 @@ Section discrete_quotient.
       + intros s v; apply (fom_rels M s), (vec_map repr v).
     Defined.
 
-    Let H1 s v : In s ls -> cls (fom_syms M s v) = fom_syms Md s (vec_map cls v).
+    Let H1 s v : s ∊ ls -> cls (fom_syms M s v) = fom_syms Md s (vec_map cls v).
     Proof.
       intros Hs; simpl.
       apply E2.
@@ -506,7 +491,7 @@ Section discrete_quotient.
       apply E2; rewrite E1; auto.
     Qed.
 
-    Let H2 s v : In s lr -> fom_rels M s v <-> fom_rels Md s (vec_map cls v).
+    Let H2 r v : r ∊ lr -> fom_rels M r v <-> fom_rels Md r (vec_map cls v).
     Proof.
       intros Hs; simpl.
       apply fom_eq_rels_full; auto.
@@ -517,10 +502,9 @@ Section discrete_quotient.
     Let f : fo_projection ls lr M Md.
     Proof. exists cls repr; auto. Defined.
 
-    Let H3 A phi : incl (fol_syms A) ls 
-                -> incl (fol_rels A) lr
-                -> fol_sem M phi A 
-               <-> fol_sem Md (fun n => cls (phi n)) A.
+    Let H3 φ ρ :   fol_syms φ ⊑ ls 
+                -> fol_rels φ ⊑ lr
+                -> M,ρ ⊨ φ <-> Md,cls∘ρ ⊨ φ.
     Proof. intros; apply fo_model_projection with (p := f); auto. Qed.
 
     Let H4 p q : fo_bisimilar Md p q <-> p = q.
@@ -529,8 +513,8 @@ Section discrete_quotient.
       + intros H.
         rewrite <- (E1 q), <- (E1 p).
         apply E2, fom_eq_fol_characterization.
-        intros A phi Hs Hr.
-        specialize (H A (fun p => cls (phi p)) Hs Hr).
+        intros A Hs Hr phi.
+        specialize (H A Hs Hr (fun p => cls (phi p))).
         revert H; apply fol_equiv_impl.
         all: rewrite H3; auto; apply fol_sem_ext; intros []; now simpl.
       + intros []; red; tauto.
@@ -552,41 +536,118 @@ Section discrete_quotient.
       intros x y; simpl; apply dec.
     Qed.
 
-  End build_the_model.
+  End build_the_discrete_model.
+
+  (** Additional results on FO definability *)
+
+  Section FO_definability.
+
+    (* Because the fixpoint is reached after finitely many iterations, it is FO definable *)
+
+    Local Fact fom_eq_finite : { n | forall x y, x ≡ y <-> iter fom_op (fun _ _ => True) n x y }.
+    Proof. apply gfp_finite_t; eauto. Qed.
+
+    Theorem fo_bisimilar_fol_def : fol_definable ls lr M (fun φ => φ 0 ≐ φ 1).
+    Proof.
+      destruct fom_eq_finite as (n & Hn).
+      apply fol_def_equiv with (R := fun φ => iter fom_op (fun _ _ : X => True) n (φ 0) (φ 1)).
+      + intro; rewrite <- fom_eq_fol_characterization, <- Hn; tauto.
+      + apply fol_def_iter_fom_op; fol def.
+    Qed.
+
+  End FO_definability.
+
+  (** We have a much stronger statement than the decidability of ≐.
+      In fact ≐ is first order definable and this follows from the 
+      fact that X/M is finite *)
+
+  Section fo_bisimilar_formula.
+
+    (* We build a single FO formula with two variables 
+        such that:
+          a) ξ(.,.) only has two free variables, 0 and 1 
+          b) ξ is built using only symbols in ls and lr
+          c) ξ characterize bisimilarity upto ls/lr 
+
+                  x ≐ y <-> x ≡ y <-> ξ(x,y) 
+     *)
+
+    Let A := proj1_sig fo_bisimilar_fol_def.
+
+    (* Let use remove unused variables by mapping them to £0 *) 
+    
+    Definition fo_bisimilar_formula := fol_subst (fun n => match n with 0 => £1 | _ => £0 end) A.
+
+    Notation ξ := fo_bisimilar_formula.
+
+    Fact fo_bisimilar_formula_vars : fol_vars ξ ⊑ 0::1::nil.
+    Proof.
+      unfold fo_bisimilar_formula; rewrite fol_vars_subst.
+      intros n; rewrite in_flat_map; intros (? & _ & H).
+      revert x H; intros [ | [] ]; simpl; tauto.
+    Qed.
+
+    Fact fo_bisimilar_formula_syms : fol_syms ξ ⊑ ls.
+    Proof.
+      unfold fo_bisimilar_formula; red.
+      apply Forall_forall, fol_syms_subst.
+      + intros [ | []]; rew fot; auto.
+      + apply Forall_forall, (proj2_sig fo_bisimilar_fol_def).
+    Qed.
+
+    Fact fo_bisimilar_formula_rels : fol_rels ξ ⊑ lr.
+    Proof.
+      unfold fo_bisimilar_formula; rewrite fol_rels_subst.
+      apply (proj2_sig fo_bisimilar_fol_def).
+    Qed.
+
+    Fact fo_bisimilar_formula_sem φ x y : M,y·x·φ ⊨ ξ <-> x ≐ y.
+    Proof.
+      unfold fo_bisimilar_formula; rewrite fol_sem_subst.
+      apply (proj2_sig fo_bisimilar_fol_def).
+    Qed.
+
+  End fo_bisimilar_formula.
 
 End discrete_quotient.
 
+Import ListNotations.
+
 Section counter_model_to_class_FO_definability.
 
-  (* We show that there is a model over Σ = Σrel 2 = {ø,{=²}}
-      where ≡ is identity but x ≡ _ is not definable by a
-      FO formula with a single free variable 
+  (* Even though ≐ is FO definable, its equivalence classes are not *)
 
-      There are two non equivalent values that cannot be
+  (* We show that there is a model over Σ = Σrel 2 = {ø,{=²}}
+      where bisimulation ≐ is identity but x ≐ _ is not definable 
+      by a FO formula with a single free variable 
+
+      There are two non-equivalent values that cannot be
       distinguished when using a single variable
 
-      Even though ≡ is FO definable by a formula with two
-      free variables, equivalences classes of ≡ are not 
+      Even though ≐ is FO definable by a formula with two
+      free variables, equivalences classes of ≐ are not 
       FO definable *)
 
   Let Σ := Σrel 2.
 
   Let M : fo_model Σ bool.
   Proof.
-    exists.
+    exists; simpl.
     + intros [].
-    + intros []; simpl.
-      exact (rel2_on_vec eq).
+    + exact (fun _ => rel2_on_vec eq).
   Defined.
 
   Let M_dec : fo_model_dec M.
   Proof. intros [] ?; apply bool_dec. Qed.
 
-  (* A projection of M onto itself which swaps true <-> false *)
+  Notation α := true.
+  Notation β := false.
 
-  Let f : @fo_projection Σ nil (tt::nil) _ M _ M.
+  (* A projection of M onto itself which swaps α/β *)
+
+  Let f : @fo_projection Σ [] [tt] _ M _ M.
   Proof.
-    exists negb negb.
+    exists negb negb; simpl.
     + intros []; auto.
     + intros [].
     + intros [] v _; simpl.
@@ -594,49 +655,71 @@ Section counter_model_to_class_FO_definability.
       revert x y; now intros [] [].
   Defined.
 
-  Notation "⟪ A ⟫" := (fun φ => fol_sem M φ A).
-
-  Let homeomorphism (A : fol_form Σ) phi : 
-        ⟪A⟫ phi <-> ⟪A⟫ (fun x=> negb (phi x)).
+  Let homeomorphism φ ρ : M,ρ ⊨ φ <-> M,negb∘ρ ⊨ φ.
   Proof.
     apply fo_model_projection with (p := f); auto.
     all: intros []; simpl; auto.
   Qed.
 
-  Infix "≡" := (fom_eq (Σ := Σ) nil (tt::nil) M) (at level 70, no associativity).
+  Infix "≐" := (fo_bisimilar (Σ := Σ) nil [tt] M) (at level 70, no associativity).
 
   Hint Resolve finite_t_bool : core.
 
-  Let true_is_not_false : ~ true ≡ false.
+  (* α/true and β/false are not bisimilar *)
+
+  Let true_is_not_false : ~ α ≐ β.
   Proof.
     intros H.
-    apply fom_eq_fol_characterization in H; auto.
-    specialize (H (@fol_atom Σ tt (£0##£1##ø)) (fun n => match n with 0 => true | _ => false end)).
+    specialize (H (@fol_atom Σ tt (£0##£1##ø)) (incl_refl _) (incl_refl _)
+                  (fun n => match n with 0 => true | _ => false end)).
     revert H; unfold M; simpl; rew fot; simpl.
     intros [H _]; cbv; auto.
     specialize (H eq_refl); discriminate.
   Qed.
 
-  Let no_disctinct A phi : (forall n, In n (fol_vars A) -> n = 0)
-                        -> ⟪A⟫ true·phi <-> ⟪A⟫ false·phi.
+  Let bisim_is_identity x y : x ≐ y <-> x = y.
   Proof.
-    intros H.
-    set (psi n := negb (phi n)).
-    rewrite homeomorphism with (phi := false·phi) at 1.
-    apply fol_sem_ext.
-    intros n Hn; apply H in Hn; subst; auto.
+    split.
+    2: intros ->; apply fo_bisimilar_refl.
+    revert x y; intros [] [] H; auto.
+    + destruct true_is_not_false; auto.
+    + apply fo_bisimilar_sym, true_is_not_false in H as [].
+  Qed. 
+
+  (* No formula using only variable 0 can distinguish α from β *)
+
+  Let no_distinct φ ρ x y : fol_vars φ ⊑ [0] -> M,x·ρ ⊨ φ <-> M,y·ρ ⊨ φ.
+  Proof.
+    set (δ := negb∘ρ).
+    revert x y; intros [] [] H; try tauto.
+    + rewrite homeomorphism with (ρ := β·ρ) at 1.
+      apply fol_sem_ext.
+      intros n Hn; apply H in Hn as [ [] | [] ]; auto.
+    + rewrite homeomorphism with (ρ := α·ρ) at 1.
+      apply fol_sem_ext.
+      intros n Hn; apply H in Hn as [ [] | [] ]; auto.
   Qed.
 
-  (* There is a model over Σ2 with two values such that no
-      FO formula with one free variable can distinguish those 
-      two values, but there is a FO formula with 2 free variables
-      that distinguishes them *)
+  (** There is a (discrete, finite, decidable) model M over Σ2 with 
+      two values α and β such that:
+       1) FO bisimilarity (up to all symbols) is equivalent to identity
+       2) no FO formula with one free variable can distinguish the elements
+          of M, in particular distinguish α from β;
+       3) there is a FO ξ(.,.) with 2 free variables that distinguishes
+          a from b, i.e. ξ(α,α) and not ξ(β,α) (hence particular, α <> β).
+   *)
 
   Theorem FO_does_not_characterize_classes :
-     exists (M : fo_model Σ bool) (_ : fo_model_dec M) (x y : bool), 
-            ~ fom_eq (Σ := Σ) nil (tt::nil) M x y
-         /\ forall A φ, (forall n, In n (fol_vars A) -> n = 0) 
-                     -> fol_sem M x·φ A <-> fol_sem M y·φ A.
-  Proof. exists M, M_dec, true, false; auto. Qed.
+     exists (M : fo_model Σ bool) (_ : fo_model_dec M) (a b : bool), 
+              (forall x y, fo_bisimilar (Σ := Σ) nil [tt] M x y <-> x = y)
+           /\ (forall x y φ ρ, fol_vars φ ⊑ [0] -> M,x·ρ ⊨ φ <-> M,y·ρ ⊨ φ)
+           /\ exists φ, fol_vars φ ⊑ [0;1] /\ forall ρ, M,a·a·ρ ⊨ φ /\ ~ M,b·a·ρ ⊨ φ.
+  Proof. 
+    exists M, M_dec, true, false; msplit 2; auto. 
+    exists (fo_bisimilar_formula (Σ := Σ) nil [tt] finite_t_bool M_dec); split.
+    + apply fo_bisimilar_formula_vars.
+    + intro; rewrite !fo_bisimilar_formula_sem; split; auto; intro; tauto.
+  Qed.
 
 End counter_model_to_class_FO_definability.
+

--- a/theories/TRAKHTENBROT/fo_congruence.v
+++ b/theories/TRAKHTENBROT/fo_congruence.v
@@ -93,7 +93,7 @@ Section fol_congruence.
     Proof.
       unfold fol_vec_equiv.
       rewrite fol_sem_vec_fa.
-      apply forall_equiv; intros p; rew vec.
+      fol equiv; intros p; rew vec.
       rewrite fol_sem_e; simpl; tauto.
     Qed.
 
@@ -148,14 +148,14 @@ Section fol_congruence.
       Proof.
         unfold congr_syms.
         rewrite fol_sem_mforall.
-        apply forall_equiv; intros v.
+        fol equiv; intros v.
         rewrite fol_sem_mforall.
-        apply forall_equiv; intros w.
+        fol equiv; intros w.
         rewrite fol_sem_bin_fix.
-        apply (fol_bin_sem_ext fol_imp).
+        fol equiv imp.
         + unfold A; rewrite fol_vec_equiv_sem.
-          apply forall_equiv; intros p; rew vec; simpl.
-          apply fol_equiv_ext; repeat f_equal.
+          fol equiv; intros p; rew vec; simpl.
+          fol equiv; repeat f_equal.
           * rewrite env_vlift_fix1, env_vlift_fix0; auto.
           * rewrite env_vlift_fix0; auto.
         + unfold B.
@@ -230,17 +230,17 @@ Section fol_congruence.
       Proof.
         unfold congr_rels.
         rewrite fol_sem_mforall.
-        apply forall_equiv; intros v.
+        fol equiv; intros v.
         rewrite fol_sem_mforall.
-        apply forall_equiv; intros w.
+        fol equiv; intros w.
         simpl fol_sem at 1.
-        apply (fol_bin_sem_ext fol_imp).
+        fol equiv.
         + unfold A; rewrite fol_vec_equiv_sem.
-          apply forall_equiv; intros p; rew vec; simpl.
-          apply fol_equiv_ext; repeat f_equal.
+          fol equiv; intros p; rew vec; simpl.
+          fol equiv; repeat f_equal.
           * rewrite env_vlift_fix1, env_vlift_fix0; auto.
           * rewrite env_vlift_fix0; auto.
-        + apply fol_equiv_sem_ext; apply fol_equiv_ext; f_equal;
+        + fol equiv iff; fol equiv; f_equal;
             apply vec_pos_ext; intros p; rew vec; rew fot.
           * rewrite env_vlift_fix1, env_vlift_fix0; auto.
           * rewrite env_vlift_fix0; auto.
@@ -299,7 +299,7 @@ Section fol_congruence.
       unfold fol_congruent.
       rewrite fol_sem_bin_fix.
       do 2 rewrite fol_sem_lconj.
-      apply (fol_bin_sem_ext fol_conj).
+      fol equiv conj.
       + split.
         * intros H s Hs.
           apply (congr_syms_spec _ φ), H, in_map_iff.
@@ -336,7 +336,7 @@ Section fol_congruence.
     Proof.
       unfold fol_equivalence.
       repeat (rewrite fol_sem_bin_fix).
-      repeat apply fol_bin_sem_ext.
+      repeat fol equiv conj.
       + rewrite fol_sem_quant_fix; apply forall_equiv; intro.
         rewrite fol_sem_e; simpl; tauto.
       + do 3 (rewrite fol_sem_quant_fix; apply forall_equiv; intro).
@@ -378,7 +378,7 @@ Section fol_congruence.
          <-> Σ_congruence_wrt ls lr M (fun x y => x ≈ y)
           /\ equiv _ (fun x y => x ≈ y).
     Proof.
-      apply fol_bin_sem_ext.
+      fol equiv conj.
       + apply fol_congruent_spec.
       + apply fol_equiv_spec.
     Qed.

--- a/theories/TRAKHTENBROT/fo_congruence.v
+++ b/theories/TRAKHTENBROT/fo_congruence.v
@@ -20,6 +20,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Notation ø := vec_nil.
+
 (* * First order theory of congruences *)
 
 Section congruence.

--- a/theories/TRAKHTENBROT/fo_congruence.v
+++ b/theories/TRAKHTENBROT/fo_congruence.v
@@ -20,6 +20,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
 Local Notation ø := vec_nil.
 
 (* * First order theory of congruences *)
@@ -33,9 +35,9 @@ Section congruence.
   Infix "≈" := R.
 
   Definition Σ_congruence_wrt :=
-          (forall s, In s ls -> forall v w, (forall p, vec_pos v p ≈ vec_pos w p) 
+          (forall s, s ∊ ls -> forall v w, (forall p, vec_pos v p ≈ vec_pos w p) 
                                           -> fom_syms M s v ≈ fom_syms M s w)
-       /\ (forall r, In r lr -> forall v w, (forall p, vec_pos v p ≈ vec_pos w p) 
+       /\ (forall r, r ∊ lr -> forall v w, (forall p, vec_pos v p ≈ vec_pos w p) 
                                           -> fom_rels M r v <-> fom_rels M r w).
 
 End congruence.
@@ -44,7 +46,7 @@ Section fol_congruence.
 
   Variables (Σ : fo_signature) (e : rels Σ) (H_ae : ar_rels _ e = 2)
             (ls : list (syms Σ)) (lr : list (rels Σ))
-            (He : In e lr). 
+            (He : e ∊ lr). 
 
   Notation 𝕋 := (fol_term Σ).
   Notation 𝔽 := (fol_form Σ).
@@ -68,7 +70,7 @@ Section fol_congruence.
 
     Local Definition fol_vec_equiv n := fol_vec_fa (vec_set_pos (fun p : pos n => £(pos2nat p+n) ≡ £(pos2nat p))).
 
-    Local Fact fol_vec_equiv_syms n : incl (fol_syms (fol_vec_equiv n)) nil.
+    Local Fact fol_vec_equiv_syms n : fol_syms (fol_vec_equiv n) ⊑ nil.
     Proof. 
       unfold fol_vec_equiv.
       rewrite fol_syms_vec_fa.
@@ -79,7 +81,7 @@ Section fol_congruence.
       rew vec; rewrite fol_syms_e; simpl; tauto.
     Qed.
 
-    Local Fact fol_vec_equiv_rels n : incl (fol_rels (fol_vec_equiv n)) (e::nil).
+    Local Fact fol_vec_equiv_rels n : fol_rels (fol_vec_equiv n) ⊑ e::nil.
     Proof. 
       unfold fol_vec_equiv.
       rewrite fol_rels_vec_fa.
@@ -110,10 +112,10 @@ Section fol_congruence.
       Let g : 𝕋 := in_fot s (vec_set_pos (fun p => £(pos2nat p+n))).
       Let B := g ≡ f.
 
-      Let HrA : incl (fol_syms A) nil.       Proof. apply fol_vec_equiv_syms. Qed.
-      Let HsA : incl (fol_rels A) (e::nil).  Proof. apply fol_vec_equiv_rels. Qed.
+      Let HrA : fol_syms A ⊑ nil.     Proof. apply fol_vec_equiv_syms. Qed.
+      Let HsA : fol_rels A ⊑ e::nil.  Proof. apply fol_vec_equiv_rels. Qed.
 
-      Let HrB : incl (fol_syms B) (s::nil).
+      Let HrB : fol_syms B ⊑ s::nil.
       Proof.
         unfold B; simpl.
         rewrite H_ae; unfold eq_rect_r.
@@ -123,12 +125,12 @@ Section fol_congruence.
           apply vec_list_inv in H; destruct H as (p & ->); rew vec.
       Qed.
 
-      Let HsB : incl (fol_rels B) (e::nil).
+      Let HsB : fol_rels B ⊑ e::nil.
       Proof. simpl; cbv; tauto. Qed.
 
       Local Definition congr_syms : 𝔽 := fol_mquant fol_fa n (fol_mquant fol_fa n (A ⤑  B)).
 
-      Local Fact congr_syms_syms : incl (fol_syms congr_syms) (s::nil).
+      Local Fact congr_syms_syms : fol_syms congr_syms ⊑ s::nil.
       Proof.
         unfold congr_syms.
         do 2 rewrite fol_syms_mquant.
@@ -136,7 +138,7 @@ Section fol_congruence.
         apply incl_app; auto.
       Qed.
 
-      Local Fact congr_syms_rels : incl (fol_rels congr_syms) (e::nil).
+      Local Fact congr_syms_rels : fol_rels congr_syms ⊑ e::nil.
       Proof.
         unfold congr_syms.
         do 2 rewrite fol_rels_mquant.
@@ -180,10 +182,10 @@ Section fol_congruence.
       Let B := @fol_atom Σ r (vec_set_pos (fun p => £(pos2nat p))).
       Let C := @fol_atom Σ r (vec_set_pos (fun p => £(pos2nat p+n))).
 
-      Let HsA : incl (fol_syms A) nil.       Proof. apply fol_vec_equiv_syms. Qed.
-      Let HrA : incl (fol_rels A) (e::nil).  Proof. apply fol_vec_equiv_rels. Qed.
+      Let HsA : fol_syms A ⊑ nil.     Proof. apply fol_vec_equiv_syms. Qed.
+      Let HrA : fol_rels A ⊑ e::nil.  Proof. apply fol_vec_equiv_rels. Qed.
 
-      Let HsB : incl (fol_syms B) nil.
+      Let HsB : fol_syms B ⊑ nil.
       Proof.
         unfold B; simpl.
         intros x; rewrite in_flat_map.
@@ -191,10 +193,10 @@ Section fol_congruence.
         apply vec_list_inv in H; destruct H as (p & ->); rew vec.
       Qed.
 
-      Let HrB : incl (fol_rels B) (r::nil).
+      Let HrB : fol_rels B ⊑ r::nil.
       Proof. simpl; cbv; tauto. Qed.
 
-      Let HsC : incl (fol_syms C) nil.
+      Let HsC : fol_syms C ⊑ nil.
       Proof. 
         unfold C; simpl.
         intros x; rewrite in_flat_map.
@@ -203,12 +205,12 @@ Section fol_congruence.
         destruct Ht as (p & ->); rew vec; simpl; tauto.
       Qed.
 
-      Let HrC : incl (fol_rels C) (e::r::nil).
+      Let HrC : fol_rels C ⊑ e::r::nil.
       Proof. simpl; cbv; tauto. Qed.
 
       Local Definition congr_rels : 𝔽 := fol_mquant fol_fa n (fol_mquant fol_fa n (A ⤑  (C ↔ B))).
 
-      Local Fact congr_rels_syms : incl (fol_syms congr_rels) nil.
+      Local Fact congr_rels_syms : fol_syms congr_rels ⊑ nil.
       Proof.
         unfold congr_rels.
         do 2 rewrite fol_syms_mquant.
@@ -216,7 +218,7 @@ Section fol_congruence.
         repeat (apply incl_app; auto).
       Qed.
 
-      Local Fact congr_rels_rels : incl (fol_rels congr_rels) (e::r::nil).
+      Local Fact congr_rels_rels : fol_rels congr_rels ⊑ e::r::nil.
       Proof.
         unfold congr_rels.
         do 2 rewrite fol_rels_mquant.
@@ -254,7 +256,7 @@ Section fol_congruence.
         fol_lconj (map congr_syms ls) 
       ⟑ fol_lconj (map congr_rels lr).
 
-    Local Fact fol_congruent_syms : incl (fol_syms fol_congruent) ls.
+    Local Fact fol_congruent_syms : fol_syms fol_congruent ⊑ ls.
     Proof.
       unfold fol_congruent.
       rewrite fol_syms_bin.
@@ -272,7 +274,7 @@ Section fol_congruence.
         intros [].
     Qed.
 
-    Local Fact fol_congruent_rels : incl (fol_rels fol_congruent) lr.
+    Local Fact fol_congruent_rels : fol_rels fol_congruent ⊑ lr.
     Proof.
       unfold fol_congruent.
       rewrite fol_rels_bin.
@@ -330,7 +332,7 @@ Section fol_congruence.
       repeat rewrite fol_syms_e; auto.
     Qed.
 
-    Local Fact fol_equivalence_rels : incl (fol_rels fol_equivalence) (e::nil).
+    Local Fact fol_equivalence_rels : fol_rels fol_equivalence ⊑ e::nil.
     Proof. simpl; cbv; tauto. Qed.
   
     Fact fol_equiv_spec φ : 
@@ -357,14 +359,14 @@ Section fol_congruence.
           fol_congruent 
         ⟑ fol_equivalence.
 
-    Fact fol_congruence_syms : incl (fol_syms fol_congruence) ls.
+    Fact fol_congruence_syms : fol_syms fol_congruence ⊑ ls.
     Proof.
       unfold fol_congruence.
       rewrite fol_syms_bin, fol_equivalence_syms, <- app_nil_end.
       apply fol_congruent_syms.
     Qed.
 
-    Fact fol_congruence_rels : incl (fol_rels fol_congruence) lr.
+    Fact fol_congruence_rels : fol_rels fol_congruence ⊑ lr.
     Proof.
       unfold fol_congruence.
       rewrite fol_rels_bin.

--- a/theories/TRAKHTENBROT/fo_logic.v
+++ b/theories/TRAKHTENBROT/fo_logic.v
@@ -22,7 +22,10 @@ Set Implicit Arguments.
 
 (* * The syntax and semantics of FO logic *)
 
-Notation ø := vec_nil.
+Local Notation ø := vec_nil.
+
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
 
 Opaque fo_term_subst fo_term_map fo_term_sem.
 
@@ -84,7 +87,7 @@ Section fol_subst.
 
   Definition fol_vars_max A := lmax (fol_vars A).
 
-  Fact fol_vars_max_spec A n : In n (fol_vars A) -> n <= fol_vars_max A.
+  Fact fol_vars_max_spec A n : n ∊ fol_vars A -> n <= fol_vars_max A.
   Proof. apply lmax_prop. Qed.
 
   Fixpoint fol_syms (A : 𝔽) :=
@@ -125,7 +128,7 @@ Section fol_subst.
   where "A ⦃ σ ⦄" := (fol_subst σ A).
 
   Fact fol_subst_ext σ ρ A : 
-         (forall n, In n (fol_vars A) -> σ n = ρ n) 
+         (forall n, n ∊ fol_vars A -> σ n = ρ n) 
        -> A⦃σ⦄ = A⦃ρ⦄.
   Proof.
     intros Hfg; revert A σ ρ Hfg. 
@@ -167,7 +170,7 @@ Section fol_subst.
   Proof. rewrite fol_vars_subst, <- flat_map_single; auto. Qed.
 
   Fact fol_syms_subst P σ (A : 𝔽) : 
-        (forall n, In n (fol_vars A) -> Forall P (fo_term_syms (σ n)))  
+        (forall n, n ∊ fol_vars A -> Forall P (fo_term_syms (σ n)))  
      -> Forall P (fol_syms A) -> Forall P (fol_syms (A⦃σ⦄)).
   Proof.
     revert σ.
@@ -326,7 +329,7 @@ Section fol_semantics.
 
   (* Semantics depends only on occuring variables *)
 
-  Fact fol_sem_ext φ ψ A : (forall n, In n (fol_vars A) -> φ n = ψ n) -> ⟪A⟫ φ <-> ⟪A⟫ ψ.
+  Fact fol_sem_ext φ ψ A : (forall n, n ∊ fol_vars A -> φ n = ψ n) -> ⟪A⟫ φ <-> ⟪A⟫ ψ.
   Proof.
     intros H; revert A φ ψ H.
     induction A as [ | p v | b A IHA B IHB | q A IHA ]; simpl; intros phi psy H; try tauto.
@@ -390,7 +393,7 @@ Section fol_semantics.
 
   Definition fol_lift t n : 𝕋 := match n with 0 => t | S n => £n end.
 
-  Corollary fol_sem_lift φ t A : ⟪ A⦃fol_lift t⦄ ⟫ φ <-> ⟪A⟫ (⟦t⟧ φ)·φ.
+  Corollary fol_sem_lift φ t A : ⟪A⦃fol_lift t⦄⟫ φ <-> ⟪A⟫ (⟦t⟧ φ)·φ.
   Proof.
     rewrite fol_sem_subst.
     apply fol_sem_ext; intros [ | n ] _; simpl; rew fot; auto.
@@ -398,7 +401,7 @@ Section fol_semantics.
 
   (* Bigops, ie finitary conjunction and disjunction *)
 
-  Fact fol_sem_lconj lf φ : ⟪fol_lconj lf⟫ φ <-> forall f, In f lf -> ⟪ f ⟫ φ.
+  Fact fol_sem_lconj lf φ : ⟪fol_lconj lf⟫ φ <-> forall f, f ∊ lf -> ⟪f⟫ φ.
   Proof.
     induction lf as [ | f lf IHlf ]; simpl.
     + split; tauto.
@@ -409,16 +412,14 @@ Section fol_semantics.
   Qed.
 
   Fact fol_sem_lconj_app l m φ : 
-            ⟪ fol_lconj (l++m) ⟫ φ 
-        <-> ⟪ fol_lconj l ⟫ φ 
-         /\ ⟪ fol_lconj m ⟫ φ.
+         ⟪fol_lconj (l++m)⟫ φ <-> ⟪fol_lconj l⟫ φ /\ ⟪fol_lconj m⟫ φ.
   Proof.
-    do 3 rewrite fol_sem_lconj; split.
+    rewrite !fol_sem_lconj; split.
     + intros H; split; intros; apply H, in_app_iff; firstorder.
     + intros (H1 & H2) f; rewrite in_app_iff; firstorder.
   Qed.
 
-  Fact fol_sem_ldisj lf φ : ⟪fol_ldisj lf⟫ φ <-> exists f, In f lf /\ ⟪ f ⟫ φ.
+  Fact fol_sem_ldisj lf φ : ⟪fol_ldisj lf⟫ φ <-> exists f, f ∊ lf /\ ⟪f⟫ φ.
   Proof.
     induction lf as [ | f lf IHlf ]; simpl.
     + split; try tauto; intros ( ? & [] & _).
@@ -432,11 +433,9 @@ Section fol_semantics.
   Qed.
 
   Fact fol_sem_ldisj_app l m φ : 
-            ⟪ fol_ldisj (l++m) ⟫ φ 
-        <-> ⟪ fol_ldisj l ⟫ φ 
-         \/ ⟪ fol_ldisj m ⟫ φ.
+         ⟪fol_ldisj (l++m)⟫ φ <-> ⟪fol_ldisj l⟫ φ \/ ⟪fol_ldisj m⟫ φ.
   Proof.
-    do 3 rewrite fol_sem_ldisj; split.
+    rewrite !fol_sem_ldisj; split.
     + intros (f & H1 & H2); revert H1; rewrite in_app_iff; firstorder.
     + intros [ (? & ? & ?) | (? & ? & ?) ]; firstorder auto with *.
   Qed.
@@ -461,7 +460,7 @@ Section fol_semantics.
     rewrite app_nil_end; auto. 
   Qed.
  
-  Fact fol_sem_vec_fa n A φ : ⟪ @fol_vec_fa n A ⟫ φ <-> forall p, ⟪ vec_pos A p ⟫ φ.
+  Fact fol_sem_vec_fa n A φ : ⟪@fol_vec_fa n A⟫ φ <-> forall p, ⟪vec_pos A p⟫ φ.
   Proof.
     unfold fol_vec_fa; rewrite fol_sem_lconj; split.
     + intros H p; apply H, in_vec_list, in_vec_pos.
@@ -562,12 +561,12 @@ Section fo_model_simulation.
 
   Record fo_simulation := Mk_fo_simulation {
     fos_simul :> X -> Y -> Prop;
-    fos_syms  : forall s v w, In s ls 
+    fos_syms  : forall s v w, s ∊ ls 
                           -> (forall p, fos_simul (vec_pos v p) (vec_pos w p))
                           -> fos_simul (fom_syms M s v) (fom_syms N s w);
-    fos_rels  : forall s v w, In s lr 
+    fos_rels  : forall r v w, r ∊ lr 
                           -> (forall p, fos_simul (vec_pos v p) (vec_pos w p))
-                          -> fom_rels M s v <-> fom_rels N s w;
+                          -> fom_rels M r v <-> fom_rels N r w;
     fos_total : forall x, exists y, fos_simul x y;
     fos_surj  : forall y, exists x, fos_simul x y;
   }.
@@ -576,8 +575,8 @@ Section fo_model_simulation.
     fop_surj :> X -> Y; 
     fop_inj  : Y -> X;
     fop_eq   : forall x, fop_surj (fop_inj x) = x;
-    fop_syms : forall s v, In s ls -> fop_surj (fom_syms M s v) = fom_syms N s (vec_map fop_surj v);
-    fop_rels : forall s v, In s lr -> fom_rels M s v <-> fom_rels N s (vec_map fop_surj v);
+    fop_syms : forall s v, s ∊ ls -> fop_surj (fom_syms M s v) = fom_syms N s (vec_map fop_surj v);
+    fop_rels : forall r v, r ∊ lr -> fom_rels M r v <-> fom_rels N r (vec_map fop_surj v);
   }.
 
   Fact fo_proj_simul : fo_projection -> fo_simulation.
@@ -606,8 +605,8 @@ Section fo_model_simulation.
   (* The simulation lifts from variables to terms *)
 
   Let fo_term_simulation t φ ψ :
-           (forall n : nat, In n (fo_term_vars t) -> φ n ⋈ ψ n) 
-        -> incl (fo_term_syms t) ls
+           (forall n, n ∊ fo_term_vars t -> φ n ⋈ ψ n) 
+        -> fo_term_syms t ⊑ ls
         -> ⟦t⟧ φ ⋈ ⟦t⟧' ψ.
   Proof.
     revert φ ψ.
@@ -632,9 +631,9 @@ Section fo_model_simulation.
   (* We assume the simulation to be total and surjective *)
 
   Theorem fo_model_simulation A φ ψ :
-           incl (fol_syms A) ls
-        -> incl (fol_rels A) lr
-        -> (forall n : nat, In n (fol_vars A) -> φ n ⋈ ψ n) 
+           fol_syms A ⊑ ls
+        -> fol_rels A ⊑ lr
+        -> (forall n, n ∊ fol_vars A -> φ n ⋈ ψ n) 
         -> ⟪A⟫ φ <-> ⟪A⟫' ψ.
   Proof.
     revert φ ψ.
@@ -667,9 +666,9 @@ Section fo_model_simulation.
 End fo_model_simulation.
 
 Theorem fo_model_projection Σ ls lr X M Y N (p : @fo_projection Σ ls lr X M Y N) A φ ψ : 
-           (forall n, In n (fol_vars A) -> p (φ n) = ψ n)
-        -> incl (fol_syms A) ls 
-        -> incl (fol_rels A) lr
+           (forall n, n ∊ fol_vars A -> p (φ n) = ψ n)
+        -> fol_syms A ⊑ ls 
+        -> fol_rels A ⊑ lr
         -> fol_sem M φ A <-> fol_sem N ψ A.
 Proof.
   intros H1 H2 H3.
@@ -686,16 +685,16 @@ Section fo_model_projection.
            (X : Type) (M : fo_model Σ X) (φ : nat -> X) 
            (Y : Type) (N : fo_model Σ Y) (ψ : nat -> Y)
            (i : X -> Y) (j : Y -> X) (E : forall x, i (j x) = x)
-           (Hs : forall s v, In s ls -> i (fom_syms M s v) = fom_syms N s (vec_map i v))
-           (Hr : forall s v, In s lr -> fom_rels M s v <-> fom_rels N s (vec_map i v)).
+           (Hs : forall s v, s ∊ ls -> i (fom_syms M s v) = fom_syms N s (vec_map i v))
+           (Hr : forall r v, r ∊ lr -> fom_rels M r v <-> fom_rels N r (vec_map i v)).
   
   Let p : fo_projection ls lr M N.
   Proof. exists i j; auto. Defined.
 
   Theorem fo_model_projection' A : 
-           (forall n, In n (fol_vars A) -> i (φ n) = ψ n)
-        -> incl (fol_syms A) ls 
-        -> incl (fol_rels A) lr
+           (forall n, n ∊ fol_vars A -> i (φ n) = ψ n)
+        -> fol_syms A ⊑ ls 
+        -> fol_rels A ⊑ lr
         -> fol_sem M φ A <-> fol_sem N ψ A.
   Proof. apply fo_model_projection with (p := p). Qed.
 
@@ -707,7 +706,7 @@ Section fo_model_nosyms.
            (X : Type) (M M' : fo_model Σ X) (φ : nat -> X)
            (A : fol_form Σ)
            (HA : fol_syms A = nil)
-           (H : forall r v, In r (fol_rels A) -> fom_rels M r v <-> fom_rels M' r v).
+           (H : forall r v, r ∊ fol_rels A -> fom_rels M r v <-> fom_rels M' r v).
 
   Theorem fo_model_nosyms : fol_sem M φ A <-> fol_sem M' φ A.
   Proof.

--- a/theories/TRAKHTENBROT/fo_logic.v
+++ b/theories/TRAKHTENBROT/fo_logic.v
@@ -330,7 +330,7 @@ Section fol_semantics.
   Proof.
     intros H; revert A φ ψ H.
     induction A as [ | p v | b A IHA B IHB | q A IHA ]; simpl; intros phi psy H; try tauto.
-    + apply fol_equiv_ext; f_equal.
+    + fol equiv rel.
       apply vec_map_ext; intros w Hw. 
       apply fo_term_sem_ext; auto.
       intros n Hn; apply H, in_flat_map; exists w; split; auto.
@@ -376,7 +376,7 @@ Section fol_semantics.
   Theorem fol_sem_subst φ σ A : ⟪ A⦃σ⦄ ⟫ φ <-> ⟪A⟫ (fun n => ⟦σ n⟧ φ).
   Proof.
     revert φ σ; induction A as [ | p v | b A IHA B IHB | q A IHA ]; simpl; intros phi f; try tauto.
-    + apply fol_equiv_ext; f_equal.
+    + fol equiv rel.
       rewrite vec_map_map; apply vec_map_ext.
       intros; rewrite fo_term_sem_subst; auto.
     + apply fol_bin_sem_ext; auto.

--- a/theories/TRAKHTENBROT/fo_sat.v
+++ b/theories/TRAKHTENBROT/fo_sat.v
@@ -20,6 +20,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Notation ø := vec_nil.
+
 (* * Definition of first order satisfiability *)
 
 Section satisfiability.

--- a/theories/TRAKHTENBROT/fo_sat.v
+++ b/theories/TRAKHTENBROT/fo_sat.v
@@ -71,3 +71,11 @@ Section satisfiability.
 
 End satisfiability.
 
+Definition FSAT := @fo_form_fin_dec_SAT.
+Definition FSATEQ := @fo_form_fin_dec_eq_SAT.
+Definition FSAT' := @fo_form_fin_discr_dec_SAT.
+
+Arguments FSAT : clear implicits.
+Arguments FSAT' : clear implicits.
+
+

--- a/theories/TRAKHTENBROT/fo_sat_dec.v
+++ b/theories/TRAKHTENBROT/fo_sat_dec.v
@@ -23,6 +23,8 @@ Set Implicit Arguments.
 (* * Decidability results for FSAT *)
 
 Local Notation ø := vec_nil.
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
 
 Section FSAT_ext.
 
@@ -181,12 +183,17 @@ Section enum_models.
   Let model := { M : fo_model Σ X & 
                { _ : nat -> X & fo_model_dec M } }.
 
+  (* Equivalence of FO models over type X up-to the symbols in ls lr 
+     and the variables in ln,
+     ie same extensional interpretation of function symbols and 
+     equivalent interpretation of relations symbols *)
+
   Local Definition FO_model_equiv : model -> model -> Prop.
   Proof.
     intros ((s1,r1) & rho1 & H1 ) ((s2,r2) & rho2 & H2).
-    exact (  (forall s, In s ls -> forall v, s1 s v = s2 s v) 
-          /\ (forall r, In r lr -> forall v, @r1 r v <-> r2 r v) 
-          /\ (forall n, In n ln -> rho1 n = rho2 n) ).
+    exact (  (forall s, s ∊ ls -> forall v, s1 s v = s2 s v) 
+          /\ (forall r, r ∊ lr -> forall v, @r1 r v <-> r2 r v) 
+          /\ (forall n, n ∊ ln -> rho1 n = rho2 n) ).
   Defined.
 
   Let combine : (funs * rels * (nat -> X)) -> model.
@@ -194,6 +201,8 @@ Section enum_models.
     intros ((f,(g & Hg)),rho).
     exists {| fom_syms := f; fom_rels := g |}, rho; auto.
   Defined.
+
+  (* There are finitely many models upto equivalence *)
 
   Local Theorem finite_t_model_upto : finite_t_upto _ FO_model_equiv.
   Proof.
@@ -222,9 +231,9 @@ Section enum_models.
   
   Theorem FO_model_equiv_spec (M1 M2 : model) A : 
              FO_model_equiv M1 M2 
-          -> incl (fol_vars A) ln
-          -> incl (fol_syms A) ls
-          -> incl (fol_rels A) lr
+          -> fol_vars A ⊑ ln
+          -> fol_syms A ⊑ ls
+          -> fol_rels A ⊑ lr
           -> FO_sem M1 A <-> FO_sem M2 A.
   Proof.
     intros H1 H2 H3 H4.

--- a/theories/TRAKHTENBROT/fo_sat_dec.v
+++ b/theories/TRAKHTENBROT/fo_sat_dec.v
@@ -88,7 +88,7 @@ Section FSAT_ext.
     + intros s v _; simpl; do 2 f_equal.
       apply vec_pos_ext; intro; rew vec.
     + intros r v _; simpl.
-      apply fol_equiv_ext; f_equal.
+      fol equiv rel.
       apply vec_pos_ext; intro; rew vec.
   Defined.
   

--- a/theories/TRAKHTENBROT/fol_ops.v
+++ b/theories/TRAKHTENBROT/fol_ops.v
@@ -73,6 +73,25 @@ Qed.
 Notation forall_equiv := (@fol_quant_sem_ext _ fol_fa).
 Notation exists_equiv := (@fol_quant_sem_ext _ fol_ex).
 
+Tactic Notation "fol" "equiv" "fa" := apply forall_equiv.
+Tactic Notation "fol" "equiv" "ex" := apply exists_equiv.
+Tactic Notation "fol" "equiv" "iff" := apply fol_equiv_sem_ext.
+Tactic Notation "fol" "equiv" "conj" := apply (fol_bin_sem_ext fol_conj).
+Tactic Notation "fol" "equiv" "disj" := apply (fol_bin_sem_ext fol_disj).
+Tactic Notation "fol" "equiv" "imp" := apply (fol_bin_sem_ext fol_imp).
+Tactic Notation "fol" "equiv" "rel" := apply fol_equiv_ext; f_equal.
+
+Tactic Notation "fol" "equiv" :=
+  match goal with
+    | |- (forall _, _) <-> (forall _, _) => fol equiv fa
+    | |- (exists _, _) <-> (exists _, _) => fol equiv ex
+    | |- ( _ <-> _) <-> (_ <-> _) => fol equiv iff
+    | |- ( _ \/ _) <-> (_ \/ _) => fol equiv disj
+    | |- ( _ /\ _) <-> (_ /\ _) => fol equiv conj
+    | |- ( _ -> _) <-> (_ -> _) => fol equiv imp
+    | |- ?r _ _ <-> ?r _ _ => fol equiv rel
+  end.
+
 Fact forall_list_sem_dec X (P : X -> Prop) (l : list X) :  
        (forall x, { P x } + { ~ P x }) 
     -> { forall x, In x l -> P x } + { ~ forall x, In x l -> P x }.

--- a/theories/TRAKHTENBROT/gfp.v
+++ b/theories/TRAKHTENBROT/gfp.v
@@ -200,7 +200,7 @@ Section gfp.
 
   Variable HF6 : finite_t M.     (* Finiteness of the domain *)
 
-  (* When M is finite, there is a list [T1;...;Tk] of relations of
+  (** When M is finite, there is a list [T1;...;Tk] of relations of
       type M -> M -> Prop which contains every weakly decidable relations 
       upto equivalence. 
 

--- a/theories/TRAKHTENBROT/hfs.v
+++ b/theories/TRAKHTENBROT/hfs.v
@@ -365,7 +365,7 @@ Section hfs.
   (* For the non-empty finite type pos (S n), there is a computably
       surjective map from a transitive set l onto pos (S n) 
 
-      The case of the empty model is rules out in our case
+      The case of the empty model is ruled out in our case
       because we always need to be able to interpret some variable
       in unscoped De Bruijn syntax
     *)
@@ -479,8 +479,7 @@ Section hfs.
   Proof.
     unfold hfs_opair.
     intros H.
-    apply hfs_pair_inj in H.
-    destruct H as [ (H1 & H2) | (H1 & H2) ];
+    apply hfs_pair_inj in H as [ (H1 & H2) | (H1 & H2) ];
       apply hfs_pair_inj in H1; apply hfs_pair_inj in H2; 
       revert H1 H2;
       do 2 intros [ [] | [] ]; subst; auto.

--- a/theories/TRAKHTENBROT/hfs.v
+++ b/theories/TRAKHTENBROT/hfs.v
@@ -440,6 +440,13 @@ Section hfs.
     rewrite hfs_empty_spec; tauto.
   Qed.
 
+  Fact hfs_pair_spec' p r s : p = hfs_pair r s <-> (forall x, x ∈ p <-> x = r \/ x = s).
+  Proof.
+    rewrite hfs_mem_ext.
+    apply (fol_quant_sem_ext fol_fa); intro.
+    rewrite hfs_pair_spec; tauto.
+  Qed.
+
   Opaque hfs_pair.
 
   Fact hfs_pair_pow r s t : r ∈ t -> s ∈ t -> hfs_pair r s ∈ hfs_pow t.
@@ -490,6 +497,14 @@ Section hfs.
     split.
     + apply hfs_opair_inj.
     + intros [ [] [] ]; auto.
+  Qed.
+
+  Fact hfs_opair_spec' p x y : p = ⟬x,y⟭ <-> exists a b, a = hfs_pair x x 
+                                                     /\ b = hfs_pair x y
+                                                     /\ p = hfs_pair a b.
+  Proof.
+    unfold hfs_opair; split; eauto.
+    intros (? & ? & -> & -> & ->); auto.
   Qed.
 
   Fixpoint hfs_tuple n (v : vec hfs n) :=

--- a/theories/TRAKHTENBROT/hfs.v
+++ b/theories/TRAKHTENBROT/hfs.v
@@ -158,7 +158,7 @@ Section hfs.
   Proof.
     unfold hfs_cons.
     rewrite btm_repr_cls; btm simpl.
-    apply (fol_bin_sem_ext fol_disj).
+    fol equiv.
     + rewrite <- bt_cls_hfs_repr_iff, bt_cls_hfs_repr; tauto.
     + tauto.
   Qed.
@@ -184,7 +184,7 @@ Section hfs.
           right; exists y; auto. }
     destruct H as (s & Hs).
     exists s; intro a; rewrite Hs.
-    apply exists_equiv; intro; rewrite Hl; tauto.
+    fol equiv; intro; rewrite Hl; tauto.
   Qed.
 
   (* This is the decidable comprehension *)  
@@ -443,7 +443,7 @@ Section hfs.
   Fact hfs_pair_spec' p r s : p = hfs_pair r s <-> (forall x, x ∈ p <-> x = r \/ x = s).
   Proof.
     rewrite hfs_mem_ext.
-    apply (fol_quant_sem_ext fol_fa); intro.
+    fol equiv; intro.
     rewrite hfs_pair_spec; tauto.
   Qed.
 

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -104,13 +104,13 @@ Section membership.
   Notation "p ≋ ⦃ a , b ⦄" := (mb_is_pair p a b).
 
   Fact mb_is_pair_comm p x y : p ≋ ⦃x,y⦄ -> p ≋ ⦃y,x⦄.
-  Proof. unfold mb_is_pair; apply forall_equiv; intro; tauto. Qed.
+  Proof. unfold mb_is_pair; fol equiv fa; intro; tauto. Qed.
 
   Add Parametric Morphism: (mb_is_pair) with signature 
      (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (iff) as mb_is_pair_congruence.
   Proof.
     intros p q H1 x x' H2 y y' H3.
-    apply forall_equiv; intros a.
+    fol equiv fa; intro.
     rewrite H1, H2, H3; tauto.
   Qed.
 
@@ -144,7 +144,7 @@ Section membership.
      (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (iff) as mb_is_opair_congruence.
   Proof.
     intros p q H1 x x' H2 y y' H3.
-    do 2 (apply exists_equiv; intros ?).
+    do 2 (fol equiv ex; intro).
     rewrite H1, H2, H3; tauto.
   Qed.
 
@@ -454,17 +454,16 @@ Section FOL_encoding.
         simpl Σ2_is_tuple.
         simpl mb_is_tuple.
         rewrite fol_sem_quant_fix.
-        apply (fol_quant_sem_ext fol_ex); intros y.
+        fol equiv ex; intros y.
         rewrite fol_sem_bin_fix.
-        apply fol_bin_sem_ext.
+        fol equiv conj.
         * reflexivity.
         * rewrite IHn, vec_map_map; reflexivity. 
     Qed.
 
     Fact Σ2_is_tuple_in_spec r n v ψ : ⟪@Σ2_is_tuple_in r n v⟫ ψ <-> mb_is_tuple_in mem (ψ r) (vec_map ψ v).
     Proof.
-      simpl; apply (fol_quant_sem_ext fol_ex); intros y.
-      apply (fol_bin_sem_ext fol_conj).
+      simpl; fol equiv ex; intro; fol equiv conj.
       + rewrite Σ2_is_tuple_spec, vec_map_map; simpl; reflexivity.
       + reflexivity.
     Qed.
@@ -473,19 +472,17 @@ Section FOL_encoding.
     Proof.
       unfold Σ2_has_tuples.
       rewrite fol_sem_mforall.
-      apply (fol_quant_sem_ext fol_fa); intros v.
+      fol equiv fa; intros v.
       rewrite fol_sem_bin_fix.
-      apply (fol_bin_sem_ext fol_imp).
+      fol equiv imp.
       + rewrite fol_sem_vec_fa.
-        apply (fol_quant_sem_ext fol_fa); intros p.
-        rew vec.
-        simpl.
-        rewrite env_vlift_fix0, env_vlift_fix1.
-        reflexivity.
+        fol equiv; intros p.
+        rew vec; simpl.
+        now rewrite env_vlift_fix0, env_vlift_fix1.
       + rewrite fol_sem_quant_fix.
-        apply (fol_quant_sem_ext fol_ex); intros x.
+        fol equiv ex; intros x.
         rewrite Σ2_is_tuple_spec; simpl.
-        apply fol_equiv_ext; f_equal.
+        fol equiv rel.
         apply vec_pos_ext; intros p.
         rew vec; simpl.
         rewrite env_vlift_fix0; auto.
@@ -498,23 +495,23 @@ Section FOL_encoding.
     Proof. 
       unfold Σ2_is_tot, mb_is_tot.
       rewrite fol_sem_mforall.
-      apply forall_equiv; intros v.
+      fol equiv; intros v.
       rewrite fol_sem_bin_fix.
-      apply (fol_bin_sem_ext fol_imp).
+      fol equiv imp.
       + rewrite fol_sem_vec_fa.
-        apply forall_equiv; intros p.
-        rew vec. 
-        simpl; rewrite env_vlift_fix0, env_vlift_fix1; tauto.
-      + rewrite fol_sem_quant_fix; apply exists_equiv; intros x.
-        rewrite fol_sem_quant_fix; apply exists_equiv; intros p.
-        rewrite fol_sem_quant_fix; apply exists_equiv; intros t.
+        fol equiv; intros p.
+        rew vec; simpl. 
+        rewrite env_vlift_fix0, env_vlift_fix1; tauto.
+      + rewrite fol_sem_quant_fix; fol equiv ex; intros x.
+        rewrite fol_sem_quant_fix; fol equiv ex; intros p.
+        rewrite fol_sem_quant_fix; fol equiv ex; intros t.
         do 3 (rewrite fol_sem_bin_fix).
-        repeat apply (fol_bin_sem_ext fol_conj).
+        repeat fol equiv conj.
         * simpl; rewrite env_vlift_fix1; tauto.
         * simpl; rewrite env_vlift_fix1; tauto.
         * rewrite Σ2_is_opair_spec; simpl; tauto.
         * rewrite Σ2_is_tuple_spec; simpl.
-          apply fol_equiv_ext; f_equal.
+          fol equiv.
           apply vec_pos_ext; intros q; rew vec.
           simpl; rewrite env_vlift_fix0; auto.
     Qed.

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -95,9 +95,13 @@ Section membership.
     + rewrite H1, H2; auto.
   Qed.
 
+  Reserved Notation "p ≋ ⦃ a , b ⦄" (at level 70, format "p  ≋  ⦃ a , b ⦄").
+  Reserved Notation "p ≋ ⦅ a , b ⦆" (at level 70, format "p  ≋  ⦅ a , b ⦆").
+  Reserved Notation "t ≋ ⦉ v ⦊" (at level 70, format "t  ≋  ⦉ v ⦊").
+
   Definition mb_is_pair p x y := forall a, a ∈ p <-> a ≈ x \/ a ≈ y.
 
-  Notation "p ≋ ⦃ a , b ⦄" := (mb_is_pair p a b) (at level 70, format "p  ≋  ⦃ a , b ⦄").
+  Notation "p ≋ ⦃ a , b ⦄" := (mb_is_pair p a b).
 
   Fact mb_is_pair_comm p x y : p ≋ ⦃x,y⦄ -> p ≋ ⦃y,x⦄.
   Proof. unfold mb_is_pair; apply forall_equiv; intro; tauto. Qed.
@@ -132,9 +136,9 @@ Section membership.
 
   (* Ordered pairs (x,y) := {{x},{x,y}}, Kuratowski encoding *)
 
-  Definition mb_is_opair p x y := exists a b, mb_is_pair a x x /\ mb_is_pair b x y /\ mb_is_pair p a b.
+  Definition mb_is_opair p x y := exists a b, a ≋ ⦃x,x⦄ /\ b ≋ ⦃x,y⦄ /\ p ≋ ⦃a,b⦄.
 
-  Notation "p ≋ ⦅ a , b ⦆" := (mb_is_opair p a b) (at level 70, format "p  ≋  ⦅ a , b ⦆").
+  Notation "p ≋ ⦅ a , b ⦆" := (mb_is_opair p a b).
 
   Add Parametric Morphism: (mb_is_opair) with signature 
      (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (iff) as mb_is_opair_congruence.
@@ -172,10 +176,9 @@ Section membership.
   Fixpoint mb_is_tuple t n (v : vec X n) :=
     match v with 
       | vec_nil => forall z, z ∉ t
-      | x##v    => exists t', mb_is_opair t x t' /\ mb_is_tuple t' v
-    end.
-
-  Notation "t ≋ ⦉ v ⦊" := (mb_is_tuple t v) (at level 70, format "t  ≋  ⦉ v ⦊").
+      | x##v    => exists t', t ≋ ⦅x,t'⦆ /\ t' ≋ ⦉v⦊
+    end
+  where "t ≋ ⦉ v ⦊" := (mb_is_tuple t v).
 
   Fact mb_is_tuple_congr p q n (v : vec X n) : p ≈ q -> p ≋ ⦉v⦊ -> q ≋ ⦉v⦊ .
   Proof.

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -20,6 +20,9 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "∊" := In (at level 70, no associativity).
+Local Infix "⊑" := incl (at level 70, no associativity). 
+
 (* * The first order theory of membership *)
 
 Section membership.
@@ -126,7 +129,9 @@ Section membership.
 
   Definition mb_is_pair p x y := forall a, a ∈ p <-> a ≈ x \/ a ≈ y.
 
-  Fact mb_is_pair_comm p x y : mb_is_pair p x y -> mb_is_pair p y x.
+  Notation "p ≋ ⦃ a , b ⦄" := (mb_is_pair p a b) (at level 70, format "p  ≋  ⦃ a , b ⦄").
+
+  Fact mb_is_pair_comm p x y : p ≋ ⦃x,y⦄ -> p ≋ ⦃y,x⦄.
   Proof. unfold mb_is_pair; apply forall_equiv; intro; tauto. Qed.
 
   Add Parametric Morphism: (mb_is_pair) with signature 
@@ -137,15 +142,16 @@ Section membership.
     rewrite H1, H2, H3; tauto.
   Qed.
 
-  Fact mb_is_pair_fun p q x y : mb_is_pair p x y -> mb_is_pair q x y -> p ≈ q.
+  Fact mb_is_pair_fun p q x y : p ≋ ⦃x,y⦄ -> q ≋ ⦃x,y⦄ -> p ≈ q.
   Proof. intros H1 H2; red in H1, H2; intro; rewrite H1, H2; tauto. Qed.
 
   (* Many cases here, automation helps !! *)
 
-  Fact mb_is_pair_inj p x y x' y' : mb_is_pair p x y 
-                                 -> mb_is_pair p x' y' 
-                                 -> x ≈ x' /\ y ≈ y'
-                                 \/ x ≈ y' /\ y ≈ x'.
+  Fact mb_is_pair_inj p x y x' y' : 
+         p ≋ ⦃x,y⦄  
+      -> p ≋ ⦃x',y'⦄ 
+      -> x ≈ x' /\ y ≈ y'
+      \/ x ≈ y' /\ y ≈ x'.
   Proof.
     unfold mb_is_pair; intros H1 H2.
     generalize (proj1 (H2 x)) (proj1 (H2 y)); rewrite H1, H1, mb_equiv_refl_True, mb_equiv_refl_True.
@@ -153,14 +159,10 @@ Section membership.
     intros [] [] [] []; auto.
   Qed.
 
-  Fact mb_is_pair_inj' p x y : mb_is_pair p x x 
-                            -> mb_is_pair p y y
-                            -> x ≈ y.
-  Proof.
-    intros H1 H2; generalize (mb_is_pair_inj H1 H2); tauto.
-  Qed.
+  Fact mb_is_pair_inj' p x y : p ≋ ⦃x,x⦄ -> p ≋ ⦃y,y⦄ -> x ≈ y.
+  Proof. intros H1 H2; generalize (mb_is_pair_inj H1 H2); tauto. Qed.
 
-  Fact mb_is_pair_dec p x y : { mb_is_pair p x y } + { ~ mb_is_pair p x y }.
+  Fact mb_is_pair_dec p x y : { p ≋ ⦃x,y⦄ } + { ~ p ≋ ⦃x,y⦄ }.
   Proof. 
     unfold mb_is_pair.
     apply (fol_quant_sem_dec fol_fa); auto; intros u.
@@ -170,9 +172,11 @@ Section membership.
 
   Hint Resolve mb_is_pair_dec : core.
 
-  (* Ordered pairs (x,y) := {{x},{x,y}}, Von Neuman encoding *)
+  (* Ordered pairs (x,y) := {{x},{x,y}}, Kuratowski encoding *)
 
   Definition mb_is_opair p x y := exists a b, mb_is_pair a x x /\ mb_is_pair b x y /\ mb_is_pair p a b.
+
+  Notation "p ≋ ⦅ a , b ⦆" := (mb_is_opair p a b) (at level 70, format "p  ≋  ⦅ a , b ⦆").
 
   Add Parametric Morphism: (mb_is_opair) with signature 
      (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (iff) as mb_is_opair_congruence.
@@ -183,7 +187,7 @@ Section membership.
     rewrite H1, H2, H3; tauto.
   Qed.
 
-  Fact mb_is_opair_fun p q x y : mb_is_opair p x y -> mb_is_opair q x y -> p ≈ q.
+  Fact mb_is_opair_fun p q x y : p ≋ ⦅x,y⦆ -> q ≋ ⦅x,y⦆  -> p ≈ q.
   Proof.
     intros (a & b & H1 & H2 & H3) (u & v & G1 & G2 & G3).
     generalize (mb_is_pair_fun H1 G1) (mb_is_pair_fun H2 G2); intros E1 E2.
@@ -191,9 +195,7 @@ Section membership.
     revert H3 G3; apply mb_is_pair_fun.
   Qed.
 
-  Fact mb_is_opair_inj p x y x' y' : mb_is_opair p x y 
-                                  -> mb_is_opair p x' y' 
-                                  -> x ≈ x' /\ y ≈ y'.
+  Fact mb_is_opair_inj p x y x' y' : p ≋ ⦅x,y⦆  -> p ≋ ⦅x',y'⦆ -> x ≈ x' /\ y ≈ y'.
   Proof.
     intros (a & b & H1 & H2 & H3) (u & v & G1 & G2 & G3).
     generalize (mb_is_pair_inj H3 G3); intros [ (E1 & E2) | (E1 & E2) ].
@@ -208,7 +210,7 @@ Section membership.
         rewrite E4, <- E5; auto.
   Qed.
 
-  Fact mb_is_opair_dec p x y : { mb_is_opair p x y } + { ~ mb_is_opair p x y }.
+  Fact mb_is_opair_dec p x y : { p ≋ ⦅x,y⦆  } + { ~ p ≋ ⦅x,y⦆  }.
   Proof.
     unfold mb_is_opair.
     do 2 (apply (fol_quant_sem_dec fol_ex); auto; intro).
@@ -216,46 +218,6 @@ Section membership.
   Qed.
 
   Hint Resolve mb_is_opair_dec : core.
-
-  (* Ordered triples (x,y,z) := ((x,y),z) *)
-
-  Definition mb_is_otriple t x y z := exists p, mb_is_opair p x y /\ mb_is_opair t p z.
- 
-  Add Parametric Morphism: (mb_is_otriple) with signature 
-     (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (mb_equiv) ==> (iff) as mb_is_otriple_congruence.
-  Proof.
-    intros p q H1 x x' H2 y y' H3 z z' H4.
-    unfold mb_is_otriple.
-    apply exists_equiv; intros t.
-    rewrite H1, H2, H3, H4; tauto.
-  Qed.
-
-  Fact mb_is_otriple_fun p q x y z : mb_is_otriple p x y z -> mb_is_otriple q x y z -> p ≈ q.
-  Proof.
-    intros (t1 & H1 & H2) (t2 & H3 & H4).
-    generalize (mb_is_opair_fun H1 H3); intros E.
-    rewrite E in H2.
-    apply (mb_is_opair_fun H2 H4).
-  Qed.
-
-  Fact mb_is_otriple_inj t x y z x' y' z' : 
-             mb_is_otriple t x y z 
-          -> mb_is_otriple t x' y' z' 
-          -> x ≈ x' /\ y ≈ y' /\ z ≈ z'.
-  Proof.
-    intros (p & H1 & H2) (q & H3 & H4).
-    destruct (mb_is_opair_inj H2 H4) as (H5 & H6).
-    rewrite H5 in H1.
-    generalize (mb_is_opair_inj H1 H3); tauto.
-  Qed.
-
-  Fact mb_is_otriple_dec p x y z : { mb_is_otriple p x y z } + { ~ mb_is_otriple p x y z }.
-  Proof.
-    apply (fol_quant_sem_dec fol_ex); auto; intro.
-    repeat (apply (fol_bin_sem_dec fol_conj); auto).
-  Qed.
-
-  Hint Resolve mb_is_otriple_dec : core.
 
   (* n-tuples *)
 
@@ -265,7 +227,9 @@ Section membership.
       | x##v    => exists t', mb_is_opair t x t' /\ mb_is_tuple t' v
     end.
 
-  Fact mb_is_tuple_congr p q n v : p ≈ q -> @mb_is_tuple p n v -> mb_is_tuple q v.
+  Notation "t ≋ ⦉ v ⦊" := (mb_is_tuple t v) (at level 70, format "t  ≋  ⦉ v ⦊").
+
+  Fact mb_is_tuple_congr p q n (v : vec X n) : p ≈ q -> p ≋ ⦉v⦊ -> q ≋ ⦉v⦊ .
   Proof.
     revert p q; induction v as [ | n x v IHv ]; intros p q.
     + simpl; intros E H x; rewrite <- E; auto.
@@ -273,7 +237,7 @@ Section membership.
       rewrite <- E; auto.
   Qed.
 
-  Fact mb_is_tuple_fun p q n v : @mb_is_tuple p n v -> mb_is_tuple q v -> p ≈ q.
+  Fact mb_is_tuple_fun p q n (v : vec _ n) : p ≋ ⦉v⦊  -> q ≋ ⦉v⦊  -> p ≈ q.
   Proof.
     revert p q; induction v as [ | n x v IHv ]; intros p q.
     + simpl; intros H1 H2.
@@ -286,12 +250,10 @@ Section membership.
       revert H1 H3; apply mb_is_opair_fun.
   Qed.
 
-  Fact mb_is_tuple_inj t n v w : 
-             @mb_is_tuple t n v 
-          -> mb_is_tuple t w 
-          -> forall p, vec_pos v p ≈ vec_pos w p.
+  Fact mb_is_tuple_inj t n (v w : vec _ n) p : 
+         t ≋ ⦉v⦊  -> t ≋ ⦉w⦊  -> vec_pos v p ≈ vec_pos w p.
   Proof.
-    revert t w; induction v as [ | n x v IHv ]; intros t w.
+    intros H1 H2; revert t w H1 H2 p; induction v as [ | n x v IHv ]; intros t w.
     + intros _ _ p; invert pos p.
     + vec split w with y.
       intros (p & H1 & H2) (q & H3 & H4).
@@ -301,7 +263,7 @@ Section membership.
       intros j; invert pos j; auto.
   Qed.
 
-  Fact mb_is_tuple_dec t n v : { @mb_is_tuple t n v } + { ~ mb_is_tuple t v }.
+  Fact mb_is_tuple_dec t n (v : vec _ n) : { t ≋ ⦉v⦊  } + { ~ t ≋ ⦉v⦊  }.
   Proof.
     revert t; induction v as [ | x n v IHv ]; intros t.
     + apply (fol_quant_sem_dec fol_fa); auto; intro.
@@ -312,51 +274,42 @@ Section membership.
 
   Hint Resolve mb_is_tuple_dec : core.
 
-  (* mb_has .... *)
+  (* mb_has_* from elements in l *)
 
   Definition mb_has_pairs (l : X) :=
-     forall x y, x ∈ l -> y ∈ l -> exists p, mb_is_pair p x y.
-
-  Definition mb_has_otriples (l : X) :=
-    forall x y z, x ∈ l -> y ∈ l -> z ∈ l -> exists t, mb_is_otriple t x y z.
+     forall x y, x ∈ l -> y ∈ l -> exists p, p ≋ ⦃x,y⦄ .
 
   Definition mb_has_tuples (l : X) n :=
-    forall v, (forall p, vec_pos v p ∈ l) -> exists t, @mb_is_tuple t n v.
+    forall v : vec _ n, (forall p, vec_pos v p ∈ l) -> exists t, t ≋ ⦉v⦊.
 
-  Definition mb_is_otriple_in r x y z :=
-    exists t, mb_is_otriple t x y z /\ t ∈ r.
+  Definition mb_is_tuple_in r n (v : vec _ n) :=
+    exists t, t ≋ ⦉v⦊ /\ t ∈ r.
 
-  Definition mb_is_tuple_in r n v :=
-    exists t, @mb_is_tuple t n v /\ t ∈ r.
+  Notation "t ∋ ⦉ v ⦊" := (mb_is_tuple_in t v) (at level 70, format "t  ∋  ⦉ v ⦊").
 
-  Fact mb_is_tuple_in_congr x y n v : y ≈ x -> @mb_is_tuple_in x n v -> @mb_is_tuple_in y n v.
+  Fact mb_is_tuple_in_congr x y n (v : vec _ n) : y ≈ x -> x ∋ ⦉v⦊ -> y ∋ ⦉v⦊ .
   Proof.
     intros E (t & H1 & H2); exists t; split; auto.
     rewrite  E; auto.
   Qed.
 
-  Fact mb_is_otriple_in_dec r x y z : { mb_is_otriple_in r x y z } + { ~ mb_is_otriple_in r x y z }.
-  Proof.
-    apply (fol_quant_sem_dec fol_ex); auto; intro.
-    repeat (apply (fol_bin_sem_dec fol_conj); auto).
-  Qed.
-
-  Fact mb_is_tuple_in_dec r n v : { @mb_is_tuple_in r n v } + { ~ mb_is_tuple_in r v }.
+  Fact mb_is_tuple_in_dec r n (v : vec _ n) : { r ∋ ⦉v⦊  } + { ~ r ∋ ⦉v⦊  }.
   Proof.
     apply (fol_quant_sem_dec fol_ex); auto; intro.
     apply (fol_bin_sem_dec fol_conj); auto.
   Qed.
 
-  (* mb total and functiona *)
+  (* mb total and functional *)
 
   Definition mb_is_tot n (l s : X) :=
-    forall v, (forall p, vec_pos v p ∈ l) -> exists x p t, x ∈ l /\ p ∈ s /\ mb_is_opair p x t /\ @mb_is_tuple t n v.
+    forall v, (forall p : pos n, vec_pos v p ∈ l) 
+            -> exists x p t, x ∈ l /\ p ∈ s /\ p ≋ ⦅x,t⦆  /\ t ≋ ⦉v⦊.
 
   Definition mb_is_fun (l s : X) :=
     forall p q x x' y, x ∈ l -> x' ∈ l 
                     -> p ∈ s -> q ∈ s
-                    -> mb_is_opair p x y 
-                    -> mb_is_opair q x' y
+                    -> p ≋ ⦅x,y⦆ 
+                    -> q ≋ ⦅x',y⦆
                     -> x ≈ x'.
 
 End membership.
@@ -371,7 +324,7 @@ Section FOL_encoding.
   Variable (Y : Type) (M2 : fo_model Σ2 Y).
 
   Let mem a b := fom_rels M2 tt (a##b##ø).
-  Infix "∈m" := mem (at level 59, no associativity).
+  Infix "∈ₘ" := mem (at level 59, no associativity).
 
   Definition Σ2_mem x y := @fol_atom Σ2 tt (£x##£y##ø).
   Infix "∈" := Σ2_mem.
@@ -394,22 +347,12 @@ Section FOL_encoding.
             ⟑ Σ2_is_pair 0    (2+x) (2+y)
             ⟑ Σ2_is_pair (2+p) 1     0.
 
-  Fact Σ2_is_opair_vars p x y : incl (fol_vars (Σ2_is_opair p x y)) (p::x::y::nil).
+  Fact Σ2_is_opair_vars p x y : fol_vars (Σ2_is_opair p x y) ⊑ p::x::y::nil.
   Proof. cbv; tauto. Qed.
 
-  Definition Σ2_is_otriple p x y z := 
-          ∃   Σ2_is_opair 0     (S x) (S y)
-            ⟑ Σ2_is_opair (S p)  0    (S z).
-
-  Definition Σ2_is_otriple_in r x y z := 
-          ∃   Σ2_is_otriple 0 (S x) (S y) (S z) 
-            ⟑ 0 ∈ (S r).
-
-  Definition Σ2_has_otriples l :=
-        ∀∀∀   2 ∈ (3+l) 
-                      ⤑ 1 ∈ (3+l) 
-                      ⤑ 0 ∈ (3+l) 
-                      ⤑ ∃ Σ2_is_otriple 0 3 2 1.
+  (* A 0-tuple <> is the empty set
+     A (1+n)-tuple <x##v> is a pair (x,k) where k is the n-tuple <v>
+   *)
 
   Fixpoint Σ2_is_tuple t n : vec nat n -> fol_form Σ2 :=
     match n with 
@@ -418,8 +361,7 @@ Section FOL_encoding.
                             ⟑ Σ2_is_tuple 0 (vec_map S (vec_tail v))
     end.
 
-
-  Fact Σ2_is_tuple_vars t n v : incl (fol_vars (@Σ2_is_tuple t n v)) (t::vec_list v).
+  Fact Σ2_is_tuple_vars t n v : fol_vars (@Σ2_is_tuple t n v) ⊑ t::vec_list v.
   Proof.
     revert t v; induction n as [ | n IHn ]; intros t v.
     + vec nil v; cbv; tauto.
@@ -436,11 +378,13 @@ Section FOL_encoding.
         - rewrite vec_list_vec_map, in_map_iff in H1.
           destruct H1 as (y & <- & H1); simpl in *.
           destruct H2 as [ -> | [] ]; tauto.
-  Qed. 
+  Qed.
+
+  (* v is n-tuple belonging to r *) 
 
   Definition Σ2_is_tuple_in r n v := ∃ @Σ2_is_tuple 0 n (vec_map S v) ⟑ 0 ∈ (S r).
 
-  Fact Σ2_is_tuple_in_vars r n v : incl (fol_vars (@Σ2_is_tuple_in r n v)) (r::vec_list v).
+  Fact Σ2_is_tuple_in_vars r n v : fol_vars (@Σ2_is_tuple_in r n v) ⊑ r::vec_list v.
   Proof.
     unfold Σ2_is_tuple_in.
     intros x; rewrite fol_vars_quant, in_flat_map.
@@ -448,8 +392,7 @@ Section FOL_encoding.
     rewrite fol_vars_bin, in_app_iff in H1.
     destruct H1 as [ H1 | H1 ].
     + apply Σ2_is_tuple_vars in H1.
-      rewrite vec_list_vec_map in H1; simpl in H1.
-      rewrite in_map_iff in H1.
+      simpl in H1; rewrite vec_list_vec_map, in_map_iff in H1.
       destruct H1 as [ <- | (z & <- & H1) ]; simpl in *; try tauto.
       destruct H2 as [ <- | [] ]; auto.
     + simpl in H1.
@@ -464,9 +407,6 @@ Section FOL_encoding.
        fol_mquant fol_fa n ( (fol_vec_fa (vec_set_pos (fun p : pos n => pos2nat p ∈ (l+n))))
                                          ⤑ ∃∃∃ 2 ∈ ((3+l)+n) ⟑ 1 ∈ ((3+s)+n) ⟑ Σ2_is_opair 1 2 0 ⟑ @Σ2_is_tuple 0 n (vec_set_pos (fun p : pos n => 3+pos2nat p)) ).
 
-(*  Definition Σ2_is_tot l s :=
-    ∀ 0 ∈ (1+l) ⤑ ∃∃ 0 ∈ (3+l) ⟑ 1 ∈ (3+s) ⟑ Σ2_is_opair 1 0 2. *)
-
   Definition Σ2_is_fun l s :=
     ∀∀∀∀∀ 2 ∈ (5+l) ⤑ 1 ∈ (5+l) ⤑
           4 ∈ (5+s) ⤑ 3 ∈ (5+s) ⤑
@@ -476,9 +416,6 @@ Section FOL_encoding.
 
   Definition Σ2_list_in l lv := fol_lconj (map (fun x => x ∈ l) lv).
 
-  Fact Σ2_is_otriple_in_vars r x y z : incl (fol_vars (Σ2_is_otriple_in r x y z)) (r::x::y::z::nil).
-  Proof. intros a; simpl; tauto. Qed.
-
   Notation "⟪ A ⟫" := (fun ψ => fol_sem M2 ψ A).
 
   Section semantics.
@@ -486,7 +423,7 @@ Section FOL_encoding.
     Fact Σ2_transitive_spec t ψ : ⟪Σ2_transitive t⟫ ψ = mb_transitive mem (ψ t).
     Proof. reflexivity. Qed.
  
-    Fact Σ2_non_empty_spec l ψ : ⟪Σ2_non_empty l⟫ ψ = exists x, x ∈m ψ l.
+    Fact Σ2_non_empty_spec l ψ : ⟪Σ2_non_empty l⟫ ψ = exists x, x ∈ₘ ψ l.
     Proof. reflexivity. Qed.
 
     Fact Σ2_incl_spec x y ψ : ⟪Σ2_incl x y⟫ ψ = mb_incl mem (ψ x) (ψ y).
@@ -502,15 +439,6 @@ Section FOL_encoding.
     Proof. reflexivity. Qed.
 
     Fact Σ2_is_opair_spec p x y ψ : ⟪Σ2_is_opair p x y⟫ ψ = mb_is_opair mem (ψ p) (ψ x) (ψ y).
-    Proof. reflexivity. Qed.
-
-    Fact Σ2_is_otriple_spec p x y z ψ : ⟪Σ2_is_otriple p x y z⟫ ψ = mb_is_otriple mem (ψ p) (ψ x) (ψ y) (ψ z).
-    Proof. reflexivity. Qed.
-
-    Fact Σ2_is_otriple_in_spec r x y z ψ : ⟪Σ2_is_otriple_in r x y z⟫ ψ = mb_is_otriple_in mem (ψ r) (ψ x) (ψ y) (ψ z).
-    Proof. reflexivity. Qed.
-
-    Fact Σ2_has_otriples_spec l ψ : ⟪Σ2_has_otriples l⟫ ψ = mb_has_otriples mem (ψ l).
     Proof. reflexivity. Qed.
 
     Fact Σ2_is_tuple_spec t n v ψ : ⟪@Σ2_is_tuple t n v⟫ ψ <-> mb_is_tuple mem (ψ t) (vec_map ψ v).
@@ -586,7 +514,7 @@ Section FOL_encoding.
           simpl; rewrite env_vlift_fix0; auto.
     Qed.
 
-    Fact Σ2_list_in_spec l lv ψ : ⟪Σ2_list_in l lv⟫ ψ <-> forall x, In x lv -> ψ x ∈m ψ l.
+    Fact Σ2_list_in_spec l lv ψ : ⟪Σ2_list_in l lv⟫ ψ <-> forall x, x ∊ lv -> ψ x ∈ₘ ψ l.
     Proof.
       unfold Σ2_list_in; rewrite fol_sem_lconj.
       split.
@@ -598,10 +526,5 @@ Section FOL_encoding.
     Qed.
 
   End semantics.
-
-  Fact Σ2_is_otriple_in_equiv r x y z φ ψ :
-               ⟪Σ2_is_otriple_in 3 2 1 0⟫ z·y·x·r·φ
-           <-> ⟪Σ2_is_otriple_in 3 2 1 0⟫ z·y·x·r·ψ.
-  Proof. cbv beta; do 2 rewrite Σ2_is_otriple_in_spec; simpl; tauto. Qed.
 
 End FOL_encoding. 

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -20,6 +20,7 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Notation ø := vec_nil.
 Local Infix "∊" := In (at level 70, no associativity).
 Local Infix "⊑" := incl (at level 70, no associativity). 
 

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -7,20 +7,22 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Lia Max Bool.
+Require Import List Arith.
 
 From Undecidability.Synthetic
-  Require Import Definitions ReducibilityFacts
-                 InformativeDefinitions InformativeReducibilityFacts.
+  Require Import Definitions 
+                 ReducibilityFacts
+                 InformativeDefinitions 
+                 InformativeReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import utils_tac utils_list utils_nat finite.
+  Require Import utils_tac utils_list finite.
 
 From Undecidability.Shared.Libs.DLW.Vec 
   Require Import pos vec.
 
 From Undecidability.TRAKHTENBROT
-  Require Import notations utils decidable
+  Require Import notations utils decidable discernable
                  fol_ops fo_sig fo_terms fo_logic
                  fo_sat fo_sat_dec
 
@@ -29,7 +31,10 @@ From Undecidability.TRAKHTENBROT
                  Sig_Sig_fin
                  Sig_rem_props
                  Sig_rem_constants
-                 Sig0 Sig1 Sig1_1.
+                 Sig0 
+                 Sig1 
+                 Sig1_1
+                 Sig_discernable.
 
 Set Implicit Arguments.
 
@@ -166,10 +171,9 @@ Section FSAT_FULL_MONADIC_DEC.
            (H1 : discrete (syms Σ)) 
            (H2 : discrete (rels Σ))
            (H3 : forall s, ar_syms Σ s <= 1)
-           (H4 : forall r, ar_rels Σ r <= 1)
-           (A : fol_form Σ).
+           (H4 : forall r, ar_rels Σ r <= 1).
 
-  Theorem FSAT_FULL_MONADIC_DEC : decidable (FSAT _ A).
+  Theorem FSAT_FULL_MONADIC_DEC A : decidable (FSAT Σ A).
   Proof.
     destruct FSAT_FULL_MONADIC_FSAT_11 with Σ as (f & Hf); auto.
     destruct FSAT_FULL_Σ11_DEC with (A := f A) as [ H | H ]; auto.
@@ -190,10 +194,9 @@ Section FSAT_PROP_ONLY_DEC.
 
   Variable (Σ : fo_signature)
            (H1 : discrete (rels Σ))
-           (H2 : forall r, ar_rels Σ r = 0)
-           (A : fol_form Σ).
+           (H2 : forall r, ar_rels Σ r = 0).
 
-  Theorem FSAT_PROP_ONLY_DEC : decidable (FSAT _ A).
+  Theorem FSAT_PROP_ONLY_DEC A : decidable (FSAT Σ A).
   Proof.
     destruct (FSAT_PROP_FSAT_x0 _ H2) as (f & Hf).
     destruct FSAT_FULL_MONADIC_DEC with (A := f A)
@@ -221,3 +224,107 @@ Proof.
   + apply FSAT_FULL_MONADIC_DEC; auto.
   + apply FSAT_PROP_ONLY_DEC; auto.
 Qed.
+
+Local Infix "≢" := discernable (at level 70, no associativity).
+
+Theorem Σ11_discernable_dec_FSAT X Y : 
+          (forall u v : X, decidable (u ≢ v))
+       -> (forall u v : Y, decidable (u ≢ v))
+       -> forall A, decidable (FSAT (Σ11 X Y) A).
+Proof.
+  intros H0 H1 A.
+  destruct (Sig_discernable_dec_to_discrete H0 H1 A) 
+    as (DX & DY & ? & ? & ? & ? & B & HB); auto.
+  destruct FSAT_FULL_MONADIC_DEC with (A := B); simpl; auto.
+  + left; tauto.
+  + right; tauto.
+Qed. 
+
+Section FSAT_FULL_MONADIC_discernable.
+
+  Variable (Σ : fo_signature) 
+           (H1 : forall u v : syms Σ, decidable (u ≢ v))
+           (H2 : forall u v : rels Σ, decidable (u ≢ v))
+           (H3 : forall s, ar_syms Σ s <= 1)
+           (H4 : forall r, ar_rels Σ r <= 1).
+
+  Theorem FSAT_FULL_MONADIC_discernable A : decidable (FSAT Σ A).
+  Proof.
+    destruct (FSAT_FULL_MONADIC_FSAT_11 _ H3 H4) as (f & Hf).
+    destruct (Σ11_discernable_dec_FSAT H1 H2 (f A)) as [ H | H ].
+    + left; apply Hf; auto.
+    + right; contradict H; apply Hf; auto.
+  Qed.
+
+End FSAT_FULL_MONADIC_discernable.
+
+Section FSAT_PROP_ONLY_discernable.
+
+  Variable (Σ : fo_signature)
+           (H1 : forall u v : rels Σ, decidable (u ≢ v))
+           (H2 : forall r, ar_rels Σ r = 0).
+
+  Theorem FSAT_PROP_ONLY_discernable A : decidable (FSAT Σ A).
+  Proof.
+    destruct (FSAT_PROP_FSAT_x0 _ H2) as (f & Hf).
+    destruct FSAT_FULL_MONADIC_discernable with (A := f A)
+      as [ H | H ]; auto.
+    + intros [].
+    + left; revert H; apply Hf; auto.
+    + right; contradict H; revert H; apply Hf; auto.
+  Qed.
+
+End FSAT_PROP_ONLY_discernable.
+
+Theorem FULL_MONADIC_discernable (Σ : fo_signature) :
+          { _ : forall u v : syms Σ, decidable (u ≢ v) &
+          { _ : forall u v : rels Σ, decidable (u ≢ v)
+              | (forall s, ar_syms Σ s <= 1)
+             /\ (forall r, ar_rels Σ r <= 1) } }
+        + { _ : forall u v : rels Σ, decidable (u ≢ v)
+              | forall r, ar_rels Σ r = 0 }
+       -> forall A, decidable (FSAT Σ A).
+Proof.
+  intros [ (H1 & H2 & H3 & H4) | (H1 & H2) ].
+  + apply FSAT_FULL_MONADIC_discernable; auto.
+  + apply FSAT_PROP_ONLY_discernable; auto.
+Qed.
+
+(* For a monadic signature Σ (arity 0 or 1) with at least one unary relation,
+
+   FSAT is decidable iff both syms and rels have decidable discernability 
+*)
+
+Theorem FULL_MONADIC_discernable_dec_FSAT_dec_equiv Σ r : 
+            ar_rels Σ r = 1 
+         -> (forall s, ar_syms Σ s <= 1)
+         -> (forall r, ar_rels Σ r <= 1)
+         -> ( (forall u v : syms Σ, decidable (u ≢ v))
+            * (forall u v : rels Σ, decidable (u ≢ v)) )
+          ≋ forall A, decidable (FSAT Σ A).
+Proof.
+  intros Hr H1 H2.
+  split.
+  + intros (? & ?); apply FSAT_FULL_MONADIC_discernable; auto.
+  + intros H3; split.
+    * apply FSAT_dec_implies_discernable_syms_dec with r; auto.
+    * apply FSAT_dec_implies_discernable_rels_dec; auto.
+Qed.
+
+(* For a signature with only constant relations (arity 0),
+   FSAT is decidable iff relations have decidable discernability *) 
+
+Theorem MONADIC_PROP_discernable_dec_FSAT_dec_equiv (Σ : fo_signature) :
+            (forall r, @ar_rels Σ r = 0)
+        ->  (forall u v : rels Σ, decidable (u ≢ v))
+          ≋  forall A, decidable (FSAT Σ A).
+Proof.
+  intros H; split.
+  + intros; apply FULL_MONADIC_discernable; eauto.
+  + intros H1.
+    assert (forall A, decidable (FSAT (Σ0 Σ) A)) as H2.
+    { revert H1; apply ireduction_decidable, FSAT_x0_FSAT_PROP; auto. }
+    exact (FSAT_dec_implies_discernable_rels_dec H2).
+Qed. 
+
+

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -67,7 +67,7 @@ Section FSAT_MONADIC_DEC.
            (H2 : discrete P)
            (A : fol_form (Σ11 F P)).
 
-  Theorem FSAT_MONADIC_DEC : decidable (fo_form_fin_dec_SAT A).
+  Theorem FSAT_MONADIC_DEC : decidable (FSAT _ A).
   Proof.
     destruct Sig_discrete_to_pos with (A := A)
       as (n & m & i & j & B & HB).
@@ -106,7 +106,7 @@ Section FSAT_Σ11_DEC.
            (HP2 : discrete P)
            (A : fol_form (Σ11 (pos n) P)).
 
-  Theorem FSAT_Σ11_DEC : decidable (fo_form_fin_dec_SAT A).
+  Theorem FSAT_Σ11_DEC : decidable (FSAT _ A).
   Proof.
     destruct FSAT_MONADIC_11_FSAT_MONADIC_1 with (n := n) (1 := HP1)
       as (f & Hf).
@@ -125,7 +125,7 @@ Section FSAT_FULL_Σ11_DEC.
 
   Hint Resolve finite_t_pos : core.
 
-  Theorem FSAT_FULL_Σ11_DEC : decidable (fo_form_fin_dec_SAT A).
+  Theorem FSAT_FULL_Σ11_DEC : decidable (FSAT _ A).
   Proof.
     destruct Sig_discrete_to_pos with (A := A)
       as (n & m & i & j & B & HB); auto.
@@ -177,10 +177,8 @@ Section FSAT_PROP_ONLY_DEC.
 
   Theorem FSAT_PROP_ONLY_DEC : decidable (FSAT _ A).
   Proof.
-    assert (H: decidable (fo_form_fin_dec_SAT_in (Σ_Σ0 A) unit)).
-    { apply FSAT_in_dec; simpl; auto.
-      + intros [].
-      + apply finite_t_unit. }
+    assert (H: decidable (FSAT _ (Σ_Σ0 A))).
+    { apply FSAT_FULL_MONADIC_DEC; auto; intros []. }
     destruct H as [ H | H ].
     + left; revert H; apply Σ_Σ0_correct; auto.
     + right; contradict H; revert H; apply Σ_Σ0_correct; auto.

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -38,6 +38,8 @@ From Undecidability.TRAKHTENBROT
 
 Set Implicit Arguments.
 
+Local Infix "≢" := discernable (at level 70, no associativity).
+
 (* * Collection of high-level synthetic decidability results *)
 
 Section Sig_MONADIC_Sig_11.
@@ -224,8 +226,6 @@ Proof.
   + apply FSAT_FULL_MONADIC_DEC; auto.
   + apply FSAT_PROP_ONLY_DEC; auto.
 Qed.
-
-Local Infix "≢" := discernable (at level 70, no associativity).
 
 Theorem Σ11_discernable_dec_FSAT X Y : 
           (forall u v : X, decidable (u ≢ v))

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -56,14 +56,21 @@ End Sig_MONADIC_Sig_11.
 
 Section Sig_MONADIC_PROP.
 
+  (* FSAT Σ(X,Y) and FSAT Σ(ø,Y) are inter-reducible
+     is the arities on rels/Y are all 0, ie Propositional case 
+
+     Σ0 maps Σ into a signature with no function symbols and
+     the same relation symbols, all of arity 0
+   *)  
+
   Variable (Σ : fo_signature) 
            (HΣ : forall r, ar_rels Σ r = 0).
 
   Theorem FSAT_PROP_FSAT_x0 : FSAT Σ ⪯ᵢ FSAT (Σ0 Σ).
-  Proof.
-    exists (@Σ_Σ0 Σ).
-    exact (Σ_Σ0_correct HΣ).
-  Qed.
+  Proof. exists (@Σ_Σ0 Σ); exact (Σ_Σ0_correct HΣ). Qed.
+
+  Theorem FSAT_x0_FSAT_PROP : FSAT (Σ0 Σ) ⪯ᵢ FSAT Σ.
+  Proof. exists (Σ0_Σ HΣ); exact (Σ0_Σ_correct HΣ). Qed.
 
 End Sig_MONADIC_PROP.
 

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -7,10 +7,11 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Lia Max.
+Require Import List Arith Lia Max Bool.
 
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.InformativeDefinitions Undecidability.Synthetic.InformativeReducibilityFacts.
+From Undecidability.Synthetic
+  Require Import Definitions ReducibilityFacts
+                 InformativeDefinitions InformativeReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW.Utils
   Require Import utils_tac utils_list utils_nat finite.
@@ -72,10 +73,9 @@ Section FSAT_MONADIC_DEC.
       as (n & m & i & j & B & HB).
     + simpl; intros s; destruct (H1 s).
     + apply H2.
-    + assert (n = 0) as Hn.
+    + assert (n = 0) as ->.
       { destruct n; auto.
         destruct (H1 (i pos0)). }
-      subst n.
       simpl in *.
       destruct FSAT_ΣP1_dec with (V := pos 0) (A := B)
         as [ H | H ].
@@ -111,8 +111,7 @@ Section FSAT_Σ11_DEC.
     destruct FSAT_MONADIC_11_FSAT_MONADIC_1 with (n := n) (1 := HP1)
       as (f & Hf).
     specialize (Hf A).
-    destruct FSAT_MONADIC_DEC with (A := f A) as [ H | H ]; simpl; auto.
-    + intros [].
+    destruct FSAT_MONADIC_DEC with (A := f A) as [ H | H ]; simpl; auto; try easy.
     + left; revert H; apply Hf.
     + right; contradict H; revert H; apply Hf.
   Qed.

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -54,6 +54,19 @@ Section Sig_MONADIC_Sig_11.
 
 End Sig_MONADIC_Sig_11.
 
+Section Sig_MONADIC_PROP.
+
+  Variable (Σ : fo_signature) 
+           (HΣ : forall r, ar_rels Σ r = 0).
+
+  Theorem FSAT_PROP_FSAT_x0 : FSAT Σ ⪯ᵢ FSAT (Σ0 Σ).
+  Proof.
+    exists (@Σ_Σ0 Σ).
+    exact (Σ_Σ0_correct HΣ).
+  Qed.
+
+End Sig_MONADIC_PROP.
+
 (* Check FSAT_FULL_MONADIC_FSAT_11.
 Print Assumptions FSAT_FULL_MONADIC_FSAT_11. *)
 
@@ -138,11 +151,9 @@ End FSAT_FULL_Σ11_DEC.
 
 Section FSAT_FULL_MONADIC_DEC.
 
-  (* I do not think we can be more general than that. In
-     particular, decidability of FSAT implies discreteness
-     I think. For instance, let r1 and r2 be two rels
-     then ~ (r1(£0,..,£k) <-> r2(£0,..,£k)) is satisfiable
-     iff r1 <> r2 ?? TO CHECK *)
+  (* We can be (a bit) more general here, see discernable.v 
+     However, decidable discernability is required 
+     for showing FSAT is decidable *)
 
   Variable (Σ : fo_signature)
            (H1 : discrete (syms Σ)) 
@@ -177,11 +188,12 @@ Section FSAT_PROP_ONLY_DEC.
 
   Theorem FSAT_PROP_ONLY_DEC : decidable (FSAT _ A).
   Proof.
-    assert (H: decidable (FSAT _ (Σ_Σ0 A))).
-    { apply FSAT_FULL_MONADIC_DEC; auto; intros []. }
-    destruct H as [ H | H ].
-    + left; revert H; apply Σ_Σ0_correct; auto.
-    + right; contradict H; revert H; apply Σ_Σ0_correct; auto.
+    destruct (FSAT_PROP_FSAT_x0 _ H2) as (f & Hf).
+    destruct FSAT_FULL_MONADIC_DEC with (A := f A)
+      as [ H | H ]; auto.
+    + intros [].
+    + left; revert H; apply Hf; auto.
+    + right; contradict H; revert H; apply Hf; auto.
   Qed.
 
 End FSAT_PROP_ONLY_DEC.

--- a/theories/TRAKHTENBROT/red_utils.v
+++ b/theories/TRAKHTENBROT/red_utils.v
@@ -7,15 +7,18 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import List Arith Bool Lia Eqdep_dec.
+Require Import List.
 
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.InformativeDefinitions Undecidability.Synthetic.InformativeReducibilityFacts.
+From Undecidability.Synthetic
+  Require Import Definitions 
+                 ReducibilityFacts 
+                 InformativeDefinitions 
+                 InformativeReducibilityFacts.
 
 From Undecidability.PCP Require Import PCP.
 
 From Undecidability.Shared.Libs.DLW.Utils
-  Require Import utils_tac utils_list utils_nat finite.
+  Require Import utils_tac utils_list finite.
 
 From Undecidability.Shared.Libs.DLW.Vec 
   Require Import pos vec.
@@ -59,12 +62,7 @@ Qed.
 
     The reduction is the identity here !! *)
 
-Definition FSAT := @fo_form_fin_dec_SAT.
-
-Arguments FSAT : clear implicits.
-
-Theorem fo_form_fin_dec_SAT_discr_equiv Σ A : 
-    @fo_form_fin_dec_SAT Σ A <-> @fo_form_fin_discr_dec_SAT Σ A.
+Theorem fo_form_fin_dec_SAT_discr_equiv Σ A : FSAT Σ A <-> FSAT' Σ A.
 Proof.
   split.
   + apply fo_form_fin_dec_SAT_fin_discr_dec.
@@ -74,7 +72,7 @@ Qed.
 (* Check fo_form_fin_dec_SAT_discr_equiv.
 Print Assumptions fo_form_fin_dec_SAT_discr_equiv. *)
 
-Corollary FIN_DEC_SAT_FIN_DISCR_DEC_SAT Σ : FSAT Σ ⪯ᵢ @fo_form_fin_discr_dec_SAT Σ.
+Corollary FIN_DEC_SAT_FIN_DISCR_DEC_SAT Σ : FSAT Σ ⪯ᵢ FSAT' Σ.
 Proof. exists (fun A => A); red; apply fo_form_fin_dec_SAT_discr_equiv. Qed.
 
 (* Check FIN_DEC_SAT_FIN_DISCR_DEC_SAT.
@@ -92,7 +90,7 @@ Section FIN_DEC_EQ_SAT_FIN_DEC_SAT.
 
   Variable (Σ : fo_signature) (e : rels Σ) (He : ar_rels _ e = 2).
 
-  Theorem FIN_DEC_EQ_SAT_FIN_DEC_SAT : fo_form_fin_dec_eq_SAT e He ⪯ᵢ  FSAT Σ.
+  Theorem FIN_DEC_EQ_SAT_FIN_DEC_SAT : FSATEQ e He ⪯ᵢ FSAT Σ.
   Proof.
     exists (fun A => Σ_noeq (fol_syms A) (e::fol_rels A) _ He  A).
     intros A; split.

--- a/theories/TRAKHTENBROT/reln_hfs.v
+++ b/theories/TRAKHTENBROT/reln_hfs.v
@@ -24,23 +24,23 @@ Set Implicit Arguments.
 
 Section bt_model_n.
 
-  (* This discussion briefly describes how we encode finite and discrete 
-      model X with a computable n-ary relation R into an hereditary finite 
-      set (hfs) with to elements l and r, l representing the points in X
+  (*  This discussion briefly describes how we encode finite and discrete 
+      model X with a decidable nt-ary relation R into an hereditary finite 
+      set (hfs) with two elements l and r, l representing the points in X
       and r representing the n-tuples in R.
 
       Because X is finite and discrete, one can compute a bijection X <~> pos n
       where n is the cardinal of X. Hence we assume that X = pos n and the
-      ternary relation is R : pos n -> pos n -> pos n -> Prop
+      nt-art relation is R : vec (pos n) nt -> Prop
       
-      1) We find a transitive hfs l such that pos n bijects with the elements
+      1) We find a transitive hfs l such that (pos n) bijects with the elements
          of l (transitive means ∀x, x∈l -> x⊆l). Hence
 
                             pos n <-> { x | x ∈ l } 
 
          For this, we use the encoding of natural numbers into sets, 
          ie 0 := ø and 1+i := {i} U i and choose l to be the encoding 
-         of n (the cardinal of X=pos n above).
+         of n (the cardinal of X = pos n above).
 
          Notice that since l is transitive then so is P(l) (powerset)
          and hence P^i(l) for any i.
@@ -48,12 +48,12 @@ Section bt_model_n.
       2) forall x,y ∈ l, both {x} and {x,y} belong to P(l) 
          hence (x,y) = {{x},{x,y}} ∈ P(P(l))=P^2(l)
         
-      3) P^1(l) = P(l) contains the empty set
+      3) l contains the empty set (cardinal > 0)
   
-      4) Hence P^(2n+1)(l) contains all n-tuples build from the elements of l
-         by induction on n
+      4) Hence P^2nt(l) contains all nt-tuples build 
+         from the elements of l by induction on n
 
-      5) So we can encode R as hfs r ∈ p := P^(2n+2)(l) = P(P^(2n+1)(l)) and
+      5) So we can encode R as hfs r ∈ p := P^(2nt+1)(l) = P(P^2nt(l)) and
          p serves as our model, ie 
 
                       Y := { x : hfs | x ∈b p } 
@@ -69,20 +69,21 @@ Section bt_model_n.
 
       *)
 
-  (* We have computed the transitive closure, spec'ed and proved finite *)  
-
   Variable (X : Type) (Xfin : finite_t X) (Xdiscr : discrete X) (x0 : X) (nt : nat).
 
+  Notation "∅" := hfs_empty.
   Infix "∈" := hfs_mem.
   Notation "x ⊆ y" := (forall u, u ∈ x -> u ∈ y).
   Notation "⟬ x , y ⟭" := (hfs_opair x y).
 
-  Let X_surj_hfs : { l : hfs & { f : hfs -> X & 
+  (* First we compute a bijection with the cardinal of X *)
+
+  Let X_surj_hfs : { d : hfs & { f : hfs -> X & 
                     { g : X -> hfs |
-                      hfs_transitive l
-                   /\ hfs_empty ∈ l
-                   /\ (forall p, g p ∈ l)
-                   /\ (forall x, x ∈ l -> exists p, x = g p)
+                      hfs_transitive d
+                   /\ ∅ ∈ d
+                   /\ (forall p, g p ∈ d)
+                   /\ (forall x, x ∈ d -> exists p, x = g p)
                    /\ (forall p, f (g p) = p) } } }.
   Proof.
     destruct (finite_t_discrete_bij_t_pos Xfin)
@@ -101,38 +102,35 @@ Section bt_model_n.
 
   (* First a surjective map from some transitive set l to X *)
 
-  Let l := projT1 X_surj_hfs.
+  Let d := projT1 X_surj_hfs.
   Let s := projT1 (projT2 X_surj_hfs).
   Let i := proj1_sig (projT2 (projT2 (X_surj_hfs))).
 
-  Let Hl : hfs_transitive l.
-  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hempty : hfs_empty ∈ l.
-  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hs : forall x, s (i x) = x. 
-  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hi : forall x, i x ∈ l. 
-  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hi' : forall s, s ∈ l -> exists x, s = i x.
+  Let Hd : hfs_transitive d.       Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+  Let Hempty : ∅ ∈ d.              Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+  Let Hs : forall x, s (i x) = x.  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+  Let Hi : forall x, i x ∈ d.      Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+
+  Let Hi' : forall s, s ∈ d -> exists x, s = i x.
   Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
 
-  (* Now we build P^5 l that contains all the set of triples of l *)
+  (* Now we build P^(1+2nt) d that contains all the sets of nt-tuples of d *)
 
-  Let p := iter hfs_pow l (1+(2*nt)).
+  Let p := iter hfs_pow d (1+(2*nt)).
 
   Let Hp1 : hfs_transitive p.
   Proof. apply hfs_iter_pow_trans; auto. Qed.
 
-  Let Hp2 : l ∈ p.
+  Let Hp2 : d ∈ p.
   Proof.
     apply hfs_iter_pow_le with (n := 1); simpl; auto; try lia.
     apply hfs_pow_spec; auto.
   Qed.
 
-  Let Hp5 n v : (forall p, vec_pos v p ∈ l) -> @hfs_tuple n v ∈ iter hfs_pow l (2*n).
+  Let Hp5 n v : (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ iter hfs_pow d (2*n).
   Proof. apply hfs_tuple_pow; auto. Qed.
 
-  Let Hp6 n v : n <= nt -> (forall p, vec_pos v p ∈ l) -> @hfs_tuple n v ∈ p.
+  Let Hp6 n v : n <= nt -> (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ p.
   Proof. 
     intros L H; apply Hp5 in H.
     revert H; apply hfs_iter_pow_le; try lia; auto.
@@ -143,18 +141,18 @@ Section bt_model_n.
 
   Hint Resolve finite_t_prod hfs_mem_fin_t : core.
 
-  (* We encode R as a subset of tuples of elements of l in p *)
+  (* We encode R as a subset of tuples of elements of d in p *)
 
   Let encode_R : { r | r ∈ p 
-                      /\ (forall v, @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ l)
+                      /\ (forall v, @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ d)
                       /\ forall v, R v <-> hfs_tuple (vec_map i v) ∈ r }.
   Proof.
-    set (P v := R (vec_map s v) /\ forall q, vec_pos v q ∈ l).
+    set (P v := R (vec_map s v) /\ forall q, vec_pos v q ∈ d).
     set (f := @hfs_tuple nt). 
     destruct hfs_comprehension with (P := P) (f := f) as (r & Hr).
     + apply fin_t_dec.
       * intros; apply HR.
-      * apply fin_t_vec with (P := fun t => t ∈ l).
+      * apply fin_t_vec with (P := fun t => t ∈ d).
         apply hfs_mem_fin_t.
     + exists r; msplit 2.
       * unfold p; rewrite plus_comm, iter_plus with (b := 1).
@@ -186,7 +184,7 @@ Section bt_model_n.
   Let Hr1 : r ∈ p.
   Proof. apply (proj2_sig encode_R). Qed.
 
-  Let Hr2 v : @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ l.
+  Let Hr2 v : @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ d.
   Proof. apply (proj2_sig encode_R). Qed.
 
   Let Hr3 v : R v <-> hfs_tuple (vec_map i v) ∈ r.
@@ -202,9 +200,17 @@ Section bt_model_n.
     destruct (hfs_mem_dec x p); split; try tauto; discriminate.
   Qed.
 
+  Let p_bool_spec1 x : x ∈ p -> p_bool x = true.
+  Proof. apply p_bool_spec. Qed.
+
+  Let p_bool_spec2 x : p_bool x = true -> x ∈ p.
+  Proof. apply p_bool_spec. Qed.
+
   Let Y := sig (fun x => p_bool x = true).
 
-  Let eqY : forall x y : Y, proj1_sig x = proj1_sig y -> x = y.
+  Notation π1 := (@proj1_sig _ _).
+
+  Let eqY : forall x y : Y, π1 x = π1 y -> x = y.
   Proof. 
     intros (x & Hx) (y & Hy); simpl.
     intros; subst; f_equal; apply UIP_dec, bool_dec.
@@ -226,41 +232,45 @@ Section bt_model_n.
     + right; contradict D; inversion D; auto.
   Qed.
 
-  Let mem (x y : Y) := proj1_sig x ∈ proj1_sig y.
+  Let mem (x y : Y) := π1 x ∈ π1 y.
 
   Let mem_dec : forall x y, { mem x y } + { ~ mem x y }.
   Proof.
     intros (a & ?) (b & ?); unfold mem; simpl; apply hfs_mem_dec.
   Qed.
 
-  Let yl : Y.    Proof. exists l; apply p_bool_spec, Hp2. Defined.
-  Let yr : Y.    Proof. exists r; apply p_bool_spec, Hr1. Defined.
+  Let mem_equiv_Y u v : u ∈ p -> v ∈ p
+                     -> (forall y : Y, π1 y ∈ u <-> π1 y ∈ v)
+                    <-> (forall x : hfs, x ∈ u <-> x ∈ v).
+  Proof.
+    intros Hu Hv; split; intros H.
+    2: intro; apply H; auto.
+    intros x; split; intros Hx.
+    + generalize (Hp1 Hx Hu); rewrite p_bool_spec; intros G;
+      apply (@H (exist _ _ G)); auto.
+    + generalize (Hp1 Hx Hv); rewrite p_bool_spec; intros G;
+      apply (@H (exist _ _ G)); auto.
+  Qed.
+
+  Let yd : Y.    Proof. exists d; abstract (apply p_bool_spec, Hp2). Defined.
+  Let yr : Y.    Proof. exists r; abstract (apply p_bool_spec, Hr1). Defined.
 
   (* Membership equivalence is identity in the model *)
 
-  Let is_equiv : forall x y, mb_equiv mem x y <-> proj1_sig x = proj1_sig y.
+  Let is_equiv : forall x y, mb_equiv mem x y <-> π1 x = π1 y.
   Proof.
     intros (x & Hx) (y & Hy); simpl.
     unfold mb_equiv, mem; simpl; split.
-    2: intros []; tauto.
-    intros H.
-    apply hfs_mem_ext.
-    intros z; split; intros Hz.
-    * apply p_bool_spec in Hx.
-      generalize (Hp1 Hz Hx).
-      rewrite p_bool_spec; intros H'.
-      apply (H (exist _ z H')); auto.
-    * apply p_bool_spec in Hy.
-      generalize (Hp1 Hz Hy).
-      rewrite p_bool_spec; intros H'.
-      apply (H (exist _ z H')); auto.
+    2: { intros []; tauto. }
+    rewrite mem_equiv_Y; auto; apply hfs_mem_ext.
   Qed.
 
   Let is_pair : forall x y k, mb_is_pair mem k x y 
-                          <-> proj1_sig k = hfs_pair (proj1_sig x) (proj1_sig y).
+                          <-> π1 k = hfs_pair (π1 x) (π1 y).
   Proof.
     intros (x & Hx) (y & Hy) (k & Hk); simpl.
-    unfold mb_is_pair; simpl; rewrite hfs_mem_ext.
+    unfold mb_is_pair; simpl. 
+    rewrite hfs_mem_ext.
     generalize Hx Hy Hk; revert Hx Hy Hk.
     do 3 rewrite <- p_bool_spec at 1.
     intros Hx' Hy' Hk' Hx Hy Hk.
@@ -276,7 +286,7 @@ Section bt_model_n.
   Qed.
  
   Let is_opair : forall x y k, mb_is_opair mem k x y 
-                           <-> proj1_sig k = ⟬proj1_sig x,proj1_sig y⟭.
+                           <-> π1 k = ⟬π1 x,π1 y⟭.
   Proof.
     intros (x & Hx) (y & Hy) (k & Hk); simpl.
     unfold mb_is_opair; split.
@@ -296,7 +306,7 @@ Section bt_model_n.
   Qed.
 
   Let is_tuple n : forall v t, @mb_is_tuple _ mem t n v 
-                           <-> proj1_sig t = hfs_tuple (vec_map (@proj1_sig _ _) v).
+                           <-> π1 t = hfs_tuple (vec_map π1 v).
   Proof.
     induction n as [ | n IHn ]; intros v (t & Ht).
     + vec nil v; clear v; simpl; split.
@@ -316,16 +326,16 @@ Section bt_model_n.
         rewrite <- H2.
         apply is_opair with (k := exist _ t Ht); auto.
       * intros ->.
-        assert (H1 : p_bool (hfs_tuple (vec_map (@proj1_sig _ _) v)) = true).
+        assert (H1 : p_bool (hfs_tuple (vec_map π1 v)) = true).
         { apply p_bool_spec.
           apply p_bool_spec in Ht.
           apply hfs_trans_opair_inv, proj2, hfs_trans_pair_inv in Ht; tauto. }
-        exists (exist _ (hfs_tuple (vec_map (@proj1_sig _ _) v)) H1); split.
+        exists (exist _ (hfs_tuple (vec_map π1 v)) H1); split.
         - rewrite is_opair; simpl; auto.
         - rewrite IHn; simpl; auto.
   Qed.
 
-  Let has_tuples : mb_has_tuples mem yl nt.
+  Let has_tuples : mb_has_tuples mem yd nt.
   Proof.
     intros v Hv.
     set (t := hfs_tuple (vec_map (proj1_sig (P:=fun x : hfs => p_bool x = true)) v)).
@@ -339,14 +349,13 @@ Section bt_model_n.
   Proof.
     intros x.
     exists (i x).
-    apply p_bool_spec.
-    generalize (Hi x) Hp2; apply Hp1.
+    abstract (apply p_bool_spec; generalize (Hi x) Hp2; apply Hp1).
   Defined.
 
-  Let Hi'' x : mem (i' x) yl.
-  Proof. unfold i', yl, mem; simpl; auto. Qed.
+  Let Hi'' x : mem (i' x) yd.
+  Proof. unfold i', yd, mem; simpl; auto. Qed.
 
-  Let s' (y : Y) : X := s (proj1_sig y).
+  Let s' (y : Y) : X := s (π1 y).
 
   (*
     For finite and discrete type X, non empty (as witnessed by a given element)
@@ -354,17 +363,17 @@ Section bt_model_n.
     and discrete, equipped with a Boolean binary membership predicate ∈ which is 
     extensional. Y is a finite (set like) model which contains two sets yl and 
     yr and there is a bijection between X and (the elements of) yl. All ordered 
-    triples build from elements of yl exist in Y, and yr encodes R in the set 
-    of (ordered) triples it contains. 
+    nt-tuples build from elements of yl exist in Y, and yr encodes R in the set 
+    of (ordered) nt-tuples it contains. 
     Finally, membership equivalence (≈) is the same as identity (=) in Y.
 
     Membership equivalence : x ≈ y := ∀z, z∈x <-> z∈y
     Membership extensional : x ≈ y -> ∀z, x∈z -> y∈z
 
-    Triples are build the usual way (in set theory)
+    Tuples are build the usual way (in set theory)
       - z ∈ {x,y} := z ≈ x \/ z ≈ y
       - ordered pairs: (x,y) is {{x},{x,y}}
-      - ordered triples: (x,y,z) is ((x,y),z)
+      - ordered triples: (x,y,z) is ((x,y),z), etc
 
     Non-emptyness is not really necessary but then bijection between X=ø and yl
     has to be implemented with dependent functions, more cumbersome to work
@@ -378,36 +387,19 @@ Section bt_model_n.
   
   Theorem reln_hfs : { Y : Type &
                      { _ : finite_t Y & 
-                     { _ : discrete Y &
                      { mem : Y -> Y -> Prop &
                      { _ : forall u v, { mem u v } + { ~ mem u v } & 
-                     { yl : Y &
+                     { yd : Y &
                      { yr : Y & 
                      { i : X -> Y & 
                      { s : Y -> X &
-                             mb_member_ext mem
-                          /\ mb_has_tuples mem yl nt
-                          /\ (forall x, mem (i x) yl)
-                          /\ (forall y, mem y yl -> exists x, y = i x)
-                          /\ (forall x, s (i x) = x)
+                             (forall x, mem (i x) yd)
+                          /\ (forall y, mem y yd -> exists x, y = i x)
                           /\ (forall v, R v <-> mb_is_tuple_in mem yr (vec_map i v))
-                          /\ (forall x y, mb_equiv mem x y <-> x = y)
-                      }}}}}}}}}.
+                      }}}}}}}}.
   Proof.
-    exists Y, HY, discrY, mem, mem_dec, yl, yr, i', s'.
-    msplit 6; auto.
-    + intros (u & Hu) (v & Hv) (w & Hw); unfold mem; simpl.
-      unfold mb_equiv; simpl; intros H.
-      cut (u = v); [ intros []; auto | ].
-      apply hfs_mem_ext.
-      apply p_bool_spec in Hu.
-      apply p_bool_spec in Hv.
-      clear w Hw.
-      intros x; split; intros Hx.
-      * generalize (Hp1 Hx Hu); rewrite p_bool_spec; intros H'.
-        apply (H (exist _ x H')); auto.
-      * generalize (Hp1 Hx Hv); rewrite p_bool_spec; intros H'.
-        apply (H (exist _ x H')); auto.
+    exists Y, HY, mem, mem_dec, yd, yr, i', s'.
+    msplit 2; auto.
     + intros y Hy; unfold i'.
       destruct (Hi' Hy) as (x & Hx).
       exists x; apply eqY; simpl; auto.
@@ -424,8 +416,6 @@ Section bt_model_n.
         simpl in H1, H2.
         rewrite vec_map_map in H1; subst t.
         apply H2. 
-    + intros x y; rewrite is_equiv; split; auto.
-      intros; subst; auto.
   Qed.
 
 End bt_model_n.

--- a/theories/TRAKHTENBROT/reln_hfs.v
+++ b/theories/TRAKHTENBROT/reln_hfs.v
@@ -80,7 +80,7 @@ Section bt_model_n.
 
   Section the_model.
 
-    Let X_surj_hfs : { d : hfs & 
+    Local Definition X_surj_hfs : { d : hfs & 
                      { f : hfs -> X & 
                      { g : X -> hfs |
                         hfs_transitive d

--- a/theories/TRAKHTENBROT/reln_hfs.v
+++ b/theories/TRAKHTENBROT/reln_hfs.v
@@ -78,145 +78,164 @@ Section bt_model_n.
 
   (* First we compute a bijection with the cardinal of X *)
 
-  Let X_surj_hfs : { d : hfs & { f : hfs -> X & 
-                    { g : X -> hfs |
-                      hfs_transitive d
-                   /\ ∅ ∈ d
-                   /\ (forall p, g p ∈ d)
-                   /\ (forall x, x ∈ d -> exists p, x = g p)
-                   /\ (forall p, f (g p) = p) } } }.
-  Proof.
-    destruct (finite_t_discrete_bij_t_pos Xfin)
-      as ([ | n ] & Hn); auto.
-    1: { exfalso; destruct Hn as (f & g & H1 & H2).
-         generalize (f x0); intro p; invert pos p. }
-    destruct Hn as (f & g & H1 & H2).
-    destruct (hfs_pos_n_transitive n) 
-      as (l & g' & f' & G1 & G0 & G2 & G3 & G4).
-    exists l, (fun x => g (g' x)), (fun x => f' (f x)); msplit 4; auto.
-    + intros x Hx.
-      destruct (G3 x Hx) as (p & Hp).
-      exists (g p); rewrite H2; auto.
-    + intros p; rewrite G4; auto.
-  Qed.
+  Section the_model.
 
-  (* First a surjective map from some transitive set l to X *)
+    Let X_surj_hfs : { d : hfs & 
+                     { f : hfs -> X & 
+                     { g : X -> hfs |
+                        hfs_transitive d
+                     /\ ∅ ∈ d
+                     /\ (forall p, g p ∈ d)
+                     /\ (forall x, x ∈ d -> exists p, x = g p)
+                     /\ (forall p, f (g p) = p) 
+                     }}}.
+    Proof.
+      destruct (finite_t_discrete_bij_t_pos Xfin)
+        as ([ | n ] & Hn); auto.
+      1: { exfalso; destruct Hn as (f & g & H1 & H2).
+           generalize (f x0); intro p; invert pos p. }
+      destruct Hn as (f & g & H1 & H2).
+      destruct (hfs_pos_n_transitive n) 
+        as (l & g' & f' & G1 & G0 & G2 & G3 & G4).
+      exists l, (fun x => g (g' x)), (fun x => f' (f x)); msplit 4; auto.
+      + intros x Hx.
+        destruct (G3 x Hx) as (p & Hp).
+        exists (g p); rewrite H2; auto.
+      + intros p; rewrite G4; auto.
+    Qed.
 
-  Let d := projT1 X_surj_hfs.
-  Let s := projT1 (projT2 X_surj_hfs).
-  Let i := proj1_sig (projT2 (projT2 (X_surj_hfs))).
+    (* First a surjective map from some transitive set d to X *)
 
-  Let Hd : hfs_transitive d.       Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hempty : ∅ ∈ d.              Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hs : forall x, s (i x) = x.  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
-  Let Hi : forall x, i x ∈ d.      Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+    Local Definition d := projT1 X_surj_hfs.
+    Local Definition s := projT1 (projT2 X_surj_hfs).
+    Local Definition i := proj1_sig (projT2 (projT2 (X_surj_hfs))).
 
-  Let Hi' : forall s, s ∈ d -> exists x, s = i x.
-  Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+    Let Hd : hfs_transitive d.       Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
+    Let Hempty : ∅ ∈ d.              Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
 
-  (* Now we build P^(1+2nt) d that contains all the sets of nt-tuples of d *)
+    Local Fact Hs : forall x, s (i x) = x.  
+    Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
 
-  Let p := iter hfs_pow d (1+(2*nt)).
+    Local Fact Hi : forall x, i x ∈ d.
+    Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
 
-  Let Hp1 : hfs_transitive p.
-  Proof. apply hfs_iter_pow_trans; auto. Qed.
+    Local Fact Hi' : forall s, s ∈ d -> exists x, s = i x.
+    Proof. apply (proj2_sig (projT2 (projT2 (X_surj_hfs)))). Qed.
 
-  Let Hp2 : d ∈ p.
-  Proof.
-    apply hfs_iter_pow_le with (n := 1); simpl; auto; try lia.
-    apply hfs_pow_spec; auto.
-  Qed.
+    (* Now we build P^(1+2nt) d that contains all the sets of nt-tuples of d *)
 
-  Let Hp5 n v : (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ iter hfs_pow d (2*n).
-  Proof. apply hfs_tuple_pow; auto. Qed.
+    Local Definition p := iter hfs_pow d (1+(2*nt)).
 
-  Let Hp6 n v : n <= nt -> (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ p.
-  Proof. 
-    intros L H; apply Hp5 in H.
-    revert H; apply hfs_iter_pow_le; try lia; auto.
-  Qed.
+    Local Fact Hp1 : hfs_transitive p.
+    Proof. apply hfs_iter_pow_trans; auto. Qed.
+
+    Local Fact Hp2 : d ∈ p.
+    Proof.
+      apply hfs_iter_pow_le with (n := 1); simpl; auto; try lia.
+      apply hfs_pow_spec; auto.
+    Qed.
+
+    Local Fact Hp5 n v : (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ iter hfs_pow d (2*n).
+    Proof. apply hfs_tuple_pow; auto. Qed.
+
+    Local Fact Hp6 n v : n <= nt -> (forall p, vec_pos v p ∈ d) -> @hfs_tuple n v ∈ p.
+    Proof. 
+      intros L H; apply Hp5 in H.
+      revert H; apply hfs_iter_pow_le; try lia; auto.
+    Qed.
+
+  End the_model.
 
   Variable (R : vec X nt -> Prop).
   Hypothesis HR : forall v, { R v } + { ~ R v }.
 
   Hint Resolve finite_t_prod hfs_mem_fin_t : core.
+  Hint Resolve Hp1 Hp2 Hp5 Hp6 Hs Hi Hi' : core.
 
-  (* We encode R as a subset of tuples of elements of d in p *)
+  Section the_relation.
 
-  Let encode_R : { r | r ∈ p 
+    (* We encode R as a subset of tuples of elements of d in p *)
+
+    Let encode_R : { r | r ∈ p 
                       /\ (forall v, @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ d)
                       /\ forall v, R v <-> hfs_tuple (vec_map i v) ∈ r }.
-  Proof.
-    set (P v := R (vec_map s v) /\ forall q, vec_pos v q ∈ d).
-    set (f := @hfs_tuple nt). 
-    destruct hfs_comprehension with (P := P) (f := f) as (r & Hr).
-    + apply fin_t_dec.
-      * intros; apply HR.
-      * apply fin_t_vec with (P := fun t => t ∈ d).
-        apply hfs_mem_fin_t.
-    + exists r; msplit 2.
-      * unfold p; rewrite plus_comm, iter_plus with (b := 1).
-        apply hfs_pow_spec; intros x; rewrite Hr.
-        intros (v & H1 & <-).
-        apply Hp5, H1.
-      * unfold f; intros v.
-        rewrite Hr.
-        intros (w & H1 & H2).
-        apply hfs_tuple_spec in H2; subst w.
-        apply H1.
-      * intros v.
-        rewrite Hr.
-        split.
-        - exists (vec_map i v); split; auto.
-          split; auto.
-          ++ rewrite vec_map_map.
-             revert H; apply fol_equiv_ext.
-             f_equal; apply vec_pos_ext; intro; rew vec.
-          ++ intro; rew vec.
-        - intros (w & (H1 & _) & H2).
-          apply hfs_tuple_spec in H2.
-          revert H1; subst w; apply fol_equiv_ext.
-          f_equal; apply vec_pos_ext; intro; rew vec.
-  Qed.
+    Proof.
+      set (P v := R (vec_map s v) /\ forall q, vec_pos v q ∈ d).
+      set (f := @hfs_tuple nt).
+      destruct hfs_comprehension with (P := P) (f := f) as (r & Hr).
+      + apply fin_t_dec.
+        * intros; apply HR.
+        * apply fin_t_vec with (P := fun t => t ∈ d).
+          apply hfs_mem_fin_t.
+      + exists r; msplit 2.
+        * unfold p; rewrite plus_comm, iter_plus with (b := 1).
+          apply hfs_pow_spec; intros x; rewrite Hr.
+          intros (v & H1 & <-).
+          apply Hp5, H1.
+        * unfold f; intros v.
+          rewrite Hr.
+          intros (w & H1 & H2).
+          apply hfs_tuple_spec in H2; subst w.
+          apply H1.
+        * intros v.
+          rewrite Hr.
+          split.
+          - exists (vec_map i v); split; auto.
+            split; auto.
+            ++ rewrite vec_map_map.
+               revert H; apply fol_equiv_ext.
+               f_equal; apply vec_pos_ext; intro; rew vec.
+            ++ intro; rew vec.
+          - intros (w & (H1 & _) & H2).
+            apply hfs_tuple_spec in H2.
+            revert H1; subst w; apply fol_equiv_ext.
+            f_equal; apply vec_pos_ext; intro; rew vec.
+    Qed.
 
-  Let r := proj1_sig encode_R.
+    Local Definition r := proj1_sig encode_R.
   
-  Let Hr1 : r ∈ p.
-  Proof. apply (proj2_sig encode_R). Qed.
+    Local Fact Hr1 : r ∈ p.
+    Proof. apply (proj2_sig encode_R). Qed.
 
-  Let Hr2 v : @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ d.
-  Proof. apply (proj2_sig encode_R). Qed.
+    Local Fact Hr2 v : @hfs_tuple nt v ∈ r -> forall q, vec_pos v q ∈ d.
+    Proof. apply (proj2_sig encode_R). Qed.
 
-  Let Hr3 v : R v <-> hfs_tuple (vec_map i v) ∈ r.
-  Proof. apply (proj2_sig encode_R). Qed.
+    Local Fact Hr3 v : R v <-> hfs_tuple (vec_map i v) ∈ r.
+    Proof. apply (proj2_sig encode_R). Qed.
+
+  End the_relation.
+
+  Hint Resolve Hr1 Hr2 Hr3 : core.
 
   (* The Boolean encoding of x ∈ p *)
 
-  Let p_bool x := if hfs_mem_dec x p then true else false.
+  Local Definition p_bool x := if hfs_mem_dec x p then true else false.
 
-  Let p_bool_spec x : x ∈ p <-> p_bool x = true.
+  Local Fact p_bool_spec x : x ∈ p <-> p_bool x = true.
   Proof.   
     unfold p_bool.
     destruct (hfs_mem_dec x p); split; try tauto; discriminate.
   Qed.
 
-  Let p_bool_spec1 x : x ∈ p -> p_bool x = true.
+  Local Fact p_bool_spec1 x : x ∈ p -> p_bool x = true.
   Proof. apply p_bool_spec. Qed.
 
-  Let p_bool_spec2 x : p_bool x = true -> x ∈ p.
+  Local Fact p_bool_spec2 x : p_bool x = true -> x ∈ p.
   Proof. apply p_bool_spec. Qed.
 
-  Let Y := sig (fun x => p_bool x = true).
+  Local Definition Y := sig (fun x => p_bool x = true).
 
-  Notation π1 := (@proj1_sig _ _).
+  Notation π1 := (@proj1_sig _ (fun x => p_bool x = true)).
 
-  Let eqY : forall x y : Y, π1 x = π1 y -> x = y.
+  Hint Resolve p_bool_spec p_bool_spec1 p_bool_spec2 : core.
+
+  Local Fact eqY : forall x y : Y, π1 x = π1 y -> x = y.
   Proof. 
     intros (x & Hx) (y & Hy); simpl.
     intros; subst; f_equal; apply UIP_dec, bool_dec.
   Qed.
 
-  Let HY : finite_t Y.
+  Local Fact HY : finite_t Y.
   Proof. 
     apply fin_t_finite_t.
     + intros; apply UIP_dec, bool_dec.
@@ -224,7 +243,9 @@ Section bt_model_n.
       intros x; auto.
   Qed.
 
-  Let discrY : discrete Y.
+  (* This one is not needed anymore *)
+
+  Local Fact discrY : discrete Y.
   Proof.
     intros (x & Hx) (y & Hy).
     destruct (hfs_eq_dec x y) as [ -> | D ].
@@ -232,32 +253,64 @@ Section bt_model_n.
     + right; contradict D; inversion D; auto.
   Qed.
 
-  Let mem (x y : Y) := π1 x ∈ π1 y.
+  Local Definition mem (x y : Y) := π1 x ∈ π1 y.
 
-  Let mem_dec : forall x y, { mem x y } + { ~ mem x y }.
+  Local Fact mem_dec : forall x y, { mem x y } + { ~ mem x y }.
   Proof.
     intros (a & ?) (b & ?); unfold mem; simpl; apply hfs_mem_dec.
   Qed.
 
-  Let mem_equiv_Y u v : u ∈ p -> v ∈ p
-                     -> (forall y : Y, π1 y ∈ u <-> π1 y ∈ v)
-                    <-> (forall x : hfs, x ∈ u <-> x ∈ v).
+  Local Definition yd : Y := exist _ _ (p_bool_spec1 Hp2).
+  Local Definition yr : Y := exist _ _ (p_bool_spec1 Hr1).
+
+  Local Fact fa_mem_Y (P : _ -> Prop) :
+                           (forall a, a ∈ p -> P a)
+                       <-> (forall a, P (π1 a)).
   Proof.
-    intros Hu Hv; split; intros H.
-    2: intro; apply H; auto.
-    intros x; split; intros Hx.
-    + generalize (Hp1 Hx Hu); rewrite p_bool_spec; intros G;
-      apply (@H (exist _ _ G)); auto.
-    + generalize (Hp1 Hx Hv); rewrite p_bool_spec; intros G;
-      apply (@H (exist _ _ G)); auto.
+    split.
+    + intros H (a & Ha); simpl; auto.
+    + intros H a Ha.
+      apply (H (exist _ _ (p_bool_spec1 Ha))).
   Qed.
 
-  Let yd : Y.    Proof. exists d; abstract (apply p_bool_spec, Hp2). Defined.
-  Let yr : Y.    Proof. exists r; abstract (apply p_bool_spec, Hr1). Defined.
+  Local Fact ex_mem_Y (P : _ -> Prop) :
+                           (exists a, a ∈ p /\ P a)
+                       <-> (exists a, P (π1 a)).
+  Proof.
+    split.
+    + intros (a & H & Ha). 
+      exists (exist _ a (p_bool_spec1 H)); auto.
+    + intros ((a & Ha) & H); simpl in *; eauto.
+  Qed.
+
+  Local Fact mem_fa_Y (P : _ -> Prop) k : k ∈ p -> (forall a, P a -> a ∈ p)
+                       -> (forall a, a ∈ k <-> P a)
+                       <-> (forall a, π1 a ∈ k <-> P (π1 a)).
+  Proof.
+    intros H1 H2.
+    rewrite <- fa_mem_Y with (P := fun a => a ∈ k <-> P a).
+    split.
+    + intros H ? _; auto.
+    + intros H a; split. 
+      * intros Ha; apply H; auto.
+        apply (Hp1 Ha); auto.
+      * intros Ha; apply H; auto.
+  Qed.
 
   (* Membership equivalence is identity in the model *)
 
-  Let is_equiv : forall x y, mb_equiv mem x y <-> π1 x = π1 y.
+  Local Fact mem_equiv_Y u v : 
+                        u ∈ p 
+                     -> v ∈ p
+                     -> (forall y : Y, π1 y ∈ u <-> π1 y ∈ v)
+                    <-> (forall x : hfs, x ∈ u <-> x ∈ v).
+  Proof.
+    intros Hu Hv.
+    symmetry; apply mem_fa_Y; auto.
+    intros s Hs; apply (Hp1 Hs); auto.
+  Qed.
+
+  Local Fact is_equiv : forall x y, mb_equiv mem x y <-> π1 x = π1 y.
   Proof.
     intros (x & Hx) (y & Hy); simpl.
     unfold mb_equiv, mem; simpl; split.
@@ -265,31 +318,46 @@ Section bt_model_n.
     rewrite mem_equiv_Y; auto; apply hfs_mem_ext.
   Qed.
 
-  Let is_pair : forall x y k, mb_is_pair mem k x y 
-                          <-> π1 k = hfs_pair (π1 x) (π1 y).
+  Local Fact mem_ext_Y x y : x ∈ p -> y ∈ p -> (forall a, π1 a ∈ x <-> π1 a ∈ y) <-> x = y.
   Proof.
-    intros (x & Hx) (y & Hy) (k & Hk); simpl.
-    unfold mb_is_pair; simpl. 
-    rewrite hfs_mem_ext.
-    generalize Hx Hy Hk; revert Hx Hy Hk.
-    do 3 rewrite <- p_bool_spec at 1.
-    intros Hx' Hy' Hk' Hx Hy Hk.
-    split.
-    + intros H a; split; rewrite hfs_pair_spec; [ intros Ha | intros [ Ha | Ha ] ].
-      * generalize (Hp1 Ha Hk'); rewrite p_bool_spec; intros Ha'.
-        specialize (H (exist _ a Ha')); simpl in H.
-        repeat rewrite is_equiv in H; apply H; auto.
-      * subst; apply (H (exist _ x Hx)); repeat rewrite is_equiv; simpl; auto.
-      * subst; apply (H (exist _ y Hy)); repeat rewrite is_equiv; simpl; auto.
-    + intros H (a & Ha); repeat rewrite is_equiv; simpl; rewrite <- hfs_pair_spec.
-      apply H.
+    intros H1 H2; split.
+    + intros H; apply hfs_mem_ext.
+      rewrite mem_fa_Y; auto.
+      intros z Hz; apply (Hp1 Hz); auto.
+    + intros ->; tauto.
   Qed.
- 
-  Let is_opair : forall x y k, mb_is_opair mem k x y 
-                           <-> π1 k = ⟬π1 x,π1 y⟭.
+
+  Hint Resolve mem_ext_Y : core.
+
+  Tactic Notation "fol" "equiv" :=
+    match goal with
+      | |- (forall _, _) <-> (forall _, _) => apply (fol_quant_sem_ext fol_fa)
+      | |- (exists _, _) <-> (exists _, _) => apply (fol_quant_sem_ext fol_ex)
+      | |- ( _ <-> _) <-> (_ <-> _) => apply fol_equiv_sem_ext
+      | |- ( _ \/ _) <-> (_ \/ _) => apply (fol_bin_sem_ext fol_disj)
+      | |- ( _ /\ _) <-> (_ /\ _) => apply (fol_bin_sem_ext fol_conj)
+    end.
+
+  Local Fact is_pair : forall x y k, mb_is_pair mem k x y 
+                                 <-> π1 k = hfs_pair (π1 x) (π1 y).
   Proof.
     intros (x & Hx) (y & Hy) (k & Hk); simpl.
-    unfold mb_is_opair; split.
+    unfold mb_is_pair; simpl.
+    unfold mb_equiv, mem; simpl.
+    rewrite hfs_pair_spec'.
+    rewrite mem_fa_Y; auto.
+    2: intros ? [ -> | -> ]; auto.
+    fol equiv; intros (a & Ha); simpl.
+    fol equiv; try tauto.
+    fol equiv; auto.
+  Qed.
+
+  Local Fact is_opair : forall x y k, mb_is_opair mem k x y 
+                                  <-> π1 k = ⟬π1 x,π1 y⟭.
+  Proof.
+    intros (x & Hx) (y & Hy) (k & Hk); simpl.
+    unfold mb_is_opair; simpl.
+    split.
     + intros ((a & Ha) & (b & Hb) & H); revert H.
       repeat rewrite is_pair; simpl.
       intros (-> & -> & ->); auto.
@@ -305,8 +373,8 @@ Section bt_model_n.
       repeat rewrite is_pair; simpl; auto.
   Qed.
 
-  Let is_tuple n : forall v t, @mb_is_tuple _ mem t n v 
-                           <-> π1 t = hfs_tuple (vec_map π1 v).
+  Local Fact is_tuple n : forall v t, @mb_is_tuple _ mem t n v 
+                                  <-> π1 t = hfs_tuple (vec_map π1 v).
   Proof.
     induction n as [ | n IHn ]; intros v (t & Ht).
     + vec nil v; clear v; simpl; split.
@@ -329,13 +397,13 @@ Section bt_model_n.
         assert (H1 : p_bool (hfs_tuple (vec_map π1 v)) = true).
         { apply p_bool_spec.
           apply p_bool_spec in Ht.
-          apply hfs_trans_opair_inv, proj2, hfs_trans_pair_inv in Ht; tauto. }
+          apply hfs_trans_opair_inv, proj2, hfs_trans_pair_inv in Ht; auto; tauto. }
         exists (exist _ (hfs_tuple (vec_map π1 v)) H1); split.
         - rewrite is_opair; simpl; auto.
         - rewrite IHn; simpl; auto.
   Qed.
 
-  Let has_tuples : mb_has_tuples mem yd nt.
+  Local Fact has_tuples : mb_has_tuples mem yd nt.
   Proof.
     intros v Hv.
     set (t := hfs_tuple (vec_map (proj1_sig (P:=fun x : hfs => p_bool x = true)) v)).
@@ -345,27 +413,24 @@ Section bt_model_n.
     apply is_tuple; simpl; reflexivity.
   Qed.
 
-  Let i' : X -> Y.
-  Proof.
-    intros x.
-    exists (i x).
-    abstract (apply p_bool_spec; generalize (Hi x) Hp2; apply Hp1).
-  Defined.
-
-  Let Hi'' x : mem (i' x) yd.
+  Local Definition i' x : Y := exist _ _ (p_bool_spec1 (Hp1 (Hi x) Hp2)).
+ 
+  Local Fact Hi'' x : mem (i' x) yd.
   Proof. unfold i', yd, mem; simpl; auto. Qed.
 
-  Let s' (y : Y) : X := s (π1 y).
+  Hint Resolve Hi'' : core.
+
+  Local Definition s' (y : Y) : X := s (π1 y).
 
   (*
     For finite and discrete type X, non empty (as witnessed by a given element)
     equipped with a Boolean ternary relation R, one can compute a type Y, finite
-    and discrete, equipped with a Boolean binary membership predicate ∈ which is 
-    extensional. Y is a finite (set like) model which contains two sets yl and 
-    yr and there is a bijection between X and (the elements of) yl. All ordered 
-    nt-tuples build from elements of yl exist in Y, and yr encodes R in the set 
+    (and discrete), equipped with a Boolean binary membership predicate ∈ (which is 
+    extensional). Y is a finite (set like) model which contains two sets yd and 
+    yr and there is a bijection between X and (the elements of) yd. All ordered 
+    nt-tuples build from elements of yd exist in Y, and yr encodes R in the set 
     of (ordered) nt-tuples it contains. 
-    Finally, membership equivalence (≈) is the same as identity (=) in Y.
+    (Finally, membership equivalence (≈) is the same as identity (=) in Y).
 
     Membership equivalence : x ≈ y := ∀z, z∈x <-> z∈y
     Membership extensional : x ≈ y -> ∀z, x∈z -> y∈z
@@ -375,11 +440,13 @@ Section bt_model_n.
       - ordered pairs: (x,y) is {{x},{x,y}}
       - ordered triples: (x,y,z) is ((x,y),z), etc
 
-    Non-emptyness is not really necessary but then bijection between X=ø and yl
-    has to be implemented with dependent functions, more cumbersome to work
+    Non-emptyness is not really necessary but then the bijection between X=ø 
+    and yl has to be implemented with dependent functions, more cumbersome to work
     with. And first order models can never be empty because one has to be able
-    to interpret variables. Maybe a discussion on the case of empty models
-    could be necessary, the logic been reduced to True/False in that case.
+    to interpret variables. 
+
+    Maybe a discussion on the case of empty models could help, but then 
+    the FO logic been reduced to True/False in that case.
     Any ∀ formula is True, any ∃ is False and no atomic formula can ever
     be evaluated (because it contains terms that cannot be interpreted). 
     Only closed formula have a meaning in the empty model 
@@ -414,8 +481,7 @@ Section bt_model_n.
       * intros ((t & Ht) & H1 & H2).
         rewrite is_tuple in H1.
         simpl in H1, H2.
-        rewrite vec_map_map in H1; subst t.
-        apply H2. 
+        rewrite vec_map_map in H1; subst t; auto.
   Qed.
 
 End bt_model_n.

--- a/theories/TRAKHTENBROT/reln_hfs.v
+++ b/theories/TRAKHTENBROT/reln_hfs.v
@@ -329,15 +329,6 @@ Section bt_model_n.
 
   Hint Resolve mem_ext_Y : core.
 
-  Tactic Notation "fol" "equiv" :=
-    match goal with
-      | |- (forall _, _) <-> (forall _, _) => apply (fol_quant_sem_ext fol_fa)
-      | |- (exists _, _) <-> (exists _, _) => apply (fol_quant_sem_ext fol_ex)
-      | |- ( _ <-> _) <-> (_ <-> _) => apply fol_equiv_sem_ext
-      | |- ( _ \/ _) <-> (_ \/ _) => apply (fol_bin_sem_ext fol_disj)
-      | |- ( _ /\ _) <-> (_ /\ _) => apply (fol_bin_sem_ext fol_conj)
-    end.
-
   Local Fact is_pair : forall x y k, mb_is_pair mem k x y 
                                  <-> π1 k = hfs_pair (π1 x) (π1 y).
   Proof.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -692,6 +692,7 @@ TRAKHTENBROT/Sig_one_rel.v
 TRAKHTENBROT/Sig_Sig_fin.v
 TRAKHTENBROT/Sig_rem_props.v
 TRAKHTENBROT/Sig_rem_constants.v
+TRAKHTENBROT/Sig_discernable.v
 
 TRAKHTENBROT/Sig0.v
 TRAKHTENBROT/Sig1.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -657,6 +657,7 @@ TRAKHTENBROT/utils.v
 TRAKHTENBROT/decidable.v
 TRAKHTENBROT/enumerable.v
 TRAKHTENBROT/fol_ops.v
+TRAKHTENBROT/discernable.v
 
 TRAKHTENBROT/gfp.v
 TRAKHTENBROT/btree.v


### PR DESCRIPTION
Not supposed to be merged right now. More precise description, to be completed.

+ Improved notations to correspond more closely to the paper (LMCS)
+ a new finite quotient along a partial equivalence relation and a list of defined elements (not necessarily all of them) in `Shared/Libs/DLW/Utils/fin_quotient.v`
+ `list_seteq` in `Shared/Libs/DLW/Utils/seteq.v`:
  - a nice inductive characterization of extensional identity of lists (same members)
  - `list_seteq` is permutation augmented with contraction equivalence
  - used to simplify the proof of `bti_equiv` in `btree.v`.
+ better automation in `btree.v`, most proofs are now very short.
+ cleanup (removed dead code) and better notations in `membership.v`
+ simplified the reduction from `Σn` to `Σ2` by removing some unnecessary axioms, impacts `reln_hfs.v` and `Sign_Sig2.v`
+ a better tactic notation `fol equiv *` for proving `A o B <-> A' o B'` where `o` is a binary connective or other. Not all the code is fully updated to use this tactic. 

A finer characterization for decidability of `FSAT` over monadic signatures (arity less than one):
+ as in the `discrete` signature case, one has to distinguish if there is a unary relation or else if all relation symbols are nullary;
+ two symbols are _discernable_ if they can be mapped to two different values in `bool`, eg `f x = true` and `f y = false` for some `f : rels -> bool` (equivalently, they can be mapped to two different values of a discrete type);
+ if there is a unary relation symbol: _`FSAT` is decidable iff discernability of function symbols and of relation symbols are decidable_;
+ if all relation symbols are nullary (arity 0):  _`FSAT` is decidable iff discernability of relation symbols is decidable_.
