### PR TITLE
Port everything to 8.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
         opam update
         opam upgrade
 #        opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
-        opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#54a001b79
-        opam pin add -n -y -k git coq-equations.dev+8.15 "github.com/mattam82/Coq-Equations.git#722cccfe0
+        opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#54a001b79"
+        opam pin add -n -y -k git coq-equations.dev+8.15 "github.com/mattam82/Coq-Equations.git#722cccfe0"
         opam install . --deps-only --with-doc --with-test 
         opam list --installed
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,9 @@ jobs:
         opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
         opam update
         opam upgrade
-        opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
-        opam pin add -n -y -k git coq-smpl.8.14 "https://github.com/uds-psl/smpl.git#d9b4d79"
+#        opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
+        opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#54a001b79
+        opam pin add -n -y -k git coq-equations.dev+8.15 "github.com/mattam82/Coq-Equations.git#722cccfe0
         opam install . --deps-only --with-doc --with-test 
         opam list --installed
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    
+
     - name: Build dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -37,9 +37,9 @@ jobs:
         opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
         opam update
         opam upgrade
-#        opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
+        opam pin add -n -y -k git coq-metacoq-template.dev+8.15 "https://github.com/yforster/template-coq.git#dad61c22c3"
         opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#54a001b79"
-        opam pin add -n -y -k git coq-equations.dev+8.15 "github.com/mattam82/Coq-Equations.git#722cccfe0"
+        opam pin add -n -y -k git coq-equations.dev+8.15 "https://github.com/yforster/Coq-Equations.git#b70c4acf8"
         opam install . --deps-only --with-doc --with-test 
         opam list --installed
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Coq Library of Undecidability Proofs
 
