### PR TITLE
Improvements (notations, shorter proofs, etc) for IMSELL

### DIFF
--- a/theories/FRACTRAN/FRACTRAN/fractran_utils.v
+++ b/theories/FRACTRAN/FRACTRAN/fractran_utils.v
@@ -122,27 +122,13 @@ Section fractran_utils.
 
   Fact fractran_step_dec l x : { y | l /F/ x → y } + { fractran_stop l x }.
   Proof.
-    revert x; induction l as [ | (a,b) l IH ]; intros x.
+    induction l as [ | (a,b) l IH ].
     + right; rewrite fractan_stop_nil_inv; auto.
-    + destruct x as [ | x ].
-      { left; exists 0; constructor 1; ring. }
-      destruct a as [ | a ].
-      { left; exists 0; constructor 1; ring. }
-      destruct b as [ | b ].
-      * assert (~ divides 0 (S a*S x)) as C.
-        { intros C; apply divides_0_inv, mult_is_O in C; lia. }
-        destruct (IH (S x)) as [ (y & Hy) | Hx ].
-        - left; exists y; constructor 2; auto.
-        - right; rewrite fractan_stop_cons_inv; split; auto.
-      * generalize (div_rem_spec1 (S a*S x) (S b)).
-        case_eq (rem (S a * S x) (S b)).
-        - intros H1 H2; left; exists (div (S a*S x) (S b)); constructor 1; rewrite H2 at 2; ring.
-        - intros d Hd _.
-          assert (~ divides (S b) (S a*S x)) as C.
-          { rewrite divides_rem_eq, Hd; discriminate. }
-          destruct (IH (S x)) as [ (y & Hy) | Hx ].
-          ++ left; exists y; constructor 2; auto.
-          ++ right; rewrite fractan_stop_cons_inv; split; auto.
+    + destruct (divides_dec (a*x) b) as [ (y & Hy) | ].
+      * left; exists y; constructor 1; rewrite Hy; ring.
+      * destruct IH as [ (y & ?) | ].
+        - left; exists y; now constructor 2.
+        - right; apply fractan_stop_cons_inv; auto.
   Qed.
 
   (* Now we treat the cases where (_,0) occurs in l *)

--- a/theories/ILL/IMSELL.v
+++ b/theories/ILL/IMSELL.v
@@ -26,11 +26,13 @@ Section IMSELL.
   Variables (var bang : Type)
             (bang_le : bang -> bang -> Prop)   (* a pre-order on modalities *)
             (bang_U : bang -> Prop)            (* universal modalities have structural rules *)
-            . 
+            .
+
+  Notation Λ := bang.
 
   Inductive imsell_form : Type :=
     | imsell_var  : var -> imsell_form
-    | imsell_ban  : bang -> imsell_form -> imsell_form
+    | imsell_ban  : Λ -> imsell_form -> imsell_form
     | imsell_imp  : imsell_form -> imsell_form -> imsell_form.
 
   Infix "⊸" := imsell_imp.

--- a/theories/ILL/Ll/imsell.v
+++ b/theories/ILL/Ll/imsell.v
@@ -93,7 +93,8 @@ Section IMSELL.
 
     Hypothesis HK_antitone : forall u v, u ≤ v -> K v ⊆ K u.
 
-    Notation ø := vec_zero.
+    Notation "⦳" := vec_zero.
+    Notation ø := vec_nil.
 
     Definition imsell_tps_mult (X Y : _ -> Prop) (x : vec _ n) := exists a b, x = vec_plus a b /\ X a /\ Y b.
     Definition imsell_tps_imp (X Y : _ -> Prop) (v : vec _ n) := forall x, X x -> Y (vec_plus x v).
@@ -101,16 +102,16 @@ Section IMSELL.
     Infix "⊛" := imsell_tps_mult (at level 65, right associativity).
     Infix "-⊛" := imsell_tps_imp (at level 65, right associativity).
 
-    Fact imsell_tps_imp_zero X Y : (X -⊛ Y) ø <-> X ⊆ Y.
+    Fact imsell_tps_imp_zero X Y : (X -⊛ Y) ⦳ <-> X ⊆ Y.
     Proof.
       split.
       + intros ? ? ?; rewrite <- vec_zero_plus, vec_plus_comm; auto.
       + intros ? ?; rewrite vec_plus_comm, vec_zero_plus; auto.
     Qed.
 
-    Hypothesis HK_unit0 : forall u, K u ø.
+    Hypothesis HK_unit0 : forall u, K u ⦳.
     Hypothesis HK_plus  : forall u, K u ⊛ K u ⊆ K u.
-    Hypothesis HK_unit1 : forall u, U u -> forall x, K u x -> x = ø.
+    Hypothesis HK_unit1 : forall u, U u -> forall x, K u x -> x = ⦳.
 
     Fact imsell_tps_mult_mono (X1 X2 Y1 Y2 : _ -> Prop) : 
               X1 ⊆ X2 -> Y1 ⊆ Y2 -> X1⊛Y1 ⊆ X2⊛Y2.
@@ -127,10 +128,10 @@ Section IMSELL.
       end
     where "⟦ A ⟧" := (imsell_tps A).
 
-    Fact imsell_tps_bang_zero u A : ⟦![u]A⟧ ø <-> ⟦A⟧ ø.
+    Fact imsell_tps_bang_zero u A : ⟦![u]A⟧ ⦳ <-> ⟦A⟧ ⦳.
     Proof. simpl; split; auto; tauto. Qed.
 
-    Fact imsell_tps_bang_U u A : U u -> (forall v, ⟦![u]A⟧ v <-> v = ø) <-> ⟦A⟧ ø.
+    Fact imsell_tps_bang_U u A : U u -> (forall v, ⟦![u]A⟧ v <-> v = ⦳) <-> ⟦A⟧ ⦳.
     Proof.
       intros Hu; split.
       + intros H; rewrite <- imsell_tps_bang_zero, H; auto.
@@ -143,7 +144,7 @@ Section IMSELL.
 
     Fixpoint imsell_tps_list Γ :=
       match Γ with
-        | nil  => eq ø
+        | nil  => eq ⦳
         | A::Γ => ⟦A⟧⊛⟪Γ⟫
       end
     where "⟪ Γ ⟫" := (imsell_tps_list Γ).
@@ -169,10 +170,10 @@ Section IMSELL.
           exists g, d; auto.
     Qed.
 
-    Fact imsell_tps_list_zero Γ : (forall A, A ∊ Γ -> ⟦A⟧ ø) -> ⟪Γ⟫ ø.
+    Fact imsell_tps_list_zero Γ : (forall A, A ∊ Γ -> ⟦A⟧ ⦳) -> ⟪Γ⟫ ⦳.
     Proof.
       induction Γ as [ | A Γ IH ]; simpl; auto; intros H.
-      exists ø, ø; msplit 2; auto; now rewrite vec_zero_plus.
+      exists ⦳, ⦳; msplit 2; auto; now rewrite vec_zero_plus.
     Qed.
 
     Fact imsell_tps_lbang u Γ : u ≼ Γ -> ⟪‼Γ⟫ ⊆ K u.
@@ -217,7 +218,7 @@ Section IMSELL.
       apply imsell_tps_perm, Permutation_sym; auto.
     Qed.
 
-    Fact imsell_sequent_tps_eq Γ A : [< Γ |- A >] ø <-> ⟪Γ⟫ ⊆ ⟦A⟧.
+    Fact imsell_sequent_tps_eq Γ A : [< Γ |- A >] ⦳ <-> ⟪Γ⟫ ⊆ ⟦A⟧.
     Proof.
       split.
       * intros H x Hx.
@@ -227,7 +228,7 @@ Section IMSELL.
         rewrite vec_plus_comm, vec_zero_plus; auto.
     Qed.
 
