### PR TITLE
CM2 decision procedures

### DIFF
--- a/theories/CounterMachines/CM2.v
+++ b/theories/CounterMachines/CM2.v
@@ -2,19 +2,30 @@
   Autor(s):
     Andrej Dudenhefner (1) 
   Affiliation(s):
-    (1) Saarland University, Saarbrücken, Germany
+    (1) TU Dortmund University, Dortmund, Germany
 *)
 
 (* 
   Problem(s):
-    Two Counter Machine Halting (CM2_HALT)
+    Two-counter Machine Halting (CM2_HALT)
+    Two-counter Machine Reversibility (CM2_REV)
+    Reversible Two-counter Machine Halting (CM2_REV_HALT)
+    Two-counter Machine Uniform Boundedness (CM2_UBOUNDED)
+    Two-counter Machine Uniform Mortality (CM2_UMORTAL)
 *)
 
-Require Import List.
+Require Import List ssrfun.
 
-Definition State : Set := nat.
 (* a configuration consists of a state and two counter values *)
-Record Config : Set := mkConfig { state : State; value1 : nat; value2 : nat }.
+Definition Config : Set := nat * (nat * nat).
+
+(* accessors for state, value1, value2 of configurations *)
+Definition state (x: Config) : nat := fst x.
+Arguments state !x /.
+Definition value1 (x: Config) : nat := fst (snd x).
+Arguments value1 !x /.
+Definition value2 (x: Config) : nat := snd (snd x).
+Arguments value2 !x /.
 
 (* the instruction inc true maps 
       a configuration (p, (v1, v2)) to (1+p, (v1, 1+v2))
@@ -28,38 +39,94 @@ Record Config : Set := mkConfig { state : State; value1 : nat; value2 : nat }.
       a configuration (p, (1+v1, v2)) to (q, (v1, v2)) *)
 Inductive Instruction : Set := 
   | inc : bool -> Instruction
-  | dec : bool -> State -> Instruction.
+  | dec : bool -> nat -> Instruction.
 
-(* a two counter machine is a list of instructions *)
+(* a two-counter machine is a list of instructions *)
 Definition Cm2 : Set := list Instruction.
 
-(* two counter machine step function *)
-Definition step (M: Cm2) (x: Config) : Config :=
+(* partial two-counter machine step function *)
+Definition step (M: Cm2) (x: Config) : option Config :=
   match nth_error M (state x) with
-  | None => x (* halting configuration *)
+  | None => None (* halting configuration *)
   | Some (inc b) => (* increase counter, goto next state*)
-    {| state := 1 + (state x); 
-       value1 := (if b then 0 else 1) + (value1 x);
-       value2 := (if b then 1 else 0) + (value2 x) |}
+    Some (1 + (state x), ((if b then 0 else 1) + (value1 x), (if b then 1 else 0) + (value2 x)))
   | Some (dec b y) => (* decrease counter, if successful goto state y *)
-    if b then 
-      match value2 x with
-      | 0 => {| state := 1 + (state x); value1 := value1 x; value2 := 0 |}
-      | S n => {| state := y; value1 := value1 x; value2 := n |}
-      end
-    else
-      match value1 x with
-      | 0 => {| state := 1 + (state x); value1 := 0; value2 := value2 x |}
-      | S n => {| state := y; value1 := n; value2 := value2 x |}
-      end
+    Some (
+      if b then 
+        match value2 x with
+        | 0 => (1 + (state x), (value1 x, 0))
+        | S n => (y, (value1 x, n))
+        end
+      else
+        match value1 x with
+        | 0 => (1 + (state x), (0, value2 x))
+        | S n => (y, (n, value2 x))
+        end)
   end.
-(* unfold step if the configuration is decomposed *)
-Arguments step _ !x /.
 
-(* halting configuration property *)
-Definition halting (M : Cm2) (x: Config) : Prop := step M x = x.
+(* iterated partial two-counter machine step function *)
+Definition steps (M: Cm2) (k: nat) (x: Config) : option Config :=
+  Nat.iter k (obind (step M)) (Some x).
 
-(* Two Counter Machine Halting Problem *)
+(* two-counter machine configuration reachability *)
+Definition reaches (M: Cm2) (x y: Config) :=
+  exists k, steps M k x = Some y.
+
+(* does M eventually terminate starting from the configuration x? *)
+Definition terminating (M: Cm2) (x: Config) :=
+  exists k, steps M k x = None.
+
+(* injectivity of the step function *)
+Definition reversible (M : Cm2) : Prop := 
+  forall x y z, step M x = Some z -> step M y = Some z -> x = y.
+
+(* k bounds the number of reachable configurations from x *)
+Definition bounded (M: Cm2) (k: nat) (x: Config) : Prop := 
+  exists (L: list Config), (length L <= k) /\
+    (forall (y: Config), reaches M x y -> In y L).
+
+(* uniform bound for number of reachable configurations *)
+Definition uniformly_bounded (M: Cm2) : Prop :=
+  exists k, forall x, bounded M k x.
+
+(* k bounds the number of steps in a terminating run from x *)
+Definition mortal (M: Cm2) (k: nat) (x: Config) : Prop := 
+  steps M k x = None.
+
+(* uniform bound for number of steps until termination *)
+Definition uniformly_mortal (M: Cm2) : Prop :=
+  exists k, forall x, mortal M k x.
+
+(* Two-counter Machine Halting:
+   Given a two-counter machine M,
+   does a run in M starting from configuration (0, (0, 0)) eventually halt? *)
 Definition CM2_HALT : Cm2 -> Prop :=
-  fun M => exists (n: nat), 
-    halting M (Nat.iter n (step M) {| state := 0; value1 := 0; value2 := 0 |}).
+  fun M => terminating M (0, (0, 0)).
+
+(* Two-counter Machine Reversibility:
+   Given a two-counter machine M,
+   is the step function of M injective? *)
+Definition CM2_REV : Cm2 -> Prop :=
+  fun M => reversible M.
+
+(* Reversible Two-counter Machine Halting:
+   Given a reversible two-counter machine M and a configucation x, 
+   does a run in M starting from x eventually halt? *)
+Definition CM2_REV_HALT : { M: Cm2 | reversible M } * Config -> Prop :=
+  fun '((exist _ M _), x) => terminating M x.
+
+(* Two-counter Machine Uniform Boundedness:
+   Given a two-counter machine M,
+   is there a uniform bound n,
+   such that for any configuration x,
+   the number of reacheable configurations from x is bounded by n? *)
+Definition CM2_UBOUNDED : Cm2 -> Prop :=
+  fun M => uniformly_bounded M.
+
+(* Two-counter Machine Uniform Mortality:
+   Given a two-counter machine M,
+   is there a uniform bound n,
+   such that for any configuration x,
+   a run in M starting from x halts after at most n steps? *)
+Definition CM2_UMORTAL : Cm2 -> Prop :=
+  fun M => uniformly_mortal M.

