### PR TITLE
Several problems on sequences of nats or Booleans

### DIFF
--- a/theories/MuRec/RA_UNIV_HALT.v
+++ b/theories/MuRec/RA_UNIV_HALT.v
@@ -19,23 +19,55 @@ Set Implicit Arguments.
 
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
+(* We build a primitive µ-recursive algorithm
+
+     ra_pr_univ : recalg 2
+
+   with two argument (n##k##ø)
+     - n encodes a finitary valuation nat -> nat
+     - k encodes a finite list of H10C constraints
+   
+   1) ra_pr_univ always terminates (it is primitive recursive)
+   2) ra_pr_univ outputs 0 iff the valuation n solves the equations k
+
+*)
+
+Definition ra_pr_univ := ra_h10c_eval.
+
+Theorem ra_pr_univ_pr : prim_rec ra_pr_univ.
+Proof. apply ra_h10c_eval_pr. Qed.
+
+Definition PRIMEREC_UNIV_PROBLEM := nat.
+Definition PRIMEREC_UNIV_MEETS_ZERO (n : PRIMEREC_UNIV_PROBLEM) := exists k, ⟦ra_pr_univ⟧ (k##n##vec_nil) 0.
+
 (* We build a universal µ-recusive algorithm of size 8708
 
       ra_univ : recalg 1
 
     which is just a particular µ-recursive algorithm. It is
     universal w.r.t. elementary Diophantine constraints 
-    as established in Reductions/H10C_RA_UNIV.v
+    as established in Reductions/H10C_SAT_to_RA_UNIV_HALT.v
 
     Basically, its termination predicate RA_UNIV_HALT 
     can simulate the solvability of any list of elementary 
     Diophantine constraints, making it undecidable *)
+
+Definition ra_univ := ra_min_univ ra_pr_univ.
+
+Definition RA_UNIV_PROBLEM := nat.
+Definition RA_UNIV_HALT (n : RA_UNIV_PROBLEM) : Prop := ex (⟦ra_univ⟧ (n##vec_nil)).
+Definition RA_UNIV_AD_HALT (n : RA_UNIV_PROBLEM) : Prop := ex (⟦ra_univ_ad⟧ (n##vec_nil)).
 
 (* Check ra_size ra_univ. *)
 (* Eval compute in ra_size ra_univ. *)
 (* Check ra_size ra_univ_ad. *)
 (* Eval compute in ra_size ra_univ_ad. *)
 
-Definition RA_UNIV_PROBLEM := nat.
-Definition RA_UNIV_HALT (n : RA_UNIV_PROBLEM) : Prop := ex (⟦ra_univ⟧ (n##vec_nil)).
-Definition RA_UNIV_AD_HALT (n : RA_UNIV_PROBLEM) : Prop := ex (⟦ra_univ_ad⟧ (n##vec_nil)).
+Definition PRIMESEQ_PROBLEM := { f : recalg 1 | prim_rec f }.
+Definition PRIMESEQ_MEETS_ZERO (P : PRIMESEQ_PROBLEM) := exists n, ⟦proj1_sig P⟧ (n##vec_nil) 0.
+
+Definition NATSEQ_PROBLEM := nat -> nat.
+Definition NATSEQ_MEETS_ZERO (f : NATSEQ_PROBLEM) : Prop := exists n, f n = 0.
+
+Definition BOOLSEQ_PROBLEM := nat -> bool.
+Definition BOOLSEQ_MEETS_TRUE (f : BOOLSEQ_PROBLEM) : Prop := exists n, f n = true.

--- a/theories/MuRec/RA_UNIV_HALT_undec.v
+++ b/theories/MuRec/RA_UNIV_HALT_undec.v
@@ -7,14 +7,60 @@ Require Import Undecidability.Synthetic.Undecidability.
 
 Require Import Undecidability.MuRec.RA_UNIV_HALT.
 
-Require Undecidability.MuRec.Reductions.H10C_SAT_to_RA_UNIV_HALT.
+Require Import Undecidability.MuRec.Reductions.H10C_SAT_to_RA_UNIV_HALT.
 Require Import Undecidability.DiophantineConstraints.H10C_undec.
 
 (* Undecidability of Universal µ-recusive Algorithm Halting *)
-Theorem RA_UNIV_HALT_undec : undecidable RA_UNIV_HALT.
+
+Theorem PRIMEREC_UNIV_MEETS_ZERO_undec : undecidable PRIMEREC_UNIV_MEETS_ZERO.
 Proof.
   apply (undecidability_from_reducibility H10C_SAT_undec).
-  exact H10C_SAT_to_RA_UNIV_HALT.H10C_SAT_RA_UNIV_HALT.
+  apply H10C_SAT_PRIMEREC_UNIV_MEETS_ZERO.
+Qed.
+
+Check PRIMEREC_UNIV_MEETS_ZERO_undec.
+
+Theorem PRIMESEQ_MEETS_ZERO_undec : undecidable PRIMESEQ_MEETS_ZERO.
+Proof.
+  apply (undecidability_from_reducibility PRIMEREC_UNIV_MEETS_ZERO_undec).
+  apply PRIMEREC_PRIMESEQ_MEETS_ZERO.
+Qed.
+
+Check PRIMESEQ_MEETS_ZERO_undec.
+
+Theorem NATSEQ_MEETS_ZERO_undec : undecidable NATSEQ_MEETS_ZERO.
+Proof.
+  apply (undecidability_from_reducibility PRIMESEQ_MEETS_ZERO_undec).
+  apply PRIMESEQ_NATSEQ_MEETS_ZERO.
+Qed.
+
+Check NATSEQ_MEETS_ZERO_undec.
+
+Theorem BOOLSEQ_MEETS_TRUE_undec : undecidable BOOLSEQ_MEETS_TRUE.
+Proof.
+  apply (undecidability_from_reducibility NATSEQ_MEETS_ZERO_undec).
+  apply reduces_dependent; exists.
+  intros f.
+  exists (fun n => match f n with 0 => true | _ => false end).
+  split; intros (n & Hn); exists n.
+  + now rewrite Hn.
+  + now destruct (f n).
+Qed.
+
+Check BOOLSEQ_MEETS_TRUE_undec.
+
+Theorem RA_UNIV_HALT_undec : undecidable RA_UNIV_HALT.
+Proof.
+  apply (undecidability_from_reducibility PRIMEREC_UNIV_MEETS_ZERO_undec).
+  exact H10C_SAT_to_RA_UNIV_HALT.PRIMEREC_UNIV_MEETS_ZERO_RA_UNIV_HALT.
 Qed.
 
 Check RA_UNIV_HALT_undec.
+
+Theorem RA_UNIV_AD_HALT_undec : undecidable RA_UNIV_AD_HALT.
+Proof.
+  apply (undecidability_from_reducibility H10UC_SAT_undec).
+  exact H10C_SAT_to_RA_UNIV_HALT.H10UC_SAT_RA_UNIV_AD_HALT.
+Qed.
+
+Check RA_UNIV_AD_HALT_undec.


### PR DESCRIPTION
This PR intends to answer a request from Yves Bertot concerning the undecidability of equality testing between (constructive) real numbers. For the moment, the PR implements the following problems, but it is open for comments or improvements:

1. we build a primitive µ-recursive _universal_ algorithm `ra_pr_univ` with 2 parameters such that the following problem is undecidable: given `n`, does the sequence `k => ra_pr_univ(n,k)` meet `0`?
2. the following problem is undecidable: given a primitive µ-recursive sequence `nat -> nat`, does it meet `0`?
3. the following problem is undecidable: given Coq sequence (ie a term) `nat -> nat`, does it meet `0`?
4. the following problem is undecidable: given a term `nat -> bool`, does it meet `true`?
5. we build a µ-recursive _universal_ (partial) algorithm `ra_univ` with one parameters such that the following problem is undecidable: given `n`, does `ra_univ(n)` terminate?

As already said, this PR is open for discussion but Yves was a bit surprised that a problem such as 3 or 4 was absent from the library.