-    Theorem imsell_tps_sound Γ A : Γ ⊢ A -> [< Γ |- A >] ø.
+    Theorem imsell_tps_sound Γ A : Γ ⊢ A -> [< Γ |- A >] ⦳.
     Proof.
       induction 1 as [ A 
                      | Γ Δ A H1 H2 IH2

--- a/theories/ILL/Ll/imsell.v
+++ b/theories/ILL/Ll/imsell.v
@@ -106,10 +106,7 @@ Section IMSELL.
 
     (* We only consider the monoids nat^n *)
 
-    Variables (n : nat) (s : nat -> vec nat n -> Prop)
-              (K : bang -> vec nat n -> Prop).
-
-    Hypothesis HK_antitone : forall u v, u ≤ v -> K v ⊆ K u.
+    Variables (n : nat) (s : nat -> vec nat n -> Prop).
 
     Notation "⦳" := vec_zero.
     Notation ø := vec_nil.
@@ -127,8 +124,11 @@ Section IMSELL.
       + intros ? ?; rewrite vec_plus_comm, vec_zero_plus; auto.
     Qed.
 
-    Hypothesis HK_unit0 : forall u, K u ⦳.
-    Hypothesis HK_plus  : forall u, K u ⊛ K u ⊆ K u.
+    Variable (K : bang -> vec nat n -> Prop).
+
+    Hypothesis HK_antitone : forall p q, p ≤ q -> K q ⊆ K p.
+    Hypothesis HK_unit0 : forall m, K m ⦳.
+    Hypothesis HK_plus  : forall m, K m ⊛ K m ⊆ K m.
     Hypothesis HK_unit1 : forall u, U u -> forall x, K u x -> x = ⦳.
 
     Fact imsell_tps_mult_mono (X1 X2 Y1 Y2 : _ -> Prop) : 
@@ -141,12 +141,12 @@ Section IMSELL.
     Fixpoint imsell_tps (A : imsell_form nat bang) x : Prop :=
       match A with
         | £ X   => s X x
-        | ![u]A => ⟦A⟧ x /\ K u x
+        | ![m]A => ⟦A⟧ x /\ K m x
         | A⊸B   => (⟦A⟧-⊛⟦B⟧) x
       end
     where "⟦ A ⟧" := (imsell_tps A).
 
-    Fact imsell_tps_bang_zero u A : ⟦![u]A⟧ ⦳ <-> ⟦A⟧ ⦳.
+    Fact imsell_tps_bang_zero m A : ⟦![m]A⟧ ⦳ <-> ⟦A⟧ ⦳.
     Proof. simpl; split; auto; tauto. Qed.
 
     Fact imsell_tps_bang_U u A : U u -> (forall v, ⟦![u]A⟧ v <-> v = ⦳) <-> ⟦A⟧ ⦳.
@@ -188,24 +188,6 @@ Section IMSELL.
           exists g, d; auto.
     Qed.
 
-    Fact imsell_tps_list_zero Γ : (forall A, A ∊ Γ -> ⟦A⟧ ⦳) -> ⟪Γ⟫ ⦳.
-    Proof.
-      induction Γ as [ | A Γ IH ]; simpl; auto; intros H.
-      exists ⦳, ⦳; msplit 2; auto; now rewrite vec_zero_plus.
-    Qed.
-
-    Fact imsell_tps_lbang u Γ : u ≼ Γ -> ⟪‼Γ⟫ ⊆ K u.
-    Proof.
-      induction Γ as [ | (v,A) Γ IH ]; simpl; intros H1 x.
-      + intros <-; auto.
-      + intros (y & z & -> & (G1 & G2) & G3).
-        apply HK_plus; exists y, z; msplit 2; auto.
-        * revert G2; apply HK_antitone; auto.
-          apply (H1 (v,A)); auto.
-        * revert G3; apply IH.
-          intros (w,B) ?; apply (H1 (_,B)); auto.
-    Qed.
-
     Fact imsell_tps_perm Γ Δ : Γ ~p Δ -> ⟪Γ⟫ ⊆ ⟪Δ⟫.
     Proof.
       induction 1 as [ | A Ga De H IH | A B Ga | ]; simpl; auto.
@@ -217,7 +199,13 @@ Section IMSELL.
         * split; auto.
           exists y, d; auto.
     Qed.
-  
+
+    Fact imsell_tps_list_zero Γ : (forall A, A ∊ Γ -> ⟦A⟧ ⦳) -> ⟪Γ⟫ ⦳.
+    Proof.
+      induction Γ as [ | A Γ IH ]; simpl; auto; intros H.
+      exists ⦳, ⦳; msplit 2; auto; now rewrite vec_zero_plus.
+    Qed.
+
     Definition imsell_sequent_tps Γ A := ⟪Γ⟫ -⊛ ⟦A⟧.
 
     Notation "'[<' Γ '|-' A '>]'" := (imsell_sequent_tps Γ A) (at level 1, format "[<  Γ  |-  A  >]").
@@ -246,16 +234,28 @@ Section IMSELL.
         rewrite vec_plus_comm, vec_zero_plus; auto.
     Qed.
 
+   Fact imsell_tps_lbang m Γ : m ≼ Γ -> ⟪‼Γ⟫ ⊆ K m.
+    Proof.
+      induction Γ as [ | (v,A) Γ IH ]; simpl; intros H1 x.
+      + intros <-; auto.
+      + intros (y & z & -> & (G1 & G2) & G3).
+        apply HK_plus; exists y, z; msplit 2; auto.
+        * revert G2; apply HK_antitone; auto.
+          apply (H1 (v,A)); auto.
+        * revert G3; apply IH.
+          intros (w,B) ?; apply (H1 (_,B)); auto.
+    Qed.
+
     Theorem imsell_tps_sound Γ A : Γ ⊢ A -> [< Γ |- A >] ⦳.
     Proof.
       induction 1 as [ A 
                      | Γ Δ A H1 H2 IH2
                      | Γ Δ A B C H1 IH1 H2 IH2
                      | Γ A B H1 IH1
-                     | u Γ A B H1 IH1
-                     | u Γ A H1 H2 IH2
-                     | u Γ A B H1 H2 IH2
-                     | u Γ A B H1 H2 IH2
+                     | Γ m A B H1 IH1
+                     | Γ m A H1 H2 IH2
+                     | Γ u A B H1 H2 IH2
+                     | Γ u A B H1 H2 IH2
                      ]; unfold imsell_sequent_tps in * |- *.
 
       + intros x; simpl; intros (y & z & H1 & H2 & H3); subst; eq goal H2.

--- a/theories/ILL/Reductions/ndMM2_IMSELL.v
+++ b/theories/ILL/Reductions/ndMM2_IMSELL.v
@@ -231,12 +231,12 @@ Section ndmm2_imsell.
   Local Fact sem_2 p x y : sem (2+p) (x##y##ø) <-> Σ //ₙ x ⊕ y ⊦ p.
   Proof. simpl; tauto. Qed.
 
-  Let K u (w : vec nat 2) := 
+  Let K m (w : vec nat 2) := 
     let x := vec_head w in
     let y := vec_head (vec_tail w) 
-    in (a ≤ u -> y = 0)
-    /\ (b ≤ u -> x = 0)
-    /\ (U u -> x = 0 /\ y = 0).
+    in (a ≤ m -> y = 0)
+    /\ (b ≤ m -> x = 0)
+    /\ (U m -> x = 0 /\ y = 0).
 
   Infix "⊛" := imsell_tps_mult (at level 65, right associativity).
   Infix "-⊛" := imsell_tps_imp (at level 65, right associativity).
@@ -244,19 +244,19 @@ Section ndmm2_imsell.
   Notation "⟦ A ⟧" := (imsell_tps sem K A).
   Notation "⟪ Γ ⟫" := (imsell_tps_list sem K Γ).
 
-  Local Fact HK1 u v : u ≤ v -> K v ⊆ K u.
+  Local Fact HK1 p q : p ≤ q -> K q ⊆ K p.
   Proof.
-    intros Huv; intro pair as x y.
+    intros Hpq; intro pair as x y.
     unfold K; simpl; intros (H1 & H2 & H3); msplit 2; intros H.
-    + apply H1, bang_le_trans with (2 := Huv); auto.
-    + apply H2, bang_le_trans with (2 := Huv); auto.
-    + apply H3, bang_U_clos with (2 := Huv); auto.
+    + apply H1, bang_le_trans with (2 := Hpq); auto.
+    + apply H2, bang_le_trans with (2 := Hpq); auto.
+    + apply H3, bang_U_clos with (2 := Hpq); auto.
   Qed.
 
-  Local Fact HK2 : forall u, K u ⦳.
+  Local Fact HK2 : forall m, K m ⦳.
   Proof. intros; split; auto. Qed.
 
-  Local Fact HK3 u : K u ⊛ K u ⊆ K u.
+  Local Fact HK3 m : K m ⊛ K m ⊆ K m.
   Proof.
     intro pair as x y.
     intros (p & q & H); revert p q H.

--- a/theories/MinskyMachines/MM.v
+++ b/theories/MinskyMachines/MM.v
@@ -46,6 +46,10 @@ Inductive mm_instr (X : Set) : Set :=
 Notation INC := mm_inc.
 Notation DEC := mm_dec.
 
+Notation INCₐ := mm_inc.
+Notation DECₐ := mm_dec.
+
+
 (* ** Semantics for MM, restricted to X = pos n for some n *)
 
 Section Minsky_Machine.
@@ -68,9 +72,9 @@ Section Minsky_Machine.
   (* Minsky machine alternate small step semantics *)
 
   Inductive mma_sss : mm_instr (pos n) -> mm_state -> mm_state -> Prop :=
-    | in_mma_sss_inc   : forall i x v,                   INC x   // (i,v) -1> (1+i,v[(S (v#>x))/x])
-    | in_mma_sss_dec_0 : forall i x k v,   v#>x = O   -> DEC x k // (i,v) -1> (1+i,v)
-    | in_mma_sss_dec_1 : forall i x k v u, v#>x = S u -> DEC x k // (i,v) -1> (k,v[u/x])
+    | in_mma_sss_inc   : forall i x v,                   INCₐ x   // (i,v) -1> (1+i,v[(S (v#>x))/x])
+    | in_mma_sss_dec_0 : forall i x k v,   v#>x = O   -> DECₐ x k // (i,v) -1> (1+i,v)
+    | in_mma_sss_dec_1 : forall i x k v u, v#>x = S u -> DECₐ x k // (i,v) -1> (k,v[u/x])
   where "i // s -1> t" := (mma_sss i s t).
 
 End Minsky_Machine.

--- a/theories/MinskyMachines/MM.v
+++ b/theories/MinskyMachines/MM.v
@@ -99,9 +99,15 @@ Section MMA_problems.
   Notation "P // s ~~> t" := (sss_output (@mma_sss _) P s t).
   Notation "P // s ↓" := (sss_terminates (@mma_sss _) P s). 
 
-  Definition MMA2_PROBLEM := (list (mm_instr (pos 2)) * vec nat 2)%type.
+  Definition MMA_PROBLEM n := (list (mm_instr (pos n)) * vec nat n)%type.
 
-  Definition MMA2_HALTS_ON_ZERO (P : MMA2_PROBLEM) := (1,fst P) // (1,snd P) ~~> (0,vec_zero).
-  Definition MMA2_HALTING (P : MMA2_PROBLEM) := (1,fst P) // (1,snd P) ↓.
+  Definition MMA_HALTS_ON_ZERO {n} (P : MMA_PROBLEM n) := (1,fst P) // (1,snd P) ~~> (0,vec_zero).
+  Definition MMA_HALTING {n} (P : MMA_PROBLEM n) := (1,fst P) // (1,snd P) ↓.
+
+  Definition MMA2_PROBLEM := MMA_PROBLEM 2.
+
+  Definition MMA2_HALTS_ON_ZERO := @MMA_HALTS_ON_ZERO 2.
+  Definition MMA2_HALTING := @MMA_HALTING 2.
 
 End MMA_problems.
+

--- a/theories/MinskyMachines/MMA/fractran_mma.v
+++ b/theories/MinskyMachines/MMA/fractran_mma.v
@@ -209,15 +209,15 @@ Section Fractran_with_two_counters.
       intros H1 H2; revert H1 i H2.
       induction 1 as [ | (p,q) ll Hq Hll IH ]; intros i H4.
       + mma sss stop.
-      + apply fractan_stop_cons_inv in H4; destruct H4 as (H4 & H5).
+      + apply fractan_stop_cons_inv in H4 as (H4 & H5).
         unfold mma_fractran_step; fold mma_fractran_step.
         set (P := mma_fractran_one p q j i); rew length.
         apply sss_compute_trans with (length P+i,x##0##ø).
-        { apply subcode_sss_compute with (P := (i,P)); auto.
-          apply sss_progress_compute, mma_fractran_one_nok_progress; auto. }
-        { apply subcode_sss_compute with (P := (length P+i,mma_fractran_step ll (length P + i))); auto.
+        * apply subcode_sss_compute with (P := (i,P)); auto.
+          apply sss_progress_compute, mma_fractran_one_nok_progress; auto.
+        * apply subcode_sss_compute with (P := (length P+i,mma_fractran_step ll (length P + i))); auto.
           replace (length P+length (mma_fractran_step ll (length P + i))+i)
-          with    (length (mma_fractran_step ll (length P + i)) + (length P+i)) by lia; auto. }
+          with    (length (mma_fractran_step ll (length P + i)) + (length P+i)) by lia; auto.
     Qed.
 
   End mma_fractran_step.
@@ -250,8 +250,7 @@ Section Fractran_with_two_counters.
             -> Q /F/ x ↓.
     Proof using HQ.
       intros ((j,w) & (k & H2) & H3); simpl fst in H3.
-      revert x H2.
-      induction on k as IHu with measure k; intros x H2.
+      revert x H2; induction on k as IHu with measure k; intros x H2.
       destruct (fractran_step_dec Q x) as [ (y & Hy) | H4 ].
       2: { exists x; split; auto; exists 0; simpl; auto. }
       generalize Hy; intros H4.

--- a/theories/MinskyMachines/MMA/fractran_mma.v
+++ b/theories/MinskyMachines/MMA/fractran_mma.v
@@ -26,10 +26,12 @@ Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).
 Local Notation "e [ v / x ]" := (vec_change e x v).
+Local Notation ø := vec_nil.
 
-Local Notation "P /MM2/ s -+> t" := (sss_progress (@mma_sss _) P s t) (at level 70, no associativity).
-Local Notation "P /MM2/ s ->> t" := (sss_compute (@mma_sss _) P s t) (at level 70, no associativity).
-Local Notation "P /MM2/ s ↓" := (sss_terminates (@mma_sss _) P s) (at level 70, no associativity). 
+Local Notation "P //ₐ s -+> t" := (sss_progress (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ->> t" := (sss_compute (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ~~> t" := (sss_output (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ↓" := (sss_terminates (@mma_sss _) P s) (at level 70, no associativity). 
 
 Local Notation "l /F/ x → y" := (fractran_step l x y) (at level 70, no associativity).
 
@@ -41,6 +43,17 @@ Section Fractran_with_two_counters.
   Hint Rewrite mma_null_length mma_transfert_length mma_incs_length mma_decs_copy_length 
                mma_mult_cst_length mma_decs_length mma_mod_cst_length mma_div_cst_length : length_db.
 
+  Notation JUMPₐ := mma_jump.
+  Notation NULLₐ := mma_null.
+  Notation TRANSFERTₐ := mma_transfert.
+  Notation INCSₐ := mma_incs.
+  Notation DECSₐ := mma_decs.
+  Notation DECS_COPYₐ := mma_decs_copy.
+  Notation MULT_CSTₐ := mma_mult_cst.
+  Notation MOD_CSTₐ := mma_mod_cst.
+  Notation DIV_CSTₐ := mma_div_cst.
+  Notation LOOPₐ := mma_loop.
+
   Let src : pos 2 := pos0.
   Let dst : pos 2 := pos1.
 
@@ -49,79 +62,62 @@ Section Fractran_with_two_counters.
   Let Hsrc_dst : src <> dst.    Proof. discriminate. Qed.
   Let Hdst_src : dst <> src.    Proof. discriminate. Qed.
 
-  Section mma_loop.
-
-    Definition mma_loop := INC src :: DEC src 1 :: nil.
-
-    Fact mma_loop_loop v : (1,mma_loop) /MM2/ (1,v) -+> (1,v).
-    Proof.
-      unfold mma_loop.
-      mma sss INC with src.
-      mma sss DEC S with src 1 (v#>src); rew vec.
-      mma sss stop.
-    Qed.
-
-    Theorem mma_loop_spec v : ~ (1,mma_loop) /MM2/ (1,v) ↓.
-    Proof.
-      intros (w & (k & Hk) & H2); revert w Hk H2.
-      induction on k as IHk with measure k; intros w Hk Hw.
-      destruct subcode_sss_progress_inv with (4 := mma_loop_loop v) (5 := Hk)
-        as (q & H1 & H2); auto.
-      { apply mma_sss_fun. }
-      apply IHk with (1 := H1) (2 := H2); auto.
-    Qed.
-  
-  End mma_loop.
-
   Section mma_fractran_one.
 
     (* FRACTRAN computation, try one fraction a/b *)
 
-    Variables (a b : nat) (p i : nat).
+    Variables (p q : nat) (j i0 : nat).
+
+    Notation i := i0.
+    Notation i1 := (5+p+i0).
+    Notation i2 := (11+p+4*q+i0).
+    Notation i3 := (16+p+7*q+i0).
+    Notation i4 := (21+p+7*q+i0).
+    Notation i5 := (26+4*p+7*q+i0).
 
     Definition mma_fractran_one :=
-           mma_mult_cst src dst a i
-        ++ mma_mod_cst dst src (11+a+4*b+i) (21+a+7*b+i) b (5+a+i)
-        ++ mma_div_cst src dst b (11+a+4*b+i)
-        ++ mma_transfert dst src (16+a+7*b+i)
-        ++ INC dst :: DEC dst p
-        :: mma_div_cst src dst a (21+a+7*b+i)
-        ++ mma_transfert dst src (26+4*a+7*b+i).
+           MULT_CSTₐ src dst p i0
+        ++ MOD_CSTₐ dst src i2 i4 q i1
+        ++ DIV_CSTₐ src dst q i2
+        ++ TRANSFERTₐ dst src i3
+        ++ INCₐ dst :: DECₐ dst j
+        :: DIV_CSTₐ src dst p i4
+        ++ TRANSFERTₐ dst src i5.
 
-    Fact mma_fractran_one_length : length mma_fractran_one = 29+4*a+7*b.
+    Fact mma_fractran_one_length : length mma_fractran_one = 29+4*p+7*q.
     Proof. unfold mma_fractran_one; rew length; lia. Qed.
 
-    Hypothesis (Ha : a <> 0) (Hb : b <> 0).
+    Hypothesis (Hp : p <> 0) (Hq : q <> 0).
 
-    (* If the state in src is compatible with a/b then
-       src becomes src*a/b and jump at p *)
+    (* If the state in src is compatible with p/q then
+       src becomes src*p/q and jump at j *)
 
     Fact mma_fractran_one_ok_progress k v :
-            k*b = a*(v#>src)
+            k*q = p*(v#>src)
          -> v#>dst = 0
-         -> (i,mma_fractran_one) /MM2/ (i,v) -+> (p,v[k/src]).
-    Proof using Ha Hb.
+         -> (i0,mma_fractran_one) //ₐ (i0,v) -+> (j,v[k/src]).
+    Proof using Hp Hq.
       intros H1 H2; unfold mma_fractran_one.
-      apply sss_progress_trans with (5+a+i,v[0/src][(k*b)/dst]).
-      { apply subcode_sss_progress with (P := (i,mma_mult_cst src dst a i)); auto.
+      apply sss_progress_trans with (i1,v[0/src][(k*q)/dst]).
+      { apply subcode_sss_progress with (P := (i,mma_mult_cst src dst p i)); auto.
         apply mma_mult_cst_progress; auto.
         rewrite H2, <- H1; do 2 f_equal; lia. }
-      apply sss_progress_trans with (11+a+4*b+i,v[(k*b)/src][0/dst]).
-      { apply subcode_sss_progress with (P := (5+a+i,mma_mod_cst dst src (11+a+4*b+i) (21+a+7*b+i) b (5+a+i))); auto.
+      apply sss_progress_trans with (i2,v[(k*q)/src][0/dst]).
+      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i4 q i1)); auto.
         apply mma_mod_cst_divides_progress with k; rew vec; try lia.
         f_equal; apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
-      apply sss_progress_trans with (16+a+7*b+i,v[0/src][k/dst]).
-      { apply subcode_sss_progress with (P := (11+a+4*b+i,mma_div_cst src dst b (11+a+4*b+i))); auto.
+      apply sss_progress_trans with (i3,v[0/src][k/dst]).
+      { apply subcode_sss_progress with (P := (i2,mma_div_cst src dst q i2)); auto.
         apply mma_div_cst_progress with k; auto; rew vec; try lia.
         f_equal; try lia.
         apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
-      apply sss_progress_trans with (19+a+7*b+i,v[k/src][0/dst]).
-      { apply subcode_sss_progress with (P := (16+a+7*b+i,mma_transfert dst src (16+a+7*b+i))); auto.
+      apply sss_progress_trans with (19+p+7*q+i0,v[k/src][0/dst]).
+      { apply subcode_sss_progress with (P := (i3,mma_transfert dst src i3)); auto.
         apply mma_transfert_progress; auto.
         f_equal; try lia.
         apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
       mma sss INC with dst.
-      mma sss DEC S with dst p 0; rew vec.
+      mma sss DEC S with dst j 0; rew vec.
       mma sss stop; f_equal.
       apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. 
     Qed.
@@ -129,31 +125,31 @@ Section Fractran_with_two_counters.
     (* If the state in src is not compatible with a/b then jump at the end of the code *)
 
     Fact mma_fractran_one_nok_progress v :
-            ~ divides b (a*(v#>src))
+            ~ divides q (p*(v#>src))
          -> v#>dst = 0
-         -> (i,mma_fractran_one) /MM2/ (i,v) -+> (length mma_fractran_one+i,v).
-    Proof using Ha Hb.
+         -> (i0,mma_fractran_one) //ₐ (i0,v) -+> (length mma_fractran_one+i0,v).
+    Proof using Hp Hq.
       rewrite mma_fractran_one_length.
       intros H1 H2; unfold mma_fractran_one.
       rewrite divides_rem_eq in H1.
       revert H1.
-      generalize (div_rem_spec1 (a*(v#>src)) b)
-                 (div_rem_spec2 (a*(v#>src)) Hb).
-      generalize (div (a*(v#>src)) b) (rem (a*(v#>src)) b); intros x y H3 H4 H5.
-      apply sss_progress_trans with (5+a+i,v[0/src][(x*b+y)/dst]).
-      { apply subcode_sss_progress with (P := (i,mma_mult_cst src dst a i)); auto.
+      generalize (div_rem_spec1 (p*(v#>src)) q)
+                 (div_rem_spec2 (p*(v#>src)) Hq).
+      generalize (div (p*(v#>src)) q) (rem (p*(v#>src)) q); intros x y H3 H4 H5.
+      apply sss_progress_trans with (i1,v[0/src][(x*q+y)/dst]).
+      { apply subcode_sss_progress with (P := (i0,mma_mult_cst src dst p i0)); auto.
         apply mma_mult_cst_progress; auto.
         rewrite H2, <- H3; do 2 f_equal; lia. }
-      apply sss_progress_trans with (21+a+7*b+i,v[(a*(v#>src))/src][0/dst]).
-      { apply subcode_sss_progress with (P := (5+a+i,mma_mod_cst dst src (11+a+4*b+i) (21+a+7*b+i) b (5+a+i))); auto.
+      apply sss_progress_trans with (i4,v[(p*(v#>src))/src][0/dst]).
+      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i4 q i1)); auto.
         apply mma_mod_cst_not_divides_progress with x y; rew vec; try lia.
         f_equal; apply vec_pos_ext; intros c; dest c dst; try lia; dest c src; lia. }
-      apply sss_progress_trans with (26+4*a+7*b+i,v[0/src][(v#>src)/dst]).
-      { apply subcode_sss_progress with (P := (21+a+7*b+i,mma_div_cst src dst a (21+a+7*b+i))); auto.
+      apply sss_progress_trans with (26+4*p+7*q+i0,v[0/src][(v#>src)/dst]).
+      { apply subcode_sss_progress with (P := (i4,mma_div_cst src dst p i4)); auto.
         apply mma_div_cst_progress with (v#>src); auto; rew vec; try lia; try ring.
         f_equal; try lia.
         apply vec_pos_ext; intros c; dest c dst; try lia; dest c src. }
-      apply subcode_sss_progress with (P := (26+4*a+7*b+i,mma_transfert dst src (26+4*a+7*b+i))); auto.
+      apply subcode_sss_progress with (P := (26+4*p+7*q+i0,mma_transfert dst src (26+4*p+7*q+i0))); auto.
       apply mma_transfert_progress; auto.
       f_equal; try lia.
       apply vec_pos_ext; intros c; dest c dst; try lia; dest c src. 
@@ -161,81 +157,81 @@ Section Fractran_with_two_counters.
 
   End mma_fractran_one.
 
+  Notation FRAC_ONEₐ := mma_fractran_one.
+
   Hint Rewrite mma_fractran_one_length : length_db.
+
+  Notation fractran_super_regular := (Forall (fun c => fst c <> 0 /\ snd c <> 0)).
 
   Section mma_fractran_step.
 
     (* One step of Fractran computation *)
 
-    Variable (p : nat).
+    Variable (j : nat).
 
-    Fixpoint mma_fractran_step ll i { struct ll } :=
-      match ll with
-        | nil       => nil
-        | (a,b)::ll => let P := mma_fractran_one a b p i
-                       in  P ++ mma_fractran_step ll (length P+i)
+    Fixpoint mma_fractran_step Q i { struct Q } :=
+      match Q with
+        | nil      => nil
+        | (p,q)::Q => let P := mma_fractran_one p q j i
+                      in  P ++ mma_fractran_step Q (length P+i)
       end.
 
-    Fact mma_fractran_step_success_progress ll i x y v : 
-            Forall (fun c => fst c <> 0 /\ snd c <> 0) ll
-         -> ll /F/ x → y
+    Fact mma_fractran_step_success_progress Q i x y v : 
+            fractran_super_regular Q
+         -> Q /F/ x → y
          -> v#>src = x
          -> v#>dst = 0
-         -> (i,mma_fractran_step ll i) /MM2/ (i,v) -+> (p,v[y/src]).
+         -> (i,mma_fractran_step Q i) //ₐ (i,v) -+> (j,v[y/src]).
     Proof.
       intros H1 H2; revert H2 i v H1.
-      induction 1 as [ a b ll x y H1 | a b ll x y H1 H2 IH2 ];
+      induction 1 as [ p q ll x y H1 | p q ll x y H1 H2 IH2 ];
         intros i v H3 H6 H7; rewrite Forall_cons_inv in H3; destruct H3 as ((H3 & H4) & H5); simpl in H3, H4;
         unfold mma_fractran_step; fold mma_fractran_step.
-      + apply subcode_sss_progress with (P := (i,mma_fractran_one a b p i)); auto.
+      + apply subcode_sss_progress with (P := (i,mma_fractran_one p q j i)); auto.
         apply mma_fractran_one_ok_progress; auto; rewrite H6, <- H1; ring.
-      + apply sss_progress_trans with (length (mma_fractran_one a b p i)+i,v).
-        { apply subcode_sss_progress with (P := (i,mma_fractran_one a b p i)); auto.
+      + apply sss_progress_trans with (length (mma_fractran_one p q j i)+i,v).
+        { apply subcode_sss_progress with (P := (i,mma_fractran_one p q j i)); auto.
           apply mma_fractran_one_nok_progress; auto; rewrite H6; auto. }
-        { apply subcode_sss_progress with (P := (length (mma_fractran_one a b p i)+i,
-                                                 mma_fractran_step ll (length (mma_fractran_one a b p i)+i))); auto.
-          apply subcode_right; lia. }
+        { apply subcode_sss_progress 
+            with (P := (length (mma_fractran_one p q j i)+i,
+                        mma_fractran_step ll (length (mma_fractran_one p q j i)+i))); auto. }
     Qed.
 
-    Fact mma_fractran_step_failure_compute ll i v : 
-            Forall (fun c => fst c <> 0 /\ snd c <> 0) ll
-         -> fractran_stop ll (v#>src)
+    Fact mma_fractran_step_failure_compute Q i v : 
+            fractran_super_regular Q
+         -> fractran_stop Q (v#>src)
          -> v#>dst = 0
-         -> (i,mma_fractran_step ll i) /MM2/ (i,v) ->> (length (mma_fractran_step ll i)+i,v).
+         -> (i,mma_fractran_step Q i) //ₐ (i,v) ->> (length (mma_fractran_step Q i)+i,v).
     Proof.
       intros H1 H2 H3; revert H1 i H2.
-      induction 1 as [ | (a,b) ll (Ha & Hb) Hll IH ]; intros i H4.
+      induction 1 as [ | (p,q) ll (Hp & Hq) Hll IH ]; intros i H4.
       + mma sss stop.
       + apply fractan_stop_cons_inv in H4; destruct H4 as (H4 & H5).
         unfold mma_fractran_step; fold mma_fractran_step.
-        set (P := mma_fractran_one a b p i); rew length.
+        set (P := mma_fractran_one p q j i); rew length.
         apply sss_compute_trans with (length P+i,v).
         { apply subcode_sss_compute with (P := (i,P)); auto.
           apply sss_progress_compute, mma_fractran_one_nok_progress; auto. }
         { apply subcode_sss_compute with (P := (length P+i,mma_fractran_step ll (length P + i))); auto.
-          { apply subcode_right; lia. }
-            replace (length P+length (mma_fractran_step ll (length P + i))+i)
-            with    (length (mma_fractran_step ll (length P + i)) + (length P+i)) by lia.
-            auto. }
+          replace (length P+length (mma_fractran_step ll (length P + i))+i)
+          with    (length (mma_fractran_step ll (length P + i)) + (length P+i)) by lia; auto. }
     Qed.
 
   End mma_fractran_step.
 
   Section fractran_mma.
 
-    Variables (ll : list (nat*nat)) (Hll : Forall (fun c => fst c <> 0 /\ snd c <> 0) ll).
+    Variables (Q : list (nat*nat)) (HQ : fractran_super_regular Q).
 
-    Let i := 1.
-
-    Definition fractran_mma := mma_fractran_step i ll i.
+    Definition fractran_mma := mma_fractran_step 1 Q 1.
 
     Lemma fractran_mma_sound v x w : 
                v#>dst = 0 
-            -> fractran_compute ll (v#>src) x
-            -> fractran_stop ll x 
+            -> fractran_compute Q (v#>src) x
+            -> fractran_stop Q x 
             -> w = v[x/src]
-            -> (i,fractran_mma) /MM2/ (i,v) ->> (length fractran_mma+i,w).
-    Proof using Hll.
+            -> (1,fractran_mma) //ₐ (1,v) ->> (length fractran_mma+1,w).
+    Proof using HQ.
       intros H1 (u & H2) H3 ?; subst w.
       revert v x H1 H2 H3.
       induction u as [ | u IHu ]; simpl; intros v y H1 H2 H3.
@@ -244,7 +240,7 @@ Section Fractran_with_two_counters.
         rewrite H2; auto.
       + destruct H2 as (z & H2 & H4).
         apply mma_fractran_step_success_progress 
-          with (1 := Hll) (p := i) (i := i) (v := v) in H2; auto.
+          with (1 := HQ) (j := 1) (i := 1) (v := v) in H2; auto.
         apply IHu with (v := v[z/src]) in H3; auto; rew vec.
         revert H3; rew vec; intros H3.
         apply sss_compute_trans with (2 := H3).
@@ -253,17 +249,17 @@ Section Fractran_with_two_counters.
 
     Lemma fractran_mma_complete v : 
                v#>dst = 0 
-            -> (i,fractran_mma) /MM2/ (i,v) ↓
-            -> ll /F/ (v#>src) ↓.
-    Proof using Hll.
+            -> (1,fractran_mma) //ₐ (1,v) ↓
+            -> Q /F/ (v#>src) ↓.
+    Proof using HQ.
       intros H1 ((j,w) & (u & H2) & H3); simpl fst in H3.
       revert v H1 H2.
       induction on u as IHu with measure u; intros v H1 H2.
-      destruct (fractran_step_dec ll (v#>src)) as [ (y & Hy) | H4 ].
+      destruct (fractran_step_dec Q (v#>src)) as [ (y & Hy) | H4 ].
       2: { exists (v#>src); split; auto; exists 0; simpl; auto. }
       generalize Hy; intros H4.
       apply mma_fractran_step_success_progress 
-        with (1 := Hll) (p := i) (i := i) (v := v) 
+        with (1 := HQ) (j := 1) (i := 1) (v := v) 
         in H4; auto.
       fold fractran_mma in H4.
       destruct subcode_sss_progress_inv with (4 := H4) (5 := H2)
@@ -276,47 +272,107 @@ Section Fractran_with_two_counters.
     Qed.
    
     Theorem fractran_mma_reduction x : 
-        ll /F/ x ↓ <-> (i,fractran_mma) /MM2/ (i,x##0##vec_nil) ↓.
-    Proof using Hll.
+        Q /F/ x ↓ <-> (1,fractran_mma) //ₐ (1,x##0##ø) ↓.
+    Proof using HQ.
       split; auto.
       + intros (y & H2 & H3).
-        exists (length fractran_mma+i,y##0##vec_nil); split; simpl; auto; try lia.
+        exists (length fractran_mma+1,y##0##vec_nil); split; simpl; auto; try lia.
         apply fractran_mma_sound with (x := y); auto.
       + apply fractran_mma_complete; auto.
     Qed.
 
   End fractran_mma.
 
+  Section fractran_mma0.
+
+    Variables (Q : list (nat*nat)) (HQ : fractran_super_regular Q).
+
+    Let P := fractran_mma Q.
+
+    Definition fractran_mma0 := P ++ NULLₐ src (length P + 1) ++ JUMPₐ 0 src.
+
+    Let fmma0_1 v : v#>dst = 0 -> (1,fractran_mma0) //ₐ (length P+1,v) -+> (0,0##0##ø).
+    Proof.
+      vec split v with x; vec split v with y; vec nil v; clear v; simpl; intros ->.
+      unfold fractran_mma0.
+      apply subcode_sss_progress with (P := (length P+1, NULLₐ src (length P + 1) ++ JUMPₐ 0 src)); auto.
+      apply sss_progress_trans with (length (NULLₐ src (length P + 1)) + length P+1,0##0##ø).
+      + apply subcode_sss_progress with (P := (length P+1,NULLₐ src (length P+1))); auto.
+        apply mma_null_progress; auto.
+      + apply subcode_sss_progress with (2 := mma_jump_progress _ src _ _); auto.
+    Qed.
+
+    Lemma fractran_mma0_sound v x : 
+               v#>dst = 0 
+            -> fractran_compute Q (v#>src) x
+            -> fractran_stop Q x 
+            -> (1,fractran_mma0) //ₐ (1,v) ->> (0,0##0##ø).
+    Proof using HQ.
+      intros H1 H2 H3.
+      unfold fractran_mma0.
+      apply sss_compute_trans with (length P+1,x##0##ø).
+      + apply subcode_sss_compute with (P := (1,P)); auto.
+        apply fractran_mma_sound with (3 := H2); auto.
+        unfold src; apply vec_pos_ext; intros p; repeat invert pos p; rew vec.
+      + apply sss_progress_compute, fmma0_1; auto.
+    Qed.
+
+    Variable x : nat.
+
+    Let Term1 := Q /F/ x ↓.
+    Let Term2 := (1,fractran_mma0) //ₐ (1,x##0##ø) ~~> (0,0##0##ø).
+    Let Term3 := (1,fractran_mma0) //ₐ (1,x##0##ø) ↓.
+
+    Theorem fractran_mma0_reduction : 
+         (Term1 -> Term2) /\ (Term2 -> Term3) /\ (Term3 -> Term1).
+    Proof using HQ.
+      msplit 2; unfold Term1, Term2, Term3.
+      + intros (y & H1 & H2); split; simpl; auto.
+        apply fractran_mma0_sound with (2 := H1); auto.
+      + now exists (0,0##0##ø).
+      + intros H1; apply fractran_mma_reduction; auto.
+        revert H1; apply subcode_sss_terminates.
+        unfold fractran_mma0, P; auto.
+    Qed.
+
+  End fractran_mma0.
+
 End Fractran_with_two_counters.
 
-Section fractran_mma_reg_reduction.
+Section fractran_mma_reg_reductions.
 
-  Variables (ll : list (nat*nat)).
+  Variables (Q : list (nat*nat)).
 
-  Let reduction : { P | Forall (fun c => snd c <> 0) ll -> forall x, ll /F/ x ↓ <-> (1,P) /MM2/ (1,x##0##vec_nil) ↓ }.
+  Let reduction : { P | fractran_regular Q 
+                     -> forall x, ( Q /F/ x ↓ -> (1,P) //ₐ (1,x##0##ø) ~~> (0,0##0##ø) )
+                               /\ ( (1,P) //ₐ (1,x##0##ø) ~~> (0,0##0##ø) -> (1,P) //ₐ (1,x##0##ø) ↓ )
+                               /\ ( (1,P) //ₐ (1,x##0##ø) ↓ -> Q /F/ x ↓ ) }.
   Proof.
-    destruct (Forall_Exists_dec (fun c : nat * nat => fst c <> 0)) with (l := ll) as [ H | H ].
+    destruct (Forall_Exists_dec (fun c : nat * nat => fst c <> 0)) with (l := Q) as [ H | H ].
     + intros (x,?); simpl; destruct (eq_nat_dec x 0); subst; auto. 
-    + exists (fractran_mma ll); intros Hll x.
-      apply fractran_mma_reduction.
-      revert H Hll; repeat rewrite Forall_forall; firstorder.
+    + exists (fractran_mma0 Q); intros HQ x.
+      apply fractran_mma0_reduction; red in HQ.
+      revert H HQ; repeat rewrite Forall_forall; firstorder.
     + rewrite Exists_exists in H.
-      exists mma_loop; intros Hll.
+      exists (mma_loop pos0 1); intros Hll.
       destruct H as ((x,y) & H1 & H2); simpl in H2.
       replace x with 0 in H1 by lia; clear H2.
-      intros n; split.
+      intros n; msplit 2.
       * intros H; exfalso.
         revert H; apply FRACTRAN_HALTING_zero_num.
         apply Exists_exists; exists (0,y); auto.
+      * now exists (0,0##0##ø).
       * intros H; exfalso; revert H; apply mma_loop_spec.
   Qed.
-  
+
   Definition fractran_reg_mma := proj1_sig reduction.
 
-  Theorem fractran_reg_mma_reduction : 
-                       Forall (fun c => snd c <> 0) ll 
-          -> forall x, ll /F/ x ↓ 
-                   <-> (1,fractran_reg_mma) /MM2/ (1,x##0##vec_nil) ↓.
-  Proof. apply (proj2_sig reduction). Qed.
+  Theorem fractran_reg_mma_reductions : 
+                       fractran_regular Q 
+          -> (forall x, Q /F/ x ↓ <-> (1,fractran_reg_mma) //ₐ (1,x##0##ø) ↓)
+          /\ (forall x, Q /F/ x ↓ <-> (1,fractran_reg_mma) //ₐ (1,x##0##ø) ~~> (0,(0##0##ø))).
+  Proof. 
+     do 2 (split; intros); repeat (apply (proj2_sig reduction); auto). 
+  Qed.
 
-End fractran_mma_reg_reduction.
+End fractran_mma_reg_reductions.

--- a/theories/MinskyMachines/MMA/fractran_mma.v
+++ b/theories/MinskyMachines/MMA/fractran_mma.v
@@ -33,14 +33,15 @@ Local Notation "P //ₐ s ->> t" := (sss_compute (@mma_sss _) P s t) (at level 7
 Local Notation "P //ₐ s ~~> t" := (sss_output (@mma_sss _) P s t) (at level 70, no associativity).
 Local Notation "P //ₐ s ↓" := (sss_terminates (@mma_sss _) P s) (at level 70, no associativity). 
 
-Local Notation "l /F/ x → y" := (fractran_step l x y) (at level 70, no associativity).
+Local Notation "Q /F/ x ≻ y" := (fractran_step Q x y) (at level 70, no associativity).
+Local Notation "Q /F/ x ⊁ *" := (fractran_stop Q x) (at level 70, no associativity).
 
 (* FRACTRAN with two counter *)
 
 Section Fractran_with_two_counters.
 
   Hint Resolve subcode_refl : core.
-  Hint Rewrite mma_null_length mma_transfert_length mma_incs_length mma_decs_copy_length 
+  Hint Rewrite mma_jump_length mma_null_length mma_transfert_length mma_incs_length mma_decs_copy_length 
                mma_mult_cst_length mma_decs_length mma_mod_cst_length mma_div_cst_length : length_db.
 
   Notation JUMPₐ := mma_jump.
@@ -64,25 +65,26 @@ Section Fractran_with_two_counters.
 
   Section mma_fractran_one.
 
-    (* FRACTRAN computation, try one fraction a/b *)
+    (* FRACTRAN computation, try one fraction u/v *)
 
-    Variables (p q : nat) (j i0 : nat).
+    Variables (p q : nat) (j i : nat).
 
-    Notation i := i0.
+    Notation i0 := i.
     Notation i1 := (5+p+i0).
-    Notation i2 := (11+p+4*q+i0).
-    Notation i3 := (16+p+7*q+i0).
-    Notation i4 := (21+p+7*q+i0).
-    Notation i5 := (26+4*p+7*q+i0).
+    Notation i2 := (6+4*q+i1).
+    Notation i3 := (5+3*q+i2). 
+    Notation i4 := (3+i3).
+    Notation i5 := (2+i4). 
+    Notation i6 := (5+3*p+i5). 
 
     Definition mma_fractran_one :=
            MULT_CSTₐ src dst p i0
-        ++ MOD_CSTₐ dst src i2 i4 q i1
+        ++ MOD_CSTₐ dst src i2 i5 q i1
         ++ DIV_CSTₐ src dst q i2
         ++ TRANSFERTₐ dst src i3
-        ++ INCₐ dst :: DECₐ dst j
-        :: DIV_CSTₐ src dst p i4
-        ++ TRANSFERTₐ dst src i5.
+        ++ JUMPₐ j dst
+        ++ DIV_CSTₐ src dst p i5
+        ++ TRANSFERTₐ dst src i6.
 
     Fact mma_fractran_one_length : length mma_fractran_one = 29+4*p+7*q.
     Proof. unfold mma_fractran_one; rew length; lia. Qed.
@@ -103,7 +105,7 @@ Section Fractran_with_two_counters.
         apply mma_mult_cst_progress; auto.
         rewrite H2, <- H1; do 2 f_equal; lia. }
       apply sss_progress_trans with (i2,v[(k*q)/src][0/dst]).
-      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i4 q i1)); auto.
+      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i5 q i1)); auto.
         apply mma_mod_cst_divides_progress with k; rew vec; try lia.
         f_equal; apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
       apply sss_progress_trans with (i3,v[0/src][k/dst]).
@@ -111,13 +113,14 @@ Section Fractran_with_two_counters.
         apply mma_div_cst_progress with k; auto; rew vec; try lia.
         f_equal; try lia.
         apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
-      apply sss_progress_trans with (19+p+7*q+i0,v[k/src][0/dst]).
+      apply sss_progress_trans with (i4,v[k/src][0/dst]).
       { apply subcode_sss_progress with (P := (i3,mma_transfert dst src i3)); auto.
         apply mma_transfert_progress; auto.
         f_equal; try lia.
         apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. }
-      mma sss INC with dst.
-      mma sss DEC S with dst j 0; rew vec.
+      apply sss_progress_compute_trans with (j,v[k/src][0/dst]).
+      { apply subcode_sss_progress with (P := (i4,JUMPₐ j dst)); auto.
+        apply mma_jump_progress; auto. }
       mma sss stop; f_equal.
       apply vec_pos_ext; intros y; dest y dst; try lia; dest y src. 
     Qed.
@@ -140,16 +143,16 @@ Section Fractran_with_two_counters.
       { apply subcode_sss_progress with (P := (i0,mma_mult_cst src dst p i0)); auto.
         apply mma_mult_cst_progress; auto.
         rewrite H2, <- H3; do 2 f_equal; lia. }
-      apply sss_progress_trans with (i4,v[(p*(v#>src))/src][0/dst]).
-      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i4 q i1)); auto.
+      apply sss_progress_trans with (i5,v[(p*(v#>src))/src][0/dst]).
+      { apply subcode_sss_progress with (P := (i1,mma_mod_cst dst src i2 i5 q i1)); auto.
         apply mma_mod_cst_not_divides_progress with x y; rew vec; try lia.
         f_equal; apply vec_pos_ext; intros c; dest c dst; try lia; dest c src; lia. }
-      apply sss_progress_trans with (26+4*p+7*q+i0,v[0/src][(v#>src)/dst]).
-      { apply subcode_sss_progress with (P := (i4,mma_div_cst src dst p i4)); auto.
+      apply sss_progress_trans with (i6,v[0/src][(v#>src)/dst]).
+      { apply subcode_sss_progress with (P := (i5,mma_div_cst src dst p i5)); auto.
         apply mma_div_cst_progress with (v#>src); auto; rew vec; try lia; try ring.
         f_equal; try lia.
         apply vec_pos_ext; intros c; dest c dst; try lia; dest c src. }
-      apply subcode_sss_progress with (P := (26+4*p+7*q+i0,mma_transfert dst src (26+4*p+7*q+i0))); auto.
+      apply subcode_sss_progress with (P := (i6,mma_transfert dst src i6)); auto.
       apply mma_transfert_progress; auto.
       f_equal; try lia.
       apply vec_pos_ext; intros c; dest c dst; try lia; dest c src. 
@@ -172,44 +175,44 @@ Section Fractran_with_two_counters.
     Fixpoint mma_fractran_step Q i { struct Q } :=
       match Q with
         | nil      => nil
-        | (p,q)::Q => let P := mma_fractran_one p q j i
+        | (p,q)::Q => let P := FRAC_ONEₐ p q j i
                       in  P ++ mma_fractran_step Q (length P+i)
       end.
 
-    Fact mma_fractran_step_success_progress Q i x y v : 
+    Notation FRAC_STEPₐ := mma_fractran_step.
+
+    Fact mma_fractran_step_success_progress Q i x y : 
             fractran_super_regular Q
-         -> Q /F/ x → y
-         -> v#>src = x
-         -> v#>dst = 0
-         -> (i,mma_fractran_step Q i) //ₐ (i,v) -+> (j,v[y/src]).
+         -> Q /F/ x ≻ y
+         -> (i,mma_fractran_step Q i) //ₐ (i,x##0##ø) -+> (j,y##0##ø).
     Proof.
-      intros H1 H2; revert H2 i v H1.
+      intros H1 H2; revert H2 i H1.
       induction 1 as [ p q ll x y H1 | p q ll x y H1 H2 IH2 ];
-        intros i v H3 H6 H7; rewrite Forall_cons_inv in H3; destruct H3 as ((H3 & H4) & H5); simpl in H3, H4;
+        intros i H3; rewrite Forall_cons_inv in H3; destruct H3 as ((H3 & H4) & H5); simpl in H3, H4;
         unfold mma_fractran_step; fold mma_fractran_step.
       + apply subcode_sss_progress with (P := (i,mma_fractran_one p q j i)); auto.
-        apply mma_fractran_one_ok_progress; auto; rewrite H6, <- H1; ring.
-      + apply sss_progress_trans with (length (mma_fractran_one p q j i)+i,v).
+        apply mma_fractran_one_ok_progress with (v := _##_##ø); auto.
+        simpl; rewrite <- H1; ring.
+      + apply sss_progress_trans with (length (mma_fractran_one p q j i)+i,x##0##ø).
         { apply subcode_sss_progress with (P := (i,mma_fractran_one p q j i)); auto.
-          apply mma_fractran_one_nok_progress; auto; rewrite H6; auto. }
+          apply mma_fractran_one_nok_progress; auto. }
         { apply subcode_sss_progress 
             with (P := (length (mma_fractran_one p q j i)+i,
                         mma_fractran_step ll (length (mma_fractran_one p q j i)+i))); auto. }
     Qed.
 
-    Fact mma_fractran_step_failure_compute Q i v : 
+    Fact mma_fractran_step_failure_compute Q i x : 
             fractran_super_regular Q
-         -> fractran_stop Q (v#>src)
-         -> v#>dst = 0
-         -> (i,mma_fractran_step Q i) //ₐ (i,v) ->> (length (mma_fractran_step Q i)+i,v).
+         -> Q /F/ x ⊁ *
+         -> (i,mma_fractran_step Q i) //ₐ (i,x##0##ø) ->> (length (mma_fractran_step Q i)+i,x##0##ø).
     Proof.
-      intros H1 H2 H3; revert H1 i H2.
+      intros H1 H2; revert H1 i H2.
       induction 1 as [ | (p,q) ll (Hp & Hq) Hll IH ]; intros i H4.
       + mma sss stop.
       + apply fractan_stop_cons_inv in H4; destruct H4 as (H4 & H5).
         unfold mma_fractran_step; fold mma_fractran_step.
         set (P := mma_fractran_one p q j i); rew length.
-        apply sss_compute_trans with (length P+i,v).
+        apply sss_compute_trans with (length P+i,x##0##ø).
         { apply subcode_sss_compute with (P := (i,P)); auto.
           apply sss_progress_compute, mma_fractran_one_nok_progress; auto. }
         { apply subcode_sss_compute with (P := (length P+i,mma_fractran_step ll (length P + i))); auto.
@@ -225,50 +228,43 @@ Section Fractran_with_two_counters.
 
     Definition fractran_mma := mma_fractran_step 1 Q 1.
 
-    Lemma fractran_mma_sound v x w : 
-               v#>dst = 0 
-            -> fractran_compute Q (v#>src) x
-            -> fractran_stop Q x 
-            -> w = v[x/src]
-            -> (1,fractran_mma) //ₐ (1,v) ->> (length fractran_mma+1,w).
+    Lemma fractran_mma_sound x y : 
+               fractran_compute Q x y
+            -> Q /F/ y ⊁ *
+            -> (1,fractran_mma) //ₐ (1,x##0##ø) ->> (length fractran_mma+1,y##0##ø).
     Proof using HQ.
-      intros H1 (u & H2) H3 ?; subst w.
-      revert v x H1 H2 H3.
-      induction u as [ | u IHu ]; simpl; intros v y H1 H2 H3.
-      + rewrite <- H2; rew vec.
-        apply mma_fractran_step_failure_compute; auto.
-        rewrite H2; auto.
+      intros (u & H2) H3.
+      revert x y H2 H3.
+      induction u as [ | u IHu ]; simpl; intros x y H2 H3.
+      + rewrite H2; apply mma_fractran_step_failure_compute; auto.
       + destruct H2 as (z & H2 & H4).
         apply mma_fractran_step_success_progress 
-          with (1 := HQ) (j := 1) (i := 1) (v := v) in H2; auto.
-        apply IHu with (v := v[z/src]) in H3; auto; rew vec.
-        revert H3; rew vec; intros H3.
+          with (1 := HQ) (j := 1) (i := 1) in H2; auto.
+        apply IHu with (x := z) in H3; auto; rew vec.
         apply sss_compute_trans with (2 := H3).
         apply sss_progress_compute; auto.
     Qed.
 
-    Lemma fractran_mma_complete v : 
-               v#>dst = 0 
-            -> (1,fractran_mma) //ₐ (1,v) ↓
-            -> Q /F/ (v#>src) ↓.
+    Lemma fractran_mma_complete x : 
+               (1,fractran_mma) //ₐ (1,x##0##ø) ↓
+            -> Q /F/ x ↓.
     Proof using HQ.
-      intros H1 ((j,w) & (u & H2) & H3); simpl fst in H3.
-      revert v H1 H2.
-      induction on u as IHu with measure u; intros v H1 H2.
-      destruct (fractran_step_dec Q (v#>src)) as [ (y & Hy) | H4 ].
-      2: { exists (v#>src); split; auto; exists 0; simpl; auto. }
+      intros ((j,w) & (k & H2) & H3); simpl fst in H3.
+      revert x H2.
+      induction on k as IHu with measure k; intros x H2.
+      destruct (fractran_step_dec Q x) as [ (y & Hy) | H4 ].
+      2: { exists x; split; auto; exists 0; simpl; auto. }
       generalize Hy; intros H4.
       apply mma_fractran_step_success_progress 
-        with (1 := HQ) (j := 1) (i := 1) (v := v) 
+        with (1 := HQ) (j := 1) (i := 1) 
         in H4; auto.
       fold fractran_mma in H4.
       destruct subcode_sss_progress_inv with (4 := H4) (5 := H2)
-        as (p & H5 & H6); auto.
+        as (r & H5 & H6); auto.
       1: apply mma_sss_fun.
       apply IHu in H6; auto; rew vec.
-      destruct H6 as (z & (k & Hk) & Hz2).
-      exists z; split; auto; exists (S k), y; split; auto.
-      revert Hk; rew vec.
+      destruct H6 as (z & (u & Hk) & Hz2).
+      exists z; split; auto; exists (S u), y; split; auto.
     Qed.
    
     Theorem fractran_mma_reduction x : 
@@ -277,7 +273,7 @@ Section Fractran_with_two_counters.
       split; auto.
       + intros (y & H2 & H3).
         exists (length fractran_mma+1,y##0##vec_nil); split; simpl; auto; try lia.
-        apply fractran_mma_sound with (x := y); auto.
+        apply fractran_mma_sound; auto.
       + apply fractran_mma_complete; auto.
     Qed.
 
@@ -291,44 +287,43 @@ Section Fractran_with_two_counters.
 
     Definition fractran_mma0 := P ++ NULLₐ src (length P + 1) ++ JUMPₐ 0 src.
 
-    Let fmma0_1 v : v#>dst = 0 -> (1,fractran_mma0) //ₐ (length P+1,v) -+> (0,0##0##ø).
+    Notation FRAC_MMAₐ := fractran_mma0.
+
+    Let fmma0_1 x : (1,FRAC_MMAₐ) //ₐ (length P+1,x##0##ø) -+> (0,0##0##ø).
     Proof.
-      vec split v with x; vec split v with y; vec nil v; clear v; simpl; intros ->.
       unfold fractran_mma0.
       apply subcode_sss_progress with (P := (length P+1, NULLₐ src (length P + 1) ++ JUMPₐ 0 src)); auto.
       apply sss_progress_trans with (length (NULLₐ src (length P + 1)) + length P+1,0##0##ø).
       + apply subcode_sss_progress with (P := (length P+1,NULLₐ src (length P+1))); auto.
         apply mma_null_progress; auto.
-      + apply subcode_sss_progress with (2 := mma_jump_progress _ src _ _); auto.
+      + apply subcode_sss_progress with (2 := mma_jump_progress _ src _ eq_refl); auto.
     Qed.
 
-    Lemma fractran_mma0_sound v x : 
-               v#>dst = 0 
-            -> fractran_compute Q (v#>src) x
-            -> fractran_stop Q x 
-            -> (1,fractran_mma0) //ₐ (1,v) ->> (0,0##0##ø).
+    Lemma fractran_mma0_sound x y : 
+               fractran_compute Q x y
+            -> fractran_stop Q y 
+            -> (1,FRAC_MMAₐ) //ₐ (1,x##0##ø) ->> (0,0##0##ø).
     Proof using HQ.
-      intros H1 H2 H3.
+      intros H2 H3.
       unfold fractran_mma0.
-      apply sss_compute_trans with (length P+1,x##0##ø).
+      apply sss_compute_trans with (length P+1,y##0##ø).
       + apply subcode_sss_compute with (P := (1,P)); auto.
-        apply fractran_mma_sound with (3 := H2); auto.
-        unfold src; apply vec_pos_ext; intros p; repeat invert pos p; rew vec.
+        apply fractran_mma_sound with (2 := H2); auto.
       + apply sss_progress_compute, fmma0_1; auto.
     Qed.
 
     Variable x : nat.
 
     Let Term1 := Q /F/ x ↓.
-    Let Term2 := (1,fractran_mma0) //ₐ (1,x##0##ø) ~~> (0,0##0##ø).
-    Let Term3 := (1,fractran_mma0) //ₐ (1,x##0##ø) ↓.
+    Let Term2 := (1,FRAC_MMAₐ) //ₐ (1,x##0##ø) ~~> (0,0##0##ø).
+    Let Term3 := (1,FRAC_MMAₐ) //ₐ (1,x##0##ø) ↓.
 
     Theorem fractran_mma0_reduction : 
          (Term1 -> Term2) /\ (Term2 -> Term3) /\ (Term3 -> Term1).
     Proof using HQ.
       msplit 2; unfold Term1, Term2, Term3.
       + intros (y & H1 & H2); split; simpl; auto.
-        apply fractran_mma0_sound with (2 := H1); auto.
+        apply fractran_mma0_sound with (1 := H1); auto.
       + now exists (0,0##0##ø).
       + intros H1; apply fractran_mma_reduction; auto.
         revert H1; apply subcode_sss_terminates.

--- a/theories/MinskyMachines/MMA/mma_defs.v
+++ b/theories/MinskyMachines/MMA/mma_defs.v
@@ -35,12 +35,12 @@ Section Minsky_Machine_alternate.
   Fact mma_sss_fun i s t1 t2 : i // s -1> t1 -> i // s -1> t2 -> t1 = t2.
   Proof.
     intros []; subst.
-    inversion 1; subst; auto.
-    inversion 1; subst; auto.
-    rewrite H in H6; discriminate.
-    inversion 1; subst; auto.
-    rewrite H in H6; discriminate.
-    rewrite H in H6; inversion H6; subst; auto.
+    + inversion 1; subst; auto.
+    + inversion 1; subst; auto.
+      rewrite H in H6; discriminate.
+    + inversion 1; subst; auto.
+      * rewrite H in H6; discriminate.
+      * rewrite H in H6; inversion H6; subst; auto.
   Qed.
   
   Fact mma_sss_total ii s : { t | ii // s -1> t }.
@@ -57,22 +57,22 @@ Section Minsky_Machine_alternate.
     destruct (mma_sss_total ii s) as (t & ?); now exists t.
   Qed.
   
-  Fact mma_sss_INC_inv x i v j w : INC x // (i,v) -1> (j,w) -> j=1+i /\ w = v[(S (v#>x))/x].
+  Fact mma_sss_INC_inv x i v j w : INCₐ x // (i,v) -1> (j,w) -> j=1+i /\ w = v[(S (v#>x))/x].
   Proof. inversion 1; subst; auto. Qed.
   
-  Fact mma_sss_DEC0_inv x k i v j w : v#>x = O -> DEC x k // (i,v) -1> (j,w) -> j = 1+i /\ w = v.
+  Fact mma_sss_DEC0_inv x k i v j w : v#>x = O -> DECₐ x k // (i,v) -1> (j,w) -> j = 1+i /\ w = v.
   Proof. 
     intros H; inversion 1; subst; auto; rewrite H in H2; try discriminate.
   Qed.
   
-  Fact mma_sss_DEC1_inv x k u i v j w : v#>x = S u -> DEC x k // (i,v) -1> (j,w) -> j=k /\ w = v[u/x].
+  Fact mma_sss_DEC1_inv x k u i v j w : v#>x = S u -> DECₐ x k // (i,v) -1> (j,w) -> j=k /\ w = v[u/x].
   Proof. 
     intros H; inversion 1; subst; auto; rewrite H in H2; try discriminate.
     inversion H2; subst; auto.
   Qed.
 
   Fact mma_sss_progress_INC P i x v st :
-         (i,INC x::nil) <sc P
+         (i,INCₐ x::nil) <sc P
       -> P // (1+i,v[(S (v#>x))/x]) ->> st
       -> P // (i,v) -+> st.
   Proof.
@@ -81,15 +81,15 @@ Section Minsky_Machine_alternate.
     apply subcode_sss_progress with (1 := H1).
     exists 1; split; auto; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; lia.
-    constructor; auto.
+    + simpl; lia.
+    + constructor; auto.
   Qed.
   
-  Corollary mma_sss_compute_INC P i x v st : (i,INC x::nil) <sc P -> P // (1+i,v[(S (v#>x))/x]) ->> st -> P // (i,v) ->> st.
+  Corollary mma_sss_compute_INC P i x v st : (i,INCₐ x::nil) <sc P -> P // (1+i,v[(S (v#>x))/x]) ->> st -> P // (i,v) ->> st.
   Proof. intros; apply sss_progress_compute; eapply mma_sss_progress_INC; eauto. Qed.
   
   Fact mma_sss_progress_DEC_0 P i x k v st :
-         (i,DEC x k::nil) <sc P
+         (i,DECₐ x k::nil) <sc P
       -> v#>x = O 
       -> P // (1+i,v) ->> st
       -> P // (i,v) -+> st.
@@ -99,15 +99,15 @@ Section Minsky_Machine_alternate.
     apply subcode_sss_progress with (1 := H1).
     exists 1; split; auto; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; lia.
-    constructor; auto.
+    + simpl; lia.
+    + constructor; auto.
   Qed.
   
   Corollary mma_sss_compute_DEC_0 P i x k v st : (i,DEC x k::nil) <sc P -> v#>x = O -> P // (1+i,v) ->> st -> P // (i,v) ->> st.
   Proof. intros; apply sss_progress_compute; eapply mma_sss_progress_DEC_0; eauto. Qed.
   
   Fact mma_sss_progress_DEC_S P i x k v u st :
-         (i,DEC x k::nil) <sc P
+         (i,DECₐ x k::nil) <sc P
       -> v#>x = S u 
       -> P // (k,v[u/x]) ->> st
       -> P // (i,v) -+> st.
@@ -117,15 +117,15 @@ Section Minsky_Machine_alternate.
     apply subcode_sss_progress with (1 := H1).
     exists 1; split; auto; apply sss_steps_1.
     apply in_sss_step with (l := nil).
-    simpl; lia.
-    constructor; auto.
+    + simpl; lia.
+    + constructor; auto.
   Qed.
   
-  Corollary mma_sss_compute_DEC_S P i x k v u st : (i,DEC x k::nil) <sc P -> v#>x = S u -> P // (k,v[u/x]) ->> st -> P // (i,v) ->> st.
+  Corollary mma_sss_compute_DEC_S P i x k v u st : (i,DECₐ x k::nil) <sc P -> v#>x = S u -> P // (k,v[u/x]) ->> st -> P // (i,v) ->> st.
   Proof. intros; apply sss_progress_compute; eapply mma_sss_progress_DEC_S; eauto. Qed.
   
   Fact mma_sss_steps_INC_inv k P i x v st :
-         (i,INC x::nil) <sc P
+         (i,INCₐ x::nil) <sc P
       -> k <> 0
       -> P // (i,v) -[k]-> st
       -> exists k', k' < k /\ P // (1+i,v[(S (v#>x))/x]) -[k']-> st.
@@ -136,12 +136,12 @@ Section Minsky_Machine_alternate.
     destruct H2; auto.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     exists k'; split.
-    lia.
-    inversion H4; subst; auto.
+    + lia.
+    + inversion H4; subst; auto.
   Qed.
   
   Fact mma_sss_steps_DEC_0_inv k P i x p v st :
-         (i,DEC x p::nil) <sc P
+         (i,DECₐ x p::nil) <sc P
       -> k <> 0
       -> v#>x = 0
       -> P // (i,v) -[k]-> st
@@ -153,13 +153,13 @@ Section Minsky_Machine_alternate.
     destruct H2; auto.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     exists k'; split.
-    lia.
-    inversion H4; subst; auto.
-    rewrite H3 in H9; discriminate.
+    + lia.
+    + inversion H4; subst; auto.
+      rewrite H3 in H9; discriminate.
   Qed.
   
   Fact mma_sss_steps_DEC_1_inv k P i x p v u st :
-         (i,DEC x p::nil) <sc P
+         (i,DECₐ x p::nil) <sc P
       -> k <> 0
       -> v#>x = S u
       -> P // (i,v) -[k]-> st
@@ -171,10 +171,10 @@ Section Minsky_Machine_alternate.
     destruct H2; auto.
     apply sss_step_subcode_inv with (1 := H1) in H4.
     exists k'; split.
-    lia.
-    inversion H4; subst; auto; rewrite H3 in H9.
-    discriminate.
-    inversion H9; subst; auto.
+    + lia.
+    + inversion H4; subst; auto; rewrite H3 in H9.
+      * discriminate.
+      * inversion H9; subst; auto.
   Qed.
 
 End Minsky_Machine_alternate.

--- a/theories/MinskyMachines/MMA/mma_simul.v
+++ b/theories/MinskyMachines/MMA/mma_simul.v
@@ -24,10 +24,10 @@ Tactic Notation "rew" "length" := autorewrite with length_db.
 Local Notation "e #> x" := (vec_pos e x).
 Local Notation "e [ v / x ]" := (vec_change e x v).
 
-Local Notation "P // s -+> t" := (sss_progress (@mma_sss _) P s t).
-Local Notation "P // s ->> t" := (sss_compute (@mma_sss _) P s t).
-Local Notation "P // s ~~> t" := (sss_output (@mma_sss _) P s t).
-Local Notation "P // s ↓" := (sss_terminates (@mma_sss _) P s).
+Local Notation "P //ₐ s -+> t" := (sss_progress (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ->> t" := (sss_compute (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ~~> t" := (sss_output (@mma_sss _) P s t) (at level 70, no associativity).
+Local Notation "P //ₐ s ↓" := (sss_terminates (@mma_sss _) P s) (at level 70, no associativity). 
 
 (* We use the generic compiler with an identity map on instructions
     to simulate termination with termination on (0,vec_zero) *)
@@ -40,8 +40,8 @@ Section mma_sim.
 
   Definition mma_instr_compile lnk (_ : nat) (ii : mm_instr (pos n)) :=
     match ii with
-      | INC k   => INC k :: nil
-      | DEC k j => DEC k (lnk j) :: nil
+      | INCₐ k   => INCₐ k :: nil
+      | DECₐ k j => DECₐ k (lnk j) :: nil
     end. 
 
   Definition mma_instr_compile_length (ii : mm_instr (pos n)) := 1.
@@ -98,22 +98,22 @@ Section mma_sim.
 
     Infix "⋈" := (@eq (vec nat n)) (at level 70, no associativity).
 
-    Local Lemma HQ1 : forall i1 v1 w1 i2 v2, v1 ⋈ w1 /\ (iP,cP) // (i1,v1) ~~> (i2,v2)     
-                    -> exists w2,    v2 ⋈ w2 /\ Q // (lnk i1,w1) ~~> (lnk i2,w2).
+    Local Lemma HQ1 : forall i1 v1 w1 i2 v2, v1 ⋈ w1 /\ (iP,cP) //ₐ (i1,v1) ~~> (i2,v2)     
+                    -> exists w2,    v2 ⋈ w2 /\ Q //ₐ (lnk i1,w1) ~~> (lnk i2,w2).
     Proof. apply (proj2_sig (projT2 lnk_Q_pair)). Qed.
 
-    Local Lemma HQ1' i1 v1 i2 v2 : (iP,cP) // (i1,v1) ~~> (i2,v2) 
-                        ->   Q // (lnk i1,v1) ~~> (lnk i2,v2).
+    Local Lemma HQ1' i1 v1 i2 v2 : (iP,cP) //ₐ (i1,v1) ~~> (i2,v2) 
+                        ->   Q //ₐ (lnk i1,v1) ~~> (lnk i2,v2).
     Proof.
       intros H; destruct (@HQ1 i1 v1 v1 i2 v2) as (w2 & <- & ?); auto.
     Qed.
 
-    Local Lemma HQ2 : forall i1 v1 w1 j2 w2, v1 ⋈ w1 /\ Q // (lnk i1,w1) ~~> (j2,w2) 
-                    -> exists i2 v2, v2 ⋈ w2 /\ (iP,cP) // (i1,v1) ~~> (i2,v2) /\ j2 = lnk i2.
+    Local Lemma HQ2 : forall i1 v1 w1 j2 w2, v1 ⋈ w1 /\ Q //ₐ (lnk i1,w1) ~~> (j2,w2) 
+                    -> exists i2 v2, v2 ⋈ w2 /\ (iP,cP) //ₐ (i1,v1) ~~> (i2,v2) /\ j2 = lnk i2.
     Proof. apply (proj2_sig (projT2 lnk_Q_pair)). Qed.
 
-    Local Lemma HQ2' i1 v1 j2 v2 :         Q // (lnk i1,v1) ~~> (j2,v2) 
-               -> exists i2, (iP,cP) // (i1,v1) ~~> (i2,v2) /\ j2 = lnk i2.
+    Local Lemma HQ2' i1 v1 j2 v2 :         Q //ₐ (lnk i1,v1) ~~> (j2,v2) 
+               -> exists i2, (iP,cP) //ₐ (i1,v1) ~~> (i2,v2) /\ j2 = lnk i2.
     Proof.
       intros H; destruct (@HQ2 i1 v1 v1 j2 v2) as (i2 & ? & <- & ? & ->); auto.
       exists i2; auto.
@@ -123,7 +123,7 @@ Section mma_sim.
  
     (* Q simulates termination of (iP,cP) while ensuring tmp1 and tmp2 stay void when it terminates *)
 
-    Local Lemma Q_spec1 : (iP,cP) // (iP,v) ↓ -> exists w', Q // (1,v) ~~> (code_end Q, w').
+    Local Lemma Q_spec1 : (iP,cP) //ₐ (iP,v) ↓ -> exists w', Q //ₐ (1,v) ~~> (code_end Q, w').
     Proof.
       intros ((i1,v1) & H1).
       exists v1.
@@ -131,7 +131,7 @@ Section mma_sim.
       destruct H1; auto.
     Qed.
 
-    Local Lemma Q_spec2 : Q // (1,v) ↓ -> (iP,cP) // (iP,v) ↓.
+    Local Lemma Q_spec2 : Q //ₐ (1,v) ↓ -> (iP,cP) //ₐ (iP,v) ↓.
     Proof.
       intros ((j,w2) & H1).
       rewrite <- (proj1 (proj2 Hlnk)) in H1.
@@ -142,8 +142,8 @@ Section mma_sim.
     Definition mma_sim := snd Q.
     Definition mma_sim_end := code_end Q.
 
-    Theorem mma_sim_spec : ((iP,cP) // (iP,v) ↓ -> exists w', (1,mma_sim) // (1,v) ~~> (1+length mma_sim, w'))
-                        /\ ((1,mma_sim) // (1,v) ↓ -> (iP,cP) // (iP,v) ↓).
+    Theorem mma_sim_spec : ((iP,cP) //ₐ (iP,v) ↓ -> exists w', (1,mma_sim) //ₐ (1,v) ~~> (1+length mma_sim, w'))
+                        /\ ((1,mma_sim) //ₐ (1,v) ↓ -> (iP,cP) //ₐ (iP,v) ↓).
     Proof.
       replace (1+length mma_sim) with (code_end Q).
       replace (1,mma_sim) with Q. 
@@ -161,7 +161,7 @@ End mma_sim.
 Section mma2_simul.
 
   (* To generalize for n register, we need a recursive nullifying code 
-     not compilcated though *)
+     not complicated though *)
 
   Variable (iP : nat) (cP : list (mm_instr (pos 2))).
 
@@ -173,7 +173,7 @@ Section mma2_simul.
   Local Definition L1 := @mma_null_length 2 pos0 eQ.
   Local Definition L2 := @mma_null_length 2 pos1 (1+eQ).
 
-  Let N_spec v : (eQ,cN) // (eQ,v) -+> (0,vec_zero).
+  Let N_spec v : (eQ,cN) //ₐ (eQ,v) -+> (0,vec_zero).
   Proof.
     unfold cN.
     apply sss_progress_trans with (1+eQ,v[0/pos0]).
@@ -199,7 +199,7 @@ Section mma2_simul.
   Let cN_sim : (eQ,cN) <sc (1,mma2_simul).
   Proof. unfold mma2_simul, eQ; auto. Qed.
 
-  Theorem mma2_simul_spec v : (iP,cP) // (iP,v) ↓ <-> (1,mma2_simul) // (1,v) ~~> (0,vec_zero).
+  Theorem mma2_simul_spec v : (iP,cP) //ₐ (iP,v) ↓ <-> (1,mma2_simul) //ₐ (1,v) ~~> (0,vec_zero).
   Proof.
     split.
     * intros H; apply mma_sim_spec in H; revert H.
@@ -221,5 +221,5 @@ End mma2_simul.
 (* Termination can be simulated with termination on (0,vec_zero) *)
 
 Theorem mma2_simulator i (P : list (mm_instr (pos 2))) :
-  { Q | forall v, (i,P) // (i,v) ↓ <-> (1,Q) // (1,v) ~~> (0,vec_zero) }.
+  { Q | forall v, (i,P) //ₐ (i,v) ↓ <-> (1,Q) //ₐ (1,v) ~~> (0,vec_zero) }.
 Proof. exists (mma2_simul i P); apply mma2_simul_spec. Qed.

--- a/theories/MinskyMachines/MMA/mma_simul.v
+++ b/theories/MinskyMachines/MMA/mma_simul.v
@@ -188,7 +188,7 @@ Section mma2_simul.
          repeat (invert pos p; rew vec). }
     pose proof L1 as L1. pose proof L2 as L2.
     apply subcode_sss_progress with (P := (2+eQ,mma_jump 0 pos0)); auto. 
-    apply mma_jump_progress.
+    apply mma_jump_progress; auto.
   Qed.
 
   Definition mma2_simul := Q ++ cN.

--- a/theories/MinskyMachines/MMA/mma_utils.v
+++ b/theories/MinskyMachines/MMA/mma_utils.v
@@ -43,12 +43,14 @@ Section Minsky_Machine_alt_utils.
 
     Variable (j : nat) (x : pos n).
 
-    Definition mma_jump := INC x :: DEC x j :: nil.
+    Definition mma_jump := INCₐ x :: DECₐ x j :: nil.
 
-    Fact mma_jump_length : length mma_jump = 2.
+    Notation JUMPₐ := mma_jump.
+
+    Fact mma_jump_length : length JUMPₐ = 2.
     Proof. auto. Qed.
     
-    Fact mma_jump_progress i v : (i,mma_jump) // (i,v) -+> (j,v).
+    Fact mma_jump_progress i v : (i,JUMPₐ) // (i,v) -+> (j,v).
     Proof.
       unfold mma_jump.
       mma sss INC with x.
@@ -58,20 +60,22 @@ Section Minsky_Machine_alt_utils.
 
   End mma_jump.
 
+  Notation JUMPₐ := mma_jump.
+
   Section mma_null.
 
     (* Empty one register/counter *)
 
-    Variable (dst : pos n).
+    Variable (dst : pos n) (i : nat).
 
-    Definition mma_null i := DEC dst i :: nil.
+    Definition mma_null := DECₐ dst i :: nil.
 
-    Fact mma_null_length i : length (mma_null i) = 1.
+    Fact mma_null_length : length mma_null = 1.
     Proof. auto. Qed.
     
-    Let mma_null_spec i k v w : v#>dst = k 
+    Let mma_null_spec k v w :   v#>dst = k 
                              -> w = v[0/dst]
-                             -> (i,mma_null i) // (i,v) -+> (1+i,w).
+                             -> (i,mma_null) // (i,v) -+> (1+i,w).
     Proof.
       unfold mma_null.
       revert v w.
@@ -84,9 +88,9 @@ Section Minsky_Machine_alt_utils.
         apply IHk; rew vec.
     Qed.
 
-    Fact mma_null_progress i v st : 
+    Fact mma_null_progress v st : 
              st = (1+i,v[0/dst])
-          -> (i,mma_null i) // (i,v) -+> st.
+          -> (i,mma_null) // (i,v) -+> st.
     Proof.
       intros; subst.
       apply mma_null_spec with (1 := eq_refl); auto.
@@ -94,23 +98,25 @@ Section Minsky_Machine_alt_utils.
 
   End mma_null.
 
+  Notation NULLₐ := mma_null.
+
   Hint Rewrite mma_null_length : length_db.
 
   Section mma_transfert.
 
     (* Added the content of src to dst while emptying src *)
 
-    Variables (src dst : pos n) (Hsd : src <> dst).
+    Variables (src dst : pos n) (Hsd : src <> dst) (i : nat).
 
-    Definition mma_transfert i := INC dst :: DEC src i :: DEC dst (3+i) :: nil.
+    Definition mma_transfert := INCₐ dst :: DECₐ src i :: DECₐ dst (3+i) :: nil.
 
-    Fact mma_transfert_length i : length (mma_transfert i) = 3.
+    Fact mma_transfert_length : length mma_transfert = 3.
     Proof. reflexivity. Qed.
 
-    Let mma_transfert_spec i v w k x :  v#>src = k
+    Let mma_transfert_spec v w k x :    v#>src = k
                                      -> v#>dst = x
                                      -> w = v[0/src][(1+k+x)/dst]
-                                     -> (i,mma_transfert i) // (i,v) -+> (2+i,w).
+                                     -> (i,mma_transfert) // (i,v) -+> (2+i,w).
     Proof.
       unfold mma_transfert.
       revert v w x.
@@ -126,9 +132,9 @@ Section Minsky_Machine_alt_utils.
         dest p dst; try lia; dest p src.
     Qed.
 
-    Fact mma_transfert_progress i v st : 
+    Fact mma_transfert_progress v st : 
            st = (3+i,v[0/src][((v#>src)+(v#>dst))/dst])
-        -> (i,mma_transfert i) // (i,v) -+> st.
+        -> (i,mma_transfert) // (i,v) -+> st.
     Proof using Hsd.
       intros ?; subst.
       apply sss_progress_trans with (2+i, v[0/src][(1+(v#>src)+(v#>dst))/dst]).
@@ -139,6 +145,8 @@ Section Minsky_Machine_alt_utils.
     Qed.
 
   End mma_transfert.
+
+  Notation TRANSFERTₐ := mma_transfert.
 
   Hint Rewrite mma_transfert_length : length_db.
 
@@ -151,7 +159,7 @@ Section Minsky_Machine_alt_utils.
     Fixpoint mma_incs k := 
       match k with 
         | 0   => nil
-        | S k => INC dst :: mma_incs k
+        | S k => INCₐ dst :: mma_incs k
       end.
 
     Fact mma_incs_length k : length (mma_incs k) = k.
@@ -166,12 +174,13 @@ Section Minsky_Machine_alt_utils.
         apply vec_pos_ext; intros p; dest p dst.
       + simpl; mma sss INC with dst.
         apply subcode_sss_compute with (P := (1+i,mma_incs k)); auto.
-        { subcode_tac; rewrite <- app_nil_end; auto. }
         apply IHk; f_equal; try lia.
         apply vec_pos_ext; intros p; dest p dst.
     Qed.
 
   End mma_incs.
+
+  Notation INCSₐ := mma_incs.
 
   Section mma_decs.
 
@@ -188,8 +197,8 @@ Section Minsky_Machine_alt_utils.
 
     Fixpoint mma_decs k i := 
       match k with 
-        | 0   => INC dst :: DEC dst p :: nil
-        | S k => DEC dst (3+i) :: INC dst :: DEC dst q :: mma_decs k (3+i)
+        | 0   => INCₐ dst :: DECₐ dst p :: nil
+        | S k => DECₐ dst (3+i) :: INCₐ dst :: DECₐ dst q :: mma_decs k (3+i)
       end.
 
     Fact mma_decs_length k i : length (mma_decs k i) = 2+3*k.
@@ -216,7 +225,6 @@ Section Minsky_Machine_alt_utils.
         * intros d Hd.
           mma sss DEC S with dst (3+i) d.
           apply subcode_sss_compute with (P := (3+i,mma_decs k (3+i))); auto.
-          { subcode_tac; rewrite <- app_nil_end; auto. }
           apply sss_progress_compute, IHk; rew vec; try lia.
     Qed.
 
@@ -234,7 +242,6 @@ Section Minsky_Machine_alt_utils.
       + unfold mma_decs; fold mma_decs.
         mma sss DEC S with dst (3+i) ((v#>dst) - 1); try lia.
         apply subcode_sss_compute with (P := (3+i,mma_decs k (3+i))); auto.
-        { subcode_tac; rewrite <- app_nil_end; auto. }
         apply sss_progress_compute, IHk; rew vec; try lia.
         apply vec_pos_ext; intros x; dest x dst; lia.
     Qed.
@@ -259,6 +266,8 @@ Section Minsky_Machine_alt_utils.
 
   End mma_decs.
 
+  Notation DECSₐ := mma_decs.
+
   Section mma_decs_copy.
 
     (* Same as mma_decs except that the quantity
@@ -268,8 +277,8 @@ Section Minsky_Machine_alt_utils.
 
     Fixpoint mma_decs_copy k i := 
       match k with 
-        | 0   => INC dst :: DEC dst p :: nil
-        | S k => DEC dst (3+i) :: INC dst :: DEC dst q :: INC tmp :: mma_decs_copy k (4+i)
+        | 0   => INCₐ dst :: DECₐ dst p :: nil
+        | S k => DECₐ dst (3+i) :: INCₐ dst :: DECₐ dst q :: INCₐ tmp :: mma_decs_copy k (4+i)
       end.
 
     Fact mma_decs_copy_length k i : length (mma_decs_copy k i) = 2+4*k.
@@ -297,7 +306,6 @@ Section Minsky_Machine_alt_utils.
           mma sss DEC S with dst (3+i) d.
           mma sss INC with tmp.
           apply subcode_sss_compute with (P := (4+i,mma_decs_copy k (4+i))); auto.
-          { subcode_tac; rewrite <- app_nil_end; auto. }
           apply sss_progress_compute; rewrite plus_assoc.
           apply IHk; rew vec; try lia.
           apply vec_pos_ext; intros x; dest x tmp; try lia; dest x dst.
@@ -318,7 +326,6 @@ Section Minsky_Machine_alt_utils.
         mma sss DEC S with dst (3+i) ((v#>dst) - 1); try lia.
         mma sss INC with tmp.
         apply subcode_sss_compute with (P := (4+i,mma_decs_copy k (4+i))); auto.
-        { subcode_tac; rewrite <- app_nil_end; auto. }
         apply sss_progress_compute, IHk; rew vec; try lia.
         apply vec_pos_ext; intros x; dest x tmp; try lia; dest x dst; lia.
     Qed.
@@ -343,6 +350,8 @@ Section Minsky_Machine_alt_utils.
 
   End mma_decs_copy.
 
+  Notation DECS_COPYₐ := mma_decs_copy.
+
   Hint Rewrite mma_incs_length mma_decs_copy_length : length_db.
  
   Section mma_mult_cst.
@@ -352,8 +361,8 @@ Section Minsky_Machine_alt_utils.
     Variable (src dst : pos n) (Hsd : src <> dst) (k i : nat).
 
     Definition mma_mult_cst :=
-           DEC src (3+i) :: INC src :: DEC src (5+k+i) 
-        :: mma_incs dst (S k) ++ DEC dst i :: nil. 
+           DECₐ src (3+i) :: INCₐ src :: DECₐ src (5+k+i) 
+        :: INCSₐ dst (S k) ++ DECₐ dst i :: nil. 
 
     Fact mma_mult_cst_length : length mma_mult_cst = 5+k.
     Proof. unfold mma_mult_cst; rew length; lia. Qed.
@@ -392,6 +401,8 @@ Section Minsky_Machine_alt_utils.
 
   End mma_mult_cst.
 
+  Notation MULT_CSTₐ := mma_mult_cst.
+
   Hint Rewrite mma_mult_cst_length : length_db.
   
   Section mma_mod_cst.
@@ -401,11 +412,11 @@ Section Minsky_Machine_alt_utils.
     Variable (src dst : pos n) (Hsd : src <> dst) (p q k i : nat).
 
     Definition mma_mod_cst :=
-            DEC src (3+i)
-         :: INC dst
-         :: DEC dst p
-         :: INC src
-         :: mma_decs_copy src dst i q k (4+i).
+            DECₐ src (3+i)
+         :: INCₐ dst
+         :: DECₐ dst p
+         :: INCₐ src
+         :: DECS_COPYₐ src dst i q k (4+i).
 
     Fact mma_mod_cst_length : length mma_mod_cst = 6+4*k.
     Proof. unfold mma_mod_cst; rew length; lia. Qed.
@@ -439,7 +450,6 @@ Section Minsky_Machine_alt_utils.
         mma sss INC with src.
         apply sss_compute_trans with (i, v[(a*k+b)/src][(k+(v#>dst))/dst]).
         * apply subcode_sss_compute with (P := (4+i,mma_decs_copy src dst i q k (4+i))); auto.
-          { subcode_tac; rewrite <- app_nil_end; auto. }
           apply sss_progress_compute, mma_decs_copy_le_progress; auto; rew vec.
           { simpl; generalize (a*k); intro; lia. }
           do 3 f_equal; simpl mult; generalize (a*k); intro; lia.
@@ -459,7 +469,6 @@ Section Minsky_Machine_alt_utils.
       mma sss DEC S with src (3+i) x.
       mma sss INC with src.
       apply subcode_sss_compute with (P := (4+i,mma_decs_copy src dst i q k (4+i))); auto.
-      { subcode_tac; rewrite <- app_nil_end; auto. }
        apply sss_progress_compute, mma_decs_copy_lt_progress; auto; rew vec; lia.
     Qed.
  
@@ -490,6 +499,8 @@ Section Minsky_Machine_alt_utils.
   
   End mma_mod_cst.
 
+  Notation MOD_CSTₐ := mma_mod_cst.
+
   Hint Rewrite mma_decs_length mma_mod_cst_length : length_db.
 
   Section mma_div_cst.
@@ -502,7 +513,7 @@ Section Minsky_Machine_alt_utils.
     Let q := (5+3*k+i).
 
     Definition mma_div_cst := 
-         mma_decs src p q k i ++ INC dst :: INC src :: DEC src i :: nil.
+         DECSₐ src p q k i ++ INCₐ dst :: INCₐ src :: DECₐ src i :: nil.
 
     Fact mma_div_cst_length : length mma_div_cst = 5+3*k.
     Proof. unfold mma_div_cst; rew length; lia. Qed.
@@ -544,6 +555,36 @@ Section Minsky_Machine_alt_utils.
 
   End mma_div_cst.
 
+  Notation DIV_CSTₐ := mma_div_cst.
+
   Hint Rewrite mma_div_cst_length : length_db.
+
+  Section mma_loop.
+
+    Variables (src : pos n) (i : nat).
+
+    Definition mma_loop := INC src :: DEC src i :: nil.
+
+    Fact mma_loop_loop v : (i,mma_loop) // (i,v) -+> (i,v).
+    Proof.
+      unfold mma_loop.
+      mma sss INC with src.
+      mma sss DEC S with src i (v#>src); rew vec.
+      mma sss stop.
+    Qed.
+
+    Theorem mma_loop_spec v : ~ (i,mma_loop) // (i,v) ↓.
+    Proof.
+      intros (w & (k & Hk) & H2); revert w Hk H2.
+      induction on k as IHk with measure k; intros w Hk Hw.
+      destruct subcode_sss_progress_inv with (4 := mma_loop_loop v) (5 := Hk)
+        as (q & H1 & H2); auto.
+      { apply mma_sss_fun. }
+      apply IHk with (1 := H1) (2 := H2); auto.
+    Qed.
+  
+  End mma_loop.
+
+  Notation LOOPₐ := mma_loop.
 
 End Minsky_Machine_alt_utils.

--- a/theories/MinskyMachines/MMA2_undec.v
+++ b/theories/MinskyMachines/MMA2_undec.v
@@ -13,7 +13,7 @@ From Undecidability.FRACTRAN
   Require Import FRACTRAN FRACTRAN_undec.
 
 From Undecidability.MinskyMachines 
-  Require Import MMA FRACTRAN_to_MMA2 MMA2_to_MMA2_zero.
+  Require Import MMA FRACTRAN_to_MMA2.
 
 Lemma MMA2_HALTING_undec : undecidable MMA2_HALTING.
 Proof.
@@ -25,8 +25,8 @@ Check MMA2_HALTING_undec.
 
 Lemma MMA2_HALTS_ON_ZERO_undec : undecidable MMA2_HALTS_ON_ZERO.
 Proof.
-  apply (undecidability_from_reducibility MMA2_HALTING_undec).
-  apply MMA2_MMA2_HALTS_ON_ZERO.
+  apply (undecidability_from_reducibility FRACTRAN_REG_undec).
+  apply FRACTRAN_REG_MMA2_HALTS_ON_ZERO.
 Qed.
 
 Check MMA2_HALTS_ON_ZERO_undec.

--- a/theories/MinskyMachines/MMenv/mme_utils.v
+++ b/theories/MinskyMachines/MMenv/mme_utils.v
@@ -181,7 +181,6 @@ Section mm_env_utils.
             simpl; revert H5; apply subcode_sss_progress; auto.
           - replace (2*length (dst::ll)+i) with (2*length ll+(2+i)) by (rew length; lia).
             revert H8; simpl; apply subcode_sss_compute; auto.
-            subcode_tac; rewrite <- app_nil_end; auto.
     Qed.
 
   End mm_list_erase.
@@ -448,7 +447,6 @@ Section mm_env_utils.
         * revert H2; apply subcode_sss_progress; auto.
         * replace (2+n+i) with (n+(2+i)) by lia.
           revert H4; apply subcode_sss_compute; auto.
-          subcode_tac; rewrite <- app_nil_end; auto.
     Qed.
 
   End mm_set.

--- a/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
@@ -29,34 +29,29 @@ Set Implicit Arguments.
 
 Set Default Proof Using "Type".
 
-Local Notation "P /MMA/ s ↓" := (sss_terminates (@mma_sss 2) P s) (at level 70, no associativity).
+Local Notation "P //ₐ s ↓" := (sss_terminates (@mma_sss 2) P s) (at level 70, no associativity).
 
-Theorem fractran_reg_mma2 l : 
-          fractran_regular l
-       ->   { Q : list (mm_instr (pos 2)) 
-            | forall x, l /F/ x ↓ <-> (1,Q) /MMA/ (1,x##0##vec_nil) ↓ }.
-Proof.
-  intros Hl.
-  exists (fractran_reg_mma l).
-  apply fractran_reg_mma_reduction; auto.
-Qed.
-
-Section FRACTRAN_REG_MMA2.
+Section FRACTRAN_REG_MMA2_and_ON_ZERO.
 
   Let f : FRACTRAN_REG_PROBLEM -> MMA2_PROBLEM.
   Proof.
-    intros (l & x & Hl).
-    destruct (fractran_reg_mma2 Hl) as (Q & HQ).
-    exact (Q, (x##0##vec_nil)).
+    intros (Q & x & _).
+    exact (fractran_reg_mma Q,x##0##vec_nil).
   Defined.
 
   Theorem FRACTRAN_REG_MMA2_HALTING : FRACTRAN_REG_HALTING ⪯ MMA2_HALTING.
   Proof.
-    exists f. 
-    intros (l & x & Hl); simpl.
-    destruct (fractran_reg_mma2 Hl) as (Q & HQ); apply HQ.
+    exists f; intros (? & ? & ?); simpl.
+    now apply fractran_reg_mma_reductions.
   Qed.
 
-End FRACTRAN_REG_MMA2.
+  Theorem FRACTRAN_REG_MMA2_HALTS_ON_ZERO : FRACTRAN_REG_HALTING ⪯ MMA2_HALTS_ON_ZERO.
+  Proof.
+    exists f; intros (? & ? & ?); simpl.
+    now apply fractran_reg_mma_reductions.
+  Qed.
+
+End FRACTRAN_REG_MMA2_and_ON_ZERO.
 
 Check FRACTRAN_REG_MMA2_HALTING.
+Check FRACTRAN_REG_MMA2_HALTS_ON_ZERO.

--- a/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
@@ -36,19 +36,19 @@ Section FRACTRAN_REG_MMA2_and_ON_ZERO.
   Let f : FRACTRAN_REG_PROBLEM -> MMA2_PROBLEM.
   Proof.
     intros (Q & x & _).
-    exact (fractran_reg_mma Q,x##0##vec_nil).
+    exact (fractran_mma0 Q,x##0##vec_nil).
   Defined.
 
   Theorem FRACTRAN_REG_MMA2_HALTING : FRACTRAN_REG_HALTING ⪯ MMA2_HALTING.
   Proof.
     exists f; intros (? & ? & ?); simpl.
-    now apply fractran_reg_mma_reductions.
+    now apply fractran_reg_mma0_reductions.
   Qed.
 
   Theorem FRACTRAN_REG_MMA2_HALTS_ON_ZERO : FRACTRAN_REG_HALTING ⪯ MMA2_HALTS_ON_ZERO.
   Proof.
     exists f; intros (? & ? & ?); simpl.
-    now apply fractran_reg_mma_reductions.
+    now apply fractran_reg_mma0_reductions.
   Qed.
 
 End FRACTRAN_REG_MMA2_and_ON_ZERO.

--- a/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
@@ -1,0 +1,259 @@
+(**************************************************************)
+(*   Copyright Dominique Larchey-Wendling [*]                 *)
+(*                                                            *)
+(*                             [*] Affiliation LORIA -- CNRS  *)
+(**************************************************************)
+(*      This file is distributed under the terms of the       *)
+(*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
+(**************************************************************)
+
+Require Import List Arith Lia Relations.
+
+From Undecidability.MinskyMachines
+  Require Import MMA mma_defs ndMM2.
+
+From Undecidability.Shared.Libs.DLW 
+  Require Import utils Vec.pos Vec.vec Code.sss.
+
+From Undecidability.Synthetic
+  Require Import Definitions ReducibilityFacts.
+
+Set Implicit Arguments.
+
+Set Default Proof Using "Type".
+
+Section MMA2_ndMM2.
+
+  Notation nSTOP := (@ndmm2_stop _).
+  Notation nINC  := (@ndmm2_inc _).
+  Notation nDEC  := (@ndmm2_dec _).
+  Notation nZERO := (@ndmm2_zero _).
+
+  Notation α := true. 
+  Notation β := false.
+
+  Definition mma2_instr_enc i (ρ : mm_instr (pos 2)) :=
+    match ρ with
+      | INC pos0   => nINC α i (1+i) :: nil
+      | INC _      => nINC β i (1+i) :: nil
+      | DEC pos0 j => nDEC α i j :: nZERO α  i (1+i) :: nil
+      | DEC _    j => nDEC β i j :: nZERO β i (1+i) :: nil
+    end.
+
+  Fixpoint mma2_linstr_enc i l :=
+    match l with
+      | nil => nil
+      | ρ::l => mma2_instr_enc i ρ ++ mma2_linstr_enc (1+i) l
+    end.
+
+  Fact mma2_linstr_enc_app i l m : mma2_linstr_enc i (l++m) = mma2_linstr_enc i l ++ mma2_linstr_enc (length l+i) m.
+  Proof.
+    revert i; induction l as [ | ? l IHl ]; intros ?; simpl; auto.
+    rewrite app_ass, IHl; do 3 f_equal; auto.
+  Qed.
+
+  Fact mma2_linstr_enc_In i P c : 
+          In c (mma2_linstr_enc i P) 
+       -> exists l r ρ, P = l++ρ::r /\ In c (mma2_instr_enc (length l+i) ρ).
+  Proof.
+    revert i; induction P as [ | ρ P IH ]; intros i.
+    + intros [].
+    + simpl; rewrite in_app_iff; intros [ H | H ].
+      * exists nil, P, ρ; split; auto.
+      * destruct (IH (1+i)) as (l & r & ρ' & H1 & H2); auto.
+        exists (ρ::l), r, ρ'; split; auto.
+        - simpl; f_equal; auto.
+        - eq goal H2; do 2 f_equal; simpl; lia.
+  Qed.
+
+  Notation "Σ // a ⊕ b ⊦ u" := (ndmm2_accept Σ a b u) (at level 70, no associativity).
+
+  Notation "i // s -1> t" := (mma_sss i s t).
+  Notation "P // r :1> s" := (sss_step (@mma_sss _) P r s)  (at level 70, no associativity).
+  Notation "P // s ↠ t" := (sss_compute (@mma_sss _) P s t) (at level 70, no associativity).
+  Notation "P // s ~~> t" := (sss_output (@mma_sss _) P s t).
+
+  Local Fact mma2_instr_enc_sound Σ ρ s1 s2 : 
+          ρ // s1 -1> s2 
+       -> match s1, s2 with  
+            | (i,v1), (j,v2) => 
+            let a  := vec_pos v1 pos0 in
+            let b  := vec_pos v1 pos1 in
+            let a' := vec_pos v2 pos0 in
+            let b' := vec_pos v2 pos1 
+            in    incl (mma2_instr_enc i ρ) Σ 
+               -> Σ // a' ⊕ b' ⊦ j 
+               -> Σ // a  ⊕ b  ⊦ i
+          end.
+  Proof.
+    induction 1 as [ i x v | i x k v Hv | i x k v u Hv ]; try revert Hv;
+      vec split v with a; vec split v with b; vec nil v; repeat invert pos x; simpl.
+    + constructor 2 with (1+i); auto.
+    + constructor 3 with (1+i); auto.
+    + intros -> ?; constructor 6 with (1+i); auto.
+    + intros -> ?; constructor 7 with (1+i); auto.
+    + intros -> ?; constructor 4 with k; auto.
+    + intros -> ?; constructor 5 with k; auto.
+  Qed.
+
+  Local Fact mma2_step_linstr_sound Σ P s1 s2 : 
+          (1,P) // s1 :1> s2 
+       -> match s1, s2 with  
+            | (i,v1), (j,v2) => 
+            let a  := vec_pos v1 pos0 in
+            let b  := vec_pos v1 pos1 in
+            let a' := vec_pos v2 pos0 in
+            let b' := vec_pos v2 pos1 
+            in    incl (mma2_linstr_enc 1 P) Σ 
+               -> Σ // a' ⊕ b' ⊦ j 
+               -> Σ // a  ⊕ b  ⊦ i
+          end.
+  Proof.
+    intros (n & L & ρ & R & v & H1 & H2 & H3).
+    subst s1; destruct s2 as (j,w).
+    inversion H1; subst n P; clear H1; simpl.
+    intros H; apply (mma2_instr_enc_sound _ H3).
+    apply incl_tran with (2 := H).
+    rewrite mma2_linstr_enc_app; simpl.
+    rewrite plus_comm.
+    apply incl_appr, incl_appl, incl_refl.
+  Qed.
+
+  Variable P : list (mm_instr (pos 2)).
+
+  Definition mma2_prog_enc := nSTOP 0 :: mma2_linstr_enc 1 P.
+  Notation Σ := mma2_prog_enc.
+
+  Local Lemma mma2_prog_enc_compute s1 s2 : 
+          (1,P) // s1 ↠ s2 
+       -> match s1, s2 with  
+            | (i,v1), (j,v2) => 
+            let a  := vec_pos v1 pos0 in
+            let b  := vec_pos v1 pos1 in
+            let a' := vec_pos v2 pos0 in
+            let b' := vec_pos v2 pos1 
+            in    Σ // a' ⊕ b' ⊦ j 
+               -> Σ // a  ⊕ b  ⊦ i
+          end.
+  Proof.
+    intros (n & Hn).
+    induction Hn as [ (i,v) | n (i,st1) (j,st2) (k,st3) H1 H2 IH2 ]; simpl; auto.
+    revert IH2; simpl; intros IH3 H; generalize (IH3 H).
+    apply (mma2_step_linstr_sound _ H1), incl_tl, incl_refl.
+  Qed. 
+ 
+  Local Lemma mma2_prog_enc_stop : Σ // 0 ⊕ 0 ⊦ 0.
+  Proof. constructor 1; simpl; auto. Qed.
+
+  Hint Resolve mma2_prog_enc_stop : core.
+
+  Notation ø := vec_nil.
+
+  Local Lemma mma2_prog_enc_complete a b p : 
+             Σ // a ⊕ b ⊦ p -> (1,P) // (p,a##b##ø) ↠ (0,0##0##ø).
+  Proof.
+    induction 1 as [ u H 
+                   | a b u v H H1 IH1
+                   | a b u v H H1 IH1
+                   | a b u v H H1 IH1
+                   | a b u v H H1 IH1
+                   | b p u H H1 IH1
+                   | a p u H H1 IH1 ].
+    + destruct H as [ H | H ]. 
+      * inversion H; subst u. 
+        exists 0; constructor 1.
+      * apply mma2_linstr_enc_In in H
+          as (l & r & [ x | x ] & H1 & H2); repeat invert pos x; simpl in H2.
+        1-2: now destruct H2.
+        1-2: now destruct H2 as [ | [] ].
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x ] & H3 & H2); repeat invert pos x; simpl in H2.
+      2: now destruct H2.
+      2-3: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | [] ]; inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss INC with pos0.
+      mma sss stop.
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x ] & H3 & H2); repeat invert pos x; simpl in H2.
+      1: now destruct H2.
+      2-3: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | [] ]; inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss INC with pos1.
+      mma sss stop.
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x ] & H3 & H2); repeat invert pos x; simpl in H2.
+      1-2: now destruct H2.
+      2: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | H2 ].
+      2: now destruct H2.
+      inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss DEC S with pos0 v a.
+      mma sss stop.
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x ] & H3 & H2); repeat invert pos x; simpl in H2.
+      1-2: now destruct H2.
+      1: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | H2 ].
+      2: now destruct H2.
+      inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss DEC S with pos1 v b.
+      mma sss stop.
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x j ] & H3 & H2); repeat invert pos x; simpl in H2.
+      1-2: now destruct H2.
+      2: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | [ H2 | [] ] ].
+      1: easy.
+      inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss DEC 0 with pos0 j.
+      mma sss stop.
+    + destruct H as [ H | H ]; try discriminate.
+      apply mma2_linstr_enc_In in H
+        as (l & r & [ x | x j ] & H3 & H2); repeat invert pos x; simpl in H2.
+      1-2: now destruct H2.
+      1: now destruct H2 as [ | [] ].
+      destruct H2 as [ H2 | [ H2 | [] ] ].
+      1: easy.
+      inversion H2; subst.
+      apply sss_compute_trans with (2 := IH1).
+      rewrite H3.
+      mma sss DEC 0 with pos1 j.
+      mma sss stop.
+  Qed.
+
+  Theorem MMA2_ndMM2_equiv a b : MMA2_HALTS_ON_ZERO (P,a##b##ø) <-> Σ // a ⊕ b ⊦ 1.
+  Proof.
+    split.
+    + intros (H1 & _). 
+      apply mma2_prog_enc_compute in H1.
+      apply H1; auto.
+    + intros H1; split.
+      * apply mma2_prog_enc_complete, H1.
+      * simpl; lia.
+  Qed.
+
+End MMA2_ndMM2.
+
+Theorem reduction : MMA2_HALTS_ON_ZERO ⪯ @ndMM2_ACCEPT nat.
+Proof.
+  apply reduces_dependent; exists.
+  intros (P & v). 
+  vec split v with a; vec split v with b; vec nil v.
+  exists (existT _ (mma2_prog_enc P) (1,(a,b))).
+  apply MMA2_ndMM2_equiv.
+Qed.

--- a/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
@@ -24,20 +24,20 @@ Set Default Proof Using "Type".
 
 Section MMA2_ndMM2.
 
-  Notation nSTOP := (@ndmm2_stop _).
-  Notation nINC  := (@ndmm2_inc _).
-  Notation nDEC  := (@ndmm2_dec _).
-  Notation nZERO := (@ndmm2_zero _).
+  Notation STOPₙ := (@ndmm2_stop _).
+  Notation INCₙ  := (@ndmm2_inc _).
+  Notation DECₙ  := (@ndmm2_dec _).
+  Notation ZEROₙ := (@ndmm2_zero _).
 
   Notation α := true. 
   Notation β := false.
 
   Definition mma2_instr_enc i (ρ : mm_instr (pos 2)) :=
     match ρ with
-      | INC pos0   => nINC α i (1+i) :: nil
-      | INC _      => nINC β i (1+i) :: nil
-      | DEC pos0 j => nDEC α i j :: nZERO α  i (1+i) :: nil
-      | DEC _    j => nDEC β i j :: nZERO β i (1+i) :: nil
+      | INCₐ pos0   => INCₙ α i (1+i) :: nil
+      | INCₐ _      => INCₙ β i (1+i) :: nil
+      | DECₐ pos0 j => DECₙ α i j :: ZEROₙ α  i (1+i) :: nil
+      | DECₐ _    j => DECₙ β i j :: ZEROₙ β i (1+i) :: nil
     end.
 
   Fixpoint mma2_linstr_enc i l :=
@@ -121,7 +121,7 @@ Section MMA2_ndMM2.
 
   Variable P : list (mm_instr (pos 2)).
 
-  Definition mma2_prog_enc := nSTOP 0 :: mma2_linstr_enc 1 P.
+  Definition mma2_prog_enc := STOPₙ 0 :: mma2_linstr_enc 1 P.
   Notation Σ := mma2_prog_enc.
 
   Local Lemma mma2_prog_enc_compute s1 s2 : 

--- a/theories/MinskyMachines/Reductions/MM_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/MM_to_MMA2.v
@@ -54,4 +54,5 @@ Proof.
   exists (fractran_mma l), (fun v => ps 1 * exp 1 v ## 0 ## vec_nil).
   intros v; rewrite H2.
   apply fractran_mma_reduction; trivial.
+  revert H1; apply Forall_impl; tauto.
 Qed.

--- a/theories/MinskyMachines/ndMM2.v
+++ b/theories/MinskyMachines/ndMM2.v
@@ -17,7 +17,7 @@ Section Non_deterministic_Minsky_Machines.
 
   Variables loc : Set.
 
-  (* four instructions: STOP, INC, DEC and ZERO (test) 
+  (* four instructions: STOPₙ, INCₙ, DECₙ and ZEROₙ (test) 
 
      only two nat valued registers, indexed with bool
      ie true/α of which the values are denoted "a" below
@@ -28,11 +28,11 @@ Section Non_deterministic_Minsky_Machines.
      can stop the computation by itself. This model is
      inherently no-deterministic.
 
-     STOP p:     accepts location p when α = β = 0
-     INC x p q:  at location p, x += 1 and jumps to location q
-     DEC x p q:  at location p, x -= 1 (if possible) and jumps to location q
-                 if x is already 0 then this instruction cannot compute
-     ZERO x p q: at location p, jumps to location q when x = 0 
+     STOPₙ p:     accepts location p when α = β = 0
+     INCₙ x p q:  at location p, x += 1 and jumps to location q
+     DECₙ x p q:  at location p, x -= 1 (if possible) and jumps to location q
+                  if x is already 0 then this instruction cannot compute
+     ZEROₙ x p q: at location p, jumps to location q when x = 0 
 
      *)
 
@@ -45,10 +45,10 @@ Section Non_deterministic_Minsky_Machines.
   Notation α := true. 
   Notation β := false.
 
-  Notation STOP := ndmm2_stop.
-  Notation INC  := ndmm2_inc.
-  Notation DEC  := ndmm2_dec.
-  Notation ZERO := ndmm2_zero.
+  Notation STOPₙ := ndmm2_stop.
+  Notation INCₙ  := ndmm2_inc.
+  Notation DECₙ  := ndmm2_dec.
+  Notation ZEROₙ := ndmm2_zero.
 
   Infix "∊" := In (at level 70).
 
@@ -57,7 +57,7 @@ Section Non_deterministic_Minsky_Machines.
 
      Notice that eg 
 
-          [ STOP 0 ; INC α 0 4 ; DEC β 0 2 ]
+          [ STOPₙ 0 ; INCₙ α 0 4 ; DECₙ β 0 2 ]
 
      can both accept location 0 (if α = β = 0)
      or increment α and jump to location 4
@@ -81,25 +81,25 @@ Section Non_deterministic_Minsky_Machines.
 
   Inductive ndmm2_accept (Σ : list ndmm2_instr) : nat -> nat -> loc -> Prop :=
 
-    | in_ndmm2a_stop  : forall p,         STOP p ∊ Σ      ->  Σ //   0 ⊕   0 ⊦ p
+    | in_ndmm2a_stop  : forall p,         STOPₙ p ∊ Σ      ->  Σ //   0 ⊕   0 ⊦ p
 
-    | in_ndmm2a_inc_a : forall a b p q,   INC α p q ∊ Σ   ->  Σ // 1+a ⊕   b ⊦ q
-                                                          ->  Σ //   a ⊕   b ⊦ p
+    | in_ndmm2a_inc_a : forall a b p q,   INCₙ α p q ∊ Σ   ->  Σ // 1+a ⊕   b ⊦ q
+                                                           ->  Σ //   a ⊕   b ⊦ p
 
-    | in_ndmm2a_inc_b : forall a b p q,   INC β p q ∊ Σ   ->  Σ //   a ⊕ 1+b ⊦ q
-                                                          ->  Σ //   a ⊕   b ⊦ p
+    | in_ndmm2a_inc_b : forall a b p q,   INCₙ β p q ∊ Σ   ->  Σ //   a ⊕ 1+b ⊦ q
+                                                           ->  Σ //   a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_a : forall a b p q,   DEC α p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
-                                                          ->  Σ // 1+a ⊕   b ⊦ p
+    | in_ndmm2a_dec_a : forall a b p q,   DECₙ α p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
+                                                           ->  Σ // 1+a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_b : forall a b p q,   DEC β p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
-                                                          ->  Σ //   a ⊕ 1+b ⊦ p
+    | in_ndmm2a_dec_b : forall a b p q,   DECₙ β p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
+                                                           ->  Σ //   a ⊕ 1+b ⊦ p
 
-    | in_ndmm2a_zero_a : forall b p q,    ZERO α p q ∊ Σ  ->  Σ //   0 ⊕   b ⊦ q
-                                                          ->  Σ //   0 ⊕   b ⊦ p
+    | in_ndmm2a_zero_a : forall b p q,    ZEROₙ α p q ∊ Σ  ->  Σ //   0 ⊕   b ⊦ q
+                                                           ->  Σ //   0 ⊕   b ⊦ p
 
-    | in_ndmm2a_zero_b : forall a p q,    ZERO β p q ∊ Σ  ->  Σ //   a ⊕   0 ⊦ q
-                                                          ->  Σ //   a ⊕   0 ⊦ p
+    | in_ndmm2a_zero_b : forall a p q,    ZEROₙ β p q ∊ Σ  ->  Σ //   a ⊕   0 ⊦ q
+                                                           ->  Σ //   a ⊕   0 ⊦ p
 
   where "Σ // a ⊕ b ⊦ u" := (ndmm2_accept Σ a b u).
 

--- a/theories/MinskyMachines/ndMM2.v
+++ b/theories/MinskyMachines/ndMM2.v
@@ -83,22 +83,22 @@ Section Non_deterministic_Minsky_Machines.
 
     | in_ndmm2a_stop  : forall p,         STOP p ∊ Σ      ->  Σ //   0 ⊕   0 ⊦ p
 
-    | in_ndmm2a_inc_1 : forall a b p q,   INC α p q ∊ Σ   ->  Σ // 1+a ⊕   b ⊦ q
+    | in_ndmm2a_inc_a : forall a b p q,   INC α p q ∊ Σ   ->  Σ // 1+a ⊕   b ⊦ q
                                                           ->  Σ //   a ⊕   b ⊦ p
 
-    | in_ndmm2a_inc_0 : forall a b p q,   INC β p q ∊ Σ   ->  Σ //   a ⊕ 1+b ⊦ q
+    | in_ndmm2a_inc_b : forall a b p q,   INC β p q ∊ Σ   ->  Σ //   a ⊕ 1+b ⊦ q
                                                           ->  Σ //   a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_1 : forall a b p q,   DEC α p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
+    | in_ndmm2a_dec_a : forall a b p q,   DEC α p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
                                                           ->  Σ // 1+a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_0 : forall a b p q,   DEC β p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
+    | in_ndmm2a_dec_b : forall a b p q,   DEC β p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
                                                           ->  Σ //   a ⊕ 1+b ⊦ p
 
-    | in_ndmm2a_zero_1 : forall b p q,    ZERO α p q ∊ Σ  ->  Σ //   0 ⊕   b ⊦ q
+    | in_ndmm2a_zero_a : forall b p q,    ZERO α p q ∊ Σ  ->  Σ //   0 ⊕   b ⊦ q
                                                           ->  Σ //   0 ⊕   b ⊦ p
 
-    | in_ndmm2a_zero_0 : forall a p q,    ZERO β p q ∊ Σ  ->  Σ //   a ⊕   0 ⊦ q
+    | in_ndmm2a_zero_b : forall a p q,    ZERO β p q ∊ Σ  ->  Σ //   a ⊕   0 ⊦ q
                                                           ->  Σ //   a ⊕   0 ⊦ p
 
   where "Σ // a ⊕ b ⊦ u" := (ndmm2_accept Σ a b u).

--- a/theories/MinskyMachines/ndMM2.v
+++ b/theories/MinskyMachines/ndMM2.v
@@ -68,9 +68,9 @@ Section Non_deterministic_Minsky_Machines.
      in ndMM2/ndmm2_utils.v
   *)
 
-  Reserved Notation "Σ // a ⊕ b ⊦ u" (at level 70, no associativity).
+  Reserved Notation "Σ //ₙ a ⊕ b ⊦ u" (at level 70, no associativity).
 
-  (* Σ // a ⊕ b ⊦ u denotes 
+  (* Σ //ₙ a ⊕ b ⊦ u denotes 
 
          "Σ accepts the initial location u with values α:=a and β:=b"
 
@@ -81,34 +81,34 @@ Section Non_deterministic_Minsky_Machines.
 
   Inductive ndmm2_accept (Σ : list ndmm2_instr) : nat -> nat -> loc -> Prop :=
 
-    | in_ndmm2a_stop  : forall p,         STOPₙ p ∊ Σ      ->  Σ //   0 ⊕   0 ⊦ p
+    | in_ndmm2a_stop  : forall p,         STOPₙ p ∊ Σ      ->  Σ //ₙ   0 ⊕   0 ⊦ p
 
-    | in_ndmm2a_inc_a : forall a b p q,   INCₙ α p q ∊ Σ   ->  Σ // 1+a ⊕   b ⊦ q
-                                                           ->  Σ //   a ⊕   b ⊦ p
+    | in_ndmm2a_inc_a : forall a b p q,   INCₙ α p q ∊ Σ   ->  Σ //ₙ 1+a ⊕   b ⊦ q
+                                                           ->  Σ //ₙ   a ⊕   b ⊦ p
 
-    | in_ndmm2a_inc_b : forall a b p q,   INCₙ β p q ∊ Σ   ->  Σ //   a ⊕ 1+b ⊦ q
-                                                           ->  Σ //   a ⊕   b ⊦ p
+    | in_ndmm2a_inc_b : forall a b p q,   INCₙ β p q ∊ Σ   ->  Σ //ₙ   a ⊕ 1+b ⊦ q
+                                                           ->  Σ //ₙ   a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_a : forall a b p q,   DECₙ α p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
-                                                           ->  Σ // 1+a ⊕   b ⊦ p
+    | in_ndmm2a_dec_a : forall a b p q,   DECₙ α p q ∊ Σ   ->  Σ //ₙ   a ⊕   b ⊦ q
+                                                           ->  Σ //ₙ 1+a ⊕   b ⊦ p
 
-    | in_ndmm2a_dec_b : forall a b p q,   DECₙ β p q ∊ Σ   ->  Σ //   a ⊕   b ⊦ q
-                                                           ->  Σ //   a ⊕ 1+b ⊦ p
+    | in_ndmm2a_dec_b : forall a b p q,   DECₙ β p q ∊ Σ   ->  Σ //ₙ   a ⊕   b ⊦ q
+                                                           ->  Σ //ₙ   a ⊕ 1+b ⊦ p
 
-    | in_ndmm2a_zero_a : forall b p q,    ZEROₙ α p q ∊ Σ  ->  Σ //   0 ⊕   b ⊦ q
-                                                           ->  Σ //   0 ⊕   b ⊦ p
+    | in_ndmm2a_zero_a : forall b p q,    ZEROₙ α p q ∊ Σ  ->  Σ //ₙ   0 ⊕   b ⊦ q
+                                                           ->  Σ //ₙ   0 ⊕   b ⊦ p
 
-    | in_ndmm2a_zero_b : forall a p q,    ZEROₙ β p q ∊ Σ  ->  Σ //   a ⊕   0 ⊦ q
-                                                           ->  Σ //   a ⊕   0 ⊦ p
+    | in_ndmm2a_zero_b : forall a p q,    ZEROₙ β p q ∊ Σ  ->  Σ //ₙ   a ⊕   0 ⊦ q
+                                                           ->  Σ //ₙ   a ⊕   0 ⊦ p
 
-  where "Σ // a ⊕ b ⊦ u" := (ndmm2_accept Σ a b u).
+  where "Σ //ₙ a ⊕ b ⊦ u" := (ndmm2_accept Σ a b u).
 
   (* A problem is a program, a start location and initial values for α/β *)
 
   Definition ndMM2_problem := { Σ : list ndmm2_instr & loc * (nat * nat) }%type.
 
   Definition ndMM2_ACCEPT (i : ndMM2_problem) : Prop := 
-    match i with existT _ Σ (u,(a,b)) => Σ // a ⊕ b ⊦ u end.
+    match i with existT _ Σ (u,(a,b)) => Σ //ₙ a ⊕ b ⊦ u end.
 
 End Non_deterministic_Minsky_Machines.
 

--- a/theories/MinskyMachines/ndMM2_undec.v
+++ b/theories/MinskyMachines/ndMM2_undec.v
@@ -10,13 +10,13 @@
 Require Import Undecidability.Synthetic.Undecidability.
 
 From Undecidability.MinskyMachines
-  Require Import MM2 MM2_undec ndMM2 MM2_to_ndMM2_ACCEPT.
+  Require Import MMA MMA2_undec ndMM2 MMA2_to_ndMM2_ACCEPT.
 
 (* Undecidability of acceptance for two counters non-deterministic
    Minsky machines with nat indexed instructions *)
 
 Theorem ndMM2_undec : undecidable (@ndMM2_ACCEPT nat).
 Proof.
-  apply (undecidability_from_reducibility MM2_HALTS_ON_ZERO_undec).
-  apply MM2_to_ndMM2_ACCEPT.reduction.
+  apply (undecidability_from_reducibility MMA2_HALTS_ON_ZERO_undec).
+  apply MMA2_to_ndMM2_ACCEPT.reduction.
 Qed.

--- a/theories/MuRec/ra_mm_env.v
+++ b/theories/MuRec/ra_mm_env.v
@@ -284,7 +284,6 @@ Section ra_compiler.
           replace (length P+(length Q+2*k)+i) 
             with  (2*k+(length P+length Q+i)) by lia.
           revert G8; apply subcode_sss_compute; auto.
-          subcode_tac; rewrite <- app_nil_end; auto. 
     + intros H4.
       assert ((i,P) // (i,e) ↓) as H5.
       { revert H4; apply subcode_sss_terminates; auto. }
@@ -757,7 +756,6 @@ Section ra_compiler.
         + rewrite Q1_length.
           replace s2 with (length F+(11+9*n+i)).
           revert F2; apply subcode_sss_compute; auto.
-          subcode_tac; rewrite <- app_nil_end; auto.
           unfold s2; lia.
         + unfold out_code, code_end, fst, snd.
           rew length; rewrite Q1_length; unfold s2; lia. }

--- a/theories/Shared/Libs/DLW/Code/subcode.v
+++ b/theories/Shared/Libs/DLW/Code/subcode.v
@@ -207,14 +207,14 @@ Ltac subcode_tac :=
             => (match i with ?j::nil => match type of H with context[j] => apply subcode_trans with (2 := H) end end ||
                 match type of H with context[i] => apply subcode_trans with (2 := H) end)
        end;
-       match goal with
+       try match goal with
          | |- subcode (_,?i) (_,?c) => focus_goal i c 
        end;
        match goal with 
-         | |- subcode (_,?i::nil) (_,?l++?i::?r) => exists l, r 
-         | |- subcode _ (_,?l++_++?r)            => exists l, r 
-         | |- subcode (_,?i) (_,?l++?i)          => exists l, nil 
-       end;
+         | |- subcode (_,?i)      (_,?l++?i)      => exists l, nil 
+         | |- subcode (_,?i::nil) (_,?l++?i::?r)  => exists l, r 
+         | |- subcode (_,?i)      (_,?l++?i++?r)  => exists l, r 
+       end; try rewrite <- !app_nil_end;
        split; auto; rew length; try lia.
 
 (* Add it to auto so that fam sss * will try it to solve the subcode goal it generates *)

--- a/theories/StackMachines/BSM/bsm_utils.v
+++ b/theories/StackMachines/BSM/bsm_utils.v
@@ -706,7 +706,6 @@ Section Binary_Stack_Machines.
       bsm sss POP 0 with c (S (S (S (length (tile h l t1 t2) + i)))) q (list_repeat Zero (length ll) ++ One :: lc).
       apply subcode_sss_compute with (P := (3+length (tile h l t1 t2)+i, 
                                             decoder s (S (S (S (length (tile h l t1 t2)+i)))) (ll++(th,tl)::lr))); auto.
-      subcode_tac; solve list eq.
       apply IHll with th tl lr lc; auto.
       rew vec.
       f_equal.
@@ -752,7 +751,6 @@ Section Binary_Stack_Machines.
       exists r.
       bsm sss POP 0 with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k).
       revert Hr; rew vec; apply subcode_sss_compute; auto.
-      subcode_tac; solve list eq.
     Qed.
 
     (* There might be a trailing 1 but the list of 0s is too long *)
@@ -785,7 +783,6 @@ Section Binary_Stack_Machines.
       exists r.
       bsm sss POP 0 with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k++lc).
       revert Hr; rew vec; apply subcode_sss_compute; auto.
-      subcode_tac; solve list eq.
     Qed.
     
     (* A full decoder of a list of boolean into a list a valid tile indices,
@@ -877,7 +874,6 @@ Section Binary_Stack_Machines.
       unfold full_decoder.
       apply subcode_sss_compute_trans with (P := (5+i,decoder i (5 + i) lt)) 
            (st2 := (i,v[(list_nat_bool ln++lc)/c][(th++v#>h)/h][(tl++v#>l)/l])); auto.
-      subcode_tac; solve list eq.
       subst lt; apply decoder_spec_ok with (list_nat_bool ln++lc); auto.
       rewrite H3; revert H1; solve list eq.
 
@@ -931,7 +927,6 @@ Section Binary_Stack_Machines.
       exists (v [(list_repeat Zero r++One::list_nat_bool ln++lc)/c]); split.
       apply sss_compute_trans with (1 := H2); auto.
       unfold full_decoder; revert Hr; apply subcode_sss_compute; auto.
-      subcode_tac; solve list eq.
       intros; rew vec.
 
       apply Exists_cons in Hln.
@@ -970,7 +965,6 @@ Section Binary_Stack_Machines.
       revert Hr.
       unfold full_decoder.
       apply subcode_sss_compute; auto.
-      subcode_tac; solve list eq.
     Qed.
     
     (* Correctness lemma for the full decoder when

--- a/theories/StackMachines/Util/SMN_transform.v
+++ b/theories/StackMachines/Util/SMN_transform.v
@@ -703,11 +703,11 @@ Proof.
   have [? ?] : x <> z2 /\ y <> z2.
   { have /fresh_StateP : In ([], a :: r, x, ([], b :: r', y)) M1.
     { rewrite /M1 /AddFreshLoop.M' ?in_app_iff. by right. }
-    by lia. }
+    unfold z2; lia. }
   have ? : z1 <> z2.
   { have /fresh_StateP : In ([], [a], x, ([a], [], z1)) M1.
     { rewrite /M1 /AddFreshLoop.M' ?in_app_iff. left. by left. }
-    by lia. }
+    unfold z2; lia. }
   
   (* az1r -> az2r' is derivable *)
   have ? : reachable M2 ([a], r, z1) ([a], r', z2).

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -240,6 +240,7 @@ MinskyMachines/Reductions/MM_to_MMA2.v
 MinskyMachines/Reductions/MUREC_MM.v
 MinskyMachines/Reductions/BSM_HALTING_to_MM2_HALTING.v
 MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
+MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
 
 MinskyMachines/MM/mm_defs.v         
 MinskyMachines/MM/mm_utils.v        


### PR DESCRIPTION
This PR provides improvements to the `IMSELL` undecidability results code. I would like it to be merged quickly so that I can refer to it in the final version of the upcoming FSCD21 paper [pre-print](https://members.loria.fr/DLarchey/files/papers/fscd21.pdf) that presents this work and also the _previously undocumented_ reduction from `FRACTRAN` to `MMA(2)` and `MMA0(2)` (two counters alternate Minsky machines). 

Also some updates to the library code:

+ improved `subcode_tac` in `Shared/Libs/DLW/Code/subcode.v` to solve more subcode detection automatically. Some proofs get a bit simplified in the `MM` and `BSM` code, ie. `subcode_tac; ...` is removed on many occasions in eg `StackMachines/BSM/bsm_utils.v` and `MuRec/ra_mm_env.v`;
+ better notations for alternate `MM` (ie. `INCₐ` instead of `INC`, but they are synonymous) to remind of the alternate semantics;
+ some cleanup of proofs in `FRACTRAN`.

Although some of my shared libs have been slightly improved, and some cleanup in the `FRACTRAN` code, this PR should not impact the rest of the project.

I also intend to create a _tag on a fork of this commit_ with a specialized `README.md` that would look like [this one](https://github.com/DmxLarchey/coq-library-undecidability/tree/fscd21). Fortunately, tags do not pollute the branch namespace ;-)