--- a/theories/CounterMachines/CM2_dec.v
+++ b/theories/CounterMachines/CM2_dec.v
@@ -1,0 +1,55 @@
+(* 
+  Autor(s):
+    Andrej Dudenhefner (1) 
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(* 
+  Decidability Results(s):
+    Decidability of Two-counter Machine Reversibility (CM2_REV_dec)
+    Decidability of Reversible Two-counter Machine Halting (CM2_REV_HALT_dec)
+    Decidability of Two-counter Machine Uniform Boundedness (CM2_UBOUNDED_dec)
+    Decidability of Two-counter Machine Uniform Mortality (CM2_UMORTAL_dec)
+*)
+
+Require Import Undecidability.Synthetic.Definitions.
+
+Require Import Undecidability.CounterMachines.CM2.
+From Undecidability.CounterMachines.Deciders Require
+  CM2_REV_dec CM2_REV_HALT_dec CM2_UBOUNDED_dec CM2_UMORTAL_dec.
+
+(* Decidability of Two-counter Machine Reversibility *)
+Theorem CM2_REV_dec : decidable CM2_REV.
+Proof.
+  exists CM2_REV_dec.decide.
+  exact CM2_REV_dec.decide_spec.
+Qed.
+
+Check CM2_REV_dec.
+
+(* Decidability of Reversible Two-counter Machine Halting *)
+Theorem CM2_REV_HALT_dec : decidable CM2_REV_HALT.
+Proof.
+  exists CM2_REV_HALT_dec.decide.
+  exact CM2_REV_HALT_dec.decide_spec.
+Qed.
+
+Check CM2_REV_HALT_dec.
+
+(* Decidability ofTwo-counter Machine Uniform Boundedness *)
+Theorem CM2_UBOUNDED_dec : decidable CM2_UBOUNDED.
+Proof.
+  exists CM2_UBOUNDED_dec.decide.
+  exact CM2_UBOUNDED_dec.decide_spec.
+Qed.
+
+Check CM2_UBOUNDED_dec.
+(* Decidability ofTwo-counter Machine Uniform Mortality *)
+Theorem CM2_UMORTAL_dec : decidable CM2_UMORTAL.
+Proof.
+  exists CM2_UMORTAL_dec.decide.
+  exact CM2_UMORTAL_dec.decide_spec.
+Qed.
+
+Check CM2_UMORTAL_dec.

--- a/theories/CounterMachines/Deciders/CM2_REV_HALT_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_REV_HALT_dec.v
@@ -1,0 +1,854 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Reversible Two-counter Machine Halting (CM2_REV_HALT)
+*)
+
+Require Import List PeanoNat Lia Operators_Properties.
+Import ListNotations.
+Require Import Undecidability.CounterMachines.CM2.
+From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+Section Construction.
+Variable M : Cm2.
+Variable HM : reversible M.
+
+(* partial two counter machine step function without jumps *)
+Definition step' (x: Config) : option Config :=
+  match nth_error M (state x) with
+  | None => None (* halting configuration *)
+  | Some (inc b) => (* increase counter, goto next state*)
+    Some (1 + (state x), ((if b then 0 else 1) + (value1 x), (if b then 1 else 0) + (value2 x)))
+  | Some (dec b y) => (* halt on jump *)
+    if b then
+      if value2 x is 0 then Some (1 + (state x), (value1 x, 0)) else None
+    else
+      if value1 x is 0 then Some (1 + (state x), (0, value2 x)) else None
+  end.
+
+Definition steps' n x : option Config :=
+  Nat.iter n (obind step') (Some x).
+
+#[local] Notation step := (CM2.step M).
+#[local] Notation steps := (CM2.steps M).
+#[local] Notation terminating := (CM2.terminating M).
+#[local] Notation non_terminating := (CM2_facts.non_terminating M).
+#[local] Notation reaches := (CM2.reaches M).
+#[local] Notation reaches_plus := (CM2_facts.reaches_plus M).
+
+Definition reaches' x y := exists k, steps' k x = Some y.
+
+(* step includes step' *)
+Lemma step'_incl x y : step' x = Some y -> step x = Some y.
+Proof.
+  rewrite /step' /step. case: (nth_error M (state x)); last done.
+  case; first done.
+  move=> [] q; [by case: (value2 x)|by case: (value1 x)].
+Qed.
+
+(* steps includes steps' *)
+Lemma steps'_incl k x y : steps' k x = Some y -> steps k x = Some y.
+Proof.
+  elim: k y; first done.
+  move=> k /=. case: (steps' k x) => [y|]; last done.
+  move=> /(_ y erefl) -> /=. by apply: step'_incl.
+Qed.
+
+Corollary reaches'_incl {x y} : reaches' x y -> reaches x y.
+Proof. move=> [k /steps'_incl ?]. by exists k. Qed.
+
+Opaque nth_error.
+Arguments nth_error_In {_ _ _ _}.
+
+(* key lemma on the way to ensure that equivalent configurations behave identically
+   every steps' computation without jumps increases the starting configuration
+   (a > 0 -> value1 x > 0), (b > 0 -> value2 x > 0) in the same way *)
+Lemma steps'E k x y : steps' k x = Some y ->
+  exists n m, value1 y = value1 x + n /\ value2 y = value2 x + m /\ 
+    forall a b, (a > 0 -> value1 x > 0) -> (b > 0 -> value2 x > 0) ->
+      steps' k (state x, (a, b)) = Some (state y, (a + n, b + m)).
+Proof.
+  elim: k x y.
+  { move=> x y [<-]. exists 0, 0. do 2 (split; first by lia).
+    move=> a b ?? /=. by rewrite ?Nat.add_0_r. }
+  move=> k IH x y /=.
+  case Hx': (steps' k x) => [x'|]; last done.
+  move: Hx' => /IH [n] [m] [Hax'] [Hbx'] {}IH /=.
+  rewrite /(step' x'). case Hi: (nth_error M (state x')) => [i|]; last done.
+  move: i Hi => [].
+  - move=> c Hi [<-] /=. exists ((if c then 0 else 1) + n), ((if c then 1 else 0) + m).
+    split; first by lia. split; first by lia.
+    move=> a b Ha Hb. rewrite IH; [done|done|].
+    rewrite /= /step' Hi /=. congr Some. congr pair. congr pair; lia.
+  - move=> [] q Hi.
+    + case H'bx': (value2 x') => [|bx']; last done.
+      move=> [<-] /=. exists n, 0.
+      split; first by lia. split; first by lia.
+      move=> a b ??. rewrite IH; [done|done|].
+      rewrite /step' /= Hi. have ->: b + m = 0 by lia. 
+      congr Some. congr pair. congr pair; lia.
+    + case H'ax': (value1 x') => [|ax']; last done.
+      move=> [<-] /=. exists 0, m.
+      split; first by lia. split; first by lia.
+      move=> a b ??. rewrite IH; [done|done|].
+      rewrite /step' /= Hi. have ->: a + n = 0 by lia.
+      congr Some. congr pair. congr pair; lia.
+Qed.
+
+Corollary reaches'E x y : reaches' x y ->
+  exists n m, value1 y = value1 x + n /\ value2 y = value2 x + m /\ 
+    forall a b, (a > 0 -> value1 x > 0) -> (b > 0 -> value2 x > 0) ->
+      reaches' (state x, (a, b)) (state y, (a + n, b + m)).
+Proof.
+  move=> [k] /steps'E [n] [m] [?] [?] H.
+  exists n, m. split; [done|split; [done|]].
+  move=> ????. exists k. by apply: H.
+Qed.
+
+Lemma step'_inc_state x y :
+  step' x = Some y -> state y = 1 + (state x).
+Proof.
+  rewrite /step'. case: (nth_error M (state x)); last done.
+  move=> [].
+  - by move=> c [/(f_equal state)] /= <-.
+  - move: (value1 x) (value2 x) => [|?] [|?] [] _ //.
+    all: by move=> [/(f_equal state)] /= <-.
+Qed.
+
+Lemma target_index p c q : nth_error M p = Some (dec c q) -> q = 0 \/ length M < q.
+Proof using HM.
+  move=> Hp. suff: not (q = S (q - 1) /\ (q - 1 < length M)) by lia.
+  move=> [Hq /nth_error_Some].
+  case Hi: (nth_error M (q - 1)) => [i|]; last done.
+  move=> _.
+  move: i c Hp Hi => [].
+  - move=> [] [] Hp Hi.
+    + have := HM (p, (2, 2)) (q - 1, (2, 0)) (q, (2, 1)).
+      rewrite /step /= Hp Hi -Hq. by move=> /(_ erefl erefl) [].
+    + have := HM (p, (2, 2)) (q - 1, (1, 1)) (q, (1, 2)).
+      rewrite /step /= Hp Hi -Hq. by move=> /(_ erefl erefl) [].
+    + have := HM (p, (2, 2)) (q - 1, (1, 1)) (q, (2, 1)).
+      rewrite /step /= Hp Hi -Hq. by move=> /(_ erefl erefl) [].
+    + have := HM (p, (2, 2)) (q - 1, (0, 2)) (q, (1, 2)).
+      rewrite /step /= Hp Hi -Hq. by move=> /(_ erefl erefl) [].
+  - move=> t ? [] Hp Hi.
+    + have := HM (p, (0, 1)) (q - 1, (0, 0)) (q, (0, 0)).
+      rewrite /step /= Hp Hi -Hq.
+      by move: t {Hi} => [] /(_ erefl erefl) [].
+    + have := HM (p, (1, 0)) (q - 1, (0, 0)) (q, (0, 0)).
+      rewrite /step /= Hp Hi -Hq.
+      by move: t {Hi} => [] /(_ erefl erefl) [].
+Qed.
+
+Corollary reaches'I x : 
+  { y | reaches' x y /\ 
+    (if step y is Some z then state z = 0 \/ length M <= state z else True) }.
+Proof using HM.
+  move Hn: (length M - state x) => n. elim: n x Hn.
+  { move=> x ?. exists x. split; first by exists 0.
+    rewrite /step. by have /nth_error_None -> : (length M <= state x) by lia. }
+  move=> n IH x ?. case Hy: (step' x) => [y|].
+  - move: (Hy) => /step'_inc_state ?.
+    have /IH : (length M - state y = n) by lia.
+    move=> [z] [Hyz ?]. exists z. split; last done.
+    move: Hyz => [k Hk]. exists (1+k).
+    by rewrite /steps' iter_plus /= Hy.
+  - exists x. split; first by exists 0.
+    move: Hy. rewrite /step' /step.
+    case Hi: (nth_error M (state x)) => [i|]; last done.
+    case: i Hi; first done.
+    move=> [] q.
+    + move: (value2 x) => [|b]; first done.
+      move=> /target_index /=. lia.
+    + move: (value1 x) => [|a]; first done.
+      move=> /target_index /=. lia.
+Qed.
+
+(* step with counters of same positivity *)
+Lemma step_parallel {x y} x' :
+  step x = Some y ->
+  (state x = state x' /\ (value1 x > 0 <-> value1 x' > 0) /\ (value2 x > 0 <-> value2 x' > 0)) ->
+  exists y', step x' = Some y' /\ 
+  state y = state y' /\ 
+  value1 x + value1 y' = value1 x' + value1 y /\
+  value2 x + value2 y' = value2 x' + value2 y.
+Proof.
+  move=> + [Hx']. rewrite /step -Hx'. case: (nth_error M (state x)); last done.
+  move=> [].
+  { move=> c [<-] ?. eexists. split; [reflexivity|move=> /=; lia]. }
+  move=> [] p.
+  - case: (value2 x) => [|?] [<-] ?.
+    + have ->: value2 x' = 0 by lia.
+      eexists. split; [reflexivity|move=> /=; lia].
+    + have ->: value2 x' = S ((value2 x') - 1) by lia.
+      eexists. split; [reflexivity|move=> /=; lia].
+  - case: (value1 x) => [|?] [<-] ?.
+    + have ->: value1 x' = 0 by lia.
+      eexists. split; [reflexivity|move=> /=; lia].
+    + have ->: value1 x' = S ((value1 x') - 1) by lia.
+      eexists. split; [reflexivity|move=> /=; lia].
+Qed.
+
+(* if (1, 1) f->>t-> (0, 1 + m), then (a, b) t->> (0, a * m + b) *)
+Lemma dec_a_0 x m : reaches' (0, (1, 1)) x -> 
+  step x = Some (0, (0, 1 + m)) ->
+  forall a b, reaches (0, (a, b)) (0, (0, a * m + b)).
+Proof.
+  move=> H1x H2x. elim.
+  - move=> b. by exists 0.
+  - move=> a IH b. move: H1x => /reaches'E [n'] [m'] /= [Hax] [Hbx].
+    move=> /(_ (S a) b ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_trans. apply.
+    have ->: m + a * m + b = a * m + (m + b) by lia.
+    apply: (reaches_trans _ (IH (m + b))).
+    exists 1. move: H2x. rewrite /= /step. case: (nth_error M (state x)); last done.
+    move=> [].
+    + move=> c []. lia.
+    + move=> [] q.
+      * move: (value2 x) Hbx => [|bx]; first by lia.
+        rewrite Hax. move=> ? []. by lia.
+      * move: (value1 x) Hax => [|ax]; first by lia.
+        move=> ? [? ? ?] /=. congr (Some (_, (_, _))); lia.
+Qed.
+
+(* if (1, 1) f->>t-> (1 + n, 0), then (a, b) t->> (b * n + a, 0) *)
+Lemma dec_b_0 x n : reaches' (0, (1, 1)) x -> 
+  step x = Some (0, (1 + n, 0)) ->
+  forall a b, reaches (0, (a, b)) (0, (b * n + a, 0)).
+Proof.
+  move=> H1x H2x a b. elim: b a.
+  - move=> a. by exists 0.
+  - move=> b IH a. move: H1x => /reaches'E [n'] [m'] /= [Hax] [Hbx].
+    move=> /(_ a (S b) ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_trans. apply.
+    have ->: n + b * n + a = b * n + (n + a) by lia.
+    apply: (reaches_trans _ (IH (n + a))).
+    exists 1. move: H2x. rewrite /= /step. case: (nth_error M (state x)); last done.
+    move=> [].
+    + move=> c [] /=. lia.
+    + move=> [] q.
+      * move: (value2 x) Hbx => [|bx]; first by lia.
+        move=> ? [? ? ?] /=. congr (Some (_, (_, _))); lia.
+      * move: (value1 x) Hax => [|ax]; first by lia.
+        rewrite Hbx. move=> ? []. by lia.
+Qed.
+
+(* if (1, 1) ->> (S a, S b), then (a', b') does not terminate *)
+Lemma dec_loop x n m : reaches' (0, (1, 1)) x -> 
+  step x = Some (0, (1 + n, 1 + m)) ->
+  forall a b, non_terminating (0, (a, b)).
+Proof.
+  move=> [k Hk] Hx a b k' /(steps_k_monotone (k' * S k)) /(_ ltac:(lia)).
+  elim: k' a b; first done.
+  move=> k' IH a b. have ->: S k' * S k = (k + 1) + (k' * S k) by lia.
+  have : steps (k + 1) (0, (a, b)) = Some (0, (n + a, b + m)).
+  {
+    move: Hk => /steps'E [n'] [m'] /= [Hax] [Hbx].
+    move=> /(_ a b ltac:(lia) ltac:(lia)).
+    move=> /steps'_incl /steps_plus ->.
+    move: Hx. rewrite /= /step. case: (nth_error M (state x)); last done.
+    move=> [].
+    - move=> c [] /= -> ??. congr (Some (_, (_, _))); lia.
+    - move=> [] q.
+      + move: (value2 x) Hbx => [|bx] Hbx; first done.
+        move=> [->] ?? /=.
+        have ->: b + m' = S (b + m) by lia.
+        congr (Some (_, (_, _))); lia.
+      + move: (value1 x) Hax => [|ax] Hax; first done.
+        move=> [->] ?? /=.
+        have ->: a + n' = S (n + a) by lia.
+        congr (Some (_, (_, _))); lia.
+    }
+    move=> /steps_plus ->. by apply: IH.
+Qed.
+
+Lemma reaches'_None_terminating x y :
+  reaches' x y -> step y = None ->
+  forall a b, (a > 0 -> value1 x > 0) -> (b > 0 -> value2 x > 0) -> 
+    terminating (state x, (a, b)).
+Proof.
+  move=> Hx /step_None Hy a b ? ?.
+  move: Hx => /reaches'E [n] [m] /= [?] [?].
+  move=> /(_ a b ltac:(lia) ltac:(lia)) /reaches'_incl.
+  move=> /reaches_terminating. apply.
+  exists 1. by apply /step_None.
+Qed.
+
+Lemma reaches'_Some_terminating x y z :
+  reaches' x y -> step y = Some z -> length M <= state z ->
+  forall a b, (value1 x > 0 <-> a > 0) -> (value2 x > 0 <-> b > 0) -> 
+    terminating (state x, (a, b)).
+Proof.
+  move=> Hx Hy Hz a b ? ?.
+  move: Hx => /reaches'E [n] [m] /= [?] [?].
+  move=> /(_ a b ltac:(lia) ltac:(lia)) /reaches'_incl.
+  move: Hy => /(step_parallel (state y, (a + n, b + m))) /= /(_ ltac:(lia)).
+  move=> [[pz [az bz]]] /= [?] [?] ?. subst pz.
+  move=> /reaches_terminating. apply.
+  apply: reaches_terminating; first by (exists 1; eassumption).
+  exists 1. by apply /step_None /nth_error_None.
+Qed.
+
+Lemma terminating_orI p a b x y : 
+  reaches' (p, (S a, S b)) x ->
+  step x = Some y ->
+  length M <= state y ->
+  (forall a', terminating (p, (S a', 0))) + (forall b', terminating (p, (0, S b'))).
+Proof.
+  rewrite /(step x). case Hi: (nth_error M (state x)) => [i|]; last done.
+  move: i Hi => [].
+  { (* inc instruction *)
+    move=> c Hx H'x [/(f_equal state) /= H'y] ?. left=> a'.
+    move: H'x => /reaches'E [n] [m] /= [?] [?].
+    move=> /(_ (S a') 0 ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    exists 2 => /=. rewrite /step /= Hx /=.
+    by have /nth_error_None -> : length M <= S (state x) by lia. }
+  (* dec instruction *)
+  move=> [] q Hx.
+  - move=> +++ /ltac:(right).
+    move=> /reaches'E [n] [m] /= [->] [->] Hk.
+    move=> [/(f_equal state)] /= <- ?.
+    move=> b'. move: Hk => /(_ 0 (S b') ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    exists 2. rewrite /= /step /= Hx /=.
+    by have /nth_error_None -> : length M <= q by lia.
+  - move=> +++ /ltac:(left).
+    move=> /reaches'E [n] [m] /= [->] [->] Hk.
+    move=> [/(f_equal state)] /= <- ?.
+    move=> a'. move: Hk => /(_ (S a') 0 ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    exists 2. rewrite /= /step /= Hx /=.
+    by have /nth_error_None -> : length M <= q by lia.
+Qed.
+
+Lemma transition_loop a b: 
+  (forall a' b', (a > 0 <-> a' > 0) -> (b > 0 <-> b' > 0) -> 
+     exists a'' b'', reaches_plus (0, (a', b')) (0, (a'', b'')) /\
+       (a' > 0 <-> a'' > 0) /\ (b' > 0 <-> b'' > 0)) ->
+  non_terminating (0, (a, b)).
+Proof.
+  move=> H. apply: (reaches_plus_invariant_loop 
+    (fun '(p', (a', b')) => p' = 0 /\ (a > 0 <-> a' > 0) /\ (b > 0 <-> b' > 0))); last by lia.
+  move=> [px [ax bx]] [->] H'.
+  move: (H') => [/H] {}H /H [ax'] [bx'] [? ?].
+  exists (0, (ax', bx')). split; [done|lia].
+Qed.
+
+(* not (1, 1) f->>t-> (0, 0) *)
+Lemma not_transition_1_1_to_0_0 x : reaches' (0, (1, 1)) x -> step x <> Some (0, (0, 0)).
+Proof.
+  move=> /reaches'E [n] [m] /= [H1x] [H2x] _.
+  rewrite /step. case: (nth_error M (state x)); last done.
+  move=> [].
+  - move=> ? [] ?. lia.
+  - move=> [] ?; rewrite ?H1x ?H2x; case; lia.
+Qed.
+
+Lemma dec_stepI {x y} : step x = Some y -> state y = 0 -> 
+  (value1 y < value1 x -> In (dec false 0) M) /\
+  (value2 y < value2 x -> In (dec true 0) M).
+Proof.
+  rewrite /step. case Hi: (nth_error M (state x)) => [i|]; last done.
+  case: i Hi.
+  - by move=> [] _ [<-].
+  - move=> [] ? /nth_error_In Hi [<-].
+    + case: (value2 x) => [|b]; first done.
+      move=> /= ?. subst. split; [lia|done].
+    + case: (value1 x) => [|a]; first done.
+      move=> /= ?. subst. split; [done|lia].
+Qed.
+
+Lemma rev_dec_unique : In (dec false 0) M -> In (dec true 0) M -> False.
+Proof using HM.
+  move=> /(@In_nth_error Instruction) [p Hp] /(@In_nth_error Instruction) [q Hq].
+  suff: (p, (1, 0)) = (q, (0, 1)) by case.
+  have := (HM (p, (1, 0)) (q, (0, 1)) (0, (0, 0))).
+  rewrite /step Hp Hq. by apply.
+Qed.
+
+(* uniform transition from equivalence class (0, 0) *)
+Lemma transition_0_0 :
+  (* terminating equivalence class (0, 0) *)
+  (terminating (0, (0, 0))) +
+  (* non-terminating equivalence class (0, 0) *)
+  (non_terminating (0, (0, 0))) +
+  (* uniform transition to equivalence class (S a, 0) *)
+  (exists a', reaches (0, (0, 0)) (0, (S a', 0))) +
+  (* uniform transition to equivalence class (0, S b) *)
+  (exists b', reaches (0, (0, 0)) (0, (0, S b'))) +
+  (* uniform transition to equivalence class (S a, S b) *)
+  (exists a' b', reaches (0, (0, 0)) (0, (S a', S b'))).
+Proof using HM.
+  have [y [/reaches'_incl Hk]] := reaches'I (0, (0, 0)).
+  case Hz: (step y) => [[pz [az bz]]|]; first last.
+  { (* termination *)
+    move=> _. do 4 left.
+    move: Hk => /reaches_terminating. apply.
+    by exists 1. }
+  have H0z : reaches_plus (0, (0, 0)) (pz, (az, bz)).
+  { apply: reaches_reaches_plus; [by eassumption|exists 1].
+    split; [lia|done]. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* termination *)
+    move=> /nth_error_None H'z. do 4 left.
+    move: H0z => /reaches_plus_incl /reaches_terminating. apply.
+    exists 1. by apply /step_None. }
+  move=> /= ?. subst pz. move: az bz H0z {Hz} => [|az] [|bz] H0z.
+  - (* non-termination *)
+    do 3 left. right. by apply: reaches_plus_self_loop.
+  - (* transition to (0, S b) *)
+    do 1 left. right. exists bz. by apply /reaches_plus_incl.
+  - (* transition to (S a, 0) *)
+    do 2 left. right. exists az. by apply /reaches_plus_incl.
+  - (* transition to (S a, S b) *)
+    right. exists az, bz. by apply /reaches_plus_incl.
+Qed.
+
+(* uniform transition from equivalence class (S a, 0) *)
+Lemma transition_Sa_0 :
+  (* terminating equivalence class (S a, 0) *)
+  (forall a, terminating (0, (S a, 0))) +
+  (* non-terminating equivalence class (S a, 0) *)
+  (forall a, non_terminating (0, (S a, 0))) +
+  (* uniform transition to equivalence class (0, 0) *)
+  (forall a, reaches (0, (S a, 0)) (0, (0, 0))) +
+  (* uniform transition to equivalence class (0, S b) *)
+  (forall a, exists b', reaches (0, (S a, 0)) (0, (0, S b'))) +
+  (* uniform transition to equivalence class (S a, S b) *)
+  (forall a, exists a' b', reaches (0, (S a, 0)) (0, (S a', S b'))).
+Proof using HM.
+  have [x' [Hx']] := reaches'I (0, (1, 0)).
+  case H'x': (step x') => [y'|]; first last.
+  { (* case: (1, 0) f->> HALT; uniform termination *)
+    move=> _. do 4 left. move=> a. move: Hx' => /reaches'_None_terminating.
+    apply=> /=; by [assumption|lia]. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* case: (1, 0) f->>t-> HALT; uniform termination *)
+    move: Hx' H'x' => /reaches'_Some_terminating H /H {}H /H {}H.
+    do 4 left. move=> a. apply: H => /=; lia. }
+  move: y' H'x' => [py' [ay' [|by']]] + /= Hy'; subst py'.
+  { (* case: (1, 0) f->>t-> (_, 0) *)
+    move: ay' => [|ay'] H'x'.
+    - (* case: (1, 0) f->>t-> (0, 0) uniform transition to (0, 0) *)
+      do 2 left. right. move=> a. elim: (S a); first by exists 0.
+      move=> {}a IH. move: Hx' => /reaches'E.
+      move=> [n'] [m'] /= [Hax] [Hbx] /(_ (S a) 0 ltac:(lia) ltac:(lia)).
+      move=> /reaches'_incl Hk. apply: (reaches_trans Hk).
+      move: H'x' => /(step_parallel (state x', (S a + n', m'))) /= /(_ ltac:(lia)).
+      move=> [[pz [az bz]]] /= [/step_reaches] H [?] ?.
+      apply: (reaches_trans H). subst pz.
+      move: IH. congr reaches. congr (_, (_, _)); lia.
+    - (* non-termination *)
+      do 3 left. right. move=> a. apply: transition_loop => a' b' ??.
+      move: Hx' H'x' => /reaches'E [n] [m] /= [?] [?].
+      move=> /(_ a' b' ltac:(lia) ltac:(lia)) /reaches'_incl Hk'.
+      move=> /(step_parallel (state x', (a' + n, b' + m))) /=.
+      move=> /(_ ltac:(lia)) [[pz [az bz]]] [/step_reaches_plus Hz] /= [? ?].
+      subst pz. exists az, bz. split; last by lia.
+      apply: reaches_reaches_plus; by eassumption. }
+  move: ay' => [|ay'] H'x'; first last.
+  { (* case: (1, 0) f->>t-> (S a, S b) uniform transition to (S a, S b) *)
+    right. move=> a.
+    move: Hx' => /reaches'E [n] [m] /= [Hax'] [Hbx'].
+    move=> /(_ (S a) 0 ltac:(lia) ltac:(lia)) /reaches'_incl.
+    move: H'x' => /(step_parallel (state x', (S a + n, m))) /=.
+    move=> /(_ ltac:(lia)) [[pz' [az' bz']]] /= [/step_reaches Hz'] [? ?] Hx'.
+    exists (az' - 1), (bz' - 1). apply /(reaches_trans Hx').
+    move: Hz'. congr reaches. congr (_, (_, _)); lia. }
+  (* case: (1, 0) f->>t-> (0, S b) *)
+  have := reaches'I (0, (1, 1)).
+  move=> [x] [Hx]. case H'x: (step x) => [y|]; first last.
+  { (* case: (1, 1) f->> HALT; uniform termination *)
+    move=> _. do 4 left. move=> a. move: Hx => /reaches'_None_terminating.
+    apply => /=; by [assumption|lia]. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* case: (1, 1) f->>t-> HALT; uniform termination *)
+    move=> Hy. move: (Hx) (H'x) (Hy) => /terminating_orI => H /H {}H /H {H} [?|HS]; first by (do 4 left).
+    do 4 left. move=> [|a].
+    { apply: (reaches_terminating _ (HS by')).
+      by apply: (reaches_trans (reaches'_incl Hx') (step_reaches H'x')). }
+    move: Hx' => /reaches'E [n] [m] /= [?] [?].
+    move=> /(_ (S (S a)) 0 ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    move: H'x' => /(step_parallel (state x', (S (S a) + n, m))) /=.
+    move=> /(_ ltac:(lia)) [[pz' [az' bz']]] /= [Hz'] [?] ?.
+    move: Hz' => /step_reaches /reaches_terminating. apply.
+    subst pz'. move: Hx => /reaches'E [n'] [m'] /= [?] [?].
+    move=> /(_ az' bz' ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    move: H'x => /(step_parallel (state x, (az' + n', bz' + m'))) /=.
+    move=> /(_ ltac:(lia)) [z] [Hz] [?] ?.
+    move: Hz => /step_reaches /reaches_terminating. apply.
+    exists 1. apply /step_None /nth_error_None. lia. }
+  (* case (1, 1) f->>t-> (a, b) at index 0 *)
+  move=> H0y. move Ha'y: (value1 y) => a'y. move Hb'y: (value2 y) => b'y.
+  move: b'y Hb'y => [|b'y] H2y.
+  { (* case: (1, 1) f->>t-> (_, 0) impossible *)
+    exfalso. apply: rev_dec_unique.
+    + apply: (proj1 (dec_stepI H'x' ltac:(done))).
+      move: Hx' => /reaches'E [n] [m] /= [?] [?]. lia.
+    + apply: (proj2 (dec_stepI H'x H0y)).
+      move: Hx => /reaches'E [n] [m] /= [?] [?]. lia. }
+  move: a'y Ha'y => [|a'y] H1y.
+  - (* case: (1, 1) f->>t-> (0, S b') uniform transition to (0, Sb') *)
+    do 1 left. right. move=> a.
+    move: Hx' => /reaches'E [n] [m] /= [?] [?].
+    move=> /(_ (S a) 0 ltac:(lia) ltac:(lia)) /reaches'_incl Hk'.
+    move: H'x' => /(step_parallel (state x', (S a + n, m))) /=.
+    move=> /(_ ltac:(lia)) [y'] [/step_reaches Hy'] [H0y'] ?.
+    move: Hx H'x => /dec_a_0 H. rewrite (Config_eta y) H0y H1y H2y.
+    move=> /H {H} => /(_ a (S by')) Hk''.
+    exists (a * b'y + by').
+    apply /(reaches_trans Hk') /(reaches_trans Hy').
+    rewrite (Config_eta y').
+    move: Hk''. congr reaches; congr (_, (_, _)); lia.
+  - (* case: (1, 1) f->>t-> (S a', S b') loop *)
+    do 3 left. right. move=> a. apply: dec_loop; [eassumption|].
+    by rewrite H'x (Config_eta y) H0y H1y H2y.
+Qed.
+
+(* uniform transition from equivalence class (0, S b) *)
+Lemma transition_0_Sb :
+  (* terminating equivalence class *)
+  (forall b, terminating (0, (0, S b))) +
+  (* non-terminating equivalence class*)
+  (forall b, non_terminating (0, (0, S b))) +
+  (* uniform transition to equivalence class (0, 0) *)
+  (forall b, reaches (0, (0, S b)) (0, (0, 0))) +
+  (* uniform transition to equivalence class (S a, 0) *)
+  (forall b, exists a', reaches (0, (0, S b)) (0, (S a', 0))) +
+  (* uniform transition to equivalence class (S a, S b) *)
+  (forall b, exists a' b', reaches (0, (0, S b)) (0, (S a', S b'))).
+Proof using HM.
+  have [x' [Hx']] := reaches'I (0, (0, 1)).
+  case H'x': (step x') => [y'|]; first last.
+  { (* case: (0, 1) f->> HALT; uniform termination *)
+    move=> _. do 4 left. move=> b. move: Hx' => /reaches'_None_terminating.
+    apply=> /=; by [assumption|lia]. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* case: (0, 1) f->>t-> HALT; uniform termination *)
+    move: Hx' H'x' => /reaches'_Some_terminating H /H {}H /H {}H.
+    do 4 left. move=> b. apply: H => /=; lia. }
+  move: y' H'x' => [py' [[|ay'] by']] + /= Hy'; subst py'.
+  { (* case: (0, 1) f->>t-> (0, _) *)
+    move: by' => [|by'] H'x'.
+    - (* case: (0, 1) f->>t-> (0, 0) uniform transition to (0, 0) *)
+      do 2 left. right. move=> b. elim: (S b); first by exists 0. 
+      move=> {}b IH. move: Hx' => /reaches'E.
+      move=> [n'] [m'] /= [Hax] [Hbx] /(_ 0 (S b) ltac:(lia) ltac:(lia)).
+      move=> /reaches'_incl Hk. apply: (reaches_trans Hk).
+      move: H'x' => /(step_parallel (state x', (n', S b + m'))) /= /(_ ltac:(lia)).
+      move=> [[pz [az bz]]] /= [/step_reaches] H [?] ?.
+      apply: (reaches_trans H). subst pz.
+      move: IH. congr reaches. congr (_, (_, _)); lia.
+    - (* non-termination *)
+      do 3 left. right. move=> b. apply: transition_loop => a' b' ??.
+      move: Hx' H'x' => /reaches'E [n] [m] /= [?] [?].
+      move=> /(_ a' b' ltac:(lia) ltac:(lia)) /reaches'_incl Hk'.
+      move=> /(step_parallel (state x', (a' + n, b' + m))) /=.
+      move=> /(_ ltac:(lia)) [[pz [az bz]]] [/step_reaches_plus Hz] /= [? ?].
+      subst pz. exists az, bz. split; last by lia.
+      apply: reaches_reaches_plus; by eassumption. }
+  move: by' => [|by'] H'x'; first last.
+  { (* case: (0, 1) f->>t-> (S a, S b) uniform transition to (S a, S b) *)
+    right. move=> b.
+    move: Hx' => /reaches'E [n] [m] /= [Hax'] [Hbx'].
+    move=> /(_ 0 (S b) ltac:(lia) ltac:(lia)) /reaches'_incl.
+    move: H'x' => /(step_parallel (state x', (n, S b + m))) /=.
+    move=> /(_ ltac:(lia)) [[pz' [az' bz']]] /= [/step_reaches Hz'] [? ?] Hx'.
+    exists (az' - 1), (bz' - 1). apply /(reaches_trans Hx').
+    move: Hz'. congr reaches. congr (_, (_, _)); lia. }
+  (* case: (0, 1) f->>t-> (S a, 0) *)
+  have := reaches'I (0, (1, 1)).
+  move=> [x] [Hx]. case H'x: (step x) => [y|]; first last.
+  { (* case: (1, 1) f->> HALT; uniform termination *)
+    move=> _. do 4 left. move=> b. move: Hx => /reaches'_None_terminating.
+    apply => /=; by [assumption|lia]. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* case: (1, 1) f->>t-> HALT; uniform termination *)
+    move=> Hy. move: (Hx) (H'x) (Hy) => /terminating_orI => H /H {}H /H {H} [HS|?]; last by (do 4 left).
+    do 4 left. move=> [|b].
+    { apply: (reaches_terminating _ (HS ay')).
+      by apply: (reaches_trans (reaches'_incl Hx') (step_reaches H'x')). }
+    move: Hx' => /reaches'E [n] [m] /= [?] [?].
+    move=> /(_ 0 (S (S b)) ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    move: H'x' => /(step_parallel (state x', (n, S (S b) + m))) /=.
+    move=> /(_ ltac:(lia)) [[pz' [az' bz']]] /= [Hz'] [?] ?.
+    move: Hz' => /step_reaches /reaches_terminating. apply.
+    subst pz'. move: Hx => /reaches'E [n'] [m'] /= [?] [?].
+    move=> /(_ az' bz' ltac:(lia) ltac:(lia)).
+    move=> /reaches'_incl /reaches_terminating. apply.
+    move: H'x => /(step_parallel (state x, (az' + n', bz' + m'))) /=.
+    move=> /(_ ltac:(lia)) [z] [Hz] [?] ?.
+    move: Hz => /step_reaches /reaches_terminating. apply.
+    exists 1. apply /step_None /nth_error_None. lia. }
+  (* case (1, 1) f->>t-> (a, b) at index 0 *)
+  move=> H0y. move Ha'y: (value1 y) => a'y. move Hb'y: (value2 y) => b'y.
+  move: a'y Ha'y => [|a'y] H1y.
+  { (* case: (1, 1) f->>t-> (0, _) impossible *)
+    exfalso. apply: rev_dec_unique.
+    + apply: (proj1 (dec_stepI H'x H0y)).
+      move: Hx => /reaches'E [n] [m] /= [?] [?]. lia.
+    + apply: (proj2 (dec_stepI H'x' ltac:(done))).
+      move: Hx' => /reaches'E [n] [m] /= [?] [?]. lia. }
+  move: b'y Hb'y => [|b'y] H2y.
+  - (* case: (1, 1) f->>t-> (S a', 0) uniform transition to (S a', 0') *)
+    do 1 left. right. move=> b.
+    move: Hx' => /reaches'E [n] [m] /= [?] [?].
+    move=> /(_ 0 (S b) ltac:(lia) ltac:(lia)) /reaches'_incl Hk'.
+    move: H'x' => /(step_parallel (state x', (n, S b + m))) /=.
+    move=> /(_ ltac:(lia)) [y'] [/step_reaches Hy'] [H0y'] ?.
+    move: Hx H'x => /dec_b_0 H. rewrite (Config_eta y) H0y H1y H2y.
+    move=> /H {H} => /(_ (S ay') b) Hk''.
+    exists (b * a'y + ay').
+    apply /(reaches_trans Hk') /(reaches_trans Hy').
+    rewrite (Config_eta y').
+    move: Hk''. congr reaches; congr (_, (_, _)); lia.
+  - (* case: (1, 1) f->>t-> (S a', S b') loop *)
+    do 3 left. right. move=> b. apply: dec_loop; [eassumption|].
+    by rewrite H'x (Config_eta y) H0y H1y H2y.
+Qed.
+
+(* uniform transition from equivalence class (S a, S b) *)
+Lemma transition_Sa_Sb :
+  (* terminating equivalence class (S a, 0) *)
+  (forall a b, terminating (0, (S a, S b))) +
+  (* non-terminating equivalence class (S a, 0) *)
+  (forall a b, non_terminating (0, (S a, S b))) +
+  (* uniform transition to equivalence class (0, 0) *)
+  (forall a b, reaches (0, (S a, S b)) (0, (0, 0))) +
+  (* uniform transition to equivalence class (S a, 0) *)
+  (forall a b, exists a', reaches (0, (S a, S b)) (0, (S a', 0))) +
+  (* uniform transition to equivalence class (0, S b) *)
+  (forall a b, exists b', reaches (0, (S a, S b)) (0, (0, S b'))).
+Proof using HM.
+  have := reaches'I (0, (1, 1)).
+  move=> [x] [Hk]. case H'x: (step x) => [y|]; first last.
+  { (* case: (1, 1) f->> HALT; uniform termination *)
+    move=> _. do 4 left. move=> a b.
+    move: H'x Hk => /reaches'_None_terminating H /H /=. apply; lia. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* case: (1, 0) f->>t-> HALT; uniform termination *)
+    move: H'x Hk => /reaches'_Some_terminating H /H {}H /H {}H.
+    do 4 left. move=> a b. apply: H => /=; lia. }
+  move: y H'x => [py' [[|ay'] [|by']]] H'x /= Hy'; subst py'.
+  - (* case: (1, 1) f->>t-> (0, 0) impossible *)
+    by move: Hk => /not_transition_1_1_to_0_0.
+  - (* case: (1, 1) f->>t-> (0, S b) uniform transition to (0, S b) *)
+    right. move=> a b.
+    move: Hk H'x => /dec_a_0 H /H /(_ (S a) (S b)) Hk'.
+    exists (S a * by' + S b - 1).
+    move: Hk'. congr reaches. congr (_, (_, _)); lia.
+  - (* case: (1, 1) f->>t-> (S a, 0) uniform transition to (S a, 0) *)
+    do 1 left. right. move=> a b.
+    move: Hk H'x => /dec_b_0 H /H /(_ (S a) (S b)) Hk'.
+    exists (S b * ay' + S a - 1).
+    move: Hk'. congr reaches. congr (_, (_, _)); lia.
+  - (* case: (1, 1) f->>t-> (S a, S b) non-termination *)
+    do 3 left. right. move=> a b. apply: dec_loop; by eassumption.
+Qed.
+
+
+(* equivalence classes (0, 0), (S a, 0), (0, S b), (S a, S b) *)
+Definition RZ '(a, b) '(a', b') : Prop := (a > 0 <-> a' > 0) /\ (b > 0 <-> b' > 0).
+
+Definition representatives := [(0, 0); (1, 0); (0, 1); (1, 1)].
+
+Lemma get_representative : forall ab, {v | In v representatives /\ RZ v ab}.
+Proof.
+  move=> [[|a] [|b]]; rewrite /representatives /RZ.
+  - exists (0, 0) => /=. split; [tauto|lia].
+  - exists (0, 1) => /=. split; [tauto|lia].
+  - exists (1, 0) => /=. split; [tauto|lia].
+  - exists (1, 1) => /=. split; [tauto|lia].
+Qed.
+
+Lemma uniform_transition ab :
+  In ab representatives -> 
+  (* uniform termination *)
+  (forall a'b', RZ ab a'b' -> terminating (0, a'b')) +
+  (* uniform non-termination *)
+  (forall a'b', RZ ab a'b' -> non_terminating (0, a'b')) +
+  (* uniform transition *)
+  {v | In v representatives /\
+    (forall a'b', RZ ab a'b' -> exists w, RZ v w /\ reaches_plus (0, a'b') (0, w)) }.
+Proof using HM.
+  rewrite /representatives /=.
+  have HE := @eq_or_inf (nat * nat) ltac:(by do ? decide equality).
+  case /HE; [|case /HE; [|case /HE; [|case /HE; last done]]] => <-.
+  - have [[[[|]|]|]|] := transition_0_0.
+    + move=> ?. left. left=> - [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = 0 by lia. done.
+    + move=> ?. left. right=> - [a' b'] /= ?. have ->: a' = 0 by lia. have ->: b' = 0 by lia. done.
+    + move=> H. right. exists (1, 0). split; first by tauto.
+      move: H => [a'' Hk] [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = 0 by lia.
+      exists (S a'', 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (0, 1). split; first by tauto.
+      move: H => [b'' Hk] [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = 0 by lia.
+      exists (0, S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (1, 1). split; first by tauto.
+      move: H => [a'' [b'' Hk]] [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = 0 by lia.
+      exists (S a'', S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+  - have [[[[|]|]|]|] := transition_Sa_0.
+    + move=> ?. left. left=> - [a' b'] /= ?.
+      have ->: a' = S (a' - 1) by lia. have ->: b' = 0 by lia. done.
+    + move=> ?. left. right=> - [a' b'] /= ?.
+      have ->: a' = S (a' - 1) by lia. have ->: b' = 0 by lia. done.
+    + move=> H. right. exists (0, 0). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = 0 by lia.
+      have Hk := H (a'-1). exists (0, 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (0, 1). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = 0 by lia.
+      have [b'' Hk] := H (a'-1). exists (0, S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (1, 1). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = 0 by lia.
+      have [a'' [b'' Hk]] := H (a'-1).
+      exists (S a'', S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+  - have [[[[|]|]|]|] := transition_0_Sb.
+    + move=> ?. left. left=> - [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = S (b' - 1) by lia. done.
+    + move=> ?. left. right=> - [a' b'] /= ?.
+      have ->: a' = 0 by lia. have ->: b' = S (b' - 1) by lia. done.
+    + move=> H. right. exists (0, 0). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = 0 by lia. have ->: b' = S (b' - 1) by lia.
+      have Hk := H (b'-1). exists (0, 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (1, 0). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = 0 by lia. have ->: b' = S (b' - 1) by lia.
+      have [a'' Hk] := H (b'-1). exists (S a'', 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (1, 1). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = 0 by lia. have ->: b' = S (b' - 1) by lia.
+      have [a'' [b'' Hk]] := H (b'-1).
+      exists (S a'', S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+  - have [[[[|]|]|]|] := transition_Sa_Sb.
+    + move=> ?. left. left=> - [a' b'] /= ?.
+      have ->: a' = S (a' - 1) by lia. have ->: b' = S (b' - 1) by lia. done.
+    + move=> ?. left. right=> - [a' b'] /= ?.
+      have ->: a' = S (a' - 1) by lia. have ->: b' = S (b' - 1) by lia. done.
+    + move=> H. right. exists (0, 0). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = S (b' - 1) by lia.
+      have Hk := H (a'-1) (b'-1). exists (0, 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (1, 0). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = S (b' - 1) by lia.
+      have [a'' Hk] := H (a'-1) (b'-1).
+      exists (S a'', 0). split; [lia|by apply: (reaches_neq_incl Hk)].
+    + move=> H. right. exists (0, 1). split; first by tauto.
+      move=> [a' b'] /= ?. have ->: a' = S (a' - 1) by lia. have ->: b' = S (b' - 1) by lia.
+      have [b'' Hk] := H (a'-1) (b'-1).
+      exists (0, S b''). split; [lia|by apply: (reaches_neq_incl Hk)].
+Qed.
+
+Opaque representatives.
+
+Lemma RZ_loop v : 
+  (forall ab, RZ v ab ->
+    exists a'b', RZ v a'b' /\ reaches_plus (0, ab) (0, a'b')) ->
+  forall ab, RZ v ab -> non_terminating (0, ab).
+Proof.
+  move=> Hv ab Hab k. elim: k ab Hab; first done.
+  move=> k IH ab /Hv [a'b'] [/IH] Hk [k' [? Hk']].
+  move=> /(steps_k_monotone (k' + k)) /(_ ltac:(lia)).
+  move: Hk' => /steps_plus ->. by apply: Hk.
+Qed.
+
+Lemma uniform_representative_decision v :
+  In v representatives -> 
+  (* uniform termination *)
+  (forall ab, RZ v ab -> terminating (0, ab)) +
+  (* uniform non-termination *)
+  (forall ab, RZ v ab -> non_terminating (0, ab)).
+Proof using HM.
+  move: v.
+  have: { L & incl L representatives & 
+    (forall v, In v representatives -> 
+    (forall ab, RZ v ab -> terminating (0, ab)) + (forall ab, RZ v ab -> non_terminating (0, ab)) +
+    { w | In w L /\
+      (forall ab, RZ v ab -> exists a'b', RZ w a'b' /\ reaches_plus (0, ab) (0, a'b')) } ) }.
+  { exists representatives; first done. by apply: uniform_transition. }
+  case. elim.
+  { move=> _ H v /H /= [[|]|]; [tauto|tauto|]. by move=> [?] []. }
+  move=> v0 L IH /(@incl_cons_inv (nat*nat)) [Hv0 HL] HRZ. apply: IH; first done.
+  move=> v /HRZ. move=> [[|]|]; [tauto|tauto|].
+  have HE := @eq_or_inf (nat * nat) ltac:(by do ? decide equality).
+  move=> [w] /= [/HE [|]]; first last.
+  { move=> ??. right. by exists w. }
+  move=> <-. move: Hv0 => /HRZ [[|]|].
+  - (* termination *)
+    move=> Hv0 Hv. left. left=> ab /Hv [a'b'] [/Hv0].
+    by move=> /reaches_terminating H /reaches_plus_incl /H.
+  - (* non-termination *)
+    move=> Hv0 Hv. left. right=> ab /Hv [a'b'] [/Hv0].
+    by move=> /reaches_non_terminating H /reaches_plus_incl /H.
+  - (* chaining *)
+    move=> [w'] /= [/HE [|]].
+    + (* non-termination *)
+      move=> <- /RZ_loop Hv0 Hv. left. right=> ab /Hv [a'b'] [/Hv0].
+      by move=> /reaches_non_terminating H /reaches_plus_incl /H.
+    + move=> ? Hv0 Hv. right. exists w'. split; first done.
+      move=> ab /Hv [a'b'] [/Hv0] [a''b''] [? HSk'] HSk.
+      exists a''b''. split; first done.
+      by apply: (reaches_plus_trans HSk HSk').
+Qed.
+
+Lemma uniform_decision_0 a b : (terminating (0, (a, b))) + (non_terminating (0, (a, b))).
+Proof using HM.
+  have [v []] := get_representative (a, b).
+  move=> /uniform_representative_decision [] => H /H; tauto.
+Qed.
+
+(* informative decision statement for reversible halting for Cm2 *)
+Theorem decision (c: Config) : (terminating c) + (non_terminating c).
+Proof using HM.
+  have [y [/reaches'_incl Hk]] := reaches'I c.
+  case Hz: (step y) => [[pz [az bz]]|] /=; first last.
+  { (* termination *)
+    move=> _. left. apply: (reaches_terminating Hk).
+    by exists 1. }
+  have Hcz : reaches c (pz, (az, bz)).
+  { apply: reaches_trans; [|exists 1]; by eassumption. }
+  case /(eq_or_inf Nat.eq_dec); first last.
+  { (* termination *)
+    move=> /nth_error_None Hpz. left.
+    move: Hcz => /reaches_terminating. apply.
+    exists 1. by apply /step_None. }
+  move=> ?. subst pz. case: (uniform_decision_0 az bz).
+  - (* termination *)
+    move=> /reaches_terminating H'z. left. by apply: H'z.
+  - (* non-termination *)
+    move=> /reaches_non_terminating H'z. right. by apply: H'z.
+Qed.
+
+End Construction.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for the halting problem for reversible Cm2 *)
+Definition decide : { M: Cm2 | reversible M } * Config -> bool :=
+  fun '(exist _ M HM, c) =>
+    match decision M HM c with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide CM2_REV_HALT.
+Proof.
+  rewrite /decider /reflects /decide => - [[M HM] c].
+  case: (decision M HM c).
+  - tauto.
+  - move=> H. split; [by move=> [k /H] | done].
+Qed.

--- a/theories/CounterMachines/Deciders/CM2_REV_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_REV_dec.v
@@ -1,0 +1,178 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Two-counter Machine Reversibility (CM2_REV)
+*)
+
+Require Import List ListDec PeanoNat Lia Operators_Properties.
+Import ListNotations.
+Require Import Undecidability.CounterMachines.CM2.
+From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+Section Construction.
+Variable M : Cm2.
+
+#[local] Notation step := (CM2.step M).
+#[local] Notation l := (length M).
+
+Lemma finite_characterization : let t := list_prod (seq 0 l) (list_prod [0;1;2] [0;1;2]) in
+  Forall (fun '(x, y) => step x = step y -> x = y) (list_prod t t) ->
+  reversible M.
+Proof.
+  move=> t. pose P := fun '(x, y) => x <> y /\ step x = step y.
+  have := Exists_dec P (list_prod t t).
+  apply: unnest.
+  { move=> [x y]. rewrite /P.
+    have [<-|?] := Config_eq_dec x y.
+    { right. tauto. }
+    have [<-|?] := option_Config_eq_dec (step x) (step y).
+    { by left. }
+    right. tauto. }
+  case.
+  { move=> /Exists_exists [[x y]] [Hxyt] [H1Pxy H2Pxy].
+    by move=> /Forall_forall /(_ (x, y) Hxyt H2Pxy) /H1Pxy. }
+  move=> H _.
+  have Ht : forall p1 a1 b1 p2 a2 b2,
+  ~ l <= p1 -> ~ l <= p2 -> 0 <= a1 <= 2 -> 0 <= b1 <= 2 -> 0 <= a2 <= 2 -> 0 <= b2 <= 2 -> 
+  In (p1, (a1, b1), (p2, (a2, b2))) (list_prod t t).
+  { move=> > ??????. apply /in_prod; (apply /in_prod; [apply /in_seq|apply /in_prod]).
+    all: move=> /=; lia. }
+  move=> [p1 [a1 b1]] [p2 [a2 b2]] z H1 H2.
+  suff ? : (not (p1 <> p2 \/ a1 <> a2 \/ b1 <> b2)).
+  { congr (_, (_, _)); lia. }
+  move=> H'. apply: H. apply /Exists_exists.
+  have H'p1 : not (l <= p1).
+  { move=> /nth_error_None Hp1. move: H1. by rewrite /step /= Hp1. }
+  have H'p2 : not (l <= p2).
+  { move=> /nth_error_None Hp2. move: H2. by rewrite /step /= Hp2. }
+  move: H1. rewrite -H2. clear H2.
+  rewrite /step /=.
+  case Hp1: (nth_error M p1) => [i|]; first last.
+  { move: Hp1 => /nth_error_None. lia. }
+  case Hp2: (nth_error M p2) => [j|]; first last.
+  { move: Hp2 => /nth_error_None. lia. }
+  move: H'p1 H'p2 => /Ht {}Ht /Ht {}Ht. 
+  move: i j Hp1 Hp2 => [c1|c1 q1] [c2|c2 q2].
+  - move=> + + [? ? ?]. subst p2. move=> -> [?]. subst c2.
+    lia.
+  - case: c2 H'; [move: b2=> [|b2]|move: a2=> [|a2]].
+    + move=> ? + + [? ? ?]. subst p2. by move=> ->.
+    + move=> ? Hp1 Hp2 [? ? ?]. subst q2.
+      exists ((p1, (0, 0)), (p2, (0 + (if c1 then 0 else 1), 1 + (if c1 then 1 else 0)))). split.
+      { apply: Ht; case: (c1); lia. }
+      split; first done.
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + move=> ? + + [? ? ?]. subst p2. by move=> ->.
+    + move=> ? Hp1 Hp2 [? ? ?]. subst q2.
+      exists ((p1, (0, 0)), (p2, (1 + (if c1 then 0 else 1), 0 + (if c1 then 1 else 0)))). split.
+      { apply: Ht; case: (c1); lia. }
+      split; first done.
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+  - case: c1 H'; [move: b1=> [|b1]|move: a1=> [|a1]].
+    + move=> ? + + [? ? ?]. subst p2. by move=> ->.
+    + move=> ? Hp1 Hp2 [? ? ?]. subst q1.
+      exists ((p1, (0 + (if c2 then 0 else 1), 1 + (if c2 then 1 else 0))), (p2, (0, 0))). split.
+      { apply: Ht; case: (c2); lia. }
+      split; first done.
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + move=> ? + + [? ? ?]. subst p2. by move=> ->.
+    + move=> ? Hp1 Hp2 [? ? ?]. subst q1.
+      exists ((p1, (1 + (if c2 then 0 else 1), 0 + (if c2 then 1 else 0))), (p2, (0, 0))). split.
+      { apply: Ht; case: (c2); lia. }
+      split; first done.
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+  - move: c1 a1 b1 c2 a2 b2 H' => [] => [a1 [|b1]|[|a1] b1].
+    all: move=> [] => [a2 [|b2]|[|a2] b2] ?.
+    all: move=> Hp1 Hp2 [] *; subst.
+    + lia.
+    + exists ((p1, (0, 0)), (p2, (0, 1))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + by move: Hp1 Hp2 => ->.
+    + exists ((p1, (0, 0)), (p2, (1, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (0, 1)), (p2, (0, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (0, 1)), (p2, (0, 1))).
+      split; [apply: Ht; lia|split; first by (case; lia)].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (0, 1)), (p2, (0, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (0, 1)), (p2, (1, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + by move: Hp1 Hp2 => ->.
+    + exists ((p1, (0, 0)), (p2, (0, 1))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + lia.
+    + exists ((p1, (0, 0)), (p2, (1, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (1, 0)), (p2, (0, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (1, 0)), (p2, (0, 1))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (1, 0)), (p2, (0, 0))).
+      split; [apply: Ht; lia|split; first done].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+    + exists ((p1, (1, 0)), (p2, (1, 0))).
+      split; [apply: Ht; lia|split; first by (case; lia)].
+      rewrite /step Hp1 Hp2 /=. congr (Some (_, (_, _))); lia.
+Qed.
+
+(* informative decision statement for reversibility for Cm2 *)
+Theorem decision : (reversible M) + (not (reversible M)).
+Proof.
+  pose t := list_prod (seq 0 l) (list_prod [0;1;2] [0;1;2]).
+  have := Forall_Exists_dec (fun '(x, y) => step x = step y -> x = y) _ (list_prod t t).
+  apply: unnest.
+  { move=> [x y].
+    have [<-|?] := Config_eq_dec x y.
+    { left. tauto. }
+    have := option_Config_eq_dec (step x) (step y).
+    move=> [<-|?]; [right|left]; tauto. }
+  case.
+  { move=> /finite_characterization ?. by left. }
+  move=> H. right.
+  move: H => /Exists_exists [[x y]] [H'xy] Hxy HM. apply: Hxy.
+  move=> Hxy.
+  case Hxz: (step x) => [z|]. { apply: (HM x y z); [done|by rewrite -Hxy]. }
+  move: Hxz => /step_None /nth_error_None.
+  move: x H'xy {Hxy} => [p [a b]] /in_prod_iff [+ _].
+  move=> /in_prod_iff [/in_seq + _] /=. lia.
+Qed.
+
+End Construction.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for the reversibility of Cm2 *)
+Definition decide : Cm2 -> bool :=
+  fun M =>
+    match decision M with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide CM2_REV.
+Proof.
+  rewrite /decider /reflects /decide => M.
+  case: (decision M); [tauto | done].
+Qed.

--- a/theories/CounterMachines/Deciders/CM2_UBOUNDED_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_UBOUNDED_dec.v
@@ -1,0 +1,423 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Two-counter Machine Uniform Boundedness (CM2_UBOUNDED)
+*)
+
+Require Import List ListDec PeanoNat Lia Relation_Operators Operators_Properties.
+Import ListNotations.
+Require Import Undecidability.CounterMachines.CM2.
+From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+Section Construction.
+Variable M : Cm2.
+
+#[local] Notation steps := (CM2.steps M).
+#[local] Notation bounded := (CM2.bounded M).
+#[local] Notation step := (CM2.step M).
+#[local] Notation reaches := (CM2.reaches M).
+#[local] Notation path := (CM2_facts.path M).
+
+Lemma pointwise_decision K x : {bounded K x} + {not (bounded K x)}.
+Proof.
+  case HK: (steps K x) => [y|].
+  - have [Hy|Hy] := In_dec option_Config_eq_dec (Some y) (path K x).
+    + left. apply: loop_bounded. by rewrite HK.
+    + right. apply: (NoDup_not_bounded HK).
+      apply: path_noloopI. by rewrite HK.
+  - left. by apply: mortal_bounded.
+Qed.
+
+Lemma shift_steps_a k K p a b :
+  k <= K ->
+  steps k (p, (K + a, b)) =
+  match steps k (p, (K, b)) with
+  | Some (p', (a', b')) => Some (p', (a' + a, b'))
+  | None => None
+  end.
+Proof.
+  move=> ?. rewrite [LHS]shift_steps [in RHS]shift_steps.
+  have ->: Nat.min k (K + a) = k by lia.
+  have ->: Nat.min k K = k by lia.
+  case: (steps k _) => [[? [? ?]]|]; last done.
+  congr (Some (_, (_, _))); lia.
+Qed.
+
+Lemma shift_steps_b k K p a b :
+  k <= K ->
+  steps k (p, (a, K + b)) =
+  match steps k (p, (a, K)) with
+  | Some (p', (a', b')) => Some (p', (a', b' + b))
+  | None => None
+  end.
+Proof.
+  move=> ?. rewrite [LHS]shift_steps [in RHS]shift_steps.
+  have ->: Nat.min k (K + b) = k by lia.
+  have ->: Nat.min k K = k by lia.
+  case: (steps k _) => [[? [? ?]]|]; last done.
+  congr (Some (_, (_, _))); lia.
+Qed.
+
+Lemma shift_path_a K p a b :
+  path (K+1) (p, (K+a, b)) =
+  map (fun oy => if oy is Some (p', (a', b')) then Some (p', (a'+a, b')) else None) (path (K+1) (p, (K, b))).
+Proof. 
+  rewrite /path map_map. apply: map_ext_in => k /in_seq ?.
+  apply: shift_steps_a. lia.
+Qed.
+
+Lemma shift_path_b K p a b :
+  path (K+1) (p, (a, K+b)) =
+  map (fun oy => if oy is Some (p', (a', b')) then Some (p', (a', b'+b)) else None) (path (K+1) (p, (a, K))).
+Proof. 
+  rewrite /path map_map. apply: map_ext_in => k /in_seq ?.
+  apply: shift_steps_b. lia.
+Qed.
+
+Lemma path_NoDup_a_bound K p a b : K <= a -> NoDup (path (K+1) (p, (a, b))) -> NoDup (path (K+1) (p, (K, b))).
+Proof.
+  move=> ?. have ->: a = K+(a-K) by lia.
+  rewrite shift_path_a. by apply: NoDup_map_inv.
+Qed.
+
+Lemma path_NoDup_b_bound K p a b : K <= b -> NoDup (path (K+1) (p, (a, b))) -> NoDup (path (K+1) (p, (a, K))).
+Proof.
+  move=> ?. have ->: b = K+(b-K) by lia.
+  rewrite shift_path_b. by apply: NoDup_map_inv.
+Qed.
+
+Lemma fixed_decision K :
+  {forall x : Config, bounded K x} + {~ (forall x : Config, bounded K x)}.
+Proof.
+  (* need to check configurations up to values K *)
+  have := Forall_dec (fun 'x => bounded K x) (pointwise_decision K)
+    (list_prod (seq 0 (length M)) (list_prod (seq 0 (K+1)) (seq 0 (K+1)))).
+  case; first last.
+  { move=> H. right => HK. apply /H /Forall_forall. move=> ??. by apply: HK. }
+  wlog: K /(0 < K).
+  { move: K => [|K] H HK.
+    - right. move=> /(_ (0, (0, 0))) [[|? L] [/= ? /(_ (0, (0, 0))) HL]].
+      + apply: HL. by exists 0.
+      + lia.
+    - apply: H; [lia|done]. }
+  move=> ? HK. left => x.
+  have [|/path_noloopI] := In_dec option_Config_eq_dec (steps K x) (path K x).
+  { by apply: loop_bounded. }
+  case Hz: (steps K x) => [z|]; first last.
+  { move=> _. by apply: mortal_bounded. }
+  (* not bounded *)
+  move=> Hx. exfalso.
+  move: x Hx Hz => [p [a b]] Hx Hz.
+  have Hp : not (length M <= p).
+  { move=> /nth_error_None HM. move: Hz. have -> : K = S (K - 1) by lia.
+    by rewrite /steps /= obind_oiter /step /= HM oiter_None. }
+  move: Hx Hz.
+  (* it suffices to consider configurations up to values K  *)
+  wlog: a b z /(a <= K /\ b <= K); first last.
+  { move=> ? Hx Hz. suff: bounded K (p, (a, b)).
+    { by apply: (NoDup_not_bounded Hz). }
+    move: HK => /Forall_forall.
+    apply. apply: in_prod; [|apply: in_prod]; apply /in_seq; lia. }
+  move=> H'K.
+  wlog: a b z /(a <= K).
+  { move=> H. have [/H|->] : a <= K \/ a = K + (a - K) by lia.
+    { by apply. }
+    move=> /path_NoDup_a_bound => /(_ ltac:(lia)) /H {H}.
+    rewrite shift_steps_a; first done.
+    case: (steps K (p, (K, b))) => [y|]; last done.
+    move=> H _. by apply: (H y). }
+  move=> ?. have [?|->] : b <= K \/ b = K + (b - K) by lia.
+  { move=> /H'K H /H. by apply. }
+  move=> /path_NoDup_b_bound => /(_ ltac:(lia)) /H'K.
+  rewrite shift_steps_b; first done.
+  case: (steps K (p, (a, K))) => [y|]; last done.
+  move=> H _. by apply: (H y).
+Qed.
+
+Notation l := (length M).
+
+(* from an arbitrary config arrive at config with at least one large value *)
+Lemma uniform_decision_aux1 x : let n := l*(l+1) in
+  (bounded (l*n*n+1) x) +
+  { y | (exists k, k <= l*n*n /\ steps k x = Some y) /\ (n <= value1 y \/ n <= value2 y) }.
+Proof.
+  move=> n.
+  have [|/path_noloopI Hx] :=
+    In_dec option_Config_eq_dec (steps (l*n*n) x) (path (l*n*n) x).
+  { move=> /loop_bounded H. left. apply: (bounded_monotone _ H). lia. }
+  case Hxy: (steps (l*n*n+1) x) => [y|]; first last.
+  { left. by apply: mortal_bounded. }
+  right.
+  have [/pigeonhole|] := incl_dec option_Config_eq_dec (path (l*n*n+1) x)
+    (map Some (list_prod (seq 0 l) (list_prod (seq 0 n) (seq 0 n)))).
+  { move=> H. exfalso. apply: (H _ Hx).
+    rewrite path_length map_length ?prod_length ?seq_length. lia. }
+  move=> /(not_inclE option_Config_eq_dec) [[z|]].
+  - move=> H. exists z.
+    move: H => [/in_map_iff] [k] [Hk] /in_seq ? H.
+    have H'z : not (l <= state z).
+    { move=> /nth_error_None Hz.
+      have : steps (S k) x = None by rewrite /= Hk /= /step Hz.
+      move=> /(steps_k_monotone (l*n*n+1)) /(_ ltac:(lia)).
+      by rewrite Hxy. }
+    split. { exists k. split; [lia|done]. }
+    suff : not (value1 z < n /\ value2 z < n) by lia.
+    move=> H'. apply: H. apply /in_map_iff. exists z. split; first done.
+    move: z {Hk} H'z H' => [? [? ?]] /= ??.
+    apply /in_prod; [|apply /in_prod]; apply /in_seq; lia.
+  - move=> [/in_map_iff] H. exfalso.
+    move: H => [k] [+ /in_seq ?].
+    move=> /(steps_k_monotone (l*n*n+1)) /(_ ltac:(lia)).
+    by rewrite Hxy.
+Qed.
+
+Lemma k_step_iter k p a1 b1 a2 b2 :
+  (k <= a1 \/ a1 = a2) -> (k <= b1 \/ b1 = b2) -> 
+  steps k (p, (a1, b1)) = Some (p, (a2, b2)) ->
+  let ca := if Nat.eq_dec a1 a2 then 0 else 1 in
+  let cb := if Nat.eq_dec b1 b2 then 0 else 1 in
+  forall i n a b, i <= n ->
+    steps (i*k) (p, (a1+ca*(a+n*a1),b1+cb*(b+n*b1))) =
+      Some (p, (a1+ca*(a+(n-i)*a1+i*a2),b1+cb*(b+(n-i)*b1+i*b2))).
+Proof.
+  move=> Ha Hb Hk ca cb. elim.
+  { move=> ????. congr (Some (_, (_, _))); lia. }
+  move=> i IH [|n] a b; first by lia.
+  move=> /(iffRL (Nat.succ_le_mono _ _)) /IH {}IH.
+  rewrite /= /steps iter_plus -/(steps _ _).
+  have := IH (a2+a) (b2+b). congr eq; first last.
+  { congr (Some (_, (_, _))); lia. }
+  congr Nat.iter.
+  rewrite /ca /cb.
+  move: (Nat.eq_dec a1 a2) (Nat.eq_dec b1 b2) => [?|?] [?|?] /=.
+  - rewrite ?Nat.add_0_r Hk.
+    congr (Some (_, (_, _))); lia.
+  - rewrite shift_steps_b; first lia.
+    rewrite ?Nat.add_0_r Hk.
+    congr (Some (_, (_, _))); lia.
+  - rewrite shift_steps_a; first lia.
+    rewrite ?Nat.add_0_r Hk.
+    congr (Some (_, (_, _))); lia.
+  - rewrite shift_steps_a; first lia.
+    rewrite shift_steps_b; first lia.
+    rewrite ?Nat.add_0_r Hk.
+    congr (Some (_, (_, _))); lia.
+Qed.
+
+(* probably too much? *)
+Lemma not_uniformly_boundedI k p a1 b1 a2 b2 :
+  (k <= a1 \/ a1 = a2) -> (k <= b1 \/ b1 = b2) -> 
+  (a1 <> a2 \/ b1 <> b2) ->
+  steps k (p, (a1, b1)) = Some (p, (a2, b2)) ->
+  not (uniformly_bounded M).
+Proof.
+  move=> /k_step_iter H /H {}H Hab /H /= + [K].
+  move=> /(_ _ K 0 0) /=.
+  move Ha: (a1 + _ * _) => a.
+  move Hb: (b1 + _ * _) => b.
+  move=> {}H /(_ (p, (a, b))) [L [? HL]].
+  have : incl (map (fun i => steps (i * k) (p, (a, b))) (seq 0 (K+1))) (map Some L).
+  { move=> z /in_map_iff [i] [<- /in_seq ?]. rewrite H; first by lia.
+    apply: in_map. apply: HL. exists (i*k). rewrite H; [lia|done]. }
+  move=> /pigeonhole. apply.
+  { rewrite ?map_length seq_length. lia. }
+  under map_ext_in.
+  { move=> i /in_seq ?. rewrite H; first by lia. over. }
+  apply: NoDup_map_ext; last by apply: seq_NoDup.
+  move=> i1 /in_seq ? i2 /in_seq ? [].
+  move: (Nat.eq_dec a1 a2) (Nat.eq_dec b1 b2) => [?|?] [?|?] /=; nia.
+Qed.
+
+(* from a config with the a really large value arrive at config with two large values *)
+Lemma uniform_decision_aux2 x : ({l*(l+1) <= value1 x} + {l*(l+1) <= value2 x}) ->
+  (bounded (l*l+1) x) + (not (uniformly_bounded M)) +
+    { y | (exists k, k <= l*l /\ steps k x = Some y) /\ (l <= value1 y /\ l <= value2 y) }.
+Proof.
+  move=> Hlx.
+  have [|/path_noloopI Hx] :=
+    In_dec option_Config_eq_dec (steps (l*l) x) (path (l*l) x).
+  { move=> /loop_bounded H. left. left. apply: (bounded_monotone _ H). lia. }
+  case Hxy: (steps (l*l+1) x) => [y|]; first last.
+  { left. left. by apply: mortal_bounded. }
+  pose P oz := if oz is Some z then 
+    (if Hlx then l <= value2 z else l <= value1 z) else True.
+  have HP : forall x, {P x} + {not (P x)}.
+  { move=> [? /= |]; last by left. clear P.
+    case: Hlx => ?; by apply: Compare_dec.le_dec. }
+  have [|H'x] := Exists_dec P (path (l * l + 1) x) HP.
+  { move=> /(Exists_sig P HP) [[z|]] [Hz /= H'z].
+    - right. exists z. move: Hz => /In_pathE [k [? Hk]]. split.
+      + exists k. split; [lia|done].
+      + move: Hk => /steps_values_bound. clear P HP.
+        case: Hlx H'z => /=; lia.
+    - exfalso. by move: Hz Hxy => /In_None_pathE ->. }
+  (* all value1 or value2 are smaller than l, not uniformly bounded *)
+  left. right. subst P.
+  have /pigeonhole : incl
+    (map (fun oz => if oz is Some (p, (a, b)) then (if Hlx then (p, b) else (p, a)) else (0, 0)) (path (l * l + 1) x))
+    (list_prod (seq 0 l) (seq 0 l)).
+  { move=> [p c] /in_map_iff [[[p' [a' b']]|]]; first last.
+    { move=> [_ /In_pathE].
+      move=> [?] [?] /(steps_k_monotone (l * l + 1)) /(_ ltac:(lia)).
+      by rewrite Hxy. }
+    move=> [+ H]. have ? : not (l <= p').
+    { move=> /nth_error_None Hp. move: H => /in_map_iff [k] [Hk /in_seq ?].
+      have : steps (S k) x = None by rewrite /= Hk /step /= Hp.
+      move=> /(steps_k_monotone (l*l+1)) /(_ ltac:(lia)).
+      by rewrite Hxy. }
+    case: Hlx H'x HP => /= ? H'x HP.
+    - move=> [? ?]. subst p c.
+      move: H'x H => /Forall_Exists_neg /Forall_forall H /H{H} /= ?.
+      apply /in_prod; apply /in_seq; lia.
+    - move=> [? ?]. subst p c.
+      move: H'x H => /Forall_Exists_neg /Forall_forall H /H{H} /= ?.
+      apply /in_prod; apply /in_seq; lia. }
+  apply: unnest. { rewrite map_length ?prod_length ?seq_length path_length. lia. }
+  rewrite /path map_map. move=> /(dup_seq prod_nat_nat_eq_dec) [[i j]].
+  move=> [+ ?].
+  case Hi: (steps i x) => [[p [a1 b1]]|]; first last.
+  { move: Hi => /(steps_k_monotone (l*l+1)) /(_ ltac:(lia)). by rewrite Hxy. }
+  case Hj: (steps j x) => [[p' [a2 b2]]|]; first last.
+  { move: Hj => /(steps_k_monotone (l*l+1)) /(_ ltac:(lia)). by rewrite Hxy. }
+  clear H'x.
+  have ? : not (p = p' /\ a1 = a2 /\ b1 = b2).
+  { move=> [? [? ?]]. subst p' a2 b2.
+    move: Hx. rewrite /path.
+    have -> : l*l+1 = i + (S (j-i-1)) + (S (l*l -j)) by lia.
+    rewrite seq_app seq_app /= ?map_app /= (NoDup_count_occ option_Config_eq_dec).
+    move=> /(_ (Some (p, (a1, b1)))). have ->: i + S (j - i - 1) = j by lia.
+    rewrite Hi Hj ?count_occ_app /=. case: (option_Config_eq_dec _ _); [lia|done]. }
+  case: Hlx HP => /= ? HP.
+  - move=> [? ?]. subst p' b2.
+    have ? : a1 <> a2 by lia.
+    (* x ->>i (p, (a1, b1)) ->>(j-i) (p, (a2, b2)); a1 >= j-i or b1 >= j-i *)
+    have ? : j-i <= a1.
+    { move: Hi => /steps_values_bound /=. lia. }
+    move: Hi Hj => /steps_sub H /H{H} /(_ ltac:(lia)).
+    move /not_uniformly_boundedI. apply; lia.
+  - move=> [? ?]. subst p' a2.
+    have ? : b1 <> b2 by lia.
+    have ? : j-i <= b1.
+    { move: Hi => /steps_values_bound /=. lia. }
+    move: Hi Hj => /steps_sub H /H{H} /(_ ltac:(lia)).
+    move /not_uniformly_boundedI. apply; lia.
+Qed.
+
+(* from a config with two large values decide boundedness *)
+Lemma uniform_decision_aux3 x : l <= value1 x -> l <= value2 x -> (bounded (l+1) x) + (not (uniformly_bounded M)).
+Proof.
+  move=> ??.
+  have [|/path_noloopI Hx] :=
+    In_dec option_Config_eq_dec (steps (l) x) (path (l) x).
+  { move=> /loop_bounded H. left. apply: (bounded_monotone _ H). lia. }
+  case Hxy: (steps (l+1) x) => [y|]; first last.
+  { left. by apply: mortal_bounded. }
+  right. (* not uniformly bounded *)
+  have /pigeonhole : incl
+    (map (fun oz => if oz is Some (p, (a, b)) then p else 0) (path (l + 1) x))
+    (seq 0 l).
+  { move=> p /in_map_iff [[[p' [a' b']]|]]; first last.
+    { move=> [_ /In_pathE].
+      move=> [?] [?] /(steps_k_monotone (l + 1)) /(_ ltac:(lia)).
+      by rewrite Hxy. }
+    move=> [->] H. apply /in_seq. suff : not (l <= p) by lia.
+    move=> /nth_error_None Hp. move: H => /in_map_iff [k] [Hk /in_seq ?].
+    have : steps (S k) x = None by rewrite /= Hk /step /= Hp.
+    move=> /(steps_k_monotone (l+1)) /(_ ltac:(lia)).
+    by rewrite Hxy. }
+  apply: unnest. { rewrite map_length ?seq_length path_length. lia. }
+  rewrite /path map_map. move=> /(dup_seq Nat.eq_dec) [[i j]].
+  move=> [+ ?].
+  case Hi: (steps i x) => [[p [a1 b1]]|]; first last.
+  { move: Hi => /(steps_k_monotone (l+1)) /(_ ltac:(lia)). by rewrite Hxy. }
+  case Hj: (steps j x) => [[p' [a2 b2]]|]; first last.
+  { move: Hj => /(steps_k_monotone (l+1)) /(_ ltac:(lia)). by rewrite Hxy. }
+  move=> ?. subst p'.
+  have ? : a1 <> a2 \/ b1 <> b2.
+  { suff : not (a1 = a2 /\ b1 = b2) by lia. move=> [??]. subst a2 b2.
+    move: Hx. rewrite /path.
+    have -> : l+1 = i + (S (j-i-1)) + (S (l -j)) by lia.
+    rewrite seq_app seq_app /= ?map_app /= (NoDup_count_occ option_Config_eq_dec).
+    move=> /(_ (Some (p, (a1, b1)))). have ->: i + S (j - i - 1) = j by lia.
+    rewrite Hi Hj ?count_occ_app /=. case: (option_Config_eq_dec _ _); [lia|done]. }
+  have ?: j - i <= a1 /\ j - i <= b1.
+  { move: Hi => /steps_values_bound /=. lia. }
+  move: Hi Hj => /steps_sub H /H{H} /(_ ltac:(lia)).
+  move=> /not_uniformly_boundedI. apply; lia.
+Qed.
+
+Lemma uniformly_bounded_empty : uniformly_bounded [].
+Proof.
+  exists 1. move=> x. exists [x]. split; first done.
+  move=> y [[|k]].
+  - move=> [<-]. by left.
+  - rewrite /= obind_oiter /CM2.step.
+    by case: (state x); rewrite /= oiter_None.
+Qed.
+
+(* a uniformly bounded machine M is uniformly bounded by (|M|+1)^5 *)
+Lemma bound_on_uniform_bound : uniformly_bounded M ->
+  forall x, bounded ((l+1)*(l+1)*(l+1)*(l+1)*(l+1)) x.
+Proof.
+  move=> HM x.
+  set K := ((l+1)*(l+1)*(l+1)*(l+1)*(l+1)).
+  (* x ->> y with at least one large counter *)
+  have [|[y [[k1 [Hk1 Hxy]] ?]]] := uniform_decision_aux1 x.
+  { apply: bounded_monotone. lia. }
+  have -> : K = k1 + (K - k1) by lia.
+  apply: (reaches_bounded Hxy).
+  have : {l * (l + 1) <= value1 y} + {l * (l + 1) <= value2 y}.
+  { case H: (l * (l + 1) - value1 y) => [|?]; [left|right]; lia. }
+  move=> /uniform_decision_aux2 [[|]|[z]].
+  - apply: bounded_monotone. lia.
+  - by move=> /(_ HM).
+  - move=> [[k2 [? Hyz]]] [/uniform_decision_aux3 H /H{H}].
+    move=> [/bounded_monotone Hz|].
+    + have -> : K - k1 = k2 + (K - k1 - k2) by lia.
+      apply: (reaches_bounded Hyz). apply: Hz. lia.
+    + by move=> /(_ HM).
+Qed.
+
+(* informative decision statement for uniform boundedness for Cm2 *)
+Theorem decision : (uniformly_bounded M) + (not (uniformly_bounded M)).
+Proof.
+  wlog ? : /(l > 0).
+  { move: (M) => [|? ?] /=.
+    - move=> _. left. by apply: uniformly_bounded_empty.
+    - apply. lia. }
+  pose K := (l+1)*(l+1)*(l+1)*(l+1)*(l+1).
+  (* test uniform boundedness by K ~ l^5 *)
+  have [?|HK] := fixed_decision K. { left. by exists K. }
+  (* not uniformly bounded *)
+  right. move=> /bound_on_uniform_bound => HM.
+  apply: HK => x. by apply: HM.
+Qed.
+
+End Construction.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for uniform boundedness for Cm2 *)
+Definition decide : Cm2 -> bool :=
+  fun M =>
+    match decision M with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide CM2_UBOUNDED.
+Proof.
+  rewrite /decider /reflects /decide => M.
+  case: (decision M); intuition done.
+Qed.

--- a/theories/CounterMachines/Deciders/CM2_UMORTAL_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_UMORTAL_dec.v
@@ -1,0 +1,92 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Two-counter Machine Uniform Mortality (CM2_UMORTAL)
+*)
+
+Require Import List PeanoNat Lia Operators_Properties ConstructiveEpsilon.
+Import ListNotations.
+Require Import Undecidability.CounterMachines.CM2.
+Require Undecidability.CounterMachines.Deciders.CM2_UBOUNDED_dec.
+From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+Section Construction.
+
+Variable M : Cm2.
+
+#[local] Notation steps := (CM2.steps M).
+#[local] Notation mortal := (CM2.mortal M).
+#[local] Notation bounded := (bounded M).
+
+(* uniform bound *)
+Variable K : nat.
+Variable HK : forall x, bounded K x.
+
+Lemma pos_K : K = 1 + (K - 1).
+Proof using HK.
+  suff: K <> 0 by lia.
+  move=> H'K.
+  have := HK (0, (0, 0)). rewrite H'K.
+  move=> [[|L]].
+  - by move=> [_] /(_ (0, (0, 0)) (reaches_refl _)).
+  - move=> ? /=. lia.
+Qed.
+
+Lemma uniform_decision : (uniformly_mortal M) + (not (uniformly_mortal M)).
+Proof using HK.
+  have := Forall_dec (fun 'x => mortal K x) _
+    (list_prod (seq 0 (length M)) (list_prod (seq 0 (K+1)) (seq 0 (K+1)))).
+  case.
+  { move=> x. rewrite /(mortal K). by case: (steps K x) => [y|]; [right|left]. }
+  - move=> H'M. left. exists K => - [p [a b]].
+    have [?|?] : length M <= p \/ p < length M by lia.
+    { rewrite /(mortal K) pos_K /steps iter_plus /= /step /=.
+      have -> : nth_error M p = None by apply /nth_error_None.
+      by rewrite oiter_None. }
+    apply /mortal_K_bound.
+    move: H'M => /Forall_forall. apply.
+    apply /in_prod. { apply /in_seq. lia. }
+    apply /in_prod; apply /in_seq; lia.
+  - move=> H. right => - [K' H'M]. apply: H. apply /Forall_forall.
+    move=> [p [a b]] /in_prod_iff [/in_seq ?] /in_prod_iff [/in_seq ?] /in_seq ?.
+    by apply: (bounded_mortal_bound (HK _) (H'M _)).
+Qed.
+End Construction.
+
+(* informative decision statement for uniform boundedness for Cm2 *)
+Theorem decision (M: Cm2) : (uniformly_mortal M) + (not (uniformly_mortal M)).
+Proof.
+  case: (CM2_UBOUNDED_dec.decision M).
+  - move=> /constructive_indefinite_ground_description.
+    move=> /(_ id id ltac:(done) (CM2_UBOUNDED_dec.fixed_decision M)).
+    by move=> [K /uniform_decision].
+  - move=> H. right. move=> [k Hk]. apply: H. exists k => x.
+    apply: mortal_bounded. by apply: Hk.
+Qed.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for uniform mortality for Cm2 *)
+Definition decide : Cm2 -> bool :=
+  fun M =>
+    match decision M with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide CM2_UMORTAL.
+Proof.
+  rewrite /decider /reflects /decide => M.
+  case: (decision M); intuition done.
+Qed.

--- a/theories/CounterMachines/Util/CM2_facts.v
+++ b/theories/CounterMachines/Util/CM2_facts.v
@@ -1,46 +1,403 @@
-Require Import List Lia.
+Require Import List ListDec Lia PeanoNat Relation_Operators.
 Import ListNotations.
 
+Require Import Undecidability.CounterMachines.Util.Facts.
 Require Import Undecidability.CounterMachines.CM2.
-Require Import Undecidability.CounterMachines.Util.Nat_facts.
 
-Require Import ssreflect.
+Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
+Set Default Proof Using "Type".
 
-Lemma haltingP {cm c} : halting cm c <-> length cm <= state c.
+Definition path M k x := map (fun n => steps M n x) (seq 0 k).
+
+Lemma Config_eta (x : Config) : x = (state x, (value1 x, value2 x)).
+Proof. by move: x => [? [? ?]]. Qed.
+
+Lemma Config_eq_dec (x y : Config) : {x = y} + {x <> y}.
+Proof. by do ? decide equality. Qed.
+
+Lemma option_Config_eq_dec (x y : option Config) : {x = y} + {x <> y}.
+Proof. by do ? decide equality. Qed.
+
+Definition reaches_plus (M: Cm2) (x y: Config) := exists k, 0 < k /\ steps M k x = Some y.
+Definition non_terminating (M: Cm2) (x: Config) := forall k, steps M k x <> None.
+
+Section Facts.
+Context {M : Cm2}.
+
+#[local] Notation step := (CM2.step M).
+#[local] Notation steps := (CM2.steps M).
+#[local] Notation reaches := (CM2.reaches M).
+#[local] Notation reaches_plus := (reaches_plus M).
+#[local] Notation terminating := (CM2.terminating M).
+#[local] Notation non_terminating := (non_terminating M).
+#[local] Notation mortal := (CM2.mortal M).
+#[local] Notation bounded := (CM2.bounded M).
+#[local] Notation path := (path M).
+
+Lemma step_neq x : step x <> Some x.
 Proof.
-  move:c => [p a b]. rewrite /halting /=.
-  move Hoi: (nth_error cm p) => oi.
-  case: oi Hoi; last by move=> /nth_error_None.
-  move=> [] x => [|?] Hp /=.
-  - constructor; [by case; lia | by rewrite -nth_error_None Hp].
-  - move: x a b Hp => [] [|?] [|?]; 
-      (constructor; [by case; lia | by rewrite -nth_error_None Hp]).
+  rewrite /step. case: (nth_error M (state x)); last done.
+  move: x => [p [a b]] /=.
+  case.
+  - move=> ? []. lia.
+  - move: a b => [|a] [|b] [] ? []; lia.
+Qed. 
+
+Lemma steps_k_monotone {k x} k' : steps k x = None -> k <= k' -> steps k' x = None.
+Proof.
+  move=> + ?. have ->: k' = (k' - k) + k by lia.
+  elim: (k' - k); first done.
+  by move=> ? IH /IH /= ->.
 Qed.
 
-Lemma halting_eq {cm c n} : halting cm c -> Nat.iter n (step cm) c = c.
+Lemma reaches_refl x : reaches x x.
+Proof. by exists 0. Qed.
+
+Lemma step_reaches {x y} : step x = Some y -> reaches x y.
+Proof. move=> ?. by exists 1. Qed.
+
+Lemma step_reaches_plus {x y} : step x = Some y -> reaches_plus x y.
+Proof. move=> ?. exists 1. split; [lia|done]. Qed.
+
+Lemma steps_plus {k x k' y} :
+  steps k x = Some y -> steps (k + k') x = steps k' y.
+Proof. rewrite /steps iter_plus. by move=> ->. Qed.
+
+Lemma steps_sub {i j x y z} :
+  i <= j ->
+  steps i x = Some y ->
+  steps j x = Some z ->
+  steps (j-i) y = Some z.
 Proof.
-  move=> Hc. elim: n; first done.
-  move=> ? /= ->. by rewrite Hc.
+  move=> ? Hi. rewrite [in steps j x](ltac:(lia) : j = i + (j - i)).
+  by rewrite /steps iter_plus -/(steps _ _) Hi.
 Qed.
 
-(* halting is monotone *)
-Lemma halting_monotone {cm x} (n m: nat) : n <= m ->
-  halting cm (Nat.iter n (step cm) x) -> halting cm (Nat.iter m (step cm) x).
+Lemma step_None x : step x = None <-> nth_error M (state x) = None.
 Proof.
-  move=> ? ?. have -> : m = n + (m-n) by lia.
-  rewrite iter_plus. elim: (m-n); [done | by move=> * /=; congruence].
+  rewrite /step. case: (nth_error M (state x)) => [i|]; last done.
+  case: i; first done.
+  by move: (value1 x) (value2 x) => [|?] [|?] [].
 Qed.
 
-Lemma values_ub cm c n : 
-  value1 (Nat.iter n (CM2.step cm) c) + value2 (Nat.iter n (CM2.step cm) c) <= n + value1 c + value2 c.
+Lemma step_None' x : step x = None <-> length M <= state x.
+Proof. rewrite step_None. by apply: nth_error_None. Qed.
+
+Lemma reaches_plus_reaches {x y z} : reaches_plus x y -> reaches y z -> reaches_plus x z.
 Proof.
-  move Hk : (n + value1 c + value2 c) => k.
-  have : n + value1 c + value2 c <= k by lia.
-  elim: n k c {Hk}; first done.
-  move=> n IH k [p a b]. rewrite -/(1 + n) iter_plus /=. 
-  case: (nth_error cm p).
-  - move=> [] [] => [||?|?]; move: a b => [|?] [|?] /= ?; apply: IH => /=; by lia.
-  - move=> ?. apply: IH => /=. by lia.
+  move=> [k [? Hk]] [k' Hk']. exists (k+k'). split; first by lia.
+  move: Hk. by rewrite /steps iter_plus => ->.
 Qed.
+
+Lemma reaches_reaches_plus {x y z} : reaches x y -> reaches_plus y z -> reaches_plus x z.
+Proof.
+  move=> [k Hk] [k' [? Hk']]. exists (k+k'). split; first by lia.
+  move: Hk. by rewrite /steps iter_plus => ->.
+Qed.
+
+Lemma reaches_plus_incl {x y} : reaches_plus x y -> reaches x y.
+Proof. move=> [k [? Hk]]. by exists k. Qed.
+
+Lemma reaches_neq_incl {x y} : reaches x y -> x <> y -> reaches_plus x y.
+Proof.
+  move=> [[|k]]; first by move=> [->].
+  move=> ? _. exists (S k). split; [lia|done].
+Qed.
+
+Lemma reaches_terminating {x y} : reaches x y -> terminating y -> terminating x.
+Proof.
+  move=> [k Hk] [k' Hk']. exists (k+k').
+  move: Hk. by rewrite /steps iter_plus => ->.
+Qed.
+
+Lemma reaches_non_terminating {x y} : reaches x y -> non_terminating y -> non_terminating x.
+Proof.
+  move=> [k Hk] Hy k'.
+  have [|->] : k' <= k \/ k' = k + (k' - k) by lia.
+  - by move: Hk => + /steps_k_monotone H /H => ->.
+  - rewrite (steps_plus Hk). by apply: Hy.
+Qed.
+
+Lemma reaches_non_terminating' {x y} : reaches x y -> non_terminating x -> non_terminating y.
+Proof.
+  move=> [k' Hk'] Hx k Hk.
+  apply: (Hx (k' + k)).
+  by rewrite (steps_plus Hk').
+Qed.
+
+Lemma reaches_plus_state_bound {x y} : reaches_plus x y -> state x < length M.
+Proof.
+  move=> [k [? Hk]].
+  suff: not (length M <= state x) by lia.
+  move=> /nth_error_None Hx.
+  move: Hk. have ->: k = S (k - 1) by lia.
+  by rewrite /= obind_oiter /step Hx oiter_None.
+Qed.
+
+Lemma reaches_plus_trans {x y z} : reaches_plus x y -> reaches_plus y z -> reaches_plus x z.
+Proof. by move=> /reaches_plus_incl /reaches_reaches_plus H /H. Qed.
+
+Lemma reaches_trans {x y z} : reaches x y -> reaches y z -> reaches x z.
+Proof. move=> [k Hk] [k' Hk']. exists (k+k'). by rewrite (steps_plus Hk). Qed.
+
+Lemma reaches_plus_invariant_loop (P : Config -> Prop) :
+  (forall x, P x -> exists y, reaches_plus x y /\ P y) ->
+  forall x, P x -> non_terminating x.
+Proof.
+  move=> H x Hx k. elim: k x Hx; first done.
+  move=> k IH x /H [y] [[k' [? Hk']]] /IH Hk.
+  move=> /(steps_k_monotone (k' + k)) /(_ ltac:(lia)).
+  by rewrite (steps_plus Hk').
+Qed.
+
+Corollary reaches_plus_self_loop x : reaches_plus x x -> non_terminating x.
+Proof.
+  move=> ?. apply: (reaches_plus_invariant_loop (fun y => y = x)); last done.
+  move=> y ->. by exists x. 
+Qed.
+
+Lemma steps_loop_mod {K x k} : steps (S K) x = Some x ->
+  steps k x = steps (k mod (S K)) x.
+Proof.
+  rewrite [in steps k x](Nat.div_mod_eq k (S K)).
+  move: (k mod (S K)) => k' Hx. elim: (k / S K).
+  - congr steps. lia.
+  - move=> n IH. have ->: S K * S n + k' = S K + (S K * n + k') by lia.
+    by move: Hx => /steps_plus ->.
+Qed.
+
+Lemma step_values_bound x y : step x = Some y ->
+  value1 y + value2 y <= 1 + value1 x + value2 x /\
+  value1 x + value2 x <= 1 + value1 y + value2 y /\
+  value1 x <= 1 + value1 y /\ value1 y <= 1 + value1 x /\
+  value2 x <= 1 + value2 y /\ value2 y <= 1 + value2 x.
+Proof.
+  rewrite /step.
+  case: (nth_error M (state x)); last done.
+  case.
+  - move=> [] [<-] /=; lia.
+  - move=> [] ? [<-].
+    + case Hx: (value2 x) => [|?] /=; lia.
+    + case Hx: (value1 x) => [|?] /=; lia.
+Qed.
+
+Lemma steps_values_bound k x y : steps k x = Some y ->
+  value1 y + value2 y <= k + value1 x + value2 x /\
+  value1 x + value2 x <= k + value1 y + value2 y /\
+  value1 x <= k + value1 y /\ value1 y <= k + value1 x /\
+  value2 x <= k + value2 y /\ value2 y <= k + value2 x.
+Proof.
+  elim: k x. { move=> ? [<-]. lia. }
+  move=> k IH x. rewrite /= obind_oiter.
+  case Hxz: (step x) => [z|]; last by rewrite oiter_None.
+  move=> /IH.
+  move: Hxz => /step_values_bound. lia.
+Qed.
+
+Lemma bounded_monotone {k k' x} : k <= k' -> bounded k x -> bounded k' x.
+Proof. move=> ? [L [? ?]]. exists L. split; [lia|done]. Qed.
+
+#[local] Arguments Nat.min !n !m /.
+
+Lemma shift_steps k p a b :
+  steps k (p, (a, b)) =
+  match steps k (p, (Nat.min k a, Nat.min k b)) with
+  | Some (p', (a', b')) => Some (p', (a' + (a - k), b' + (b - k)))
+  | None => None
+  end.
+Proof.
+  set x := (p, (a, b)).
+  have ->: p = state x by done.
+  have ->: a = value1 x by done.
+  have ->: b = value2 x by done.
+  elim: k (x); clear x p a b.
+  { move=> [p [a b]] /=. congr (Some (_, (_, _))); lia. }
+  move=> k IH [p [a b]].
+  rewrite /steps /= ?obind_oiter /step -/step /=.
+  case: (nth_error M p); last by rewrite ?oiter_None.
+  case.
+  - move=> c. rewrite -?/(steps _ _).
+    rewrite [in LHS]IH [in RHS]IH /=.
+    set oy1 := (steps k _).
+    set oy2 := (steps k _).
+    have <- : oy1 = oy2.
+    { congr (steps k (_, (_, _))); move: (a) (b) (c) => [|?] [|?] [|] /=; lia. }
+    case: (oy1) => [[? [? ?]]|]; last done.
+    congr (Some (_, (_, _))); move: (a) (b) (c) => [|?] [|?] [|]; lia.
+  - move=> c q. rewrite -?/(steps _ _).
+    rewrite [in LHS]IH [in RHS]IH /=.
+    set oy1 := (steps k _).
+    set oy2 := (steps k _).
+    have <- : oy1 = oy2.
+    { congr (steps k (_, (_, _))); move: (a) (b) (c) => [|?] [|?] [|] /=; lia. }
+    case: (oy1) => [[? [? ?]]|]; last done.
+    congr (Some (_, (_, _))); move: (k) (a) (b) (c) => [|?] [|?] [|?] [|] /=; lia.
+Qed.
+
+Lemma mortal_K_bound K p a b :
+  mortal K (p, (a, b)) <-> mortal K (p, (Nat.min K a, Nat.min K b)).
+Proof.
+  rewrite /mortal (shift_steps K p a b).
+  by case: (steps K (p, (Nat.min K a, Nat.min K b))) => [[? [? ?]]|].
+Qed.
+
+(* path notion *)
+
+Lemma path_length {k x} : length (path k x) = k.
+Proof. by rewrite /path map_length seq_length. Qed.
+
+Lemma In_pathE K x oy : In oy (path K x) -> exists k, k < K /\ steps k x = oy.
+Proof.
+  move=> /in_map_iff [k] [<-] /in_seq ?.
+  exists k. split; [lia|done].
+Qed.
+
+Lemma In_pathI k x K : k < K -> In (steps k x) (path K x).
+Proof.
+  move=> ?. apply /in_map_iff. exists k. split; first done.
+  apply /in_seq. lia.
+Qed.
+
+Lemma path_S {k x} y : step x = Some y -> path (S k) x = (Some x) :: (path k y).
+Proof.
+  move=> Hxy. rewrite /path /= -seq_shift map_map.
+  congr cons. apply: map_ext => - ?.
+  by rewrite /= obind_oiter Hxy.
+Qed.
+
+Lemma path_plus {k k' x} y : steps k x = Some y ->
+  path (k+k') x = path k x ++ path k' y.
+Proof.
+  move=> Hxy. rewrite /path seq_app map_app /=.
+  congr app.
+  have ->: seq k k' = map (fun i => k+i) (seq 0 k').
+  { elim: k'; first done.
+    move=> k' IH. have ->: S k' = k' + 1 by lia.
+    by rewrite ?seq_app IH map_app. }
+  rewrite map_map. apply: map_ext => - ?.
+  by move: Hxy => /steps_plus ->.
+Qed.
+
+Lemma path_S_last {k x} : path (S k) x = (path k x) ++ [steps k x].
+Proof. by rewrite /path seq_S map_app. Qed.
+
+Lemma path_loopE K x : In (steps K x) (path K x) -> 
+  forall k, In (steps k x) (path K x).
+Proof.
+  elim: K x; first done.
+  move=> K IH x. rewrite [steps _ _]/= obind_oiter.
+  case Hxz: (step x) => [z|].
+  - move=> H. rewrite (path_S z Hxz) /= in H. case: H.
+    + move=> Hzx k. have /steps_loop_mod -> : steps (S K) x = Some x.
+      { by rewrite /steps /= obind_oiter Hxz. }
+      by apply /In_pathI /(Nat.mod_upper_bound k (S K)).
+    + rewrite (path_S z Hxz).
+      move=> /IH {}IH [|k]; first by left.
+      rewrite /= obind_oiter Hxz. right. by apply: IH.
+  - rewrite oiter_None. move=> /in_map_iff [k] [Hk] /in_seq HK.
+    move=> k'. have [|Hkk'] : k' < k \/ k <= k' by lia.
+    + move=> ?. apply: In_pathI. lia.
+    + move: (Hk) => /(steps_k_monotone k') /(_ Hkk') ->.
+      rewrite -Hk. apply: In_pathI. lia.
+Qed.
+
+Lemma path_loopE' K x : In (steps K x) (path K x) -> 
+  forall y, reaches x y -> In (Some y) (path K x).
+Proof.
+  move=> /path_loopE H y [k] H'. move: (H k).
+  by congr In.
+Qed.
+
+Lemma loop_bounded K x : In (steps K x) (path K x) -> bounded K x.
+Proof.
+  move=> /path_loopE' H. 
+  exists (map (fun oy => if oy is Some y then y else x) (path K x)).
+  split. { by rewrite map_length path_length. }
+  move=> y /H {}H. apply /in_map_iff. by exists (Some y).
+Qed.
+
+Lemma path_noloopI k x :
+  ~ In (steps k x) (path k x) -> NoDup (path (k + 1) x).
+Proof.
+  elim: k x.
+  { move=> ??. constructor; [done| constructor]. }
+  move=> k IH x.
+  rewrite path_S_last /steps in_app_iff /= -/(steps k x).
+  move=> /Decidable.not_or.
+  have [|/IH ?] := In_dec option_Config_eq_dec (steps k x) (path k x).
+  - move=> /path_loopE /(_ (S k)). tauto.
+  - move=> [?] ?.
+    apply /(NoDup_Add (a := steps (S k) x) (l := path (k + 1) x)).
+    + rewrite path_S_last.
+      have := Add_app (steps (k + 1) x) (path (k + 1) x) [].
+      congr Add.
+      * congr steps. lia.
+      * by rewrite app_nil_r.
+    + constructor; first done.
+      have ->: k + 1 = S k by lia.
+      rewrite path_S_last in_app_iff /=. tauto.
+Qed.
+
+Lemma mortal_bounded {K x} : steps K x = None -> bounded K x.
+Proof.
+  move=> HK.
+  exists (map (fun oy => if oy is Some y then y else x) (path K x)).
+  split. { by rewrite map_length path_length. }
+  move=> y [k]. have [?|?] : k < K \/ K <= k by lia.
+  - move=> Hk. apply /in_map_iff. exists (Some y).
+    split; first done.
+    rewrite -Hk. by apply: In_pathI.
+  - by move: HK => /(steps_k_monotone k) /(_ ltac:(lia)) ->.
+Qed.
+
+Lemma In_None_pathE k x :
+  In None (path k x) -> steps k x = None.
+Proof.
+  move=> /In_pathE [k' [?]] /(steps_k_monotone k). apply. lia.
+Qed.
+
+Lemma NoDup_not_bounded {K x y} : 
+  steps K x = Some y -> NoDup (path (K + 1) x) -> not (bounded K x).
+Proof.
+  move=> Hxy HK [L [? HL]].
+  apply: (pigeonhole (path (K+1) x) (map Some L)).
+  - move=> [z|] /in_map_iff [k] [Hk] /in_seq ?.
+    { apply /in_map_iff. exists z. split; first done.
+      apply: HL. by exists k. }
+    by move: Hk Hxy => /(steps_k_monotone K) /(_ ltac:(lia)) ->.
+  - rewrite map_length path_length. lia.
+  - done.
+Qed.
+
+Lemma boundedE {K x} : bounded K x ->
+  (In (steps K x) (path K x)) + (steps K x = None).
+Proof.
+  move=> HK.
+  case Hy: (steps K x) => [y|]; last by right.
+  have [?|] := In_dec option_Config_eq_dec (Some y) (path K x).
+  { by left. }
+  rewrite -Hy. move=> /path_noloopI /NoDup_not_bounded.
+  by move=> /(_ y Hy HK).
+Qed.
+
+Lemma reaches_bounded {K k x y} : steps k x = Some y -> bounded K y -> bounded (k+K) x.
+Proof.
+  move=> Hxy /boundedE [HK|HK].
+  - apply: loop_bounded.
+    move: Hxy (Hxy) => /path_plus -> /steps_plus ->.
+    apply /in_app_iff. by right.
+  - apply: mortal_bounded.
+    by move: Hxy => /steps_plus ->.
+Qed.
+
+Lemma bounded_mortal_bound {K k x} : bounded K x -> mortal k x -> mortal K x.
+Proof.
+  rewrite /mortal => /boundedE + Hk.
+  case; last done.
+  move=> /path_loopE /(_ k).
+  by rewrite Hk => /In_None_pathE.
+Qed.
+
+End Facts.

--- a/theories/CounterMachines/Util/Facts.v
+++ b/theories/CounterMachines/Util/Facts.v
@@ -1,0 +1,150 @@
+Require Import Lia List PeanoNat Permutation.
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+(* transforms a goal (A -> B) -> C into goals A and B -> C *)
+Lemma unnest : forall (A B C : Type), A -> (B -> C) -> (A -> B) -> C.
+Proof. auto. Qed.
+
+(* induction principle wrt. a decreasing measure f *)
+(* example: elim /(measure_ind length) : l. *)
+Lemma measure_ind {X : Type} (f : X -> nat) (P : X -> Prop) : 
+  (forall x, (forall y, f y < f x -> P y) -> P x) -> forall (x : X), P x.
+Proof.
+  apply : well_founded_ind.
+  apply : Wf_nat.well_founded_lt_compat. move => *. by eassumption.
+Qed.
+Arguments measure_ind {X}.
+
+Lemma prod_nat_nat_eq_dec (x y : nat * nat) : {x = y} + {x <> y}.
+Proof. by do ? decide equality. Qed.
+
+Lemma eq_or_inf {X: Type} : (forall (x y: X), {x = y} + {x <> y}) ->
+  forall (x y: X) P, (x = y) \/ P -> (x = y) + P.
+Proof.
+  move=> H x y P. case: (H x y).
+  - move=> ??. by left.
+  - move=> ??. right. tauto.
+Qed.
+
+Lemma iter_plus {X} (f : X -> X) (x : X) n m : Nat.iter (n + m) f x = Nat.iter m f (Nat.iter n f x).
+Proof.
+  elim: m; first by rewrite Nat.add_0_r.
+  move=> m /= <-. by have ->: n + S m = S n + m by lia.
+Qed.
+
+Lemma Exists_sig {X : Type} P (HP : (forall x, {P x} + {~ P x})) (L : list X) :
+  Exists P L -> { x | In x L /\ P x}.
+Proof.
+  elim: L. { by move=> /Exists_nil. }
+  move=> x L IH /Exists_cons H.
+  have [/IH|?] := Exists_dec P L HP.
+  - move=> [y [? ?]]. exists y. by split; [right|].
+  - exists x. by split; [left|tauto].
+Qed.
+
+Lemma list_sum_map_le {X: Type} f g (L: list X) :
+  (forall x, f x <= g x) ->
+  list_sum (map f L) <= list_sum (map g L).
+Proof.
+  move=> Hfg. elim: L; first done.
+  move=> x L IH /=. have := Hfg x. lia.
+Qed.
+
+Lemma list_sum_map_lt {X: Type} {f g} {L: list X} {x} :
+  (forall x, f x <= g x) ->
+  In x L -> f x < g x ->
+  list_sum (map f L) < list_sum (map g L).
+Proof.
+  move=> Hfg + H'fg. elim: L; first done.
+  move=> y L IH /= [->|].
+  - have := list_sum_map_le f g L Hfg. lia.
+  - move=> /IH. have := Hfg y. lia.
+Qed.
+
+Lemma oiter_None {X : Type} (f : X -> option X) k : Nat.iter k (obind f) None = None.
+Proof. elim: k; [done | by move=> /= ? ->]. Qed.
+
+Lemma obind_oiter {X : Type} (f : X -> option X) k x : 
+  obind f (Nat.iter k (obind f) (Some x)) = Nat.iter k (obind f) (f x).
+Proof. elim: k; [done|by move=> k /= ->]. Qed.
+
+Lemma NoDup_map_ext {X Y : Type} (f : X -> Y) (l : list X) :
+  (forall x1, In x1 l -> forall x2, In x2 l -> f x1 = f x2 -> x1 = x2) -> NoDup l -> NoDup (map f l).
+Proof.
+  elim: l. { move=> *. by constructor. }
+  move=> x l IH /= H /NoDup_cons_iff [Hxl] /IH {}IH. constructor.
+  - move=> /in_map_iff [x'] [/H] ? Hx'l. have ? : x' = x by tauto.
+    subst x'. exact: (Hxl Hx'l).
+  - apply: IH. move=> x1 Hx1l x2 Hx2l /H. tauto.
+Qed.
+
+Lemma nth_error_seq {i start len} :
+  i < len -> nth_error (seq start len) i = Some (start + i).
+Proof.
+  elim: len i start; first by lia.
+  move=> len IH [|i] start.
+  { move=> ?. congr Some. lia. }
+  move=> ?. rewrite /= IH; first by lia.
+  congr Some. lia.
+Qed.
+
+(* variant of the pigeonhole principle *)
+Lemma pigeonhole {X : Type} (L L' : list X) :
+  incl L L' -> length L' < length L -> not (NoDup L).
+Proof.
+  move=> ?? HL. suff: length L = length L' by lia.
+  apply /Permutation_length /NoDup_Permutation_bis; by [|lia].
+Qed.
+
+Section DiscreteList.
+
+Context {X : Type} (X_eq_dec : forall (x y : X), {x = y} + {x <> y}).
+
+Lemma not_NoDup_consE {x} {l: list X} : (not (NoDup (x :: l))) -> In x l \/ not (NoDup l).
+Proof using X_eq_dec.
+  have [?|?] := In_dec X_eq_dec x l.
+  { move=> ?. by left. }
+  move=> Hxl. right => Hl. apply: Hxl.
+  by constructor.
+Qed.
+
+Lemma not_NoDupE {l : list X} : not (NoDup l) -> 
+  exists '(i, j), i < j < length l /\ nth_error l i = nth_error l j.
+Proof using X_eq_dec.
+  elim: l. { move=> H. exfalso. apply: H. by constructor. }
+  move=> x l IH.
+  move=> /not_NoDup_consE [|].
+  - move=> /(@In_nth_error X) [j] Hj.
+    have ? : not (length l <= j).
+    { move=> /nth_error_None. by rewrite Hj. }
+    exists (0, S j) => /=. split; [lia|done].
+  - move=> /IH [[i j]] [? ?].
+    exists (S i, S j) => /=. split; [lia|done].
+Qed.
+
+Lemma not_inclE (L L' : list X) : (not (incl L L')) -> { x | In x L /\ not (In x L')}.
+Proof using X_eq_dec.
+  elim: L. { move=> H. exfalso. by apply: H. }
+  move=> x L IH /=.
+  have [|?] := In_dec X_eq_dec x L'.
+  - move=> ? HxLL'. have /IH [y [? ?]] : ~ incl L L'.
+    { move=> H. apply: HxLL'. by move=> y /= [<-|/H]. }
+    exists y. tauto.
+  - move=> _. exists x. tauto.
+Qed.
+
+(* explicit duplicates in a mapped sequence *)
+Lemma dup_seq (f : nat -> X) start len :
+  not (NoDup (map f (seq start len))) ->
+  exists '(i, j), f i = f j /\ (start <= i /\ i < j /\ j < start+len).
+Proof using X_eq_dec.
+  move=> /not_NoDupE [[i j]]. rewrite map_length seq_length.
+  move=> [? H]. exists (start+i, start+j). split; last lia.
+  move: H. rewrite ?nth_error_map ?nth_error_seq; [lia|lia|].
+  by move=> [].
+Qed.
+
+End DiscreteList.

--- a/theories/MinskyMachines/Deciders/MM_2_HALTING_dec.v
+++ b/theories/MinskyMachines/Deciders/MM_2_HALTING_dec.v
@@ -1,0 +1,265 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Two-counter Minsky Machine Halting (MM_2_HALTING)
+*)
+
+Require Import PeanoNat Lia List.
+Import ListNotations.
+
+Require Import Undecidability.MinskyMachines.MM.
+Require Undecidability.MinskyMachines.Deciders.MPM2_HALT_dec.
+Module MPM2 := MPM2_HALT_dec.
+
+From Undecidability.Shared.Libs.DLW
+  Require Import Vec.pos Vec.vec Code.sss.
+
+Require Import Undecidability.CounterMachines.Util.Facts.
+
+Require Import ssreflect ssrbool ssrfun.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+#[local] Notation "P // s ↓" := (sss_terminates (@mm_sss _) P s).
+#[local] Notation "P // r ->> s" := (sss_compute (@mm_sss _) P r s).
+
+Section Construction.
+Context (P : list (mm_instr (pos 2))).
+
+Lemma decompose_vec2 {X : Type} (v : vec X 2) : v = vec_head v ## vec_head (vec_tail v) ## vec_nil.
+Proof.
+  by rewrite [LHS](vec_head_tail v) [in LHS](vec_head_tail (vec_tail v)) [in LHS](vec_0_nil (vec_tail (vec_tail v))).
+Qed.
+
+Lemma case_pos2 (v : pos 2) : (v = Fin.F1) + (v = Fin.FS Fin.F1).
+Proof.
+  have [?|] := pos_S_inv v; first by left.
+  move=> [w] ->. right.
+  have [->|] := pos_S_inv w; first done.
+  move=> [?]. exfalso. by apply: pos_O_inv.
+Qed.
+
+Definition to_Instruction (i : mm_instr (pos 2)) : MPM2.Instruction :=
+  match i with
+  | INC d => MPM2.inc (if case_pos2 d then false else true)
+  | DEC d p => MPM2.dec (if case_pos2 d then false else true) (if p is S q then q else length P)
+  end.
+
+Definition to_Config (s : mm_state 2) : MPM2.Config :=
+  match s with
+  | (S p, Vector.cons _ a _ (Vector.cons _ b _ _)) => (p, (a, b))
+  | (0, Vector.cons _ a _ (Vector.cons _ b _ _)) => (length P, (a, b))
+  | _ => (0, (0, 0))
+  end.
+
+(* corresponding Mpm 2 *)
+Definition M := map to_Instruction P.
+
+Lemma P_to_M_step s t : sss_step (@mm_sss _) (1, P) s t -> MPM2.step M (to_Config s) = Some (to_Config t).
+Proof.
+  rewrite /sss_step.
+  move=> [k] [P1] [i] [P2] [v] [[<- HP]] [->].
+  rewrite /MPM2.step.
+  have -> : nth_error M (MPM2.state (to_Config (1 + length P1, v))) = Some (to_Instruction i).
+  { rewrite /M HP map_app (decompose_vec2 v) nth_error_app2.
+    { by rewrite /= map_length. }
+    by rewrite /= map_length Nat.sub_diag. }
+  move Hc: (1 + length P1, v) => c H.
+  case: H Hc.
+  - move=> ? d w [<- <-]. rewrite [to_Instruction _]/= (decompose_vec2 v).
+    by case: (case_pos2 d) => /= ->.
+  - move=> ? d q w + [<- ?]. subst w. rewrite (decompose_vec2 v) /=.
+    case: (case_pos2 d).
+    + move=> /= -> ->. by case: q.
+    + move=> /= -> ->. by case: q.
+  - move=> ? d q w u + [<- ?]. subst w. rewrite (decompose_vec2 v) /=.
+    case: (case_pos2 d).
+    + by move=> /= -> ->.
+    + by move=> /= -> ->.
+Qed.
+
+Lemma P_to_M s t : ((1, P) // s ->> t) ->
+  exists n, Nat.iter n (obind (MPM2.step M)) (Some (to_Config s)) = Some (to_Config t).
+Proof.
+  move=> [n Hn]. exists n.
+  elim: n s Hn. { by move=> s /sss_steps_0_inv <-. }
+  move=> n IH s /sss_steps_S_inv' [u] [/P_to_M_step Hsu] /IH {}IH.
+  by rewrite /= obind_oiter Hsu.
+Qed.
+
+Lemma M_to_P_step s y : MPM2.step M (to_Config s) = Some y ->
+  exists t, y = to_Config t /\ sss_step (@mm_sss _) (1, P) s t.
+Proof.
+  rewrite /MPM2.step. case Hi: (nth_error M (MPM2.state (to_Config s))) => [i|]; last done.
+  case: i Hi.
+  - done.
+  - rewrite /M. move=> ? /(@nth_error_In MPM2.Instruction) /in_map_iff.
+    by move=> [[]] /= => [?|??] [].
+  - move=> c. rewrite /M nth_error_map.
+    case Hi: (nth_error P (MPM2.state (to_Config s))) => [i|]; last done.
+    move: Hi => /(@nth_error_split (mm_instr _)) [P1] [P2] [HP HP1] [Hi] [<-].
+    move: s HP1 => [p v] HP1.
+    have Hp : p = S (p - 1).
+    { move: p HP1 => [|p].
+      { rewrite (decompose_vec2 v) /= HP app_length /=. lia. }
+      move=> ? /=. lia. }
+    exists (S (S (MPM2.state (to_Config (p, v)))),
+      ((if c then 0 else 1) + MPM2.value1 (to_Config (p, v))) ##
+      ((if c then 1 else 0) + MPM2.value2 (to_Config (p, v))) ##
+      vec_nil).
+    split; first done.
+    exists 1, P1, i, P2, v.
+    split; first by congr pair.
+    split. 
+    { move: HP1. by rewrite (decompose_vec2 v) Hp /= => <-. }
+    have -> : i = INC (if c then pos1 else pos0).
+    { move: i Hi {HP} => []; last done. move=> d /=.
+      by case: (case_pos2 d) => /= -> [<-]. }
+    have := @in_mm_sss_inc 2 p (if c then pos1 else pos0) v.
+    congr mm_sss. congr pair. { by rewrite (decompose_vec2 v) Hp. }
+    case: c {Hi}.
+    + by rewrite (decompose_vec2 v) Hp /=.
+    + by rewrite (decompose_vec2 v) Hp /=.
+  - move=> c q.
+    rewrite /M nth_error_map.
+    case Hi: (nth_error P (MPM2.state (to_Config s))) => [i|]; last done.
+    move: Hi => /(@nth_error_split (mm_instr _)) [P1] [P2] [HP HP1] [Hi] [<-].
+    move: s HP1 => [p v] HP1.
+    have Hp : p = S (p - 1).
+    { move: p HP1 => [|p].
+      { rewrite (decompose_vec2 v) /= HP app_length /=. lia. }
+      move=> ? /=. lia. }
+    move: HP1. rewrite (decompose_vec2 v) Hp /= => HP1.
+    move: i HP Hi => [] /=; first done.
+    move=> d r.
+    move: (case_pos2 d) => [|] /= -> HP [] <- <-.
+    + exists (if (vec_head v) is S a then
+        (S p, a ## vec_head (vec_tail v) ## vec_nil) else 
+        (r, 0 ## vec_head (vec_tail v) ## vec_nil)).
+      split.
+      { case: (vec_head v).
+        - by case: (r).
+        - move=> ?. by rewrite [in to_Config _]Hp /to_Config. }
+      case Hv: (vec_head v) => [|a].
+      * exists 1, P1, (DEC pos0 r), P2, v.
+        split; first by congr pair.
+        split. 
+        { by rewrite [in (_, v)](decompose_vec2 v) /= HP1 Hv. }
+        have := @in_mm_sss_dec_0 2 p pos0 r v.
+        rewrite [in vec_pos v](decompose_vec2 v) /=.
+        move=> /(_ Hv).
+        by congr mm_sss; rewrite -?Hp [in (_, v)](decompose_vec2 v) Hv.
+      * exists 1, P1, (DEC pos0 r), P2, v.
+        split; first by congr pair.
+        split. 
+        { by rewrite [in (_, v)](decompose_vec2 v) /= HP1 Hv. }
+        have := @in_mm_sss_dec_1 2 p pos0 r v.
+        rewrite [in vec_pos v](decompose_vec2 v) /=.
+        move=> /(_ a Hv).
+        congr mm_sss; rewrite -?Hp.
+        ** by rewrite -Hv -(decompose_vec2 v).
+        ** by rewrite [in vec_change v](decompose_vec2 v).
+    + exists (if (vec_head (vec_tail v)) is S b then
+        (S p, vec_head v ## b ## vec_nil) else 
+        (r, vec_head v ## 0 ## vec_nil)).
+      split.
+      { case: (vec_head (vec_tail v)).
+        - by case: (r).
+        - move=> ?. by rewrite [in to_Config _]Hp /to_Config. }
+      case Hv: (vec_head (vec_tail v)) => [|b].
+      * exists 1, P1, (DEC pos1 r), P2, v.
+        split; first by congr pair.
+        split. 
+        { by rewrite [in (_, v)](decompose_vec2 v) /= HP1 Hv. }
+        have := @in_mm_sss_dec_0 2 p pos1 r v.
+        rewrite [in vec_pos v](decompose_vec2 v) /=.
+        move=> /(_ Hv).
+        by congr mm_sss; rewrite -?Hp [in (_, v)](decompose_vec2 v) Hv.
+      * exists 1, P1, (DEC pos1 r), P2, v.
+        split; first by congr pair.
+        split. 
+        { by rewrite [in (_, v)](decompose_vec2 v) /= HP1 Hv. }
+        have := @in_mm_sss_dec_1 2 p pos1 r v.
+        rewrite [in vec_pos v](decompose_vec2 v) /=.
+        move=> /(_ b Hv).
+        congr mm_sss; rewrite -?Hp.
+        ** by rewrite -Hv -(decompose_vec2 v).
+        ** by rewrite [in vec_change v](decompose_vec2 v).
+Qed.
+
+Lemma M_to_P n s y : Nat.iter n (obind (MPM2.step M)) (Some (to_Config s)) = Some y ->
+  exists t, y = to_Config t /\ ((1, P) // s ->> t).
+Proof.
+  move=> Hn.
+  suff : exists t : mm_state 2, y = to_Config t /\ sss_steps (@mm_sss _) (1, P) n s t.
+  { move=> [t] [? ?]. exists t. split; [done|by exists n]. }
+  elim: n s Hn.
+  { move=> s [<-]. exists s. split; first done. by apply: sss_steps_0. }
+  move=> n IH s /=. rewrite obind_oiter.
+  case Hz: (MPM2.step M (to_Config s)) => [z|]; last by rewrite oiter_None.
+  move: Hz => /M_to_P_step [u] [->] Hsu.
+  move=> /IH [t] [? ?]. exists t.
+  split; first done. have ->: S n = 1 + n by done.
+  apply: sss_steps_trans; last by eassumption.
+  by apply: sss_steps_1.
+Qed.
+
+#[local] Arguments to_Config : simpl never.
+
+(* informative decision statement for halting for Mm2 *)
+Lemma decision (v: vec nat 2) : ((1, P) // (1, v) ↓) + (not ((1, P) // (1, v) ↓)).
+Proof.
+  have [H|H] := MPM2.decision M (to_Config (1, v)).
+  - left. move: H => [n]. elim: n; first done.
+    move=> n IH /=.
+    case Hy: (MPM2.steps M n (to_Config (1, v))) => [y|].
+    + move: Hy => /M_to_P [t] [->] Ht H't.
+      exists t. split; first done.
+      move: t {Ht} H't => [[|p] w] /=; first by lia.
+      rewrite (decompose_vec2 w) /to_Config /= /MPM2.step /=.
+      case Hi: (nth_error M p) => [i|]; first last.
+      { move: Hi => /nth_error_None. rewrite /M map_length. lia. }
+      case: i Hi; [|done..].
+      move=> /(@nth_error_In MPM2.Instruction) /in_map_iff.
+      by move=> [[]] => [?|??] [].
+    + by move: (IH Hy).
+  - right. move=> [t] [/=] /P_to_M [n] Hn Ht.
+    apply: (H (S n)).
+    rewrite /= /MPM2.steps Hn.
+    move: t Ht {Hn} => [[|p] w].
+    + rewrite /= /MPM2.step /to_Config (decompose_vec2 w) /=.
+      suff ->: nth_error M (length P) = None by done.
+      apply /nth_error_None. by rewrite /M map_length.
+    + move=> /= [|?]; first by lia.
+      rewrite /= /MPM2.step /to_Config (decompose_vec2 w) /=.
+      suff ->: nth_error M p = None by done.
+      apply /nth_error_None. rewrite /M map_length. lia.
+Qed.
+
+End Construction.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for the halting problem for MM with two counters *)
+Definition decide : { P : list (mm_instr (pos 2)) & vec nat 2 } -> bool :=
+  fun '(existT _ P v) =>
+    match decision P v with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide MM_2_HALTING.
+Proof.
+  rewrite /decider /reflects /decide => - [P v].
+  case: (decision P v).
+  - tauto.
+  - move=> H. split; [by move=> /H | done].
+Qed.

--- a/theories/MinskyMachines/Deciders/MPM2_HALT_dec.v
+++ b/theories/MinskyMachines/Deciders/MPM2_HALT_dec.v
@@ -1,0 +1,565 @@
+(*
+  Autor(s):
+    Andrej Dudenhefner (1)
+  Affiliation(s):
+    (1) TU Dortmund University, Dortmund, Germany
+*)
+
+(*
+  Decision Procedure(s):
+    Two-counter Minsky Program Machine Halting (MPM2_HALT) [1, Chapter 11.1]
+*)
+
+(*
+  Literature:
+    [1] Minsky, Marvin Lee. Computation. Englewood Cliffs: Prentice-Hall, 1967. (Chapter 11.1)
+*)
+
+Require Import List ssrfun.
+
+(* a configuration consists of a state and two counter values *)
+Definition Config : Set := nat * (nat * nat).
+
+(* accessors for state, value1, value2 of configurations *)
+Definition state (x: Config) : nat := fst x.
+Arguments state !x /.
+Definition value1 (x: Config) : nat := fst (snd x).
+Arguments value1 !x /.
+Definition value2 (x: Config) : nat := snd (snd x).
+Arguments value2 !x /.
+
+(* the instruction zero true maps 
+      a configuration (p, (v1, v2)) to (1+p, (v1, 0))
+    the instruction zero false maps 
+      a configuration (p, (v1, v2)) (1+p, (0, v2))
+    the instruction inc true maps 
+      a configuration (p, (v1, v2)) to (1+p, (v1, 1+v2))
+    the instruction inc false maps 
+      a configuration (p, (v1, v2)) (1+p, (1+v1, v2))
+    an instruction dec true q maps
+      a configuration (p, (v1, 0)) to (q, (v1, 0)) 
+      a configuration (p, (v1, 1+v2)) to (1+p, (v1, v2)) 
+    an instruction dec false q maps
+      a configuration (p, (0, v2)) to (q, (0, v2)) 
+      a configuration (p, (1+v1, v2)) to (1+p, (v1, v2)) *)
+Inductive Instruction : Set :=
+  | halt : Instruction
+  | zero : bool -> Instruction
+  | inc : bool -> Instruction
+  | dec : bool -> nat -> Instruction.
+
+(* a two counter machine is a list of instructions *)
+Definition Mpm2 : Set := list Instruction.
+
+(* partial two counter Minsky machine step function *)
+Definition step (M: Mpm2) (x: Config) : option Config :=
+  match nth_error M (state x) with
+  | None => None (* halting configuration *)
+  | Some halt => None (* halting instruction *)
+  | Some (zero b) => (* set counter to zero, goto next state*)
+    Some (1 + (state x), ((if b then (value1 x) else 0), (if b then 0 else (value2 x))))
+  | Some (inc b) => (* increase counter, goto next state*)
+    Some (1 + (state x), ((if b then 0 else 1) + (value1 x), (if b then 1 else 0) + (value2 x)))
+  | Some (dec b y) => (* decrease counter, goto next state; if unsuccessful goto state y *)
+    Some (
+      if b then 
+        match value2 x with
+        | 0 => (y, (value1 x, 0))
+        | S n => (1 + (state x), (value1 x, n))
+        end
+      else
+        match value1 x with
+        | 0 => (y, (0, value2 x))
+        | S n => (1 + (state x), (n, value2 x))
+        end)
+  end.
+
+Definition steps (M: Mpm2) (n: nat) (x: Config) : option Config :=
+  Nat.iter n (obind (step M)) (Some x).
+
+(* does M eventually terminate starting from the configuration x? *)
+Definition terminating (M: Mpm2) (x: Config) :=
+  exists n, steps M n x = None.
+
+(* Two-counter Minsky Program Machine Halting Problem:
+   Given a two-counter Minsky program machine M and a configucation c, 
+   does a run in M starting from c eventually terminate? *)
+Definition MPM2_HALT : Mpm2 * Config -> Prop :=
+  fun '(M, c) => terminating M c.
+
+Require Import List PeanoNat Lia Operators_Properties.
+Import ListNotations.
+Require Import ssreflect ssrbool ssrfun.
+Require Import Undecidability.CounterMachines.Util.Facts.
+
+Set Default Goal Selector "!".
+Set Default Proof Using "Type".
+
+Section Construction.
+Variable M : Mpm2.
+
+#[local] Notation step := (step M).
+#[local] Notation steps := (steps M).
+#[local] Notation terminating := (terminating M).
+#[local] Notation l := (length M).
+
+(* after k steps values change at most by k (or are reset and at most k) *)
+Lemma steps_bound {k p a b p' a' b'} : steps k (p, (a, b)) = Some (p', (a', b')) -> 
+  a' <= k + a /\ b' <= k + b /\ (a' <= k \/ a <= k + a') /\ (b' <= k \/ b <= k + b').
+Proof.
+  elim: k p' a' b'.
+  { move=> p' a' b' /= []. lia. }
+  move=> k + p' a' b' /=.
+  case: (steps k (p, (a, b))) => [[p'' [a'' b'']]|]; last done.
+  move=> /(_ p'' a'' b'' ltac:(done)) IH.
+  rewrite /= /(step _).
+  case: (nth_error M (state (p'', (a'', b'')))); last done.
+  case.
+  - done.
+  - case; case; lia.
+  - case; case; lia.
+  - case => q /=.
+    + move: b'' IH => [|b''] ? []; lia.
+    + move: a'' IH => [|a''] ? []; lia.
+Qed.
+
+Definition reaches (x y: Config) := exists k, steps k x = Some y.
+Definition reaches_plus (x y: Config) := exists k, 0 < k /\ steps k x = Some y.
+Definition non_terminating x := forall k, steps k x <> None.
+
+Lemma reaches_plus_reaches {x y z} : reaches_plus x y -> reaches y z -> reaches_plus x z.
+Proof.
+  move=> [k [? Hk]] [k' Hk']. exists (k+k'). split; first by lia.
+  move: Hk. by rewrite /steps iter_plus => ->.
+Qed.
+
+Lemma reaches_reaches_plus {x y z} : reaches x y -> reaches_plus y z -> reaches_plus x z.
+Proof.
+  move=> [k Hk] [k' [? Hk']]. exists (k+k'). split; first by lia.
+  move: Hk. by rewrite /steps iter_plus => ->.
+Qed.
+
+Lemma reaches_plus_incl {x y} : reaches_plus x y -> reaches x y.
+Proof. move=> [k [? Hk]]. by exists k. Qed.
+
+Lemma reaches_terminating {x y} : reaches x y -> terminating y -> terminating x.
+Proof.
+  move=> [k Hk] [k' Hk']. exists (k+k').
+  move: Hk. by rewrite /steps iter_plus => ->.
+Qed.
+
+Lemma steps_k_monotone {k x} k' : steps k x = None -> k <= k' -> steps k' x = None.
+Proof.
+  move=> + ?. have ->: k' = (k' - k) + k by lia.
+  elim: (k' - k); first done.
+  by move=> ? IH /IH /= ->.
+Qed.
+
+Lemma steps_plus {k x k' y} :
+steps k x = Some y -> steps (k + k') x = steps k' y.
+Proof. rewrite /steps iter_plus. by move=> ->. Qed.
+
+Lemma reaches_non_terminating {x y} : reaches x y -> non_terminating y -> non_terminating x.
+Proof.
+  move=> [k Hk] Hy k'.
+  have [|->] : k' <= k \/ k' = k + (k' - k) by lia.
+  - by move: Hk => + /steps_k_monotone H /H => ->.
+  - rewrite (steps_plus Hk). by apply: Hy.
+Qed.
+
+Lemma reaches_non_terminating' {x y} : reaches x y -> non_terminating x -> non_terminating y.
+Proof.
+  move=> [k' Hk'] Hx k Hk.
+  apply: (Hx (k' + k)).
+  by rewrite (steps_plus Hk').
+Qed.
+
+Lemma reaches_plus_state_bound {x y} : reaches_plus x y -> state x < l.
+Proof.
+  move=> [k [? Hk]].
+  suff: not (l <= state x) by lia.
+  move=> /nth_error_None Hx.
+  move: Hk. have ->: k = S (k - 1) by lia.
+  by rewrite /= obind_oiter /step Hx oiter_None.
+Qed.
+
+Lemma reaches_plus_trans {x y z} : reaches_plus x y -> reaches_plus y z -> reaches_plus x z.
+Proof. by move=> /reaches_plus_incl /reaches_reaches_plus H /H. Qed.
+
+Lemma reaches_trans {x y z} : reaches x y -> reaches y z -> reaches x z.
+Proof. move=> [k Hk] [k' Hk']. exists (k+k'). by rewrite (steps_plus Hk). Qed.
+
+(* a configuration (p, (a, b))
+  is either halting or uniformly transitions into a configuration with one zero counter *)
+Lemma next_waypoint p a b :
+  terminating (p, (a, b)) +
+  { '(p', a') | forall n, exists k, 0 < k <= l - p /\ steps k (p, (n+a, b)) = Some (p', (n+a', 0)) } +
+  { '(p', b') | forall n, exists k, 0 < k <= l - p /\ steps k (p, (a, n+b)) = Some (p', (0, n+b')) }.
+Proof.
+  move Hn: (l - p) => n. elim: n p Hn a b.
+  { move=> p ? a b. left. left. exists 1. rewrite /= /step.
+    by have ->: nth_error M (state (p, (a, b))) = None
+      by (rewrite nth_error_None /=; lia). }
+  move=> n IH p ? a b.
+  case Hi: (nth_error M (state (p, (a, b)))) => [i|]; first last.
+  { left. left. exists 1. by rewrite /= /step Hi. }
+  move: i Hi => /= [].
+  - move=> Hi. left. left. exists 1. by rewrite /= /step Hi.
+  - case.
+    + move=> Hi. left. right. exists (S p, a).
+      move=> n'. exists 1. split; first by lia.
+      by rewrite /= /step /= Hi.
+    + move=> Hi. right. exists (S p, b).
+      move=> n'. exists 1. split; first by lia.
+      by rewrite /= /step /= Hi.
+  - case.
+    + move=> Hi.
+      have [[|[[p' a'] HSp]]|[[p' b'] HSp]] := IH (S p) ltac:(lia) a (S b).
+      * move=> /reaches_terminating HSp. left. left.
+        apply: HSp. exists 1. by rewrite /= /step Hi.
+      * left. right. exists (p', a').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi.
+      * right. exists (p', b').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi Nat.add_succ_r.
+    + move=> Hi.
+      have [[|[[p' a'] HSp]]|[[p' b'] HSp]] := IH (S p) ltac:(lia) (S a) b.
+      * move=> /reaches_terminating HSp. left. left.
+        apply: HSp. exists 1. by rewrite /= /step Hi.
+      * left. right. exists (p', a').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi Nat.add_succ_r.
+      * right. exists (p', b').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi.
+  - case=> q Hi.
+    + move: b => [|b].
+      { left. right. exists (q, a) => n'. exists 1. 
+        split; first by lia. by rewrite /= /step Hi. }
+      have [[|[[p' a'] HSp]]|[[p' b'] HSp]] := IH (S p) ltac:(lia) a b.
+      * move=> /reaches_terminating HSp. left. left.
+        apply: HSp. exists 1. by rewrite /= /step Hi.
+      * left. right. exists (p', a').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi.
+      * right. exists (p', b').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi Nat.add_succ_r.
+    + move: a => [|a].
+      { right. exists (q, b) => n'. exists 1. 
+        split; first by lia. by rewrite /= /step Hi. }
+      have [[|[[p' a'] HSp]]|[[p' b'] HSp]] := IH (S p) ltac:(lia) a b.
+      * move=> /reaches_terminating HSp. left. left.
+        apply: HSp. exists 1. by rewrite /= /step Hi.
+      * left. right. exists (p', a').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi Nat.add_succ_r.
+      * right. exists (p', b').
+        move=> n'.
+        have [k [? <-]] := (HSp n').
+        exists (1+k). split; first by lia.
+        apply: steps_plus. by rewrite /= /step Hi.
+Qed.
+
+(* terminate or reach uniformly next config or reach small config *)
+Corollary next_waypoint_a p a :
+  terminating (p, (a, 0)) +
+  { '(p', a') | forall n, reaches_plus (p, (n+a, 0)) (p', (n+a', 0)) } +
+  { '(p', (a', b')) | reaches (p, (a, 0)) (p', (a', b')) /\ a' <= l /\ b' <= l }.
+Proof.
+  have [[?|[[p' a'] Hp]]|[[p' b'] Hp]] := next_waypoint p a 0.
+  - left. by left.
+  - left. right. exists (p', a') => n.
+    have [k [? Hk]] := Hp n. exists k.
+    split; [lia|done].
+  - right. exists (p', (0, b')).
+    have [k [? Hk]] := Hp 0.
+    have ? := steps_bound Hk.
+    split; [by exists k|lia].
+Qed.
+
+(* terminate or reach uniformly next config or reach small config *)
+Corollary next_waypoint_b p b :
+  terminating (p, (0, b)) +
+  { '(p', b') | forall n, reaches_plus (p, (0, n+b)) (p', (0, n+b')) } +
+  { '(p', (a', b')) | reaches (p, (0, b)) (p', (a', b')) /\ a' <= l /\ b' <= l }.
+Proof.
+  have [[?|[[p' a'] Hp]]|[[p' b'] Hp]] := next_waypoint p 0 b.
+  - left. by left.
+  - right. exists (p', (a', 0)).
+    have [k [? Hk]] := Hp 0.
+    have ? := steps_bound Hk.
+    split; [by exists k|lia].
+  - left. right. exists (p', b') => n.
+    have [k [? Hk]] := Hp n. exists k.
+    split; [lia|done].
+Qed.
+
+Lemma loop_a {p a a' b} :
+  a <= a' ->
+  (forall n : nat, reaches_plus (p, (n + a, b)) (p, (n + a', b))) ->
+  non_terminating (p, (a, b)).
+Proof.
+  move=> ? Hp k.
+  suff: forall m, steps k (p, (m + a, b)) <> None by move=> /(_ 0).
+  elim: k; first done.
+  move=> k IH m.
+  have [k' [? Hk']] := Hp m.
+  move=> /(steps_k_monotone (k' + k)) /(_ ltac:(lia)).
+  move: Hk' => /steps_plus ->.
+  have ->: m + a' = (m + a' - a) + a by lia.
+  by apply: IH.
+Qed.
+
+Lemma loop_b {p a b b'} :
+  b <= b' ->
+  (forall n : nat, reaches_plus (p, (a, n + b)) (p, (a, n + b'))) ->
+  non_terminating (p, (a, b)).
+Proof.
+  move=> ? Hp k.
+  suff: forall m, steps k (p, (a, m + b)) <> None by move=> /(_ 0).
+  elim: k; first done.
+  move=> k IH m.
+  have [k' [? Hk']] := Hp m.
+  move=> /(steps_k_monotone (k' + k)) /(_ ltac:(lia)).
+  move: Hk' => /steps_plus ->.
+  have ->: m + b' = (m + b' - b) + b by lia.
+  by apply: IH.
+Qed.
+
+Lemma reaches_plus_self_loop x : reaches_plus x x -> non_terminating x.
+Proof.
+  move=> [k [? Hk]]. elim; first done.
+  move=> k' Hk'.
+  move=> /(steps_k_monotone (k + k')) /(_ ltac:(lia)).
+  by rewrite (steps_plus Hk).
+Qed.
+
+Definition update {X : Type} (f : nat -> X) n x :=
+  fun m => if Nat.eq_dec m n is left _ then x else f m.
+
+Inductive R : (nat -> option nat) -> (nat -> option nat) -> Prop :=
+  | R_None f p c : p < l -> f p = None -> R (update f p (Some c)) f
+  | R_Some c' f p c : p < l -> f p = Some c' -> c < c' -> R (update f p (Some c)) f.
+
+Lemma wf_R : well_founded R.
+Proof.
+  pose F := (fun (f : nat -> option nat) => 
+    list_sum (map (fun p => if f p is None then 1 else 0) (seq 0 l))).
+  pose G := (fun (f : nat -> option nat) => 
+    list_sum (map (fun p => if f p is Some c then c else 0) (seq 0 l))).
+  elim /(measure_ind F). elim /(measure_ind G).
+  move=> f IHG IHF. constructor => g Hgf.
+  case: Hgf IHG IHF.
+  - move=> {}f p c ? Hf IHG IHF.
+    apply: IHF. rewrite /F.
+    have /list_sum_map_lt : In p (seq 0 l) by (apply /in_seq; lia).
+    apply.
+    + move=> p''. case Hp'': (f p'') => [c''|].
+      * rewrite /update Hp''. by case: (Nat.eq_dec p'' p).
+      * rewrite /update Hp''. case: (Nat.eq_dec p'' p); lia.
+    + rewrite /update Hf. case: (Nat.eq_dec p p); lia.
+  - move=> c' {}f p c Hl Hf ? IHG IHF.
+    apply: IHG; first last.
+    { move=> h Hh. apply: IHF.
+      suff: F (update f p (Some c)) <= F f by lia.
+      apply: list_sum_map_le.
+      move=> p''. case Hp'': (f p'') => [c''|].
+      - rewrite /update Hp''. by case: (Nat.eq_dec p'' p).
+      - rewrite /update Hp''. case: (Nat.eq_dec p'' p); lia. }
+    rewrite /G.
+    have : In p (seq 0 l) by (apply /in_seq; lia).
+    move=> /list_sum_map_lt. apply.
+    + move=> p''. case Hp'': (f p'') => [c''|].
+      * rewrite /update. case: (Nat.eq_dec p'' p).
+        ** move=> ?. subst. move: Hf Hp'' => -> []. lia.
+        ** rewrite Hp''. lia.
+      * rewrite /update. case: (Nat.eq_dec p'' p).
+        ** move=> ?. subst. by move: Hf Hp'' => ->.
+        ** rewrite Hp''. lia.
+    + rewrite /update Hf. by case: (Nat.eq_dec p p).
+Qed.
+
+Lemma big_wf_a p a (f : nat -> option nat) :
+  (forall p' a', f p' = Some a' -> forall n, reaches_plus (p', (n+a', 0)) (p, (n+a, 0))) ->
+  terminating (p, (a, 0)) +
+  non_terminating (p, (a, 0)) +
+  { '(p', (a', b')) | reaches (p, (a, 0)) (p', (a', b')) /\ a' <= l /\ b' <= l }.
+Proof.
+  elim /(well_founded_induction_type wf_R) : f p a.
+  move=> f IH p a Hf.
+  have [[Hp|[[p' a'] Hp]]|[[p' [a' b']] [Hp ?]]] := next_waypoint_a p a.
+  - left. by left.
+  - have /= ? := reaches_plus_state_bound (Hp 0).
+    set P := (_ + _ + _)%type.
+    have HR : R (update f p (Some a)) f -> P.
+    { move=> /IH /(_ p' a') /=. case; [|case|].
+      - move=> p''' a'''. rewrite /update.
+        case: (Nat.eq_dec p''' p).
+        { by move=> -> [<-]. }
+        move=> ? /Hf Hp''' n.
+        by apply: (reaches_plus_trans (Hp''' n) (Hp n)).
+      - move=> /reaches_terminating Hp'. left. left.
+        by apply /Hp' /reaches_plus_incl /(Hp 0).
+      - move=> /reaches_non_terminating Hp'. left. right.
+        by apply /Hp' /reaches_plus_incl /(Hp 0).
+      - move=> [[p''' [a''' b''']]] [Hp'] ?. right.
+        exists (p''', (a''', b''')). split; last done.
+        by apply: (reaches_trans (reaches_plus_incl (Hp 0))). }
+    case H'p: (f p) => [a''|].
+    + case E: (a''-a) => [|?].
+      { left. right. move: H'p => /Hf{Hf} H'p.
+        apply: (reaches_non_terminating' (reaches_plus_incl (H'p 0))).
+        apply: (loop_a _ H'p). lia. }
+      apply /HR /(R_Some a''); [done|done|lia].
+    + by apply /HR /R_None.
+  - right. by exists (p', (a', b')).
+Qed.
+
+
+Lemma big_wf_b p b (f : nat -> option nat) :
+  (forall p' b', f p' = Some b' -> forall n, reaches_plus (p', (0, n+b')) (p, (0, n+b))) -> 
+  terminating (p, (0, b)) +
+  non_terminating (p, (0, b)) +
+  { '(p', (a', b')) | reaches (p, (0, b)) (p', (a', b')) /\ a' <= l /\ b' <= l }.
+Proof.
+  elim /(well_founded_induction_type wf_R) : f p b.
+  move=> f IH p b Hf.
+  have [[Hp|[[p' b'] Hp]]|[[p' [a' b']] [Hp ?]]] := next_waypoint_b p b.
+  - left. by left.
+  - have /= ? := reaches_plus_state_bound (Hp 0).
+    set P := (_ + _ + _)%type.
+    have HR : R (update f p (Some b)) f -> P.
+    { move=> /IH /(_ p' b') /=. case; [|case|].
+      - move=> p''' b'''. rewrite /update.
+        case: (Nat.eq_dec p''' p).
+        { by move=> -> [<-]. }
+        move=> ? /Hf Hp''' n.
+        by apply: (reaches_plus_trans (Hp''' n) (Hp n)).
+      - move=> /reaches_terminating Hp'. left. left.
+        by apply /Hp' /reaches_plus_incl /(Hp 0).
+      - move=> /reaches_non_terminating Hp'. left. right.
+        by apply /Hp' /reaches_plus_incl /(Hp 0).
+      - move=> [[p''' [a''' b''']]] [Hp'] ?. right.
+        exists (p''', (a''', b''')). split; last done.
+        by apply: (reaches_trans (reaches_plus_incl (Hp 0))). }
+    case H'p: (f p) => [b''|].
+    + case E: (b''-b) => [|?].
+      { left. right. move: H'p => /Hf{Hf} H'p.
+        apply: (reaches_non_terminating' (reaches_plus_incl (H'p 0))).
+        apply: (loop_b _ H'p). lia. }
+      apply /HR /(R_Some b''); [done|done|lia].
+    + by apply /HR /R_None.
+  - right. by exists (p', (a', b')).
+Qed.
+
+(* from any config can decide termination or get to next small waypoint *)
+Lemma next_small_waypoint p a b :
+  terminating (p, (a, b)) +
+  non_terminating (p, (a, b)) +
+  { '(p', (a', b')) | reaches_plus (p, (a, b)) (p', (a', b')) /\ a' <= l /\ b' <= l }.
+Proof.
+  have [[?|[[p' a'] Hp]]|[[p' b'] Hp]] := next_waypoint p a b.
+  - left. by left.
+  - have [[|]|] := big_wf_a p' a' (fun _ => None) ltac:(done).
+    * move=> /reaches_terminating Hp'. left. left.
+      apply: Hp'. have [k [? Hk]] := Hp 0. by exists k.
+    * move=> /reaches_non_terminating Hp'. left. right.
+      apply: Hp'. have [k [? Hk]] := Hp 0. by exists k.
+    * move=> [[p'' [a'' b'']]] [Hp'] ?. right.
+      exists (p'', (a'', b'')). split; last done.
+      apply: (reaches_plus_reaches _ Hp').
+      have [k [? Hk]] := Hp 0. exists k. split; [lia|done].
+  - have [[|]|] := big_wf_b p' b' (fun _ => None) ltac:(done).
+    * move=> /reaches_terminating Hp'. left. left.
+      apply: Hp'. have [k [? Hk]] := Hp 0. by exists k.
+    * move=> /reaches_non_terminating Hp'. left. right.
+      apply: Hp'. have [k [? Hk]] := Hp 0. by exists k.
+    * move=> [[p'' [a'' b'']]] [Hp'] ?. right.
+      exists (p'', (a'', b'')). split; last done.
+      apply: (reaches_plus_reaches _ Hp').
+      have [k [? Hk]] := Hp 0. exists k. split; [lia|done].
+Qed.
+
+Lemma small_decider p a b L : a <= l -> b <= l ->
+  Forall (fun '(p', (a', b')) => reaches_plus (p', (a', b')) (p, (a, b)) /\ p' < l /\ a' <= l /\ b' <= l ) L ->
+  NoDup L ->
+  terminating (p, (a, b)) + non_terminating (p, (a, b)).
+Proof.
+  move Hn: ((l*(l+1)*(l+1)+1) - length L) => n.
+  elim: n L Hn p a b.
+  { move=> L ? ????? H1L /NoDup_incl_length H2L.
+    have : incl L (list_prod (seq 0 l) (list_prod (seq 0 (l+1)) (seq 0 (l+1)))).
+    { move=> [p [a b]].
+      move: H1L => /Forall_forall H1L /H1L ?.
+      apply /in_prod; [|apply /in_prod]; apply /in_seq; lia. }
+    move=> /H2L. rewrite ?prod_length ?seq_length. lia. }
+  move=> n IH L ? p a b ? ? H1L H2L.
+  have [[|]|[[p' [a' b']] [Hp ?]]] := next_small_waypoint p a b; [tauto|tauto|].
+  have := In_dec _ (p, (a, b)) L. case.
+  { do ? decide equality. }
+  - move=> H'p. right. apply: reaches_plus_self_loop.
+    by move: H1L H'p => /Forall_forall H /H [].
+  - move=> H'p. 
+    have := (IH ((p, (a, b)) :: L) _ p' a' b'). case.
+    + move=> /=. lia.
+    + lia.
+    + lia.
+    + constructor.
+      * split; first done.
+        move: Hp => /reaches_plus_state_bound /=. lia.
+      * apply: Forall_impl H1L.
+        move=> [p'' [a'' b'']] [? ?]. split; last done.
+        by apply: (reaches_plus_reaches _ (reaches_plus_incl Hp)).
+    + by constructor.
+    + move=> /reaches_terminating H. left. by apply /H /reaches_plus_incl.
+    + move=> /reaches_non_terminating H. right. by apply /H /reaches_plus_incl.
+Qed.
+
+(* informative decision statement for halting for Mpm2 *)
+Lemma decision x : terminating x + non_terminating x.
+Proof.
+  move: x => [p [a b]].
+  have [[|]|] := next_small_waypoint p a b; [tauto|tauto|].
+  move=> [[p' [a' b']]] [/reaches_plus_incl Hp'] [Ha' Hb'].
+  have := small_decider p' a' b' [] Ha' Hb' ltac:(by constructor) ltac:(by constructor).
+  case.
+  - move: Hp' => /reaches_terminating H /H ?. by left.
+  - move: Hp' => /reaches_non_terminating H /H ?. by right.
+Qed.
+
+End Construction.
+
+Require Import Undecidability.Synthetic.Definitions.
+
+(* decision procedure for the halting problem for Minsky Program Machines with two counters *)
+Definition decide : Mpm2 * Config -> bool :=
+  fun '(M, c) =>
+    match decision M c with
+    | inl _ => true
+    | inr _ => false
+    end.
+
+(* decision procedure correctness *)
+Lemma decide_spec : decider decide MPM2_HALT.
+Proof.
+  rewrite /decider /reflects /decide => - [M c].
+  case: (decision M c).
+  - tauto.
+  - move=> H. split; [by move=> [k /H] | done].
+Qed.

--- a/theories/MinskyMachines/MM.v
+++ b/theories/MinskyMachines/MM.v
@@ -92,6 +92,11 @@ Section MM_problems.
   Definition MM_HALTING (P : MM_PROBLEM) :=
     match P with existT _ n (existT _ P v) => (1, P) // (1, v) ↓ end.
 
+  Definition MM_2_PROBLEM := { P : list (mm_instr (pos 2)) & vec nat 2 }.
+
+  Definition MM_2_HALTING (P : MM_2_PROBLEM) :=
+    match P with existT _ P v => (1, P) // (1, v) ↓ end.
+
 End MM_problems.
 
 Section MMA_problems.

--- a/theories/MinskyMachines/MM_dec.v
+++ b/theories/MinskyMachines/MM_dec.v
@@ -1,0 +1,26 @@
+(* 
+  Autor(s):
+    Andrej Dudenhefner (1) 
+  Affiliation(s):
+    (1) Saarland University, Saarbrücken, Germany
+*)
+
+(* 
+  Decidability Results(s):
+    Decidability of MM_HALTING with two counters (MM_2_HALTING_dec)
+*)
+
+Require Import Undecidability.Synthetic.Definitions.
+
+Require Import Undecidability.MinskyMachines.MM.
+From Undecidability.MinskyMachines.Deciders Require
+  MM_2_HALTING_dec.
+
+(* Decidability of MM_HALTING with two counters *)
+Theorem MM_2_HALTING_dec : decidable MM_2_HALTING.
+Proof.
+  exists MM_2_HALTING_dec.decide.
+  exact MM_2_HALTING_dec.decide_spec.
+Qed.
+
+Check MM_2_HALTING_dec.

--- a/theories/Synthetic/Definitions.v
+++ b/theories/Synthetic/Definitions.v
@@ -2,9 +2,9 @@
   
 (* (complement P) is the complement decision problem of P *)
 Definition complement {X} (P : X -> Prop) := fun x : X => ~ P x.
-(* (reflects b P) means that 
-   provability of the proposition P coincides with b being true *)
-Definition reflects (b : bool) (P : Prop) := P <-> b = true.
+(* (reflects b p) means that 
+   provability of the proposition p coincides with b being true *)
+Definition reflects (b : bool) (p : Prop) := p <-> b = true.
 
 (* (decider f P) means that
    the function f from the domain X of the predicate P to Booleans pointwise reflects P *)

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -39,7 +39,8 @@ StackMachines/BSM.v
 StackMachines/BSM_undec.v
 
 MinskyMachines/MM.v
-MinskyMachines/MM_undec.v       
+MinskyMachines/MM_dec.v
+MinskyMachines/MM_undec.v
 
 # Non coqdoc files
 
@@ -285,6 +286,9 @@ MinskyMachines/Reductions/MUREC_MM.v
 MinskyMachines/Reductions/BSM_HALTING_to_MM2_HALTING.v
 MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
 MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+
+MinskyMachines/Deciders/MPM2_HALT_dec.v
+MinskyMachines/Deciders/MM_2_HALTING_dec.v
 
 MinskyMachines/MM/mm_defs.v         
 MinskyMachines/MM/mm_utils.v        
@@ -719,8 +723,8 @@ TRAKHTENBROT/red_enum.v
 TRAKHTENBROT/red_undec.v
 
 CounterMachines/CM2.v
-CounterMachines/CM2_undec.v
 
+CounterMachines/Util/Facts.v
 CounterMachines/Util/Nat_facts.v
 CounterMachines/Util/CM1_facts.v
 CounterMachines/Util/CM2_facts.v
@@ -728,6 +732,13 @@ CounterMachines/Util/MM2_facts.v
 CounterMachines/Reductions/CM2_HALT_to_CM1_HALT.v
 CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
 CounterMachines/Reductions/MM2_HALTING_to_CM1_HALT.v
+CounterMachines/Deciders/CM2_REV_dec.v
+CounterMachines/Deciders/CM2_REV_HALT_dec.v
+CounterMachines/Deciders/CM2_UBOUNDED_dec.v
+CounterMachines/Deciders/CM2_UMORTAL_dec.v
+
+CounterMachines/CM2_dec.v
+CounterMachines/CM2_undec.v
 
 StackMachines/SMN.v
 StackMachines/SMN_undec.v


### PR DESCRIPTION
While decidability of Uniform Mortality (and relatedly Uniform Boundedness) for Two-counter Machines is known [1], decidability of Reversible Two-counter Machine (`Cm2`) Halting contrasts a known negative result [2].

[1] Kari, Jarkko, and Nicolas Ollinger. "Periodicity and immortality in reversible computing." International Symposium on Mathematical Foundations of Computer Science. Springer, Berlin, Heidelberg, 2008.
[2] Morita, Kenichi. "Universality of a reversible two-counter machine." Theoretical Computer Science 168.2 (1996): 303-320.

This work implements deciders for Uniform Boundedness, Uniform Mortality, and Reversible Halting for `Cm2`; full list of changes below.
- simplified CM2 definition
- added problems
  - Two-counter Machine Reversibility (`CM2_REV`)
  - Reversible Two-counter Machine Halting (`CM2_REV_HALT`)
  - Two-counter Machine Uniform Boundedness (`CM2_UBOUNDED`)
  - Two-counter Machine Uniform Mortality (`CM2_UMORTAL`)
  - Two-counter (original) Minsky Machine Halting (`MM_2_HALTING`)
- added decision procedures
  - Two-counter Machine Reversibility (`CM2_REV_dec.v`)
  - Reversible Two-counter Machine Halting (`CM2_REV_HALT_dec.v`)
  - Two-counter Machine Uniform Boundedness (`CM2_UBOUNDED_dec.v`)
  - Two-counter Machine Uniform Mortality (`CM2_UMORTAL_dec.v`)
  - Two-counter (original) Minsky Machine Halting (`MM_2_HALTING_dec.v`)
- added top-level structure
  - Decidability Results on CM2 (`CM2_dec.v`)
  - Decidability Results on MM (`MM2_dec.v`)