-[![CI](https://github.com/uds-psl/coq-library-undecidability/workflows/CI/badge.svg?branch=coq-8.14)](https://github.com/uds-psl/coq-library-undecidability/actions)
+*This branch is work in progress, several files are commented out because they are not yet ported. *
+
+[![CI](https://github.com/uds-psl/coq-library-undecidability/workflows/CI/badge.svg?branch=coq-8.15)](https://github.com/uds-psl/coq-library-undecidability/actions)
 
 The Coq Library of Undecidability Proofs contains mechanised reductions to establish undecidability results in Coq.
 The undecidability proofs are based on a synthetic approach to undecidability, where a problem `P` is considered [undecidable](theories/Synthetic/Undecidability.v#L4) if its [decidability](theories/Synthetic/Definitions.v#L6) in Coq would imply the decidability of the [halting problem of single-tape Turing machines](theories/TM/TM.v#L148) in Coq.
@@ -99,7 +101,7 @@ Then the following commands install the library:
 
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq-library-undecidability.1.0.1+8.14
+opam install coq-library-undecidability.1.0.1+8.15
 ```
 
 ### Install from git via opam
@@ -117,21 +119,21 @@ Then the following commands install the library:
 
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
-opam pin add -n -y -k git coq-smpl.8.14 "https://github.com/uds-psl/smpl.git#d9b4d79"
-opam pin add coq-library-undecidability.dev+8.14 "https://github.com/uds-psl/coq-library-undecidability.git#coq-8.14"
+opam pin add -n -y -k git coq-metacoq-template.dev+8.15 "https://github.com/MetaCoq/metacoq.git#3d83286"
+opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#d9b4d79"
+opam pin add coq-library-undecidability.dev+8.15 "https://github.com/uds-psl/coq-library-undecidability.git#coq-8.15"
 ```
 
 ### Manual installation
 
-You need `Coq 8.14` built on OCAML `>= 4.07.1`, the [Smpl](https://github.com/uds-psl/smpl) package, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
+You need `Coq 8.15` built on OCAML `>= 4.07.1`, the [Smpl](https://github.com/uds-psl/smpl) package, the [Equations](https://mattam82.github.io/Coq-Equations/) package, and the [MetaCoq](https://metacoq.github.io/metacoq/) package for Coq. If you are using opam 2 you can use the following commands to install the dependencies on a new switch:
 
 ```
 opam switch create coq-library-undecidability 4.07.1+flambda
 eval $(opam env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam pin add -n -y -k git coq-metacoq-template.dev+8.14 "https://github.com/MetaCoq/metacoq.git#3d83286"
-opam pin add -n -y -k git coq-smpl.8.14 "https://github.com/uds-psl/smpl.git#d9b4d79"
+opam pin add -n -y -k git coq-metacoq-template.dev+8.15 "https://github.com/MetaCoq/metacoq.git#3d83286"
+opam pin add -n -y -k git coq-smpl.8.15 "https://github.com/uds-psl/smpl.git#d9b4d79"
 opam install . --deps-only
 ```
 
@@ -158,7 +160,7 @@ To avoid this, you can use a non-local opam switch, i.e. `opam switch create 4.0
 
 #### Coq version
 
-Be careful that this branch only compiles under `Coq 8.14`. If you want to use a different Coq version you have to change to a different branch.
+Be careful that this branch only compiles under `Coq 8.15`. If you want to use a different Coq version you have to change to a different branch.
 Due to compatibility issues, not every branch contains exactly the same problems. 
 We recommend to use the newest branch if possible.
 

--- a/opam
+++ b/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "dev+8.14"
+version: "dev+8.15"
 maintainer: "forster@ps.uni-saarland.de"
 homepage: "https://github.com/uds-psl/coq-library-undecidability/"
 dev-repo: "git+https://github.com/uds-psl/coq-library-undecidability/"
@@ -23,11 +23,11 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {= "8.14.0"}
-  "coq-equations" {= "1.3+8.14"}
+  "coq" {>= "8.15"}
+  "coq-equations" {= "dev+8.15"}
   "ocaml"
-  "coq-smpl" {>= "8.14"}
-  "coq-metacoq-template" {= "dev+8.14"}
+  "coq-smpl" {>= "8.15"}
+#  "coq-metacoq-template" {= "dev+8.15"}
 ]
 
 synopsis: "A Coq Library of Undecidability Proofs"

--- a/opam
+++ b/opam
@@ -23,11 +23,11 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.15"}
+  "coq" {= "8.15+rc1"}
   "coq-equations" {= "dev+8.15"}
   "ocaml"
   "coq-smpl" {>= "8.15"}
-#  "coq-metacoq-template" {= "dev+8.15"}
+  "coq-metacoq-template" {= "dev+8.15"}
 ]
 
 synopsis: "A Coq Library of Undecidability Proofs"

--- a/theories/FOL/Reductions/PCPb_to_FOL.v
+++ b/theories/FOL/Reductions/PCPb_to_FOL.v
@@ -208,9 +208,9 @@ Theorem BPCP_satis R :
 Proof.
   rewrite PCPb_iff_dPCPb. split.
   - intros H. exists (list bool), (IB R), (fun _ => nil).
-    intros H'. cbn. apply H, (IB_F H').
+    intros H'. cbn. apply H, (IB_F _ _ H').
   - rewrite <- PCPb_iff_dPCPb. intros H1 H2 % (BPCP_valid R (ff:=falsity_on)).
-    apply (valid_satis H2), H1.
+    apply (valid_satis _ H2), H1.
 Qed.
 
 (* ** Reduction theorems *)

--- a/theories/FOL/Reductions/PCPb_to_FOL_class.v
+++ b/theories/FOL/Reductions/PCPb_to_FOL_class.v
@@ -140,7 +140,7 @@ Qed.
 Lemma trans_trans b (phi : form b) A :
   A ⊢I ((dnQ (trans phi)) --> trans phi).
 Proof.
-  specialize (trans_trans' phi A var var).
+  specialize (trans_trans' _ phi A var var).
   rewrite subst_var. intros H. apply (Weak H).
   clear H. induction A; cbn; trivial. setoid_rewrite subst_var. auto.
 Qed.

--- a/theories/FOL/Reductions/PCPb_to_binZF.v
+++ b/theories/FOL/Reductions/PCPb_to_binZF.v
@@ -1069,7 +1069,7 @@ Section Deduction.
     - apply AllI. erewrite map_app, ZF_subst', rm_const_shift_subst. apply H0. now rewrite map_app, ZF_subst.
     - pose proof (rm_const_tm_prv t). eapply Weak in H1. apply (ExE _ H1). 2: auto.
       edestruct (nameless_equiv_ex ([rm_const_fm p | p ∈ A0] ++ binZF)) as [x ->]. specialize (H0 A0 eq_refl).
-      apply (AllE x) in H0. apply rm_const_fm_swap with (x0:=x); auto. apply (Weak H0). auto.
+      apply (AllE x) in H0. apply rm_const_fm_swap with (x:=x); auto. apply (Weak H0). auto.
     - pose proof (rm_const_tm_prv t). eapply Weak in H1. apply (ExE _ H1). 2: auto.
       edestruct (nameless_equiv_ex ([rm_const_fm p | p ∈ A0] ++ binZF)) as [x ->]. specialize (H0 A0 eq_refl).
       apply (ExI x). apply <- rm_const_fm_swap; auto. apply (Weak H0). auto.

--- a/theories/FOL/Reductions/PCPb_to_minZF.v
+++ b/theories/FOL/Reductions/PCPb_to_minZF.v
@@ -1003,7 +1003,7 @@ Section Deduction.
     - apply AllI. erewrite map_app, ZF_subst', rm_const_shift_subst. apply H0. now rewrite map_app, ZF_subst.
     - pose proof (rm_const_tm_prv t). eapply Weak in H1. apply (ExE _ H1). 2: auto.
       edestruct (nameless_equiv_ex ([rm_const_fm p | p ∈ A0] ++ minZFeq')) as [x ->]. specialize (H0 A0 eq_refl).
-      apply (AllE x) in H0. apply rm_const_fm_swap with (x0:=x); auto. apply (Weak H0). auto.
+      apply (AllE x) in H0. apply rm_const_fm_swap with (x:=x); auto. apply (Weak H0). auto.
     - pose proof (rm_const_tm_prv t). eapply Weak in H1. apply (ExE _ H1). 2: auto.
       edestruct (nameless_equiv_ex ([rm_const_fm p | p ∈ A0] ++ minZFeq')) as [x ->]. specialize (H0 A0 eq_refl).
       apply (ExI x). apply <- rm_const_fm_swap; auto. apply (Weak H0). auto.

--- a/theories/FOL/Util/FullDeduction_facts.v
+++ b/theories/FOL/Util/FullDeduction_facts.v
@@ -36,10 +36,10 @@ Section ND_def.
     1-2,7-15: eauto using in_map.
     - apply AllI. setoid_rewrite map_map in IHprv. erewrite map_map, map_ext.
       apply IHprv. intros ?. cbn. now rewrite up_form.
-    - specialize (IHprv xi). apply AllE with (t0 := t`[xi]) in IHprv. rewrite subst_comp in *.
+    - specialize (IHprv xi). apply AllE with (t := t`[xi]) in IHprv. rewrite subst_comp in *.
       erewrite subst_ext; try apply IHprv. intros [|]; cbn; trivial.
       unfold funcomp. now setoid_rewrite subst_term_shift.
-    - specialize (IHprv xi). eapply ExI with (t0 := t`[xi]). rewrite subst_comp in *.
+    - specialize (IHprv xi). eapply ExI with (t := t`[xi]). rewrite subst_comp in *.
       erewrite subst_ext; try apply IHprv. intros [|]; cbn; trivial.
       unfold funcomp. now setoid_rewrite subst_term_shift.
     - eapply ExE in IHprv1. eassumption. rewrite map_map.

--- a/theories/FOLP/Util/FOL.v
+++ b/theories/FOLP/Util/FOL.v
@@ -754,7 +754,7 @@ Section SigExt.
       f_equal. erewrite! vec_comp. 2,3: reflexivity. apply vec_ext. intros t. unfold axioms.funcomp.
       replace (n + S i) with (n + i + 1) by lia. replace (n + i) with (n + i + 0) at 2 by lia.
       change nil with (map (@sig_drop_term' f f_ar P P_ar (n + i + 1)) nil) at 2.
-      apply sig_drop_subst_term' with (v := nil) (m := 0) (i := 1) (n := n + i) (t0 := t).
+      apply sig_drop_subst_term' with (v := nil) (m := 0) (i := 1) (n := n + i) (t := t).
   Qed.
 
   Definition ext_c' f f_ar P P_ar (n : nat) : term := @Func (sig_ext (B_S f f_ar P P_ar)) (inr n) Vector.nil.

--- a/theories/HOU/concon/conservativity.v
+++ b/theories/HOU/concon/conservativity.v
@@ -158,7 +158,7 @@ Section Conservativity.
       ord' Sigma <= 1 /\ (forall x c, c ∈ consts (tau x) -> c ∈ Consts [s; t]).
     Proof using n Leq.
       intros [m H] % ordertypingSubst_complete EQ.
-      eapply ordertypingSubst_monotone with (m0 := S m) in H; eauto.
+      eapply ordertypingSubst_monotone with (m := S m) in H; eauto.
       eapply downcast_constants_ordered in H as (Sigma & tau & ?); [|lia|eauto].
       exists Sigma; exists tau; intuition. eapply ordertypingSubst_soundness; eauto.
     Qed.
@@ -205,7 +205,7 @@ Section Conservativity.
     - intros x B H'. unfold tau. rewrite H'; destruct dec_in.
       eapply weakening_ordertyping_app, T; eauto.
       eapply ordertyping_monotone; eauto.
-    - rewrite !(subst_extensional) with (sigma0 := tau) (tau0 := sigma); eauto.
+    - rewrite !(subst_extensional) with (sigma := tau) (tau := sigma); eauto.
       all: intros; unfold tau; destruct dec_in; eauto; simplify in *.
       all: exfalso; eauto.
   Qed.

--- a/theories/HOU/concon/constants.v
+++ b/theories/HOU/concon/constants.v
@@ -223,7 +223,7 @@ Section RemoveConstants.
             rewrite <-firstn_all; cbn; now simplify.
           * eauto.  
         + econstructor; simplify; intuition.  
-          eapply vars_ordertyping_nth with (n0 := n) (Gamma0 := Gamma)
+          eapply vars_ordertyping_nth with (n := n) (Gamma := Gamma)
             in H1; eauto. 
           unfold enc_ctx;
             erewrite nth_error_app2, map_nth_error; simplify; now eauto.

--- a/theories/HOU/firstorder.v
+++ b/theories/HOU/firstorder.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 
 From Equations Require Import Equations.
-Require Import List Lia Arith Wf Morphisms Program.Program.
+Require Import List Lia Arith Init.Wf Morphisms Program.Program.
 From Undecidability.HOU Require Import unification.unification concon.conservativity calculus.calculus.
 Import ListNotations.
 
@@ -895,7 +895,7 @@ Section Retyping.
     assert (ord' L' <= n).
     - destruct s; destruct i; inv H2; simplify in H4. intuition.
       rewrite H4 in H5; simplify in H5; intuition.
-    - eapply AppR_ordertyping with (L0 := retype_ctx n L').
+    - eapply AppR_ordertyping with (L := retype_ctx n L').
       + clear H2.
         induction H0; eauto.
         econstructor. all: cbn in H3; simplify in H3. 2:intuition.
@@ -972,13 +972,13 @@ Section FirstOrderDecidable.
     sigma • s ≡ sigma • t -> sigma • s = sigma • t.
   Proof.
     intros. rewrite !subst_extensional
-              with (sigma0 := sigma)
+              with (sigma := sigma)
                    (tau := fun x => if x el (vars s ++ vars t) then sigma x else var x).
     2 - 3: intros; edestruct dec_in as [D|D]; simplify in D; intuition.
     eapply equiv_unique_normal_forms. intuition.
     1: rewrite !subst_extensional
       with (tau := sigma)
-           (sigma0 := fun x => if x el (vars s ++ vars t) then sigma x else var x); eauto. 
+           (sigma := fun x => if x el (vars s ++ vars t) then sigma x else var x); eauto. 
     1 - 2: intros; edestruct dec_in as [D|D]; simplify in D; intuition.
     all: eapply normal_subst; eauto 2; intros x; destruct dec_in; eauto 2.
     all: simplify in i; destruct i as [V|V]; eapply vars_ordertyping in V as V'; eauto 2.
@@ -991,7 +991,7 @@ Section FirstOrderDecidable.
     free' (free (length L)) sigma -> L ++ Gamma ⊩(n) sigma : L ++ Gamma -> Gamma ⊩(n) decr (length L) sigma : Gamma.
   Proof.
     intros ? ? x A ?; unfold decr. destruct H as [F1 F2].
-    eapply ordertyping_weak_preservation_under_renaming with (Gamma0 := L ++ Gamma).
+    eapply ordertyping_weak_preservation_under_renaming with (Gamma := L ++ Gamma).
     - eapply H0. rewrite nth_error_app2; simplify; eauto. 
     - intros y B H ?. eapply F2 in H2; unfold free in *; eauto. 
       rewrite nth_error_app2 in H; simplify in *; eauto.

--- a/theories/HOU/second_order/goldfarb/encoding.v
+++ b/theories/HOU/second_order/goldfarb/encoding.v
@@ -295,7 +295,7 @@ Proof.
         Injection H1; subst.
         Injection H2; subst.
         reflexivity.
-  - eapply normal_ren with (delta0 := delta) in H.
+  - eapply normal_ren with (delta := delta) in H.
     eapply head_atom in H; eauto. cbn in EQ.
     Injection EQ. Injection H0.
     unshelve eapply ren_equiv_proper in H2;

--- a/theories/HOU/second_order/goldfarb/multiplication.v
+++ b/theories/HOU/second_order/goldfarb/multiplication.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 Require Import List Lia Program.Program.
 From Undecidability.HOU Require Import std.std axioms.
-Require Import RelationClasses Morphisms Wf Init.Nat Setoid.
+Require Import RelationClasses Morphisms Init.Wf Init.Nat Setoid.
 From Undecidability.HOU Require Import calculus.calculus second_order.goldfarb.encoding.
 Require Import FinFun Coq.Arith.Wf_nat.
 Import ListNotations.

--- a/theories/HOU/second_order/goldfarb/reduction.v
+++ b/theories/HOU/second_order/goldfarb/reduction.v
@@ -1,5 +1,5 @@
 Set Implicit Arguments.
-Require Import RelationClasses Morphisms Wf List Lia Init.Nat Setoid.
+Require Import RelationClasses Morphisms Init.Wf List Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import calculus.calculus unification.unification.
 From Undecidability.HOU.second_order Require Export diophantine_equations goldfarb.encoding goldfarb.multiplication.
 Import ListNotations.

--- a/theories/HOU/std/misc.v
+++ b/theories/HOU/std/misc.v
@@ -1,5 +1,5 @@
 Set Implicit Arguments.
-Require Import List Arith Lia Morphisms Wf.
+Require Import List Arith Lia Morphisms Init.Wf.
 Import ListNotations.
 
 Definition funcomp {X Y Z} (g : Y -> Z) (f : X -> Y)  :=

--- a/theories/HOU/third_order/simplified.v
+++ b/theories/HOU/third_order/simplified.v
@@ -70,7 +70,7 @@ Section SimplifiedReduction.
     destruct P as [c C].
     intros (Delta & sigma & T1 & EQ).
     specialize (T1 0 (Arr (repeat (alpha → alpha) (length C)) alpha)); mp T1; eauto.
-    eapply ordertyping_preservation_under_renaming with (delta := add 2) (Delta0 := alpha :: alpha :: Delta) in T1.
+    eapply ordertyping_preservation_under_renaming with (delta := add 2) (Delta := alpha :: alpha :: Delta) in T1.
     2: intros ??; cbn; eauto. 
     eapply main_lemma with (u := 0) (v := 1) in T1 as (I & S & H); eauto.
     2, 3: intros (?&?&?) % vars_ren; discriminate. 

--- a/theories/HOU/unification/enumerability.v
+++ b/theories/HOU/unification/enumerability.v
@@ -243,7 +243,7 @@ Proof.
     exists Delta; exists sigma; intuition.
     pose (tau x := if nth Gamma x then sigma x else var x). exists Delta; exists tau; intuition.
     unfold tau; intros ?? H'; rewrite H'; eauto.
-    repeat rewrite subst_extensional with (sigma0 := tau) (tau0 := sigma); eauto.
+    repeat rewrite subst_extensional with (sigma := tau) (tau := sigma); eauto.
     1 - 2: intros ? H'; assert (x ∈ dom Gamma) as H1 by eauto using typing_variables; unfold tau; now domin H1.
     unfold tau. now eapply nth_error_None in H1 as ->.
   - eapply projection with (p := fun x: uni X * ctx => exists sigma, let (I, Delta) := x in Uextended (I, Delta, sigma)).

--- a/theories/HOU/unification/higher_order_unification.v
+++ b/theories/HOU/unification/higher_order_unification.v
@@ -84,8 +84,8 @@ Section Normalisation.
     pose (theta x := if nth (Gammaᵤ I) x then tau x else var x).
     exists Delta. exists theta. intuition.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
-    + rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma).
-      rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma); eauto.
+    + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
       all: intros ? H; eapply typing_variables in H; eauto; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto].

--- a/theories/HOU/unification/nth_order_unification.v
+++ b/theories/HOU/unification/nth_order_unification.v
@@ -106,7 +106,7 @@ Section NthOrderSystemUnification.
     ord' L < n -> ord A <= n ->
     Gamma ⊢₊(n) S : L -> Gamma ⊢(n) linearize_terms S : (Arr (rev L) A) → A.
   Proof.
-    intros H; econstructor; eapply AppR_ordertyping with (L0 := L).
+    intros H; econstructor; eapply AppR_ordertyping with (L := L).
     eapply orderlisttyping_preservation_under_renaming; eauto.
     intros x ?; cbn; eauto.
     econstructor; eauto; simplify; cbn; intuition.
@@ -223,8 +223,8 @@ Section Normalisation.
     pose (theta x := if nth (Gammaᵤ I) x then tau x else var x).
     exists Delta. exists theta. intuition.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
-    + rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma).
-      rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma); eauto.
+    + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
       all: intros ? H; eapply typing_variables in H; eauto; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto].
@@ -240,8 +240,8 @@ Section Normalisation.
     pose (theta x := if nth (Gamma₀ I) x then tau x else var x).
     exists Delta. exists theta. intuition.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
-    + rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma).
-      rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma); eauto.
+    + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
       all: intros ? H; eapply typing_variables in H; eauto; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto]; domin Heqo; eauto.
@@ -256,8 +256,8 @@ Section Normalisation.
     exists Delta. exists theta. intuition.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
     + intros; eauto.
-      rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma).
-      rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma); eauto.
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
       all: intros ? ?; enough (x ∈ dom Gamma₀') as D;
         [domin D; unfold theta; rewrite D; eauto|].
       all: eapply Vars_listtyping.

--- a/theories/HOU/unification/systemunification.v
+++ b/theories/HOU/unification/systemunification.v
@@ -187,7 +187,7 @@ Section SystemUnification.
   Lemma linearize_terms_typing Gamma S L A:
     Gamma ⊢₊ S : L -> Gamma ⊢ linearize_terms S : (Arr (rev L) A) → A.
   Proof.
-    intros H; econstructor; eapply AppR_typing with (L0 := L).
+    intros H; econstructor; eapply AppR_typing with (L := L).
     eapply listtyping_preservation_under_renaming; eauto.
     intros x ?; cbn; eauto.
     econstructor; eauto; simplify; cbn; intuition.
@@ -276,8 +276,8 @@ Proof.
   pose (theta x := if nth (@Gammaᵤ' _ I) x then tau x else var x).
   exists Delta. exists theta. intuition.
   + intros ???; unfold theta; rewrite H; eapply H7; eauto.
-  + rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma).
-    rewrite subst_pointwise_equiv with (sigma0 := theta) (tau0 := sigma); eauto.
+  + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
+    rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
     all: intros ? ?; enough (x ∈ dom Gammaᵤ') as D;
       [domin D; unfold theta; rewrite D|]; eauto.
     all: eapply Vars_listtyping.

--- a/theories/L/AbstractMachines/FlatPro/LM_heap_correct.v
+++ b/theories/L/AbstractMachines/FlatPro/LM_heap_correct.v
@@ -213,7 +213,7 @@ Proof.
   unfold extended;split;repeat intro. all:eauto.
 Qed.
 
-Typeclasses Opaque extended.
+#[export] Typeclasses Opaque extended.
 
 Lemma lookup_extend H H' a x g:
   extended H H' -> lookup H a x = Some g -> lookup H' a x = Some g.

--- a/theories/L/Complexity/UpToCNary.v
+++ b/theories/L/Complexity/UpToCNary.v
@@ -187,7 +187,7 @@ Qed.
 
 Section bla.
   Import FinTypes.
-  Lemma leUpToC_finCases_nary domain (Y:FinTypes.finType) Z__case (cases : forall (y:Y), Z__case y -> Rtuple domain) (f : Rarrow domain nat) (F : Rtuple domain -> nat) :
+  Lemma leUpToC_finCases_nary domain (Y:FinTypesDef.finType) Z__case (cases : forall (y:Y), Z__case y -> Rtuple domain) (f : Rarrow domain nat) (F : Rtuple domain -> nat) :
     (forall x, exists y (z : Z__case y), cases y z = x)
     -> (forall y, (fun z => App f (cases y z)) <=c (fun z => F (cases y z)))
     -> Fun' (fun x => App f x) <=c F.

--- a/theories/L/Functions/Size.v
+++ b/theories/L/Functions/Size.v
@@ -5,10 +5,10 @@ From Undecidability.L.Datatypes Require Import Lists.
 
 (* ** Extracted size of terms *)
 
-Instance term_size' : computable size'.
-Proof.
-  extract.
-Abort. (*possible, but the run time of this implementation is not good enough. *)
+(* Instance term_size' : computable size'. *)
+(* Proof. *)
+(*   extract. *)
+(* Abort. (*possible, but the run time of this implementation is not good enough. *) *)
 
 Lemma size'_surj : surjective size'.
 Proof.
@@ -79,8 +79,7 @@ Proof.
   eapply computesTime_timeLeq.
   
   2:{ unshelve (eapply uiter_total_instanceTime with (1 := sizeTR_correct) (preprocessT:=(fun _ _ => (5,tt)))).
-      4:{ extract. solverec. }
-      2:{ apply termT_sizeTR'. }
+      extract. solverec. 
   }
   split. 2:exact Logic.I.
   cbn [fst].

--- a/theories/MinskyMachines/MM/mm_comp.v
+++ b/theories/MinskyMachines/MM/mm_comp.v
@@ -235,7 +235,7 @@ Section simulator.
           destruct Hp; apply in_map_iff; exists p; split; auto.
           apply pos_list_prop.
       + apply subcode_sss_progress with (P := (length cN+iE,DEC tmp1 0::nil)); auto.
-        mm sss DEC 0 with tmp1 0.
+        mm sss DEC zero with tmp1 0.
         apply subcode_refl.
         mm sss stop.
     Qed.

--- a/theories/MinskyMachines/MM/mm_defs.v
+++ b/theories/MinskyMachines/MM/mm_defs.v
@@ -187,7 +187,7 @@ Tactic Notation "mm" "sss" "INC" "with" uconstr(a) :=
     | |- _ // _ ->> _ => apply mm_compute_INC with (x := a)
   end; auto.
 
-Tactic Notation "mm" "sss" "DEC" "0" "with" uconstr(a) uconstr(b) := 
+Tactic Notation "mm" "sss" "DEC" "zero" "with" uconstr(a) uconstr(b) := 
   match goal with
     | |- _ // _ -+> _ => apply mm_progress_DEC_0 with (x := a) (k := b)
     | |- _ // _ ->> _ => apply mm_compute_DEC_0 with (x := a) (k := b)

--- a/theories/MinskyMachines/MM/mm_no_self.v
+++ b/theories/MinskyMachines/MM/mm_no_self.v
@@ -303,7 +303,7 @@ Section remove_self_loops.
         - exists (0,0##w); split; try (simpl; lia).
           apply sc_Q_1 in H1; simpl f in H1.
           mm sss INC with (pos_nxt x).
-          subst i; clear H1; mm sss DEC 0 with pos0 0.
+          subst i; clear H1; mm sss DEC zero with pos0 0.
           mm sss stop; f_equal; simpl; subst; auto. 
         - spec in H5. { subst j; simpl in H4 |- *; lia. }
           apply sc_Q_1 in H1; simpl f in H1.
@@ -322,10 +322,10 @@ Section remove_self_loops.
            -- destruct (le_lt_dec (1+lP) p) as [ Hp1 | Hp1 ];
                 [ | destruct (eq_nat_dec p 0) as [ Hp2 | Hp2 ] ].
               ** exists (0,0##v); split; try (simpl; lia).
-                 mm sss DEC 0 with (pos_nxt x) 0.
+                 mm sss DEC zero with (pos_nxt x) 0.
                  mm sss stop.
               ** subst p; exists (0,0##v); split; try (simpl; lia).
-                 mm sss DEC 0 with (pos_nxt x) 0.
+                 mm sss DEC zero with (pos_nxt x) 0.
                  mm sss stop.
               ** apply mm_sss_DEC0_inv with (1 := Hx) in H2.
                  destruct H2; subst j w.
@@ -339,7 +339,7 @@ Section remove_self_loops.
            -- exists (0,0##w); split; simpl; auto.
               apply subcode_sss_compute_instr with (2 := H6) (st2 := (1+i,0##w)); auto.
               ** replace (0##w) with ((0##v)[u/pos_nxt x]); subst; auto; constructor; auto.
-              ** subst i; mm sss DEC 0 with pos0 0; mm sss stop.
+              ** subst i; mm sss DEC zero with pos0 0; mm sss stop.
            -- spec in H5. { simpl in H4 |- *; lia. }
               apply subcode_sss_terminates_instr with (2 := H6) (3 := H5); auto.
               replace (0##w) with ((0##v)[u/pos_nxt x]); subst; auto; constructor; auto.
@@ -376,9 +376,9 @@ Section remove_self_loops.
           ** destruct (le_lt_dec (1+lP) p) as [ Hp | Hp ];
                [ | destruct (eq_nat_dec p 0) as [ Hp2 | Hp2 ] ].
              ++ exists (p,v); split; try (simpl; lia).
-                mm sss DEC 0 with x p; mm sss stop.
+                mm sss DEC zero with x p; mm sss stop.
              ++ exists (p,v); split; try (simpl; lia).
-                mm sss DEC 0 with x p; mm sss stop.
+                mm sss DEC zero with x p; mm sss stop.
              ++ spec in H4. simpl in H5 |- *; lia.
                 spec in H4; auto.
                 apply subcode_sss_terminates_instr with (2 := G1) (3 := H4); auto; constructor.

--- a/theories/MinskyMachines/MM/mm_utils.v
+++ b/theories/MinskyMachines/MM/mm_utils.v
@@ -54,12 +54,12 @@ Section Minsky_Machine_utils.
       revert v w.
       induction k as [ | k IHk ]; intros v w H1 H2 H3; subst w.
       
-      mm sss DEC 0 with src (2+i).
+      mm sss DEC zero with src (2+i).
       mm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z src.
 
       mm sss DEC S with src (2+i) k.
-      mm sss DEC 0 with zero i; rew vec.
+      mm sss DEC zero with zero i; rew vec.
       apply sss_progress_compute.
       apply IHk; rew vec.
     Qed.
@@ -151,14 +151,14 @@ Section Minsky_Machine_utils.
       revert v w x.
       induction k as [ | k IHk ]; intros v w x H1 H2 H3 H4; subst w.
 
-      mm sss DEC 0 with src (3+i).
+      mm sss DEC zero with src (3+i).
       mm sss stop; f_equal; auto.
       apply vec_pos_ext; intros p.
       dest p dst; dest p src.
 
       mm sss DEC S with src (3+i) k.
       mm sss INC with dst.
-      mm sss DEC 0 with zero i; rew vec.
+      mm sss DEC zero with zero i; rew vec.
       replace (S k + x) with (k + S x) by lia.
       apply sss_progress_compute.
       apply IHk with (S x); rew vec.
@@ -206,7 +206,7 @@ Section Minsky_Machine_utils.
       induction k as [ | k IHk ]; intros v w H1 H4 H3.
 
       simpl in H1.
-      mm sss DEC 0 with src (6+i).
+      mm sss DEC zero with src (6+i).
       mm sss stop; f_equal; subst.
       apply vec_pos_ext; intros p.
       dest p quo; dest p src.
@@ -217,7 +217,7 @@ Section Minsky_Machine_utils.
       mm sss DEC S with src (i+6) (2*k); rew vec.
       mm sss DEC S with rem (4+i) (v#>rem); rew vec.
       mm sss INC with quo; rew vec.
-      mm sss DEC 0 with rem i; rew vec.
+      mm sss DEC zero with rem i; rew vec.
       apply sss_progress_compute.
       apply IHk; auto; rew vec.
       subst; apply vec_pos_ext; intros p.
@@ -235,7 +235,7 @@ Section Minsky_Machine_utils.
       simpl in H1.
       mm sss DEC S with src (6+i) 0.
       mm sss INC with rem.
-      mm sss DEC 0 with src (i+6); rew vec.
+      mm sss DEC zero with src (i+6); rew vec.
       mm sss stop; f_equal; try lia.
       subst; simpl.
       apply vec_pos_ext; intros p.
@@ -247,7 +247,7 @@ Section Minsky_Machine_utils.
       mm sss DEC S with src (i+6) (1+2*k); rew vec.
       mm sss DEC S with rem (4+i) (v#>rem); rew vec.
       mm sss INC with quo; rew vec.
-      mm sss DEC 0 with rem i; rew vec.
+      mm sss DEC zero with rem i; rew vec.
       apply sss_progress_compute.
       apply IHk; auto; rew vec.
       subst; apply vec_pos_ext; intros p.
@@ -322,7 +322,7 @@ Section Minsky_Machine_utils.
       unfold mm_mul2.
       revert v w; induction k as [ | k IHk ]; intros v w H1 H2 H3.
 
-      mm sss DEC 0 with src (4+i).
+      mm sss DEC zero with src (4+i).
       mm sss stop; f_equal; subst.
       apply vec_pos_ext; intros p.
       dest p dst; dest p src.
@@ -330,7 +330,7 @@ Section Minsky_Machine_utils.
       mm sss DEC S with src (4+i) k.
       mm sss INC with dst.
       mm sss INC with dst'.
-      mm sss DEC 0 with zero i; rew vec.
+      mm sss DEC zero with zero i; rew vec.
       unfold dst'; rew vec.
       apply sss_progress_compute.
       apply IHk; unfold dst'; rew vec.
@@ -488,10 +488,10 @@ Section Minsky_Machine_utils.
       apply vec_pos_ext; intros p.
       dest p tmp2; dest p src; dest p tmp1.
 
-      mm sss DEC 0 with src (13+i); rew vec.
+      mm sss DEC zero with src (13+i); rew vec.
       mm sss DEC S with tmp2 k 0; rew vec.
       mm sss INC with src'; unfold src'; rew vec.
-      mm sss DEC 0 with tmp2 e; rew vec.
+      mm sss DEC zero with tmp2 e; rew vec.
       mm sss stop; f_equal.
       apply vec_pos_ext; intros p.
       dest p tmp2; dest p src; dest p tmp1.
@@ -522,7 +522,7 @@ Section Minsky_Machine_utils.
       destruct (stack_enc_S s) as (q & Hq).
       mm sss DEC S with src (13+i) q; rew vec.
       mm sss INC with src; rew vec.
-      mm sss DEC 0 with tmp2 j; rew vec.
+      mm sss DEC zero with tmp2 j; rew vec.
       mm sss stop; f_equal.
       apply vec_pos_ext; intros p.
       dest p src; dest p tmp2; dest p tmp1.
@@ -554,7 +554,7 @@ Section Minsky_Machine_utils.
       mm sss DEC S with src (13+i) q; rew vec.
       mm sss INC with src; rew vec.
       mm sss DEC S with tmp2 j 0; rew vec.
-      mm sss DEC 0 with tmp1 k; rew vec.
+      mm sss DEC zero with tmp1 k; rew vec.
       mm sss stop; f_equal.
       apply vec_pos_ext; intros p.
       dest p src; dest p tmp2; dest p tmp1.

--- a/theories/MinskyMachines/MMA/mma_defs.v
+++ b/theories/MinskyMachines/MMA/mma_defs.v
@@ -192,7 +192,7 @@ Tactic Notation "mma" "sss" "INC" "with" uconstr(a) :=
     | |- _ // _ ->> _ => apply mma_sss_compute_INC with (x := a)
   end; auto.
 
-Tactic Notation "mma" "sss" "DEC" "0" "with" uconstr(a) uconstr(b) := 
+Tactic Notation "mma" "sss" "DEC" "zero" "with" uconstr(a) uconstr(b) := 
   match goal with
     | |- _ // _ -+> _ => apply mma_sss_progress_DEC_0 with (x := a) (k := b)
     | |- _ // _ ->> _ => apply mma_sss_compute_DEC_0 with (x := a) (k := b)

--- a/theories/MinskyMachines/MMA/mma_simul.v
+++ b/theories/MinskyMachines/MMA/mma_simul.v
@@ -72,7 +72,7 @@ Section mma_sim.
       mma sss INC with x.
       mma sss stop; now f_equal.
     + exists w1; split; auto.
-      mma sss DEC 0 with x (lnk k).
+      mma sss DEC zero with x (lnk k).
       mma sss stop; now f_equal.
     + exists (w1[u/x]); split; auto.
       mma sss DEC S with x (lnk k) u.

--- a/theories/MinskyMachines/MMA/mma_utils.v
+++ b/theories/MinskyMachines/MMA/mma_utils.v
@@ -83,7 +83,7 @@ Section Minsky_Machine_alt_utils.
       unfold mma_null.
       revert v w.
       induction k as [ | k IHk ]; intros v w H1 H2; subst w.
-      + mma sss DEC 0 with x i.
+      + mma sss DEC zero with x i.
         mma sss stop; f_equal.
         apply vec_pos_ext; intros z; dest z x.
       + mma sss DEC S with x i k.
@@ -154,7 +154,7 @@ Section Minsky_Machine_alt_utils.
     Proof.
       intros -> H.
       unfold mma_isempty, mma_jump; simpl app.
-      mma sss DEC 0 with x (3+i); rew vec.
+      mma sss DEC zero with x (3+i); rew vec.
       mma sss INC with x.
       mma sss DEC S with x p (0); rew vec.
       mma sss stop; f_equal.
@@ -200,7 +200,7 @@ Section Minsky_Machine_alt_utils.
       revert v w x.
       induction k as [ | k IHk ]; intros v w x H1 H2 H3; subst w.
       + mma sss INC with dst.
-        mma sss DEC 0 with src i; rew vec.
+        mma sss DEC zero with src i; rew vec.
         mma sss stop; f_equal; auto.
         apply vec_pos_ext; intros z; dest z dst; dest z src.
       + mma sss INC with dst.
@@ -248,7 +248,7 @@ Section Minsky_Machine_alt_utils.
     Proof.
       unfold mma_mult_cst.
       revert v st; induction x as [ | x IHx ]; intros v st Hv ?; subst.
-      + mma sss DEC 0 with src (3+i).
+      + mma sss DEC zero with src (3+i).
         apply sss_progress_compute.
         apply subcode_sss_progress with (P := (1+i,JUMPₐ (5+k+i) src)); auto. 
         apply mma_jump_progress.
@@ -318,7 +318,7 @@ Section Minsky_Machine_alt_utils.
       + unfold mma_decs; fold mma_decs.
         case_eq (v#>dst).
         * intros H2.
-          mma sss DEC 0 with dst (3+i).
+          mma sss DEC zero with dst (3+i).
           mma sss INC with dst.
           mma sss DEC S with dst q (v#>dst); rew vec.
           mma sss stop; f_equal.
@@ -398,7 +398,7 @@ Section Minsky_Machine_alt_utils.
       + unfold mma_decs_copy; fold mma_decs_copy.
         case_eq (v#>dst).
         * intros H2.
-          mma sss DEC 0 with dst (3+i).
+          mma sss DEC zero with dst (3+i).
           mma sss INC with dst.
           mma sss DEC S with dst q (v#>dst); rew vec.
           mma sss stop; f_equal.

--- a/theories/MinskyMachines/MMenv/mme_defs.v
+++ b/theories/MinskyMachines/MMenv/mme_defs.v
@@ -215,7 +215,7 @@ Tactic Notation "mm" "env" "INC" "with" uconstr(a) :=
     | |- _ // _ ->> _ => apply mm_env_compute_INC with (x := a)
   end; auto.
 
-Tactic Notation "mm" "env" "DEC" "0" "with" uconstr(a) uconstr(b) := 
+Tactic Notation "mm" "env" "DEC" "zero" "with" uconstr(a) uconstr(b) := 
   match goal with
     | |- _ // _ -+> _ => apply mm_env_progress_DEC_0 with (x := a) (k := b)
     | |- _ // _ ->> _ => apply mm_env_compute_DEC_0 with (x := a) (k := b)

--- a/theories/MinskyMachines/MMenv/mme_utils.v
+++ b/theories/MinskyMachines/MMenv/mme_utils.v
@@ -57,7 +57,7 @@ Section mm_env_utils.
       induction k as [ | k IHk ]; intros e x H1 H2 H3.
       + exists e; split.
         * intros j; dest j src; dest j dst.
-        * mm env DEC 0 with src (3+i).
+        * mm env DEC zero with src (3+i).
           mm env stop; f_equal; auto.
       + destruct IHk with (e := e⦃src⇠k⦄⦃dst⇠1+x⦄) (x := 1+x)
           as (e' & H4 & H5); rew env.
@@ -67,7 +67,7 @@ Section mm_env_utils.
           dest j src.
         * mm env DEC S with src (3+i) k.
           mm env INC with dst.
-          mm env DEC 0 with zero i; rew env.
+          mm env DEC zero with zero i; rew env.
           rewrite H2.
           apply sss_progress_compute; auto.
     Qed.
@@ -111,14 +111,14 @@ Section mm_env_utils.
       induction x as [ | x IHx ]; intros e H1 H2.
       + exists e; split.
         * intros j; dest j dst.
-        * mm env DEC 0 with dst (2+i).
+        * mm env DEC zero with dst (2+i).
           mm env stop; f_equal; auto.
       + destruct IHx with (e := e⦃dst⇠x⦄)
           as (e' & H4 & H5); rew env.
         exists e'; split.
         * intros j; rewrite H4; dest j dst.
         * mm env DEC S with dst (2+i) x.
-          mm env DEC 0 with zero i; rew env.
+          mm env DEC zero with zero i; rew env.
           apply sss_progress_compute; auto.
     Qed.
 
@@ -244,7 +244,7 @@ Section mm_env_utils.
       induction k as [ | k IHk ]; intros e x y H1 H2 H3 H4.
       + exists e; split.
         * intros j; dest j src; dest j dst; dest j tmp.
-        * mm env DEC 0 with src (4+i).
+        * mm env DEC zero with src (4+i).
           mm env stop; f_equal; auto.
       + destruct IHk with (e := e⦃src⇠k⦄⦃dst⇠1+x⦄⦃tmp⇠1+y⦄) (x := 1+x) (y := 1+y)
           as (e' & H5 & H6); rew env.
@@ -256,7 +256,7 @@ Section mm_env_utils.
         * mm env DEC S with src (4+i) k.
           mm env INC with dst.
           mm env INC with tmp.
-          mm env DEC 0 with zero i; rew env.
+          mm env DEC zero with zero i; rew env.
           rewrite H2, H3.
           apply sss_progress_compute; auto.
     Qed.

--- a/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
@@ -232,7 +232,7 @@ Section MMA2_ndMM2.
       inversion H2; subst.
       apply sss_compute_trans with (2 := IH1).
       rewrite H3.
-      mma sss DEC 0 with pos0 j.
+      mma sss DEC zero with pos0 j.
       mma sss stop.
     + destruct H as [ H | H ]; try discriminate.
       apply mma2_linstr_enc_In in H
@@ -244,7 +244,7 @@ Section MMA2_ndMM2.
       inversion H2; subst.
       apply sss_compute_trans with (2 := IH1).
       rewrite H3.
-      mma sss DEC 0 with pos1 j.
+      mma sss DEC zero with pos1 j.
       mma sss stop.
   Qed.
 

--- a/theories/MuRec/ra_mm_env.v
+++ b/theories/MuRec/ra_mm_env.v
@@ -390,7 +390,7 @@ Section ra_compiler.
     Proof.
       intros G1.
       unfold Q2.
-      mm env DEC 0 with v0 (23+length F+length G+9*n+i).
+      mm env DEC zero with v0 (23+length F+length G+9*n+i).
       mm env stop; f_equal; rew length.
       unfold s2; lia.
     Qed.
@@ -453,7 +453,7 @@ Section ra_compiler.
         { unfold s2, Q2; revert G8; apply subcode_sss_compute; auto. }
         mm env INC with m.
         { unfold s2; subcode_tac. }
-        mm env DEC 0 with zero s2.
+        mm env DEC zero with zero s2.
         { unfold s2; subcode_tac. }
         { rewrite get_set_env_neq; try lia.
           rewrite G7, get_set_env_neq; try lia.
@@ -896,7 +896,7 @@ Section ra_compiler.
       apply sss_compute_progress_trans with (length F+s1,e1).
       * unfold Q2; revert G5; apply subcode_sss_compute; auto.
       * rewrite min_Q2_length; unfold Q2.
-        mm env DEC 0 with o (3+length F+s1).
+        mm env DEC zero with o (3+length F+s1).
         1: rewrite G4; rew env.
         mm env stop.
     Qed.
@@ -924,7 +924,7 @@ Section ra_compiler.
       mm env DEC S with o (3 + length F + s1) x.
       { rewrite G4; rew env. }
       mm env INC with m.
-      mm env DEC 0 with zero s1.
+      mm env DEC zero with zero s1.
       { do 2 (rewrite get_set_env_neq; try lia).
         rewrite G4, get_set_env_neq, G1; lia. }
       mm env stop; f_equal.

--- a/theories/Shared/Libs/DLW/Utils/list_focus.v
+++ b/theories/Shared/Libs/DLW/Utils/list_focus.v
@@ -161,8 +161,9 @@ Ltac chg_hyp_3 H x :=
 Tactic Notation "focus" constr(X) := chg_goal X.
 Tactic Notation "focus" constr(X) "in" hyp(H) := chg_hyp H X. 
 
-Tactic Notation "focus" constr(X) "at" "2" := chg_goal_2 X.
-Tactic Notation "focus" constr(X) "in" hyp(H) "at" "2" := chg_hyp_2 H X. 
+Check 2.
 
-Tactic Notation "focus" constr(X) "at" "3" := chg_goal_3 X.
-Tactic Notation "focus" constr(X) "in" hyp(H) "at" "3" := chg_hyp_3 H X. 
+Tactic Notation "focus" constr(X) "in" hyp(H) "at" "two" := chg_hyp_2 H X. 
+
+Tactic Notation "focus" constr(X) "at" "three" := chg_goal_3 X.
+Tactic Notation "focus" constr(X) "in" hyp(H) "at" "three" := chg_hyp_3 H X. 

--- a/theories/Shared/Libs/PSL/EqDec.v
+++ b/theories/Shared/Libs/PSL/EqDec.v
@@ -1,16 +1,7 @@
 From Undecidability.Shared.Libs.PSL Require Import Prelim.
+From Undecidability.Shared.Libs.PSL Require Export EqDecDef.
 
 (* * Decidable predicates *)
-
-
-Definition dec (X: Prop) : Type := {X} + {~ X}.
-
-Coercion dec2bool P (d: dec P) := if d then true else false.
-
-Existing Class dec.
-
-Definition Dec (X: Prop) (d: dec X) : dec X := d.
-Arguments Dec X {d}.
 
 Lemma Dec_reflect (X: Prop) (d: dec X) :
   Dec X <-> X.
@@ -164,24 +155,6 @@ Proof.
 Defined.
 
 (* ** Discrete types *)
-
-Notation "'eq_dec' X" := (forall x y : X, dec (x=y)) (at level 70).
-
-Structure eqType :=
-  EqType {
-      eqType_X :> Type;
-      eqType_dec : eq_dec eqType_X
-    }.
-
-Arguments EqType X {_} : rename.
-
-Canonical Structure eqType_CS X (A: eq_dec X) := EqType X.
-
-#[global]
-Existing Instance eqType_dec.
-
-(* Print the base type of [eqType] in the Canonical Structure. *)
-Arguments eqType_CS (X) {_}.
 
 #[global]
 Instance unit_eq_dec :

--- a/theories/Shared/Libs/PSL/EqDecDef.v
+++ b/theories/Shared/Libs/PSL/EqDecDef.v
@@ -1,0 +1,31 @@
+Set Implicit Arguments. 
+Unset Strict Implicit.
+Unset Printing Records.
+Unset Printing Implicit Defensive.
+
+Definition dec (X: Prop) : Type := {X} + {~ X}.
+
+Coercion dec2bool P (d: dec P) := if d then true else false.
+
+Existing Class dec.
+
+Notation "'eq_dec' X" := (forall x y : X, dec (x=y)) (at level 70).
+
+Structure eqType :=
+  EqType {
+      eqType_X :> Type;
+      eqType_dec : eq_dec eqType_X
+    }.
+
+Arguments EqType X {_} : rename.
+
+Canonical Structure eqType_CS X (A: eq_dec X) := EqType X.
+
+#[global]
+Existing Instance eqType_dec.
+
+(* Print the base type of [eqType] in the Canonical Structure. *)
+Arguments eqType_CS (X) {_}.
+
+Definition Dec (X: Prop) (d: dec X) : dec X := d.
+Arguments Dec X {d}.

--- a/theories/Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
@@ -3,6 +3,7 @@
  *)
 
 From Undecidability.Shared.Libs.PSL Require Export Base.
+From Undecidability.Shared.Libs.PSL Require Import FinTypesDef.
 
 (* * Definition of useful tactics *)
 
@@ -35,12 +36,6 @@ Qed.
 
 Definition toOptionList {X: Type} (A: list X) :=
   None :: map (@Some _) A .
-
-(* This function counts the number of occurences of an element in a given list and returns the result *)
-Fixpoint count (X: Type) `{eq_dec X}  (A: list  X) (x:  X) {struct A} : nat :=
-  match A with
-  | nil => O
-  | cons y A' =>  if Dec (x=y) then S(count A' x) else count A' x end.
 
 Definition toSumList1 {X: Type}  (Y: Type) (A: list X): list (X + Y) :=
   map inl A.

--- a/theories/Shared/Libs/PSL/FiniteTypes/FinTypes.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/FinTypes.v
@@ -1,35 +1,7 @@
-From Undecidability.Shared.Libs.PSL Require Export BasicDefinitions.
+From Undecidability.Shared.Libs.PSL Require Export BasicDefinitions FinTypesDef.
 From Undecidability.Shared.Libs.PSL Require Import Bijection.
 
 (* ** Formalisation of finite types using canonical structures and type classes *)
-
-(* * Definition of finite Types *)
-
-Class finTypeC  (type:eqType) : Type :=
-  FinTypeC {
-      enum: list type;
-      enum_ok: forall x: type, count enum x = 1
-    }.
-
-Structure finType : Type :=
-  FinType
-    {
-      type:> eqType;
-      class: finTypeC type
-    }.
-
-Arguments FinType type {class}.
-#[global]
-Existing Instance class | 0.
-
-
-(* This is a hack to work-around a problem with a class of hacks *)
-#[export] Hint Extern 5 (finTypeC (EqType ?x)) => unfold x : typeclass_instances.
-
-Canonical Structure finType_CS (X : Type) {p : eq_dec X} {class : finTypeC (EqType X)} : finType := FinType (EqType X).
-
-(* Print the base type of [finType] in the Canonical Structure. *)
-Arguments finType_CS (X) {_ _}.
 
 Definition elem (F: finType) := @enum (type F) (class F).
 #[export] Hint Unfold elem : core.

--- a/theories/Shared/Libs/PSL/FiniteTypes/FinTypesDef.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/FinTypesDef.v
@@ -1,0 +1,41 @@
+From Undecidability.Shared.Libs.PSL Require Export EqDecDef.
+
+Set Implicit Arguments. 
+Unset Strict Implicit.
+Unset Printing Records.
+Unset Printing Implicit Defensive.
+
+(* This function counts the number of occurences of an element in a given list and returns the result *)
+Fixpoint count (X: Type) `{eq_dec X}  (A: list  X) (x:  X) {struct A} : nat :=
+  match A with
+  | nil => O
+  | cons y A' =>  if Dec (x=y) then S(count A' x) else count A' x end.
+
+
+(* * Definition of finite Types *)
+
+Class finTypeC  (type:eqType) : Type :=
+  FinTypeC {
+      enum: list type;
+      enum_ok: forall x: type, count enum x = 1
+  }.
+
+Structure finType : Type :=
+  FinType
+    {
+      type:> eqType;
+      class: finTypeC type
+    }.
+
+Arguments FinType type {class}.
+#[global]
+Existing Instance class | 0.
+
+
+(* This is a hack to work-around a problem with a class of hacks *)
+#[export] Hint Extern 5 (finTypeC (EqType ?x)) => unfold x : typeclass_instances.
+
+Canonical Structure finType_CS (X : Type) {p : eq_dec X} {class : finTypeC (EqType X)} : finType := FinType (EqType X).
+
+(* Print the base type of [finType] in the Canonical Structure. *)
+Arguments finType_CS (X) {_ _}.

--- a/theories/Shared/Libs/PSL/FiniteTypes/VectorFin.v
+++ b/theories/Shared/Libs/PSL/FiniteTypes/VectorFin.v
@@ -72,7 +72,7 @@ Defined.
 
 
 Lemma ProdCount (T1 T2: eqType) (A: list T1) (B: list T2) (a:T1) (b:T2)  :
-  BasicDefinitions.count (prodLists A B) (a,b) =  BasicDefinitions.count A a * BasicDefinitions.count B b .
+  FinTypesDef.count (prodLists A B) (a,b) =  FinTypesDef.count A a * FinTypesDef.count B b .
 Proof.
   induction A.
   - reflexivity.
@@ -82,7 +82,7 @@ Proof.
 Qed.
 
 Lemma prod_enum_ok (T1 T2: finType) (x: T1 * T2):
-  BasicDefinitions.count (prodLists (elem T1) (elem T2)) x = 1.
+  FinTypesDef.count (prodLists (elem T1) (elem T2)) x = 1.
 Proof.
   destruct x as [x y]. rewrite ProdCount. unfold elem.
   now repeat rewrite enum_ok.

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -9,9 +9,9 @@ From Undecidability.Shared.Libs.PSL Require Export Vectors.Fin.
 
 
 (* Vector.nth should not reduce with simpl, except the index is given with a constructor *)
-Arguments Vector.nth {A} {m} (v') !p.
-Arguments Vector.map {A B} f {n} !v /.
-Arguments Vector.map2 {A B C} g {n} !v1 !v2 /.
+(* Arguments Vector.nth {A} {m} (v') !p. *)
+(* Arguments Vector.map {A B} f {n} !v /. *)
+(* Arguments Vector.map2 {A B C} g {n} !v1 !v2 /. *)
 
 Tactic Notation "dependent" "destruct" constr(V) :=
   match type of V with

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -9,9 +9,9 @@ From Undecidability.Shared.Libs.PSL Require Export Vectors.Fin.
 
 
 (* Vector.nth should not reduce with simpl, except the index is given with a constructor *)
-(* Arguments Vector.nth {A} {m} (v') !p. *)
-(* Arguments Vector.map {A B} f {n} !v /. *)
-(* Arguments Vector.map2 {A B C} g {n} !v1 !v2 /. *)
+Arguments Vector.nth {A} {m} (v') !p. 
+Arguments Vector.map {A B} f {n} !v. 
+Arguments Vector.map2 {A B C} g {n} !v1 !v2.
 
 Tactic Notation "dependent" "destruct" constr(V) :=
   match type of V with

--- a/theories/StackMachines/BSM/bsm_defs.v
+++ b/theories/StackMachines/BSM/bsm_defs.v
@@ -242,10 +242,10 @@ End Binary_Stack_Machine.
 Tactic Notation "bsm" "sss" "POP" "empty" "with" uconstr(a) constr(b) constr(c) := 
      apply bsm_compute_POP_E with (x := a) (p := b) (q := c); auto.
 
-Tactic Notation "bsm" "sss" "POP" "0" "with" uconstr(a) constr(b) constr(c) uconstr(d) := 
+Tactic Notation "bsm" "sss" "POP" "zero" "with" uconstr(a) constr(b) constr(c) uconstr(d) := 
      apply bsm_compute_POP_0 with (x := a) (p := b) (q := c) (ll := d); auto.
 
-Tactic Notation "bsm" "sss" "POP" "1" "with" uconstr(a) constr(b) constr(c) uconstr(d) := 
+Tactic Notation "bsm" "sss" "POP" "one" "with" uconstr(a) constr(b) constr(c) uconstr(d) := 
      apply bsm_compute_POP_1 with (x := a) (p := b) (q := c) (ll := d); auto.
 
 Tactic Notation "bsm" "sss" "POP" "any" "with" uconstr(a) constr(c) constr(d) constr(e) constr(f) := 
@@ -259,10 +259,10 @@ Tactic Notation "bsm" "sss" "stop" := exists 0; apply sss_steps_0; auto.
 Tactic Notation "bsm" "inv" "POP" "empty" "with" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
      apply bsm_steps_POP_E_inv with (x := a) (p := b) (q := c) (ll := d) in H; auto.
 
-Tactic Notation "bsm" "inv" "POP" "0" "with" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
+Tactic Notation "bsm" "inv" "POP" "zero" "with" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
      apply bsm_steps_POP_0_inv with (x := a) (p := b) (q := c) (ll := d) in H; auto.
 
-Tactic Notation "bsm" "inv" "POP" "1" "with" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
+Tactic Notation "bsm" "inv" "POP" "one" "with" hyp(H) constr(a) constr(b) constr(c) constr(d) :=
      apply bsm_steps_POP_1_inv with (x := a) (p := b) (q := c) (ll := d) in H; auto.
 
 Tactic Notation "bsm" "inv" "POP" "any" "with" hyp(H) constr(a) constr(c) constr(d) constr(e) constr(f) :=

--- a/theories/StackMachines/BSM/bsm_pcp.v
+++ b/theories/StackMachines/BSM/bsm_pcp.v
@@ -94,7 +94,7 @@ Section Simulator.
        as (w & Hw1 & Hw2); rew vec.
     apply subcode_sss_compute_trans with (2 := Hw1); auto.
     apply subcode_sss_compute_trans with (2 := main_init_spec Hsa Hsh Hsl Hah Hal (14+lML) _); auto.
-    bsm sss POP 0 with s 0 0 nil; rew vec.
+    bsm sss POP zero with s 0 0 nil; rew vec.
     bsm sss stop; f_equal.
     apply vec_pos_ext; intros x.
     dest x a; dest x l; dest x h; dest x s.
@@ -132,7 +132,7 @@ Section Simulator.
     destruct H3 as (k5 & ? & H7); subst.
     unfold simulator in H7.
 
-    bsm inv POP 0 with H7 s 0 0 (@nil bool); rew vec.
+    bsm inv POP zero with H7 s 0 0 (@nil bool); rew vec.
     + destruct H7 as (k6 & H7 & H8).
       apply sss_steps_stall in H8.
       2: simpl; lia.

--- a/theories/StackMachines/BSM/bsm_utils.v
+++ b/theories/StackMachines/BSM/bsm_utils.v
@@ -57,16 +57,16 @@ Section Binary_Stack_Machines.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros p; dest x p.
 
-      bsm sss POP 1 with x i (3+i) l.
+      bsm sss POP one with x i (3+i) l.
       bsm sss PUSH with x Zero.
-      bsm sss POP 0 with x i i l; rew vec.
+      bsm sss POP zero with x i i l; rew vec.
       clear Hv.
       specialize (IHl (v[l/x])).
       spec in IHl.     
       rew vec.
       revert IHl; rew vec.
 
-      bsm sss POP 0 with x i (3+i) l.
+      bsm sss POP zero with x i (3+i) l.
       clear Hv.
       specialize (IHl (v[l/x])).
       spec in IHl.     
@@ -103,18 +103,18 @@ Section Binary_Stack_Machines.
         bsm sss stop.
         f_equal.
         apply vec_pos_ext; intros z; dest z y; dest z x.
-      * bsm sss POP 1 with x (4+i) (7+i) l.
+      * bsm sss POP one with x (4+i) (7+i) l.
         bsm sss PUSH with y One.
         bsm sss PUSH with y' Zero.
-        bsm sss POP 0 with y' i i (One::v#>y); unfold y'; rew vec.
+        bsm sss POP zero with y' i i (One::v#>y); unfold y'; rew vec.
         apply IHl; rew vec.
         apply vec_pos_ext; intros z.
         dest z y; simpl; solve list eq.
         dest z x.
-      * bsm sss POP 0 with x (4+i) (7+i) l.
+      * bsm sss POP zero with x (4+i) (7+i) l.
         bsm sss PUSH with y Zero.
         bsm sss PUSH with x Zero.
-        bsm sss POP 0 with x i i l; rew vec.
+        bsm sss POP zero with x i i l; rew vec.
         apply IHl; rew vec.
         apply vec_pos_ext; intros z.
         dest z y; simpl; solve list eq.
@@ -150,20 +150,20 @@ Section Binary_Stack_Machines.
         bsm sss stop.
         f_equal.
         apply vec_pos_ext; intros k; dest k z; dest k y; dest k x.
-      * bsm sss POP 1 with x (5+i) (9+i) l.
+      * bsm sss POP one with x (5+i) (9+i) l.
         bsm sss PUSH with y One.
         bsm sss PUSH with z One.
         bsm sss PUSH with y' Zero.
-        bsm sss POP 0 with y' i i (One::v#>y); unfold y'; rew vec.
+        bsm sss POP zero with y' i i (One::v#>y); unfold y'; rew vec.
         apply IHl; rew vec.
         apply vec_pos_ext; intros k.
         dest k z; simpl; solve list eq.
         dest k y; dest k x.
-      * bsm sss POP 0 with x (5+i) (9+i) l.
+      * bsm sss POP zero with x (5+i) (9+i) l.
         bsm sss PUSH with y Zero.
         bsm sss PUSH with z Zero.
         bsm sss PUSH with x Zero.
-        bsm sss POP 0 with x i i l; rew vec.
+        bsm sss POP zero with x i i l; rew vec.
         apply IHl; rew vec.
         apply vec_pos_ext; intros k.
         dest k z; simpl; solve list eq.
@@ -256,9 +256,9 @@ Section Binary_Stack_Machines.
       intros; rew vec.
       split; [ discriminate | intros _ ].
       bsm sss POP empty with x (4+i) (7+i).
-      bsm sss POP 1 with y q p m.
+      bsm sss POP one with y q p m.
       bsm sss PUSH with x' Zero.
-      bsm sss POP 0 with x' q q nil.
+      bsm sss POP zero with x' q q nil.
       rew vec; f_equal; auto.
       bsm sss stop; f_equal.
       unfold x'; rew vec.
@@ -270,7 +270,7 @@ Section Binary_Stack_Machines.
       intros; rew vec.
       split; [ discriminate | intros _ ].
       bsm sss POP empty with x (4+i) (7+i).
-      bsm sss POP 0 with y q p m.
+      bsm sss POP zero with y q p m.
       bsm sss stop.
 
       (* l = One::_, m = nil *)
@@ -278,7 +278,7 @@ Section Binary_Stack_Machines.
       exists (v[l/x]); split.
       intros; rew vec.
       split; [ discriminate | intros _ ].
-      bsm sss POP 1 with x (4+i) (7+i) l.
+      bsm sss POP one with x (4+i) (7+i) l.
       bsm sss POP empty with y q q; rew vec.
       bsm sss stop.
 
@@ -291,20 +291,20 @@ Section Binary_Stack_Machines.
 
       intros E1; inversion E1 as [ E ]; clear E1.
       specialize (H2 E).
-      bsm sss POP 1 with x (4+i) (7+i) l.
-      bsm sss POP 1 with y q q m; rew vec.
+      bsm sss POP one with x (4+i) (7+i) l.
+      bsm sss POP one with y q q m; rew vec.
       bsm sss PUSH with x Zero.
-      bsm sss POP 0 with x i i l; rew vec.
+      bsm sss POP zero with x i i l; rew vec.
       eq goal H2; do 2 f_equal.
       apply vec_pos_ext; intros z; dest z x.
 
       intros E1.
       spec in H3.
       contradict E1; subst; auto.
-      bsm sss POP 1 with x (4+i) (7+i) l.
-      bsm sss POP 1 with y q q m; rew vec.
+      bsm sss POP one with x (4+i) (7+i) l.
+      bsm sss POP one with y q q m; rew vec.
       bsm sss PUSH with x Zero.
-      bsm sss POP 0 with x i i l; rew vec.
+      bsm sss POP zero with x i i l; rew vec.
       eq goal H3; do 2 f_equal.
       apply vec_pos_ext; intros z; dest z x.
 
@@ -314,8 +314,8 @@ Section Binary_Stack_Machines.
       split.
       intros; rew vec.
       split; [ discriminate | intros _ ].
-      bsm sss POP 1 with x (4+i) (7+i) l.
-      bsm sss POP 0 with y q q m; rew vec.
+      bsm sss POP one with x (4+i) (7+i) l.
+      bsm sss POP zero with y q q m; rew vec.
       bsm sss stop.
 
       (* l = Zero::l', m = nil *)
@@ -324,7 +324,7 @@ Section Binary_Stack_Machines.
       split.
       intros; rew vec.
       split; [ discriminate | intros _ ].
-      bsm sss POP 0 with x (4+i) (7+i) l.
+      bsm sss POP zero with x (4+i) (7+i) l.
       bsm sss POP empty with y i q; rew vec.
       bsm sss stop.
 
@@ -334,10 +334,10 @@ Section Binary_Stack_Machines.
       split.
       intros; rew vec.
       split; [ discriminate | intros _ ].
-      bsm sss POP 0 with x (4+i) (7+i) l.
-      bsm sss POP 1 with y i q m; rew vec.
+      bsm sss POP zero with x (4+i) (7+i) l.
+      bsm sss POP one with y i q m; rew vec.
       bsm sss PUSH with y Zero.
-      bsm sss POP 0 with y q i m; rew vec.
+      bsm sss POP zero with y q i m; rew vec.
       bsm sss stop.
 
       (* l = Zero::l', m = Zero::m' *)
@@ -349,14 +349,14 @@ Section Binary_Stack_Machines.
 
       intros E1; inversion E1 as [ E ]; clear E1.
       specialize (H2 E).
-      bsm sss POP 0 with x (4+i) (7+i) l.
-      bsm sss POP 0 with y i q m; rew vec.
+      bsm sss POP zero with x (4+i) (7+i) l.
+      bsm sss POP zero with y i q m; rew vec.
 
       intros E1.
       spec in H3.
       contradict E1; subst; auto.
-      bsm sss POP 0 with x (4+i) (7+i) l.
-      bsm sss POP 0 with y i q m; rew vec.
+      bsm sss POP zero with x (4+i) (7+i) l.
+      bsm sss POP zero with y i q m; rew vec.
     Qed.
 
     Fact compare_stack_eq_spec v : 
@@ -489,14 +489,14 @@ Section Binary_Stack_Machines.
       induction k as [ | k IHk ]; intros v; intros Hx; 
         simpl list_repeat; simpl app; unfold transfer_ones; simpl in Hx.
 
-      bsm sss POP 0 with x p q l.
+      bsm sss POP zero with x p q l.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z y.
 
-      bsm sss POP 1 with x p q (list_repeat One k ++ Zero :: l).
+      bsm sss POP one with x p q (list_repeat One k ++ Zero :: l).
       bsm sss PUSH with y b.
       bsm sss PUSH with y Zero.
-      bsm sss POP 0 with y i i (b::v#>y); rew vec.
+      bsm sss POP zero with y i i (b::v#>y); rew vec.
       specialize (IHk (v [(list_repeat One k ++ Zero :: l) / x] [(b :: v #> y) / y])).
       spec in IHk.
       rew vec.
@@ -522,10 +522,10 @@ Section Binary_Stack_Machines.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z y; dest z x.
 
-      bsm sss POP 1 with x p q (list_repeat One k).
+      bsm sss POP one with x p q (list_repeat One k).
       bsm sss PUSH with y b.
       bsm sss PUSH with y Zero.
-      bsm sss POP 0 with y i i (b::v#>y); rew vec.
+      bsm sss POP zero with y i i (b::v#>y); rew vec.
       specialize (IHk (v [(list_repeat One k) / x] [(b :: v #> y) / y])).
       spec in IHk.
       rew vec.
@@ -686,7 +686,7 @@ Section Binary_Stack_Machines.
       (* The list ll is empty *)
 
       subst mm; simpl decoder.
-      bsm sss POP 1 with c (S (S (S (length (tile h l th tl) + i)))) q lc.
+      bsm sss POP one with c (S (S (S (length (tile h l th tl) + i)))) q lc.
 
       apply subcode_sss_compute_trans with (P := (1+i,tile h l th tl))
                                            (st2 := (1+length (tile h l th tl)+i,v[lc/c][(th++v#>h)/h][(tl++v#>l)/l])); auto.
@@ -696,14 +696,14 @@ Section Binary_Stack_Machines.
       apply vec_pos_ext; intros z; dest z l.
    
       bsm sss PUSH with c Zero.
-      bsm sss POP 0 with c s s lc; rew vec.
+      bsm sss POP zero with c s s lc; rew vec.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z c.
 
       (* The list ll is not empty *)
 
       subst mm; simpl.
-      bsm sss POP 0 with c (S (S (S (length (tile h l t1 t2) + i)))) q (list_repeat Zero (length ll) ++ One :: lc).
+      bsm sss POP zero with c (S (S (S (length (tile h l t1 t2) + i)))) q (list_repeat Zero (length ll) ++ One :: lc).
       apply subcode_sss_compute with (P := (3+length (tile h l t1 t2)+i, 
                                             decoder s (S (S (S (length (tile h l t1 t2)+i)))) (ll++(th,tl)::lr))); auto.
       apply IHll with th tl lr lc; auto.
@@ -732,7 +732,7 @@ Section Binary_Stack_Machines.
       simpl; unfold decoder_error.
       exists k.
       bsm sss PUSH with c Zero.
-      bsm sss POP 0 with c q q (v#>c); rew vec.
+      bsm sss POP zero with c q q (v#>c); rew vec.
       bsm sss stop.
       f_equal.
       apply vec_pos_ext; intros z; dest z c.
@@ -749,7 +749,7 @@ Section Binary_Stack_Machines.
       destruct (IHll (3 + length (tile h l t1 t2) + i) (v[(list_repeat Zero k)/c]) k)
         as (r & Hr); rew vec.
       exists r.
-      bsm sss POP 0 with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k).
+      bsm sss POP zero with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k).
       revert Hr; rew vec; apply subcode_sss_compute; auto.
     Qed.
 
@@ -766,7 +766,7 @@ Section Binary_Stack_Machines.
       simpl; unfold decoder_error.
       exists k.
       bsm sss PUSH with c Zero.
-      bsm sss POP 0 with c q q (v#>c); rew vec.
+      bsm sss POP zero with c q q (v#>c); rew vec.
       bsm sss stop.
       f_equal.
       apply vec_pos_ext; intros z; dest z c.
@@ -781,7 +781,7 @@ Section Binary_Stack_Machines.
         as (r & Hr); rew vec.
       lia.
       exists r.
-      bsm sss POP 0 with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k++lc).
+      bsm sss POP zero with c (3 + length (tile h l t1 t2) + i) q (list_repeat Zero k++lc).
       revert Hr; rew vec; apply subcode_sss_compute; auto.
     Qed.
     
@@ -835,14 +835,14 @@ Section Binary_Stack_Machines.
       unfold full_decoder.
       intros [] lc Hlc.
 
-      bsm sss POP 1 with c (4+i) p lc.
+      bsm sss POP one with c (4+i) p lc.
       bsm sss PUSH with c One.
       bsm sss PUSH with h Zero.
-      bsm sss POP 0 with h (5+i) q (v#>h); rew vec.
+      bsm sss POP zero with h (5+i) q (v#>h); rew vec.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z h; dest z c.
 
-      bsm sss POP 0 with c (4+i) p lc.
+      bsm sss POP zero with c (4+i) p lc.
       bsm sss PUSH with c Zero.
       bsm sss stop; f_equal.
       apply vec_pos_ext; intros z; dest z c.
@@ -1045,7 +1045,7 @@ Section Binary_Stack_Machines.
         apply empty_stack_spec.
 
         bsm sss PUSH with l Zero.
-        bsm sss POP 0 with l p p nil; rew vec.
+        bsm sss POP zero with l p p nil; rew vec.
         bsm sss stop.
         f_equal.
         apply vec_pos_ext; intros x; dest x l.

--- a/theories/StackMachines/Reductions/HaltSBTM_to_HaltBSM.v
+++ b/theories/StackMachines/Reductions/HaltSBTM_to_HaltBSM.v
@@ -92,12 +92,12 @@ Section fixi.
     Proof.
       unfold MOVE_L.
       destruct t as [[ [ | l ls] [ [] | ] ] rs].
-      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP one with CURR (8 + i) (5 + i) [].
         bsm sss POP empty with LEFT (14 + i) (12 + i).
         bsm sss PUSH with RIGHT true.
         bsm sss POP empty with ZERO END END.
         bsm sss stop.
-      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP zero with CURR (8 + i) (5 + i) [].
         bsm sss POP empty with LEFT (21 + i) (19 + i). 
         bsm sss PUSH with RIGHT false.
         bsm sss POP empty with ZERO END END.
@@ -105,36 +105,36 @@ Section fixi.
       - bsm sss POP empty with CURR (8 + i) (5 + i).
         bsm sss POP empty with LEFT (17 + i) END.
         bsm sss stop.
-      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP one with CURR (8 + i) (5 + i) [].
         destruct l.
-        + bsm sss POP 1 with LEFT (14 + i) (12 + i) ls.
+        + bsm sss POP one with LEFT (14 + i) (12 + i) ls.
           bsm sss PUSH with CURR true.
           bsm sss PUSH with RIGHT true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with LEFT (14 + i) (12 + i) ls.
+        + bsm sss POP zero with LEFT (14 + i) (12 + i) ls.
           bsm sss PUSH with CURR false.
           bsm sss PUSH with RIGHT true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP zero with CURR (8 + i) (5 + i) [].
         destruct l.
-        + bsm sss POP 1 with LEFT (21 + i) (19 + i) ls.
+        + bsm sss POP one with LEFT (21 + i) (19 + i) ls.
           bsm sss PUSH with CURR true.
           bsm sss PUSH with RIGHT false.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with LEFT (21 + i) (19 + i) ls.
+        + bsm sss POP zero with LEFT (21 + i) (19 + i) ls.
           bsm sss PUSH with CURR false.
           bsm sss PUSH with RIGHT false.
           bsm sss stop. 
       - bsm sss POP empty with CURR (8 + i) (5 + i).
         destruct l.
-        + bsm sss POP 1 with LEFT (17 + i) END ls.
+        + bsm sss POP one with LEFT (17 + i) END ls.
           bsm sss PUSH with CURR true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with LEFT (17 + i) END ls.
+        + bsm sss POP zero with LEFT (17 + i) END ls.
           bsm sss PUSH with CURR false.
           bsm sss POP empty with ZERO END END.
           bsm sss stop. 
@@ -174,12 +174,12 @@ Section fixi.
     Proof.
       unfold MOVE_R.
       destruct t as [[ls c] rs]; destruct rs as [ | r rs], c as [ [] | ].
-      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP one with CURR (8 + i) (5 + i) [].
         bsm sss POP empty with RIGHT (14 + i) (12 + i).
         bsm sss PUSH with LEFT true.
         bsm sss POP empty with ZERO END END.
         bsm sss stop.
-      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP zero with CURR (8 + i) (5 + i) [].
         bsm sss POP empty with RIGHT (21 + i) (19 + i). 
         bsm sss PUSH with LEFT false.
         bsm sss POP empty with ZERO END END.
@@ -187,36 +187,36 @@ Section fixi.
       - bsm sss POP empty with CURR (8 + i) (5 + i).
         bsm sss POP empty with RIGHT (17 + i) END.
         bsm sss stop.
-      - bsm sss POP 1 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP one with CURR (8 + i) (5 + i) [].
         destruct r.
-        + bsm sss POP 1 with RIGHT (14 + i) (12 + i) rs.
+        + bsm sss POP one with RIGHT (14 + i) (12 + i) rs.
           bsm sss PUSH with CURR true.
           bsm sss PUSH with LEFT true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with RIGHT (14 + i) (12 + i) rs.
+        + bsm sss POP zero with RIGHT (14 + i) (12 + i) rs.
           bsm sss PUSH with CURR false.
           bsm sss PUSH with LEFT true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-      - bsm sss POP 0 with CURR (8 + i) (5 + i) [].
+      - bsm sss POP zero with CURR (8 + i) (5 + i) [].
         destruct r.
-        + bsm sss POP 1 with RIGHT (21 + i) (19 + i) rs.
+        + bsm sss POP one with RIGHT (21 + i) (19 + i) rs.
           bsm sss PUSH with CURR true.
           bsm sss PUSH with LEFT false.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with RIGHT (21 + i) (19 + i) rs.
+        + bsm sss POP zero with RIGHT (21 + i) (19 + i) rs.
           bsm sss PUSH with CURR false.
           bsm sss PUSH with LEFT false.
           bsm sss stop. 
       - bsm sss POP empty with CURR (8 + i) (5 + i).
         destruct r.
-        + bsm sss POP 1 with RIGHT (17 + i) END rs.
+        + bsm sss POP one with RIGHT (17 + i) END rs.
           bsm sss PUSH with CURR true.
           bsm sss POP empty with ZERO END END.
           bsm sss stop.
-        + bsm sss POP 0 with RIGHT (17 + i) END rs.
+        + bsm sss POP zero with RIGHT (17 + i) END rs.
           bsm sss PUSH with CURR false.
           bsm sss POP empty with ZERO END END.
           bsm sss stop. 
@@ -343,7 +343,7 @@ Section fixM.
         eapply in_sss_step with (l := []). cbn; lia.
         econstructor 3. reflexivity.
         unfold PROG.
-        (* bsm sss POP 1 with CURR (26 + off) (51 + off) []. bsm sss stop.  *)
+        (* bsm sss POP one with CURR (26 + off) (51 + off) []. bsm sss stop.  *)
         destruct (δ (i, Some true)) as [ [[q' w] m] | ] eqn:Eq_nxt.
         + edestruct (@case_Some_false w) as [ [H H0] | [H H0]].
           * rewrite H.
@@ -387,7 +387,7 @@ Section fixM.
         eapply in_sss_step with (l := []). cbn; lia.
         econstructor 2. reflexivity.
         unfold PROG.
-(*         bsm sss POP 0 with CURR (26 + off) (51 + off) []. *) 
+(*         bsm sss POP zero with CURR (26 + off) (51 + off) []. *) 
         eapply subcode_sss_compute_trans; try eapply subcode1. 2:{ bsm sss stop. }
         destruct (δ (i, Some false)) as [ [[q' w] m] | ] eqn:Eq_nxt.
         + edestruct (@case_Some_true w) as [ [] | []].

--- a/theories/Synthetic/Infinite.v
+++ b/theories/Synthetic/Infinite.v
@@ -22,7 +22,10 @@ Proof.
   intros n H'.
   destruct (Nat.le_gt_cases (mu' d H) n) as [Hl | Hl]; eauto. 
   exfalso.
-  eapply linear_search_smallest with (start := 0). 2: exact H'. split. lia. eauto.
+  enough (mu' d H <= n) by lia.
+  eapply rel_ls_lower_bound with (start := 0); eauto with arith.
+  unfold mu, constructive_indefinite_ground_description_nat.
+  now destruct linear_search_from_0_conform.
 Qed.
 
 (* ** Definition of infinite and generating types *)

--- a/theories/TM/Code/Code.v
+++ b/theories/TM/Code/Code.v
@@ -193,7 +193,7 @@ Ltac build_eq_dec :=
 
 Lemma countMap_injective (X Y : eqType) (x : X) (A : list X) (f : X -> Y) :
   (forall x y, f x = f y -> x = y) ->
-  BasicDefinitions.count (map f A) (f x) = BasicDefinitions.count A x.
+  FinTypesDef.count (map f A) (f x) = FinTypesDef.count A x.
 Proof.
   intros HInj. revert x. induction A as [ | a A IH]; intros; cbn in *; auto.
   decide (f x = f a) as [ -> % HInj | He].
@@ -204,7 +204,7 @@ Qed.
 
 Lemma countMap_zero (X Y : eqType) (A : list X) (y : Y) (f : X -> Y) :
   (forall x, f x <> y) ->
-  BasicDefinitions.count (map f A) y = 0.
+  FinTypesDef.count (map f A) y = 0.
 Proof.
   revert y. induction A as [ | a A IH]; intros; cbn in *; auto.
   decide (y = f a) as [-> | ?]; auto. now contradiction (H a).

--- a/theories/TM/Code/Copy.v
+++ b/theories/TM/Code/Copy.v
@@ -375,8 +375,8 @@ End Move.
 
 Arguments Reset_size {X sigX cX} : simpl never.
 Arguments Reset_steps {X sigX cX} : simpl never.
-Typeclasses Opaque Reset_size.
-Typeclasses Opaque Reset_steps.
+#[export] Typeclasses Opaque Reset_size.
+#[export] Typeclasses Opaque Reset_steps.
 
 
 (* Copy a value from to an internal (right) tape *)
@@ -447,8 +447,8 @@ End CopyValue.
 
 Arguments CopyValue_size {X sig cX} : simpl never.
 Arguments CopyValue_steps {X sig cX} : simpl never.
-Typeclasses Opaque CopyValue_size.
-Typeclasses Opaque CopyValue_steps.
+#[export] Typeclasses Opaque CopyValue_size.
+#[export] Typeclasses Opaque CopyValue_steps.
 
 
 (* Copy and overwrite a value *)
@@ -524,8 +524,8 @@ End MoveValue.
 Arguments MoveValue_size_x {X sigX cX} : simpl never.
 Arguments MoveValue_size_y {X Y sigX sigY cX cY} : simpl never.
 Arguments MoveValue_steps {X Y sigX sigY cX cY} : simpl never.
-Typeclasses Opaque MoveValue_size_x MoveValue_size_y.
-Typeclasses Opaque MoveValue_steps.
+#[export] Typeclasses Opaque MoveValue_size_x MoveValue_size_y.
+#[export] Typeclasses Opaque MoveValue_steps.
 
 
 Section Translate.

--- a/theories/TM/Code/List/Concat_Repeat.v
+++ b/theories/TM/Code/List/Concat_Repeat.v
@@ -15,7 +15,7 @@ Local Arguments Encode_nat : simpl never.
 Section bla.
   Import FinTypes.
   (* Most likely: we need to make Z__case return domains... *)
-  (*Polymorphic Lemma leUpToC_finCases_nary domain (Y:FinTypes.finType) Z__case (cases : forall (y:Y), Z__case y -> Rtuple domain) (f : Rarrow domain nat) (F : Rtuple domain -> nat) :
+  (*Polymorphic Lemma leUpToC_finCases_nary domain (Y:FinTypesDef.finType) Z__case (cases : forall (y:Y), Z__case y -> Rtuple domain) (f : Rarrow domain nat) (F : Rtuple domain -> nat) :
     (forall x, exists y (z : Z__case y), cases y z = x)
     -> (forall y, (fun z => App f (cases y z)) <=c (fun z => F (cases y z)))
     -> Uncurry f <=c F.

--- a/theories/TM/Code/List/Length.v
+++ b/theories/TM/Code/List/Length.v
@@ -239,7 +239,7 @@ Section Lenght.
       hnf. cbn. do 2 eexists. repeat split; eauto.
       now intros _ _ _.
     }
-    Unshelve. 3:eassumption. exact _.
+    Unshelve. 3:eassumption. 2: exact _.
   Qed.
 
 End Lenght.

--- a/theories/TM/Hoare/HoareRegister.v
+++ b/theories/TM/Hoare/HoareRegister.v
@@ -340,7 +340,7 @@ Proof.
    eapply TerminatesIn_monotone with (T' := fun tin k' => tspec (P',P) tin /\ k <= k').
     + unfold Triple_TRel, TerminatesIn in *. intros tin k' (HP&Hk).
       specialize (HTrip (dummy_sizes tin P)) as (_&HT).
-      specialize HT with (tin0 := tin) (k0 := k). spec_assert HT as (conf&HLoop).
+      specialize HT with (tin := tin) (k := k). spec_assert HT as (conf&HLoop).
       { split. now apply tspec_tspec_withSpace. reflexivity. }
       exists conf. eapply loop_monotone; eauto.
     + unfold Triple_TRel. intros tin k' (HP&Hk). eauto.

--- a/theories/TM/L/HeapInterpreter/StepTM.v
+++ b/theories/TM/L/HeapInterpreter/StepTM.v
@@ -574,8 +574,8 @@ Section StepMachine.
       TMSimp. rename H into HIf.
       destruct HIf; TMSimp.
       { (* Then of first [CaseList], i.e. [V = g :: V'] *) rename H into HCaseList, H0 into HIf'.
-        specialize (HInt Fin0) as ?. specialize (HInt Fin1) as ?. specialize (HInt Fin2) as ?.
-        specialize (HInt Fin3) as ?. specialize (HInt Fin4) as ?. specialize (HInt Fin5) as ?. clear HInt. cbn in *.
+        pose proof (HInt Fin0) as ?. pose proof (HInt Fin1) as ?. pose proof (HInt Fin2) as ?.
+        pose proof (HInt Fin3) as ?. pose proof (HInt Fin4) as ?. pose proof (HInt Fin5) as ?. clear HInt. cbn in *.
         modpon HCaseList.
         destruct V as [ | g V']; auto; modpon HCaseList.
         destruct HIf'; TMSimp. (* This takes VERY long *)
@@ -643,12 +643,12 @@ Section StepMachine.
       cbn; repeat split; try lia.
       { exists V. repeat split; simpl_surject; eauto. apply HInt. }
       intros tmid_ bml1 (HCaseList&HCaseListInj); TMSimp. 
-      specialize (HInt Fin0) as ?.
-      specialize (HInt Fin1) as ?.
-      specialize (HInt Fin2) as ?.
-      specialize (HInt Fin3) as ?.
-      specialize (HInt Fin4) as ?.
-      specialize (HInt Fin5) as ?. 
+      pose proof (HInt Fin0) as ?.
+      pose proof (HInt Fin1) as ?.
+      pose proof (HInt Fin2) as ?.
+      pose proof (HInt Fin3) as ?.
+      pose proof (HInt Fin4) as ?.
+      pose proof (HInt Fin5) as ?. 
 
       modpon HCaseList.
       destruct bml1, V as [ | g V']; auto; modpon HCaseList.

--- a/theories/TM/L/HeapInterpreter/UnfoldClos.v
+++ b/theories/TM/L/HeapInterpreter/UnfoldClos.v
@@ -159,7 +159,7 @@ Section Fix.
   Local Arguments "*"%nat : simpl never.
 
   Local Arguments UpToC.f__UpToC {_ _} _ _.
-
+  Open Scope nat_scope.
   
   (* This function is copied from the end of the proof of SpecT__step' and not written by hand*)
   Definition steps_step H (stack : list (HAdd * list Tok * nat)) :=

--- a/theories/TM/Reductions/L_to_mTM.v
+++ b/theories/TM/Reductions/L_to_mTM.v
@@ -5,7 +5,7 @@ Require Import Undecidability.TM.L.HeapInterpreter.M_LHeapInterpreter.
 
 (* * L to TM *)
 
--Definition HaltLclosed (s : {s : term | closed s}) := exists t, eval (proj1_sig s) t. (* Halting problem for call-by-value lambda-calculus *)
+Definition HaltLclosed (s : {s : term | closed s}) := exists t, eval (proj1_sig s) t. (* Halting problem for call-by-value lambda-calculus *)
 
 Definition eva_LM_lin sigma := exists tau, evaluates step sigma tau.
 

--- a/theories/TM/TM.v
+++ b/theories/TM/TM.v
@@ -1,6 +1,6 @@
 (** * Halting problem for multi-tape and single-tape Turing machines HaltMTM and HaltTM 1  *)
 
-Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypes.
+Require Import Undecidability.Shared.Libs.PSL.FiniteTypes.FinTypesDef.
 Require Import Vector List.
 
 Unset Implicit Arguments.

--- a/theories/TRAKHTENBROT/BPCP_SigBPCP.v
+++ b/theories/TRAKHTENBROT/BPCP_SigBPCP.v
@@ -307,11 +307,11 @@ Section BPCP_FIN_DEC_EQ_SAT.
           rewrite fot_sem_lb_app_e with (H := H6).
           simpl; msplit 3; simpl; auto.
           - rew fot.
-            rewrite fot_sem_lb_app_Some with (lt0 := p) (Ht := H5) (H := Hx).
+            rewrite fot_sem_lb_app_Some with (lt := p) (Ht := H5) (H := Hx).
             ++ simpl; auto.
             ++ rew fot; simpl; auto.
           - rew fot.
-            rewrite fot_sem_lb_app_Some with (lt0 := q) (Ht := H6) (H := Hy).
+            rewrite fot_sem_lb_app_Some with (lt := q) (Ht := H6) (H := Hy).
             ++ simpl; auto.
             ++ rew fot; simpl; auto.
           - destruct H as [ (G1 & G2) | [ (G1 & G2) | (G1 & G2) ] ].

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -26,8 +26,8 @@ CounterMachines/CM1_undec.v
 SetConstraints/FMsetC.v
 SetConstraints/FMsetC_undec.v
 
-L/L.v
-L/L_undec.v
+# L/L.v
+# L/L_undec.v
 
 TM/TM.v
 TM/TM_undec.v
@@ -148,27 +148,27 @@ Shared/Libs/PSL/FiniteTypes/DepPairs.v
 Shared/Libs/PSL/FiniteTypes/Arbitrary.v
 Shared/Libs/PSL/FiniteTypes/VectorFin.v
 
-TM/L/Alphabets.v
-TM/L/CaseCom.v
-TM/L/HeapInterpreter/LookupTM.v
-TM/L/HeapInterpreter/StepTM.v
-TM/L/HeapInterpreter/M_LHeapInterpreter.v
-TM/L/HeapInterpreter/UnfoldClos.v
-TM/L/HeapInterpreter/JumpTargetTM.v
-TM/L/Transcode/Boollist_to_Enc.v
-TM/L/Transcode/Enc_to_Boollist.v
-TM/L/Transcode/BoollistEnc.v
-TM/L/Eval.v
+# TM/L/Alphabets.v
+# TM/L/CaseCom.v
+# TM/L/HeapInterpreter/LookupTM.v
+# TM/L/HeapInterpreter/StepTM.v
+# TM/L/HeapInterpreter/M_LHeapInterpreter.v
+# TM/L/HeapInterpreter/UnfoldClos.v
+# TM/L/HeapInterpreter/JumpTargetTM.v
+# TM/L/Transcode/Boollist_to_Enc.v
+# TM/L/Transcode/Enc_to_Boollist.v
+# TM/L/Transcode/BoollistEnc.v
+# TM/L/Eval.v
 
 
-TM/L/CompilerBoolFuns/Compiler_spec.v
-TM/L/CompilerBoolFuns/LComp_to_TMComp.v
-TM/L/CompilerBoolFuns/Compiler_facts.v
-TM/L/CompilerBoolFuns/Compiler_nat_facts.v
-TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
-TM/L/CompilerBoolFuns/Compiler.v
-TM/L/CompilerBoolFuns/NaryApp.v
-TM/L/CompilerBoolFuns/ClosedLAdmissible.v
+# TM/L/CompilerBoolFuns/Compiler_spec.v
+# TM/L/CompilerBoolFuns/LComp_to_TMComp.v
+# TM/L/CompilerBoolFuns/Compiler_facts.v
+# TM/L/CompilerBoolFuns/Compiler_nat_facts.v
+# TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
+# TM/L/CompilerBoolFuns/Compiler.v
+# TM/L/CompilerBoolFuns/NaryApp.v
+# TM/L/CompilerBoolFuns/ClosedLAdmissible.v
 
 PCP/Util/Facts.v
 PCP/Util/PCP_facts.v
@@ -458,8 +458,8 @@ TM/Code/BinNumbers/NTM.v
 
 TM/Single/EncodeTapes.v
 TM/Single/StepTM.v
-TM/Reductions/L_to_mTM.v
-
+# TM/Reductions/L_to_mTM.v
+  
 TM/Reductions/Arbitrary_to_Binary.v
 
 TM/Reductions/HaltTM_1_to_HaltSBTM.v
@@ -488,106 +488,106 @@ TM/Hoare/HoareMult.v
 TM/Hoare/HoareStdLib.v
 TM/Hoare/HoareLegacy.v
 
-L/Prelim/MoreBase.v
-L/Prelim/ARS.v
-L/Prelim/StringBase.v
-L/Prelim/MoreList.v
-L/Prelim/LoopSum.v
+# L/Prelim/MoreBase.v
+# L/Prelim/ARS.v
+# L/Prelim/StringBase.v
+# L/Prelim/MoreList.v
+# L/Prelim/LoopSum.v
 
-L/Util/L_facts.v
+# L/Util/L_facts.v
 
-L/Tactics/Computable.v
-L/Tactics/ComputableTime.v
+# L/Tactics/Computable.v
+# L/Tactics/ComputableTime.v
 
-L/Tactics/LTactics.v
+# L/Tactics/LTactics.v
 
-L/Tactics/Extract.v
-L/Tactics/GenEncode.v
+# L/Tactics/Extract.v
+# L/Tactics/GenEncode.v
 
-L/Tactics/Lbeta_nonrefl.v
-L/Tactics/Lproc.v
-L/Tactics/Lbeta.v
-L/Tactics/Reflection.v
-L/Tactics/LClos.v
-L/Tactics/LClos_Eval.v
-L/Tactics/Lrewrite.v
-L/Tactics/Lsimpl.v
+# L/Tactics/Lbeta_nonrefl.v
+# L/Tactics/Lproc.v
+# L/Tactics/Lbeta.v
+# L/Tactics/Reflection.v
+# L/Tactics/LClos.v
+# L/Tactics/LClos_Eval.v
+# L/Tactics/Lrewrite.v
+# L/Tactics/Lsimpl.v
 
-L/Tactics/ComputableTactics.v
-L/Tactics/ComputableDemo.v
+# L/Tactics/ComputableTactics.v
+# L/Tactics/ComputableDemo.v
 
-L/Tactics/mixedTactics.v
+# L/Tactics/mixedTactics.v
 
-L/Datatypes/LUnit.v
-L/Datatypes/LBool.v
-L/Datatypes/List/List_basics.v
-L/Datatypes/List/List_enc.v
-L/Datatypes/List/List_eqb.v
-L/Datatypes/List/List_extra.v
-L/Datatypes/List/List_fold.v
-L/Datatypes/List/List_in.v
-L/Datatypes/List/List_nat.v
-L/Datatypes/Lists.v
-L/Datatypes/LNat.v
-L/Datatypes/LOptions.v
-L/Datatypes/LProd.v
-L/Datatypes/LSum.v
-L/Datatypes/LTerm.v
-L/Datatypes/LFinType.v
-L/Datatypes/LVector.v
-
-
-L/Functions/EqBool.v
-L/Functions/Equality.v
-L/Functions/Encoding.v
-L/Functions/Decoding.v
-L/Functions/Proc.v
-L/Functions/Size.v
-L/Functions/Subst.v
-L/Functions/Eval.v
-L/Functions/LoopSum.v
-L/Functions/UnboundIteration.v
-L/Functions/FinTypeLookup.v
-L/Functions/EnumInt.v
-L/Functions/Ackermann.v
-
-L/TM/TMEncoding.v
-L/TM/TMinL.v
-L/TM/TMinL/TMinL_extract.v
-L/TM/TapeFuns.v
-L/Reductions/TM_to_L.v
-L/Reductions/H10_to_L.v
-L/Reductions/MuRec/MuRec_extract.v
-L/Reductions/MuRec.v
-
-L/Complexity/UpToC.v
-L/Complexity/UpToCNary.v
-L/Complexity/GenericNary.v
-L/Complexity/ResourceMeasures.v
-L/Complexity/LinDecode/LTD_def.v
-L/Complexity/LinDecode/LTDnat.v
-L/Complexity/LinDecode/LTDlist.v
-L/Complexity/LinDecode/LTDbool.v
+# L/Datatypes/LUnit.v
+# L/Datatypes/LBool.v
+# L/Datatypes/List/List_basics.v
+# L/Datatypes/List/List_enc.v
+# L/Datatypes/List/List_eqb.v
+# L/Datatypes/List/List_extra.v
+# L/Datatypes/List/List_fold.v
+# L/Datatypes/List/List_in.v
+# L/Datatypes/List/List_nat.v
+# L/Datatypes/Lists.v
+# L/Datatypes/LNat.v
+# L/Datatypes/LOptions.v
+# L/Datatypes/LProd.v
+# L/Datatypes/LSum.v
+# L/Datatypes/LTerm.v
+# L/Datatypes/LFinType.v
+# L/Datatypes/LVector.v
 
 
-L/AbstractMachines/LargestVar.v
-L/AbstractMachines/FlatPro/Programs.v
-L/AbstractMachines/FlatPro/ProgramsDef.v
-L/AbstractMachines/FlatPro/LM_heap_def.v
-L/AbstractMachines/FlatPro/LM_heap_correct.v
-L/AbstractMachines/FlatPro/UnfoldClos.v
+# L/Functions/EqBool.v
+# L/Functions/Equality.v
+# L/Functions/Encoding.v
+# L/Functions/Decoding.v
+# L/Functions/Proc.v
+# L/Functions/Size.v
+# L/Functions/Subst.v
+# L/Functions/Eval.v
+# L/Functions/LoopSum.v
+# L/Functions/UnboundIteration.v
+# L/Functions/FinTypeLookup.v
+# L/Functions/EnumInt.v
+# L/Functions/Ackermann.v
+
+# L/TM/TMEncoding.v
+# L/TM/TMinL.v
+# L/TM/TMinL/TMinL_extract.v
+# L/TM/TapeFuns.v
+# L/Reductions/TM_to_L.v
+# L/Reductions/H10_to_L.v
+# L/Reductions/MuRec/MuRec_extract.v
+# L/Reductions/MuRec.v
+
+# L/Complexity/UpToC.v
+# L/Complexity/UpToCNary.v
+# L/Complexity/GenericNary.v
+# L/Complexity/ResourceMeasures.v
+# L/Complexity/LinDecode/LTD_def.v
+# L/Complexity/LinDecode/LTDnat.v
+# L/Complexity/LinDecode/LTDlist.v
+# L/Complexity/LinDecode/LTDbool.v
 
 
-L/Computability/Acceptability.v
-L/Computability/Computability.v
-L/Computability/Decidability.v
-L/Computability/Enum.v
-L/Computability/Fixpoints.v
-L/Computability/MuRec.v
-L/Computability/Partial.v
-L/Computability/Por.v
-L/Computability/Seval.v
-L/Computability/Synthetic.v
+# L/AbstractMachines/LargestVar.v
+# L/AbstractMachines/FlatPro/Programs.v
+# L/AbstractMachines/FlatPro/ProgramsDef.v
+# L/AbstractMachines/FlatPro/LM_heap_def.v
+# L/AbstractMachines/FlatPro/LM_heap_correct.v
+# L/AbstractMachines/FlatPro/UnfoldClos.v
+
+
+# L/Computability/Acceptability.v
+# L/Computability/Computability.v
+# L/Computability/Decidability.v
+# L/Computability/Enum.v
+# L/Computability/Fixpoints.v
+# L/Computability/MuRec.v
+# L/Computability/Partial.v
+# L/Computability/Por.v
+# L/Computability/Seval.v
+# L/Computability/Synthetic.v
 
 
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -26,7 +26,7 @@ CounterMachines/CM1_undec.v
 SetConstraints/FMsetC.v
 SetConstraints/FMsetC_undec.v
 
-# L/L.v
+L/L.v
 # L/L_undec.v
 
 TM/TM.v
@@ -490,13 +490,13 @@ TM/Hoare/HoareMult.v
 TM/Hoare/HoareStdLib.v
 TM/Hoare/HoareLegacy.v
 
-# L/Prelim/MoreBase.v
-# L/Prelim/ARS.v
-# L/Prelim/StringBase.v
-# L/Prelim/MoreList.v
-# L/Prelim/LoopSum.v
+L/Prelim/MoreBase.v
+L/Prelim/ARS.v
+L/Prelim/StringBase.v
+L/Prelim/MoreList.v
+L/Prelim/LoopSum.v
 
-# L/Util/L_facts.v
+L/Util/L_facts.v
 
 # L/Tactics/Computable.v
 # L/Tactics/ComputableTime.v
@@ -562,10 +562,10 @@ TM/Hoare/HoareLegacy.v
 # L/Reductions/MuRec/MuRec_extract.v
 # L/Reductions/MuRec.v
 
-# L/Complexity/UpToC.v
-# L/Complexity/UpToCNary.v
-# L/Complexity/GenericNary.v
-# L/Complexity/ResourceMeasures.v
+L/Complexity/UpToC.v
+L/Complexity/UpToCNary.v
+L/Complexity/GenericNary.v
+L/Complexity/ResourceMeasures.v
 # L/Complexity/LinDecode/LTD_def.v
 # L/Complexity/LinDecode/LTDnat.v
 # L/Complexity/LinDecode/LTDlist.v
@@ -588,7 +588,7 @@ TM/Hoare/HoareLegacy.v
 # L/Computability/MuRec.v
 # L/Computability/Partial.v
 # L/Computability/Por.v
-# L/Computability/Seval.v
+L/Computability/Seval.v
 # L/Computability/Synthetic.v
 
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -116,6 +116,7 @@ Shared/Libs/PSL/Base.v
 Shared/Libs/PSL/Tactics/Tactics.v
 Shared/Libs/PSL/Tactics/AutoIndTac.v
 Shared/Libs/PSL/Prelim.v
+Shared/Libs/PSL/EqDecDef.v
 Shared/Libs/PSL/EqDec.v
 Shared/Libs/PSL/Numbers.v
 Shared/Libs/PSL/Bijection.v
@@ -139,6 +140,7 @@ Shared/Libs/PSL/Vectors/VectorForall.v
 
 Shared/Libs/PSL/FiniteTypes.v
 Shared/Libs/PSL/FiniteTypes/BasicDefinitions.v
+Shared/Libs/PSL/FiniteTypes/FinTypesDef.v
 Shared/Libs/PSL/FiniteTypes/FinTypes.v
 Shared/Libs/PSL/FiniteTypes/BasicFinTypes.v
 Shared/Libs/PSL/FiniteTypes/CompoundFinTypes.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -27,7 +27,7 @@ SetConstraints/FMsetC.v
 SetConstraints/FMsetC_undec.v
 
 L/L.v
-# L/L_undec.v
+L/L_undec.v
 
 TM/TM.v
 TM/TM_undec.v
@@ -150,27 +150,27 @@ Shared/Libs/PSL/FiniteTypes/DepPairs.v
 Shared/Libs/PSL/FiniteTypes/Arbitrary.v
 Shared/Libs/PSL/FiniteTypes/VectorFin.v
 
-# TM/L/Alphabets.v
-# TM/L/CaseCom.v
-# TM/L/HeapInterpreter/LookupTM.v
-# TM/L/HeapInterpreter/StepTM.v
-# TM/L/HeapInterpreter/M_LHeapInterpreter.v
-# TM/L/HeapInterpreter/UnfoldClos.v
-# TM/L/HeapInterpreter/JumpTargetTM.v
-# TM/L/Transcode/Boollist_to_Enc.v
-# TM/L/Transcode/Enc_to_Boollist.v
-# TM/L/Transcode/BoollistEnc.v
-# TM/L/Eval.v
+TM/L/Alphabets.v
+TM/L/CaseCom.v
+TM/L/HeapInterpreter/LookupTM.v
+TM/L/HeapInterpreter/StepTM.v
+TM/L/HeapInterpreter/M_LHeapInterpreter.v
+TM/L/HeapInterpreter/UnfoldClos.v
+TM/L/HeapInterpreter/JumpTargetTM.v
+TM/L/Transcode/Boollist_to_Enc.v
+TM/L/Transcode/Enc_to_Boollist.v
+TM/L/Transcode/BoollistEnc.v
+TM/L/Eval.v
 
 
-# TM/L/CompilerBoolFuns/Compiler_spec.v
-# TM/L/CompilerBoolFuns/LComp_to_TMComp.v
-# TM/L/CompilerBoolFuns/Compiler_facts.v
-# TM/L/CompilerBoolFuns/Compiler_nat_facts.v
-# TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
-# TM/L/CompilerBoolFuns/Compiler.v
-# TM/L/CompilerBoolFuns/NaryApp.v
-# TM/L/CompilerBoolFuns/ClosedLAdmissible.v
+TM/L/CompilerBoolFuns/Compiler_spec.v
+TM/L/CompilerBoolFuns/LComp_to_TMComp.v
+TM/L/CompilerBoolFuns/Compiler_facts.v
+TM/L/CompilerBoolFuns/Compiler_nat_facts.v
+TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
+TM/L/CompilerBoolFuns/Compiler.v
+TM/L/CompilerBoolFuns/NaryApp.v
+TM/L/CompilerBoolFuns/ClosedLAdmissible.v
 
 PCP/Util/Facts.v
 PCP/Util/PCP_facts.v
@@ -460,7 +460,7 @@ TM/Code/BinNumbers/NTM.v
 
 TM/Single/EncodeTapes.v
 TM/Single/StepTM.v
-# TM/Reductions/L_to_mTM.v
+TM/Reductions/L_to_mTM.v
   
 TM/Reductions/Arbitrary_to_Binary.v
 
@@ -498,101 +498,95 @@ L/Prelim/LoopSum.v
 
 L/Util/L_facts.v
 
-# L/Tactics/Computable.v
-# L/Tactics/ComputableTime.v
+L/Tactics/Computable.v
+L/Tactics/ComputableTime.v
 
-# L/Tactics/LTactics.v
+L/Tactics/LTactics.v
 
-# L/Tactics/Extract.v
-# L/Tactics/GenEncode.v
+L/Tactics/Extract.v
+L/Tactics/GenEncode.v
 
-# L/Tactics/Lbeta_nonrefl.v
-# L/Tactics/Lproc.v
-# L/Tactics/Lbeta.v
-# L/Tactics/Reflection.v
-# L/Tactics/LClos.v
-# L/Tactics/LClos_Eval.v
-# L/Tactics/Lrewrite.v
-# L/Tactics/Lsimpl.v
+L/Tactics/Lbeta_nonrefl.v
+L/Tactics/Lproc.v
+L/Tactics/Lbeta.v
+L/Tactics/Reflection.v
+L/Tactics/LClos.v
+L/Tactics/LClos_Eval.v
+L/Tactics/Lrewrite.v
+L/Tactics/Lsimpl.v
 
-# L/Tactics/ComputableTactics.v
-# L/Tactics/ComputableDemo.v
+L/Tactics/ComputableTactics.v
+L/Tactics/ComputableDemo.v
 
-# L/Tactics/mixedTactics.v
+L/Tactics/mixedTactics.v
 
-# L/Datatypes/LUnit.v
-# L/Datatypes/LBool.v
-# L/Datatypes/List/List_basics.v
-# L/Datatypes/List/List_enc.v
-# L/Datatypes/List/List_eqb.v
-# L/Datatypes/List/List_extra.v
-# L/Datatypes/List/List_fold.v
-# L/Datatypes/List/List_in.v
-# L/Datatypes/List/List_nat.v
-# L/Datatypes/Lists.v
-# L/Datatypes/LNat.v
-# L/Datatypes/LOptions.v
-# L/Datatypes/LProd.v
-# L/Datatypes/LSum.v
-# L/Datatypes/LTerm.v
-# L/Datatypes/LFinType.v
-# L/Datatypes/LVector.v
+L/Datatypes/LUnit.v
+L/Datatypes/LBool.v
+L/Datatypes/List/List_basics.v
+L/Datatypes/List/List_enc.v
+L/Datatypes/List/List_eqb.v
+L/Datatypes/List/List_extra.v
+L/Datatypes/List/List_fold.v
+L/Datatypes/List/List_in.v
+L/Datatypes/List/List_nat.v
+L/Datatypes/Lists.v
+L/Datatypes/LNat.v
+L/Datatypes/LOptions.v
+L/Datatypes/LProd.v
+L/Datatypes/LSum.v
+L/Datatypes/LTerm.v
+L/Datatypes/LFinType.v
+L/Datatypes/LVector.v
 
+L/Functions/EqBool.v
+L/Functions/Equality.v
+L/Functions/Encoding.v
+L/Functions/Decoding.v
+L/Functions/Proc.v
+L/Functions/Size.v
+L/Functions/Subst.v
+L/Functions/Eval.v
+L/Functions/LoopSum.v
+L/Functions/UnboundIteration.v
+L/Functions/FinTypeLookup.v
+L/Functions/EnumInt.v
+L/Functions/Ackermann.v
 
-# L/Functions/EqBool.v
-# L/Functions/Equality.v
-# L/Functions/Encoding.v
-# L/Functions/Decoding.v
-# L/Functions/Proc.v
-# L/Functions/Size.v
-# L/Functions/Subst.v
-# L/Functions/Eval.v
-# L/Functions/LoopSum.v
-# L/Functions/UnboundIteration.v
-# L/Functions/FinTypeLookup.v
-# L/Functions/EnumInt.v
-# L/Functions/Ackermann.v
-
-# L/TM/TMEncoding.v
-# L/TM/TMinL.v
-# L/TM/TMinL/TMinL_extract.v
-# L/TM/TapeFuns.v
-# L/Reductions/TM_to_L.v
-# L/Reductions/H10_to_L.v
-# L/Reductions/MuRec/MuRec_extract.v
-# L/Reductions/MuRec.v
+L/TM/TMEncoding.v
+L/TM/TMinL.v
+L/TM/TMinL/TMinL_extract.v
+L/TM/TapeFuns.v
+L/Reductions/TM_to_L.v
+L/Reductions/H10_to_L.v
+L/Reductions/MuRec/MuRec_extract.v
+L/Reductions/MuRec.v
 
 L/Complexity/UpToC.v
 L/Complexity/UpToCNary.v
 L/Complexity/GenericNary.v
 L/Complexity/ResourceMeasures.v
-# L/Complexity/LinDecode/LTD_def.v
-# L/Complexity/LinDecode/LTDnat.v
-# L/Complexity/LinDecode/LTDlist.v
-# L/Complexity/LinDecode/LTDbool.v
+L/Complexity/LinDecode/LTD_def.v
+L/Complexity/LinDecode/LTDnat.v
+L/Complexity/LinDecode/LTDlist.v
+L/Complexity/LinDecode/LTDbool.v
 
+L/AbstractMachines/LargestVar.v
+L/AbstractMachines/FlatPro/Programs.v
+L/AbstractMachines/FlatPro/ProgramsDef.v
+L/AbstractMachines/FlatPro/LM_heap_def.v
+L/AbstractMachines/FlatPro/LM_heap_correct.v
+L/AbstractMachines/FlatPro/UnfoldClos.v
 
-# L/AbstractMachines/LargestVar.v
-# L/AbstractMachines/FlatPro/Programs.v
-# L/AbstractMachines/FlatPro/ProgramsDef.v
-# L/AbstractMachines/FlatPro/LM_heap_def.v
-# L/AbstractMachines/FlatPro/LM_heap_correct.v
-# L/AbstractMachines/FlatPro/UnfoldClos.v
-
-
-# L/Computability/Acceptability.v
-# L/Computability/Computability.v
-# L/Computability/Decidability.v
-# L/Computability/Enum.v
-# L/Computability/Fixpoints.v
-# L/Computability/MuRec.v
-# L/Computability/Partial.v
-# L/Computability/Por.v
+L/Computability/Acceptability.v
+L/Computability/Computability.v
+L/Computability/Decidability.v
+L/Computability/Enum.v
+L/Computability/Fixpoints.v
+L/Computability/MuRec.v
+L/Computability/Partial.v
+L/Computability/Por.v
 L/Computability/Seval.v
-# L/Computability/Synthetic.v
-
-
-
+L/Computability/Synthetic.v
 
 HOU/std/tactics.v
 HOU/std/misc.v


### PR DESCRIPTION
Everything compiles apart from `L` because MetaCoq does not yet have an `8.15` branch. `smpl` has an `8.15` branch. `coq-equations` not yet, but the relevant commit from which one can install manually is in the CI config.

Main changes:
- `apply lem with (x0 := ...)` is now fixed to be `apply lem with (x := ...)`
- the behaviour of `/` in `Arguments` changed, which affected `Vectors.v` in `PSL` and subsequently all vector automation tactics in `TM`
- `Require Import Wf.` is now ambiguous and has to be `Require Import Init.Wf.`
- using `at "2"` in a tactic notation breaks Coq's parser (https://github.com/coq/coq/issues/15318). I temporarily changed the tactic to be `"at" "two"`. The following commands should revert the fixes once Coq is fixed: 
   ```
   git sed "s/POP one/POP 1/g"
  git sed "s/POP zero/POP 0/g"
  git sed "s/at two/at 2/g"
  git sed "s/at three/at 3/g"
  git sed "s/DEC zero/DEC 0/g"
  git sed "s/\"zero\"/\"0\"/g"
  git sed "s/\"one\"/\"1\"/g"
  git sed "s/\"two\"/\"2\"/g"
  git sed "s/\"three\"/\"3\"/g"
  ```

