### PR TITLE
global Set Default Proof Using "Type"

### DIFF
--- a/theories/CFG/Reductions/CFPP_to_CFP.v
+++ b/theories/CFG/Reductions/CFPP_to_CFP.v
@@ -11,7 +11,6 @@ Require Import Undecidability.PCP.Util.PCP_facts.
 Require Import Undecidability.Synthetic.Definitions.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Local Notation "x 'el' A" := (In x A) (at level 70).
 Local Notation "A <<= B" := (incl A B) (at level 70).

--- a/theories/CFG/Reductions/PCP_to_CFPI.v
+++ b/theories/CFG/Reductions/PCP_to_CFPI.v
@@ -11,7 +11,6 @@ Require Import Undecidability.PCP.Util.PCP_facts.
 Require Import Undecidability.Synthetic.Definitions.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 (* * PCP to CFPI *)
 Section PCP_CFPI.

--- a/theories/CFG/Reductions/PCP_to_CFPP.v
+++ b/theories/CFG/Reductions/PCP_to_CFPP.v
@@ -10,7 +10,6 @@ Require Import Undecidability.PCP.Util.PCP_facts.
 
 Require Import Undecidability.Synthetic.Definitions.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 (* * PCP to CFPP *)

--- a/theories/CounterMachines/Deciders/CM2_REV_HALT_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_REV_HALT_dec.v
@@ -17,7 +17,6 @@ From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section Construction.
 Variable M : Cm2.

--- a/theories/CounterMachines/Deciders/CM2_REV_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_REV_dec.v
@@ -17,7 +17,6 @@ From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section Construction.
 Variable M : Cm2.

--- a/theories/CounterMachines/Deciders/CM2_UBOUNDED_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_UBOUNDED_dec.v
@@ -17,7 +17,6 @@ From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section Construction.
 Variable M : Cm2.

--- a/theories/CounterMachines/Deciders/CM2_UMORTAL_dec.v
+++ b/theories/CounterMachines/Deciders/CM2_UMORTAL_dec.v
@@ -18,7 +18,6 @@ From Undecidability.CounterMachines.Util Require Import Facts CM2_facts.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section Construction.
 

--- a/theories/CounterMachines/Reductions/CM2_HALT_to_CM1_HALT.v
+++ b/theories/CounterMachines/Reductions/CM2_HALT_to_CM1_HALT.v
@@ -26,7 +26,6 @@ From Undecidability.CounterMachines.Util Require CM1_facts CM2_facts.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
+++ b/theories/CounterMachines/Reductions/MM2_HALTING_to_CM2_HALT.v
@@ -22,7 +22,6 @@ From Undecidability.CounterMachines.Util Require Import
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/CounterMachines/Util/CM2_facts.v
+++ b/theories/CounterMachines/Util/CM2_facts.v
@@ -7,7 +7,6 @@ Require Import Undecidability.CounterMachines.CM2.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Definition path M k x := map (fun n => steps M n x) (seq 0 k).
 

--- a/theories/CounterMachines/Util/Facts.v
+++ b/theories/CounterMachines/Util/Facts.v
@@ -2,7 +2,6 @@ Require Import Lia List PeanoNat Permutation.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 (* transforms a goal (A -> B) -> C into goals A and B -> C *)
 Lemma unnest : forall (A B C : Type), A -> (B -> C) -> (A -> B) -> C.

--- a/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
@@ -17,8 +17,6 @@ Require Import Undecidability.DiophantineConstraints.H10C.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section dc_list_h10c.
 
   (* Reduction from (l,ν) an instance of a DIO_ELEM_PROBLEM 

--- a/theories/DiophantineConstraints/Reductions/H10C_SAT_to_H10SQC_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/H10C_SAT_to_H10SQC_SAT.v
@@ -20,7 +20,6 @@ Require Import Undecidability.DiophantineConstraints.H10C.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/DiophantineConstraints/Reductions/H10SQC_SAT_to_H10UC_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/H10SQC_SAT_to_H10UC_SAT.v
@@ -20,7 +20,6 @@ Require Import Undecidability.DiophantineConstraints.H10C.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/DiophantineConstraints/Reductions/H10UC_SAT_to_H10UPC_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/H10UC_SAT_to_H10UPC_SAT.v
@@ -13,7 +13,6 @@ Require Import ssreflect ssrbool ssrfun.
 
 Require Import Undecidability.DiophantineConstraints.H10C.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 (* Uniform Diophantine pairs constraints are of shape:  

--- a/theories/DiophantineConstraints/Util/H10UPC_facts.v
+++ b/theories/DiophantineConstraints/Util/H10UPC_facts.v
@@ -9,8 +9,6 @@
 Require Import Arith Lia List.
 From Undecidability.DiophantineConstraints Require Import H10C.
 
-Set Default Proof Using "Type".
-
 (** Utils for H10UPC *)
 
 (** This section contains useful functions and lemmas for proofs later on. *)

--- a/theories/DiophantineConstraints/Util/h10c_utils.v
+++ b/theories/DiophantineConstraints/Util/h10c_utils.v
@@ -25,8 +25,6 @@ From Undecidability.DiophantineConstraints
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "〚 c 〛" := (h10c_sem c).
 Local Notation " '⟪' c '⟫' " := (fun φ => h10uc_sem φ c).
 

--- a/theories/FOL/Reductions/H10UPC_to_FOL.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL.v
@@ -23,7 +23,6 @@ Idea: The relation (#&#35;#) has the following properties:#<ul>#
 *)
 
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 

--- a/theories/FOL/Reductions/H10UPC_to_FOL_full_fragment.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL_full_fragment.v
@@ -22,7 +22,6 @@ Idea: The relation (#&#35;#) has the following properties:#<ul>#
 *)
 
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 (** Some utils for iteration *)

--- a/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
@@ -21,7 +21,6 @@ Idea: The relation (#&#35;#) has the following properties:#<ul>#
 *)
 
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 

--- a/theories/FOL/Reductions/H10UPC_to_FSAT.v
+++ b/theories/FOL/Reductions/H10UPC_to_FSAT.v
@@ -27,7 +27,6 @@ Idea: The relation (#&#35;#) has the following properties:#<ul>#
 
 
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 Set Mangle Names.
 

--- a/theories/FOL/Reductions/H10p_to_FA.v
+++ b/theories/FOL/Reductions/H10p_to_FA.v
@@ -4,8 +4,6 @@ Require Import Undecidability.FOL.PA.
 From Undecidability.H10 Require Import H10p.
 Require Import List Lia.
 
-Set Default Proof Using "Type".
-
 Fixpoint embed_poly p : term :=
     match p with
     | dp_nat_pfree n => num n

--- a/theories/FOL/Reductions/PCPb_to_FOL.v
+++ b/theories/FOL/Reductions/PCPb_to_FOL.v
@@ -2,10 +2,8 @@
 
 From Undecidability.PCP Require Import PCP Util.PCP_facts.
 From Undecidability.FOL Require Import Util.Deduction Util.Tarski Util.Syntax_facts FOL.
-From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts.
+From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts MoreReducibilityFacts.
 Require Import Undecidability.PCP.Reductions.PCPb_iff_dPCPb.
-
-Set Default Proof Using "Type".
 
 (* ** Validity *)
 

--- a/theories/FOL/Reductions/PCPb_to_FOL_class.v
+++ b/theories/FOL/Reductions/PCPb_to_FOL_class.v
@@ -3,12 +3,10 @@
 
 From Undecidability.FOL Require Import FOL Reductions.PCPb_to_FOL Util.Syntax_facts Util.Deduction Util.Tarski.
 Require Import Undecidability.PCP.Reductions.PCPb_iff_dPCPb Undecidability.PCP.PCP.
-From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts.
+From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts MoreReducibilityFacts.
 Require Import List.
 Require Import Undecidability.Shared.ListAutomation.
 Import ListNotations.
-
-Set Default Proof Using "Type".
 
 (* ** Double Negation Translation *)
 

--- a/theories/FOL/Reductions/PCPb_to_FOL_intu.v
+++ b/theories/FOL/Reductions/PCPb_to_FOL_intu.v
@@ -1,11 +1,9 @@
 (* * Intuitionistic FOL *)
 
-From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts.
+From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ReducibilityFacts MoreReducibilityFacts.
 From Undecidability.FOL Require Import FOL Util.Kripke Util.Deduction Util.Syntax Util.Tarski PCPb_to_FOL.
 
 From Undecidability.PCP Require Import PCP Reductions.PCPb_iff_dPCPb.
-
-Set Default Proof Using "Type".
 
 Local Hint Constructors BPCP : core.
 

--- a/theories/FOL/Reductions/PCPb_to_ZF.v
+++ b/theories/FOL/Reductions/PCPb_to_ZF.v
@@ -10,8 +10,6 @@ From Undecidability.PCP Require Import PCP Util.PCP_facts Reductions.PCPb_iff_dP
 From Undecidability Require Import Shared.ListAutomation.
 Import ListAutomationNotations.
 
-Set Default Proof Using "Type".
-
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/FOL/Reductions/PCPb_to_ZFD.v
+++ b/theories/FOL/Reductions/PCPb_to_ZFD.v
@@ -11,8 +11,6 @@ From Undecidability.PCP Require Import PCP Util.PCP_facts Reductions.PCPb_iff_dP
 From Undecidability Require Import Shared.ListAutomation.
 Import ListAutomationNotations.
 
-Set Default Proof Using "Type".
-
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/FOL/Reductions/PCPb_to_ZFeq.v
+++ b/theories/FOL/Reductions/PCPb_to_ZFeq.v
@@ -16,8 +16,6 @@ Local Unset Strict Implicit.
 
 Require Import Morphisms.
 
-Set Default Proof Using "Type".
-
 (* ** Internal axioms *)
 
 Section ZF.

--- a/theories/FOL/Reductions/PCPb_to_binZF.v
+++ b/theories/FOL/Reductions/PCPb_to_binZF.v
@@ -9,8 +9,6 @@ Local Unset Strict Implicit.
 
 Require Import Morphisms.
 
-Set Default Proof Using "Type".
-
 Local Notation vec := Vector.t.
 
 Local Hint Constructors prv : core.

--- a/theories/FOL/Reductions/PCPb_to_minZF.v
+++ b/theories/FOL/Reductions/PCPb_to_minZF.v
@@ -8,8 +8,6 @@ Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
 
-Set Default Proof Using "Type".
-
 Local Notation vec := Vector.t.
 
 Local Hint Constructors prv : core.

--- a/theories/FOL/Reductions/PCPb_to_minZFeq.v
+++ b/theories/FOL/Reductions/PCPb_to_minZFeq.v
@@ -9,8 +9,6 @@ Local Unset Strict Implicit.
 
 Require Import Morphisms.
 
-Set Default Proof Using "Type".
-
 Local Notation vec := Vector.t.
 
 

--- a/theories/FOL/Reductions/TRAKHTENBROT_to_FSAT.v
+++ b/theories/FOL/Reductions/TRAKHTENBROT_to_FSAT.v
@@ -7,7 +7,6 @@ Require Import Undecidability.Synthetic.DecidabilityFacts.
 Require Import Vector Lia.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 (* Reduction from the TRAKHTENBROT development to the FSAT problems in FOL *)
 

--- a/theories/FOL/Util/Aczel_CE.v
+++ b/theories/FOL/Util/Aczel_CE.v
@@ -4,8 +4,6 @@ From Undecidability.FOL Require Import Util.Aczel.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 (* Quotient construction assuming class extensionality (CE) *)
 
 Definition CE :=

--- a/theories/FOL/Util/Aczel_TD.v
+++ b/theories/FOL/Util/Aczel_TD.v
@@ -6,8 +6,6 @@ Require Import Setoid Morphisms.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 
 (* ** Quotient Model *)
 

--- a/theories/FOL/Util/Deduction.v
+++ b/theories/FOL/Util/Deduction.v
@@ -7,8 +7,6 @@ Import ListAutomationNotations.
 Local Set Implicit Arguments.
 Require Import Lia.
 
-Set Default Proof Using "Type".
-
 Ltac comp := repeat (progress (cbn in *; autounfold in *)).
 
 Inductive peirce := class | intu.

--- a/theories/FOL/Util/DoubleNegation.v
+++ b/theories/FOL/Util/DoubleNegation.v
@@ -7,7 +7,6 @@ From Undecidability.Shared.Libs.DLW.Wf Require Import wf_finite.
 From Undecidability.FOL Require Import FSAT.
 From Undecidability.Synthetic Require Import Definitions.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 Set Mangle Names.
 Inductive syms_func : Type := .

--- a/theories/FOL/Util/FA_facts.v
+++ b/theories/FOL/Util/FA_facts.v
@@ -3,8 +3,6 @@ Require Import Undecidability.FOL.PA.
 Require Import Lia List Vector.
 Import Vector.VectorNotations.
 
-Set Default Proof Using "Type".
-
 Section FA_prv.
 
   Variable p : peirce.

--- a/theories/FOL/Util/FullDeduction_facts.v
+++ b/theories/FOL/Util/FullDeduction_facts.v
@@ -8,8 +8,6 @@ Local Set Implicit Arguments.
 Require Import Lia.
 
 
-Set Default Proof Using "Type".
-
 Ltac comp := repeat (progress (cbn in *; autounfold in *)).
 
 Section ND_def.

--- a/theories/FOL/Util/FullTarski_facts.v
+++ b/theories/FOL/Util/FullTarski_facts.v
@@ -9,8 +9,6 @@ Require Import Vector Lia.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 Local Notation vec := Vector.t.
 
 

--- a/theories/FOL/Util/Kripke.v
+++ b/theories/FOL/Util/Kripke.v
@@ -4,8 +4,6 @@ From Undecidability Require Import FOL.Util.Deduction FOL.Util.Tarski FOL.Util.S
 From Undecidability Require Import Shared.ListAutomation.
 Import ListAutomationNotations.
 
-Set Default Proof Using "Type".
-
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/FOL/Util/Syntax_facts.v
+++ b/theories/FOL/Util/Syntax_facts.v
@@ -11,8 +11,6 @@ Local Notation vec := t.
 
 From Undecidability Require Export FOL.Util.Syntax.
 
-Set Default Proof Using "Type".
-
 Section fix_signature.
 
   Context {Σ_funcs : funcs_signature}.

--- a/theories/FOL/Util/Tarski.v
+++ b/theories/FOL/Util/Tarski.v
@@ -9,8 +9,6 @@ Require Import Vector.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 Local Notation vec := Vector.t.
 
 Section fixb.

--- a/theories/FOL/Util/ZF_model.v
+++ b/theories/FOL/Util/ZF_model.v
@@ -2,8 +2,6 @@
 From Undecidability.FOL Require Import binZF ZF Reductions.PCPb_to_ZF.
 From Undecidability.FOL Require Import Aczel Aczel_CE Aczel_TD Syntax FullTarski_facts.
 
-Set Default Proof Using "Type".
-
 (** Model of ZF *)
 
 Section ZFM.

--- a/theories/FOL/minFOL_undec.v
+++ b/theories/FOL/minFOL_undec.v
@@ -5,8 +5,6 @@ From Undecidability.FOL.Reductions Require H10UPC_to_FOL_minimal H10UPC_to_FSAT.
 From Undecidability.FOL.Reductions Require H10UPC_to_FOL_full_fragment.
 From Undecidability.Synthetic Require Import Definitions Undecidability ReducibilityFacts.
 
-Set Default Proof Using "Type".
-
 Definition minimalForm (ff:falsity_flag) := @form sig_empty sig_binary FragmentSyntax.frag_operators ff.
 
 

--- a/theories/FOLP/Reductions/PCPb_to_FOLFS.v
+++ b/theories/FOLP/Reductions/PCPb_to_FOLFS.v
@@ -6,8 +6,6 @@ From Undecidability Require Import FOLP.FOLFS.
 Require Import Undecidability.Shared.ListAutomation.
 Import ListAutomationNotations.
 
-Set Default Proof Using "Type".
-
 (* ** Bounded boolean strings *)
 
 Lemma le_irrel' n :

--- a/theories/FOLP/Util/FOL.v
+++ b/theories/FOLP/Util/FOL.v
@@ -8,8 +8,6 @@ From Undecidability.Synthetic Require Export DecidabilityFacts EnumerabilityFact
 From Undecidability.FOLP Require Export Syntax unscoped.
 Require Export Lia.
 
-Set Default Proof Using "Type".
-
 (* **** Notation *)
 
 Notation "phi --> psi" := (Impl phi psi) (right associativity, at level 55).

--- a/theories/FOLP/Util/FullFOL.v
+++ b/theories/FOLP/Util/FullFOL.v
@@ -8,8 +8,6 @@ From Undecidability.Shared Require Import ListAutomation.
 Require Export Lia.
 Import ListAutomationNotations.
 
-Set Default Proof Using "Type".
-
 (* Coercion var_term : fin >-> term. *)
 
 Notation "phi --> psi" := (Impl phi psi) (right associativity, at level 55).

--- a/theories/FOLP/Util/FullSyntax.v
+++ b/theories/FOLP/Util/FullSyntax.v
@@ -3,8 +3,6 @@
 
 From Undecidability.FOLP Require Export unscoped.
 
-Set Default Proof Using "Type".
-
 Class Signature := B_S { Funcs : Type; fun_ar : Funcs -> nat ;
               Preds : Type; pred_ar : Preds -> nat }.
 

--- a/theories/FOLP/Util/FullTarski.v
+++ b/theories/FOLP/Util/FullTarski.v
@@ -3,8 +3,6 @@
 From Undecidability.FOLP Require Export FullFOL.
 Require Import Undecidability.Shared.ListAutomation.
 
-Set Default Proof Using "Type".
-
 (* *** Tarki Models **)
 
 Section Tarski.

--- a/theories/FOLP/Util/Syntax.v
+++ b/theories/FOLP/Util/Syntax.v
@@ -4,8 +4,6 @@
 
 From Undecidability.FOLP Require Export unscoped.
 
-Set Default Proof Using "Type".
-
 Class Signature := B_S { Funcs : Type; fun_ar : Funcs -> nat ;
               Preds : Type; pred_ar : Preds -> nat }.
 

--- a/theories/FRACTRAN/FRACTRAN/fractran_utils.v
+++ b/theories/FRACTRAN/FRACTRAN/fractran_utils.v
@@ -16,8 +16,6 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.FRACTRAN.FRACTRAN.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Section fractran_utils.

--- a/theories/FRACTRAN/Reductions/MM_FRACTRAN.v
+++ b/theories/FRACTRAN/Reductions/MM_FRACTRAN.v
@@ -21,8 +21,6 @@ From Undecidability.FRACTRAN
 Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Section MM_HALTING_FRACTRAN_ALT_HALTING.

--- a/theories/H10/ArithLibs/Zp.v
+++ b/theories/H10/ArithLibs/Zp.v
@@ -20,8 +20,6 @@ From Undecidability.H10.ArithLibs
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section le_pirr.
 
   (* a dependent induction principle for le *)

--- a/theories/H10/ArithLibs/lagrange.v
+++ b/theories/H10/ArithLibs/lagrange.v
@@ -17,8 +17,6 @@ From Undecidability.H10.ArithLibs
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section utils.
 
   Fact prime_2_or_odd p : prime p -> p = 2 \/ exists n, 0 < n /\ p = 2*n+1.

--- a/theories/H10/ArithLibs/luca.v
+++ b/theories/H10/ArithLibs/luca.v
@@ -19,8 +19,6 @@ From Undecidability.H10.ArithLibs
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation power := (mscal mult 1).
 Local Notation expo := (mscal mult 1).
 

--- a/theories/H10/ArithLibs/matrix.v
+++ b/theories/H10/ArithLibs/matrix.v
@@ -16,8 +16,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section rings.
 
   Variable (R : Type) (Rzero Rone : R) (Rplus Rmult Rminus : R -> R -> R) (Ropp : R -> R)

--- a/theories/H10/DPRM.v
+++ b/theories/H10/DPRM.v
@@ -22,8 +22,6 @@ From Undecidability.MuRec Require Import recalg ra_utils recomp ra_recomp ra_dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "P /MM/ s ↓" := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity).
 Local Notation "l '/F/' x ↓" := (fractran_terminates l x) (at level 70, no associativity).
 Local Notation "'⟦' p '⟧'" := (fun φ ν => dp_eval φ ν p).

--- a/theories/H10/Dio/dio_binary.v
+++ b/theories/H10/Dio/dio_binary.v
@@ -25,8 +25,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Infix "≲" := binary_le (at level 70, no associativity).
 Local Notation power := (mscal mult 1).
 Local Notation "∑" := (msum plus 0).

--- a/theories/H10/Dio/dio_bounded.v
+++ b/theories/H10/Dio/dio_bounded.v
@@ -22,8 +22,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation power := (mscal mult 1).
 Local Notation "∑" := (msum plus 0).
 

--- a/theories/H10/Dio/dio_elem.v
+++ b/theories/H10/Dio/dio_elem.v
@@ -19,8 +19,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section interval.
 
   (* A small interval & valuation library *)

--- a/theories/H10/Dio/dio_logic.v
+++ b/theories/H10/Dio/dio_logic.v
@@ -19,8 +19,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 (* Standard De Bruijn extension and De Bruijn projection *)
 
 (* Fixpoint instead of Definition because of better unfolding properties *)

--- a/theories/H10/Dio/dio_rt_closure.v
+++ b/theories/H10/Dio/dio_rt_closure.v
@@ -19,8 +19,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation power := (mscal mult 1).
 
 Section df_seq.

--- a/theories/H10/Dio/dio_single.v
+++ b/theories/H10/Dio/dio_single.v
@@ -19,8 +19,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "∑" := (msum plus 0).
 
 Section convexity.

--- a/theories/H10/Fractran/fractran_dio.v
+++ b/theories/H10/Fractran/fractran_dio.v
@@ -24,8 +24,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section fractran_dio.
 
   Notation "l /F/ x → y" := (fractran_step l x y) (at level 70, no associativity).

--- a/theories/H10/H10Z.v
+++ b/theories/H10/H10Z.v
@@ -23,8 +23,6 @@ From Undecidability.H10.Dio
 From Undecidability.H10.ArithLibs 
   Require Import Zp lagrange.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Section diophantine_polynomial.

--- a/theories/H10/H10Z_undec.v
+++ b/theories/H10/H10Z_undec.v
@@ -34,8 +34,6 @@ From Undecidability.H10.ArithLibs
 
 Require Import Undecidability.Synthetic.Definitions.
 
-Set Default Proof Using "Type".
-
 Local Definition inj k n := 4 * n + k.
 
 Lemma injection_spec k1 k2 n m : k1 < 4 -> k2 < 4 -> inj k1 n = inj k2 m -> k1 = k2 /\ n = m.

--- a/theories/H10/H10_undec.v
+++ b/theories/H10/H10_undec.v
@@ -14,6 +14,7 @@ From Undecidability.Shared.Libs.DLW
 
 From Undecidability.Synthetic Require Import Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
+Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 Require Import Undecidability.TM.TM.
 

--- a/theories/H10/H10_undec.v
+++ b/theories/H10/H10_undec.v
@@ -14,7 +14,6 @@ From Undecidability.Shared.Libs.DLW
 
 From Undecidability.Synthetic Require Import Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 Require Import Undecidability.TM.TM.
 

--- a/theories/H10/Matija/alpha.v
+++ b/theories/H10/Matija/alpha.v
@@ -17,8 +17,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 From Undecidability.H10.ArithLibs 
   Require Import matrix Zp.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Section Zp_alpha_2.

--- a/theories/H10/Matija/cipher.v
+++ b/theories/H10/Matija/cipher.v
@@ -16,8 +16,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation power := (mscal mult 1).
 Local Notation "∑" := (msum plus 0).
 Local Infix "≲" := binary_le (at level 70, no associativity).

--- a/theories/H10/Matija/expo_diophantine.v
+++ b/theories/H10/Matija/expo_diophantine.v
@@ -22,8 +22,6 @@ From Undecidability.H10.Matija
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation expo := (mscal mult 1).
 
 Section expo_diophantine.

--- a/theories/HOU/calculus/confluence.v
+++ b/theories/HOU/calculus/confluence.v
@@ -3,8 +3,6 @@ Require Import Morphisms Setoid.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import prelim terms semantics. 
 
-Set Default Proof Using "Type".
-
 (* * Confluence *)
 Section Confluence.
 

--- a/theories/HOU/calculus/equivalence.v
+++ b/theories/HOU/calculus/equivalence.v
@@ -5,8 +5,6 @@ From Undecidability.HOU.calculus Require Import
   prelim terms syntax semantics confluence. 
 
 
-Set Default Proof Using "Type".
-
 (* * Equational Theory *)
 Section Equivalence.
   Context {X: Const}.

--- a/theories/HOU/calculus/evaluator.v
+++ b/theories/HOU/calculus/evaluator.v
@@ -5,8 +5,6 @@ From Undecidability.HOU.calculus Require Import
   prelim terms syntax semantics confluence typing order normalisation. 
 
 
-Set Default Proof Using "Type".
-
 (* * Evaluator *)
 Section Evaluator.
 

--- a/theories/HOU/calculus/normalisation.v
+++ b/theories/HOU/calculus/normalisation.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics confluence typing order. 
 
-Set Default Proof Using "Type".
-
 (* * Weak Normalisation *)
 
 

--- a/theories/HOU/calculus/order.v
+++ b/theories/HOU/calculus/order.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics typing. 
 
-Set Default Proof Using "Type".
-
  (* * Order Typing *)
 Section OrderTyping.
   

--- a/theories/HOU/calculus/semantics.v
+++ b/theories/HOU/calculus/semantics.v
@@ -2,8 +2,6 @@ Set Implicit Arguments.
 From Undecidability.HOU Require Import calculus.prelim calculus.terms calculus.syntax std.std.
 Require Import Morphisms Lia FinFun. 
 
-Set Default Proof Using "Type".
-
 (* * Semantics **)
 Section Semantics.
 

--- a/theories/HOU/calculus/syntax.v
+++ b/theories/HOU/calculus/syntax.v
@@ -3,8 +3,6 @@ Require Import List Lia.
 Import ListNotations.
 From Undecidability.HOU Require Import calculus.terms calculus.prelim std.std.
 
-Set Default Proof Using "Type".
-
 (* * Syntax *)
 Definition isVar X (e: exp X) :=
   match e with var _ => True | _ => False end.

--- a/theories/HOU/calculus/terms.v
+++ b/theories/HOU/calculus/terms.v
@@ -2,8 +2,6 @@
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU Require Export unscoped.
 
-Set Default Proof Using "Type".
-
 Section Terms.
 
   Inductive type  : Type :=

--- a/theories/HOU/calculus/terms_extension.v
+++ b/theories/HOU/calculus/terms_extension.v
@@ -5,8 +5,6 @@ From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics equivalence typing order confluence. 
 
-Set Default Proof Using "Type".
-
 (* * Terms Extension *)
 
 Notation "sigma •₊ A" := (map (subst_exp sigma) A) (at level 69).

--- a/theories/HOU/calculus/typing.v
+++ b/theories/HOU/calculus/typing.v
@@ -3,8 +3,6 @@ Require Import List Lia.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import prelim terms syntax semantics.
 
-Set Default Proof Using "Type".
-
 (* * Simple Typing *)
 
 Section Typing.

--- a/theories/HOU/concon/conservativity.v
+++ b/theories/HOU/concon/conservativity.v
@@ -5,8 +5,6 @@ From Undecidability.HOU Require Import calculus.calculus concon.conservativity_c
   unification.nth_order_unification.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Global Hint Rewrite @consts_Lam @consts_AppL @consts_AppR : simplify.
 
 (* ** Inhabiting Types *)

--- a/theories/HOU/concon/conservativity_constants.v
+++ b/theories/HOU/concon/conservativity_constants.v
@@ -3,8 +3,6 @@ Require Import Morphisms Lia List.
 From Undecidability.HOU Require Import calculus.calculus.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Conservativity *)
 
 Section Constants.

--- a/theories/HOU/concon/constants.v
+++ b/theories/HOU/concon/constants.v
@@ -5,8 +5,6 @@ From Undecidability.HOU Require Import
         concon.conservativity_constants concon.conservativity.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Constants *)
 (* ** Adding Constants *)
 Section Retracts.
@@ -199,7 +197,6 @@ Section RemoveConstants.
 
   Let inv_subst C (sigma: fin -> exp Y) (x: nat) :=
     inv_term C (sigma x).
-    Set Default Proof Using "Type".
 
   Section EncodingLemmas.
     Variable (C: list X) (n: nat).
@@ -284,14 +281,14 @@ Section RemoveConstants.
     unfold enc_ctx; erewrite map_nth_error; eauto.  
   Qed.
 
-  Unset Default Proof Using.
-
+  (* maybe a setoid bug *)
+  #[local] Unset Default Proof Using.
   Global Instance enc_proper:
     Proper (equiv (@step X) ++> equiv (@step Y)) (enc_term C).
   Proof.
     intros ?? H; unfold enc_term; now rewrite H.
   Qed.
-
+  #[local] Set Default Proof Using "Type".
 
   Global Instance inv_proper:
     Proper (equiv (@step Y) ++> equiv (@step X)) (inv_term C).
@@ -299,14 +296,15 @@ Section RemoveConstants.
     intros ?? H; unfold inv_term; now rewrite H.
   Qed.
 
-  Set Default Proof Using "Type".
+  
 
+  
   
   Lemma subst_consts_subst Z (s: exp X) sigma tau theta zeta (kappa: X -> exp Z):
     (forall x, x ∈ vars s -> sigma • subst_consts zeta (tau x) >* subst_consts kappa (theta x)) ->
     (forall x, x ∈ consts s -> sigma • zeta x >* kappa x) ->
     sigma • subst_consts zeta (tau • s) >* subst_consts kappa (theta • s).
-  Proof using ι n inv_term inv_subst enc_term enc_subst enc_const Y RE R' C.
+  Proof using n RE C.
     induction s in sigma, zeta, tau, kappa, theta |-*.
     - cbn; intros; eapply H; now econstructor.
     - cbn; intros; eapply H0; eauto.
@@ -445,7 +443,7 @@ Section RemoveConstants.
            (Consts [s₀; t₀]).
 
 
-  
+           
   Program Instance remove_constants n (I: orduni n X)
           (H: ord' (map (ctype X) (iConsts I)) < n) : orduni n Y :=
     {
@@ -466,7 +464,6 @@ Section RemoveConstants.
   Qed.
 
   
-
   Lemma remove_constants_forward n (I: orduni n X)
         (H: ord' (map (ctype X) (iConsts I)) < n):
     OU n X I -> OU n Y (remove_constants n I H).

--- a/theories/HOU/concon/enumerability.v
+++ b/theories/HOU/concon/enumerability.v
@@ -2,8 +2,6 @@ Set Implicit Arguments.
 Require Import List Lia.
 From Undecidability.HOU Require Import calculus.calculus concon.conservativity unification.unification.
 
-Set Default Proof Using "Type".
-
 (* * Enumerability from Conservativity *)
 
 (* ** Nth-Order Unification  *)

--- a/theories/HOU/firstorder.v
+++ b/theories/HOU/firstorder.v
@@ -6,8 +6,6 @@ Import ListNotations.
 
 Tactic Notation "simplify" := Undecidability.HOU.std.tactics.simplify.  
 
-Set Default Proof Using "Type".
-
 (* * First-Order Unification *)
 
 (* ** Singlepoint Substitution *)

--- a/theories/HOU/second_order/dowek/encoding.v
+++ b/theories/HOU/second_order/dowek/encoding.v
@@ -5,8 +5,6 @@ From Undecidability.HOU Require Import std.std calculus.calculus second_order.di
 From Undecidability.HOU.unification Require Import 
   systemunification nth_order_unification.
 
-Set Default Proof Using "Type".
-
 (* * Higher-Order Motivation *)
 
 (* ** Church Numerals *)

--- a/theories/HOU/second_order/dowek/reduction.v
+++ b/theories/HOU/second_order/dowek/reduction.v
@@ -5,8 +5,6 @@ Import ListNotations.
 From Undecidability.HOU.second_order Require Import diophantine_equations dowek.encoding.
 Require Import Undecidability.HOU.unification.nth_order_unification.
 
-Set Default Proof Using "Type".
-
 (* ** Equivalences *)
 Section EquationEquivalences.
 

--- a/theories/HOU/second_order/goldfarb/encoding.v
+++ b/theories/HOU/second_order/goldfarb/encoding.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import calculus.calculus second_order.diophantin
   systemunification nth_order_unification.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Second-Order Realisation *)
 
 (* ** Goldfarb Numerals *)

--- a/theories/HOU/second_order/goldfarb/motivation.v
+++ b/theories/HOU/second_order/goldfarb/motivation.v
@@ -3,8 +3,6 @@ Require Import List Lia.
 From Undecidability.HOU Require Import std.std axioms.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* ** Multiplication Motivation  *)
 Section Motivation.
 

--- a/theories/HOU/second_order/goldfarb/multiplication.v
+++ b/theories/HOU/second_order/goldfarb/multiplication.v
@@ -6,8 +6,6 @@ From Undecidability.HOU Require Import calculus.calculus second_order.goldfarb.e
 Require Import FinFun Coq.Arith.Wf_nat.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 
 Section Multiplication.
 

--- a/theories/HOU/second_order/goldfarb/reduction.v
+++ b/theories/HOU/second_order/goldfarb/reduction.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import calculus.calculus unification.unification
 From Undecidability.HOU.second_order Require Export diophantine_equations goldfarb.encoding goldfarb.multiplication.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 
 (* ** Equivalences *)
 Section EquationEquivalences.

--- a/theories/HOU/std/ars/basic.v
+++ b/theories/HOU/std/ars/basic.v
@@ -7,8 +7,6 @@ Set Implicit Arguments.
 Require Import Morphisms FinFun.
 From Undecidability.HOU Require Import std.tactics.
 
-Set Default Proof Using "Type".
-
 Section ClosureRelations.
   Variables (X: Type).
   Implicit Types (R S: X -> X -> Prop) (x y z : X).

--- a/theories/HOU/std/ars/confluence.v
+++ b/theories/HOU/std/ars/confluence.v
@@ -7,8 +7,6 @@ Set Implicit Arguments.
 Require Import Morphisms FinFun.
 From Undecidability.HOU Require Import std.tactics std.misc std.ars.basic.
 
-Set Default Proof Using "Type".
-
 #[export] Hint Constructors star multiple counted : core.
 
 Section Confluence.

--- a/theories/HOU/std/ars/evaluator.v
+++ b/theories/HOU/std/ars/evaluator.v
@@ -7,8 +7,6 @@ Set Implicit Arguments.
 Require Import Morphisms FinFun ConstructiveEpsilon.
 From Undecidability.HOU Require Import std.tactics std.decidable std.misc std.ars.basic std.ars.confluence.
 
-Set Default Proof Using "Type".
-
 Section Evaluator.
 
   Variables (X: Type) (R: X -> X -> Prop) (rho: X -> X). 

--- a/theories/HOU/std/ars/list_reduction.v
+++ b/theories/HOU/std/ars/list_reduction.v
@@ -3,8 +3,6 @@ Require Import List Morphisms FinFun.
 From Undecidability.HOU Require Import std.tactics std.ars.basic std.ars.confluence.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Section ListRelations.
 
   Variable (X : Type) (R: X -> X -> Prop).

--- a/theories/HOU/std/ars/normalisation.v
+++ b/theories/HOU/std/ars/normalisation.v
@@ -1,8 +1,6 @@
 Set Implicit Arguments.
 From Undecidability.HOU Require Import std.ars.basic.
 
-Set Default Proof Using "Type".
-
 (* Strong normalisation *)
 Section StrongNormalisation.
 

--- a/theories/HOU/std/decidable.v
+++ b/theories/HOU/std/decidable.v
@@ -1,7 +1,5 @@
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Class Dec (P: Prop) := dec: {P} + {~P}.
 Arguments dec _ {_}.
 

--- a/theories/HOU/std/enumerable.v
+++ b/theories/HOU/std/enumerable.v
@@ -4,8 +4,6 @@ Require Import List Arith Lia.
 From Undecidability.HOU Require Import std.decidable std.lists.basics std.lists.advanced std.tactics.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Notation "( A × B × .. × C )" :=
   (list_prod .. (list_prod A B) .. C) (at level 0, left associativity).
 

--- a/theories/HOU/std/lists/advanced.v
+++ b/theories/HOU/std/lists/advanced.v
@@ -2,8 +2,6 @@ Require Import List Arith Lia.
 Import ListNotations.
 From Undecidability.HOU Require Import std.tactics std.lists.basics std.decidable. 
 
-Set Default Proof Using "Type".
-
 (* nth *)
 Notation nth := nth_error. 
 Section Nth.

--- a/theories/HOU/std/lists/basics.v
+++ b/theories/HOU/std/lists/basics.v
@@ -3,8 +3,6 @@ Require Import List Arith Lia Morphisms FinFun Init.Wf.
 From Undecidability.HOU Require Import std.decidable.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Arguments incl {_} _ _.
 Definition seteq {X: Type} (A B: list X) := incl A B /\ incl B A.
 Definition strict_incl {X: Type} (A B: list X) :=

--- a/theories/HOU/std/reductions.v
+++ b/theories/HOU/std/reductions.v
@@ -3,8 +3,6 @@ Require Import Lia List.
 From Undecidability.HOU Require Import std.lists.basics std.misc std.enumerable std.decidable.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Section Reductions.
 
   Variable (X Y Z: Type).

--- a/theories/HOU/std/retracts.v
+++ b/theories/HOU/std/retracts.v
@@ -2,8 +2,6 @@ Set Implicit Arguments.
 
 From Undecidability.HOU Require Import std.misc std.decidable.
 
-Set Default Proof Using "Type".
-
 Class retract (X Y: Type) :=
   { I: X -> Y;
     R: Y -> option X;

--- a/theories/HOU/third_order/encoding.v
+++ b/theories/HOU/third_order/encoding.v
@@ -4,8 +4,6 @@ Require Import RelationClasses Morphisms List Lia
 From Undecidability.HOU Require Import std.std calculus.calculus third_order.pcp.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Third-Order Encoding *)
 Section Encoding.
 

--- a/theories/HOU/third_order/huet.v
+++ b/theories/HOU/third_order/huet.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import std.std calculus.calculus unification.uni
 From Undecidability.HOU Require Import third_order.pcp third_order.encoding.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Huet Reduction *)
 Section HuetReduction.
 

--- a/theories/HOU/third_order/pcp.v
+++ b/theories/HOU/third_order/pcp.v
@@ -3,8 +3,6 @@ Require Import List.
 From Undecidability.HOU Require Import std.std. 
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * PCP and MPCP *)
 Notation symbol := bool.
 Notation word   := (list symbol).

--- a/theories/HOU/third_order/simplified.v
+++ b/theories/HOU/third_order/simplified.v
@@ -4,8 +4,6 @@ From Undecidability.HOU Require Import std.std calculus.calculus unification.uni
 From Undecidability.HOU Require Import third_order.pcp third_order.encoding.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 Definition MPCP' '(c, C) :=
   exists I, I ⊆ nats (length C) /\
        hd c ++ @concat symbol (select I (heads C)) = tl c ++ concat (select I (tails C)).

--- a/theories/HOU/unification/enumerability.v
+++ b/theories/HOU/unification/enumerability.v
@@ -2,8 +2,6 @@ Set Implicit Arguments.
 Require Import List Lia.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.higher_order_unification unification.nth_order_unification.
 
-Set Default Proof Using "Type".
-
 (* * Enumerability *)
 
 (* ** Terms, Types and Contexts *)

--- a/theories/HOU/unification/higher_order_unification.v
+++ b/theories/HOU/unification/higher_order_unification.v
@@ -4,8 +4,6 @@ Import ListNotations.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics equivalence typing order evaluator. 
 
-Set Default Proof Using "Type".
-
 (* * Higher-Order Unification *)
 Section UnificationDefinitions.
 

--- a/theories/HOU/unification/nth_order_unification.v
+++ b/theories/HOU/unification/nth_order_unification.v
@@ -2,8 +2,6 @@ Require Import List Lia Morphisms.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.higher_order_unification unification.systemunification.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * Nth-Order Unification *)
 Section NthOrderUnificationDefinition.
 

--- a/theories/HOU/unification/systemunification.v
+++ b/theories/HOU/unification/systemunification.v
@@ -3,8 +3,6 @@ Require Import List Lia.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.higher_order_unification.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 (* * System Unification *)
 Section SystemUnification.
 

--- a/theories/ILL/ILL_undec.v
+++ b/theories/ILL/ILL_undec.v
@@ -14,7 +14,6 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 From Undecidability.PCP              Require Import PCP PCP_undec.
 From Undecidability.StackMachines    Require Import BSM.

--- a/theories/ILL/ILL_undec.v
+++ b/theories/ILL/ILL_undec.v
@@ -14,6 +14,7 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
+Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 From Undecidability.PCP              Require Import PCP PCP_undec.
 From Undecidability.StackMachines    Require Import BSM.

--- a/theories/ILL/Ll/eill.v
+++ b/theories/ILL/Ll/eill.v
@@ -187,7 +187,7 @@ Section g_eill_complete_bound.
   Theorem G_eill_complete_bound x : 
             [< map (fun c => !⦑c⦒) Σ ++ map £ Γ |- £ x >] vec_zero 
          -> Σ; Γ ⊦ x.
-  Proof.
+  Proof using w_surj.
     intros H.
     do 2 red in H.
     destruct (@Hrx Γ) as (v & Hv).
@@ -277,7 +277,7 @@ Section g_eill_complete.
             (Hvalid : forall n s, @ill_sequent_tps n s (map (fun c => !⦑c⦒) Σ ++ map £ Γ) (£ x) vec_zero).
 
   Theorem G_eill_complete : Σ; Γ ⊦ x.
-  Proof.
+  Proof using Hvalid.
     apply G_eill_complete_bound with (1 := w_surj), Hvalid.
   Qed.
 

--- a/theories/ILL/Ll/eill_mm.v
+++ b/theories/ILL/Ll/eill_mm.v
@@ -136,7 +136,7 @@ Section Minsky.
   (* We define the semantics as in the paper ToCL 2013 (DLW & Galmiche) *)
 
   Local Definition s (x : eill_vars) (v : vec nat n) : Prop.
-  Proof.
+  Proof using P k.
     refine (match le_lt_dec n x with
                  | left H1  => match le_lt_dec (2*n) x with
                      | left _   => P // (x-2*n,v) ->> (k,vec_zero)
@@ -295,10 +295,10 @@ Section Minsky.
   Qed.
  
   Lemma Σ_zero c : In c Σ -> [[ ⦑c⦒  ]] vec_zero.
-  Proof. intros H; apply in_app_or in H as []; auto. Qed.
+  Proof using Hk. intros H; apply in_app_or in H as []; auto. Qed.
   
   Corollary ill_tps_Σ_zero : ill_tps_list s (map (fun c => !⦑c⦒) Σ) vec_zero.
-  Proof.
+  Proof using Hk.
     generalize Σ Σ_zero; intros S.
     induction S as [ | A S IHS ]; intros HS.
     + simpl; auto.
@@ -309,7 +309,7 @@ Section Minsky.
   Qed.
  
   Theorem lemma_5_5 v i : Σ; vec_map_list v rx ⊦ q i -> P // (i,v) ->> (k,vec_zero).
-  Proof.
+  Proof using Hk.
     intros H.
     apply G_eill_S_ill_wc in H.
     apply ill_tps_sound with (s := s) in H.
@@ -371,7 +371,7 @@ Section Minsky.
   Qed.
   
   Lemma lemma_5_3 i v : P // (i,v) ->> (k,vec_zero) -> Σ; vec_map_list v rx ⊦ q i.
-  Proof.
+  Proof using Hk.
     intros (r & Hr); revert i v Hr.
     induction r as [ | r IHr ]; intros i v Hr.
     + apply sss_steps_0_inv in Hr.
@@ -422,7 +422,7 @@ Section Minsky.
    
   Theorem G_eill_mm i v : P // (i,v) ->> (k,vec_zero) 
                       <-> Σ; vec_map_list v rx ⊦ q i.
-  Proof.
+  Proof using Hk.
     split.
     + apply lemma_5_3.
     + now apply lemma_5_5.

--- a/theories/ILL/Ll/imsell.v
+++ b/theories/ILL/Ll/imsell.v
@@ -147,10 +147,10 @@ Section IMSELL.
     where "⟦ A ⟧" := (imsell_tps A).
 
     Fact imsell_tps_bang_zero m A : ⟦![m]A⟧ ⦳ <-> ⟦A⟧ ⦳.
-    Proof. simpl; split; auto; tauto. Qed.
+    Proof using HK_unit0. simpl; split; auto; tauto. Qed.
 
     Fact imsell_tps_bang_U u A : U u -> (forall v, ⟦![u]A⟧ v <-> v = ⦳) <-> ⟦A⟧ ⦳.
-    Proof.
+    Proof using HK_unit0 HK_unit1.
       intros Hu; split.
       + intros H; rewrite <- imsell_tps_bang_zero, H; auto.
       + intros H v; split; simpl.
@@ -235,7 +235,7 @@ Section IMSELL.
     Qed.
 
    Fact imsell_tps_lbang m Γ : m ≼ Γ -> ⟪‼Γ⟫ ⊆ K m.
-    Proof.
+    Proof using HK_unit0 HK_plus HK_antitone.
       induction Γ as [ | (v,A) Γ IH ]; simpl; intros H1 x.
       + intros <-; auto.
       + intros (y & z & -> & (G1 & G2) & G3).
@@ -247,7 +247,7 @@ Section IMSELL.
     Qed.
 
     Theorem imsell_tps_sound Γ A : Γ ⊢ A -> [< Γ |- A >] ⦳.
-    Proof.
+    Proof using All.
       induction 1 as [ A 
                      | Γ Δ A H1 H2 IH2
                      | Γ Δ A B C H1 IH1 H2 IH2

--- a/theories/ILL/Reductions/MM_EILL.v
+++ b/theories/ILL/Reductions/MM_EILL.v
@@ -20,8 +20,6 @@ From Undecidability.MinskyMachines
 From Undecidability.ILL
   Require Import ILL EILL eill eill_mm.
 
-Set Default Proof Using "Type".
-
 Local Notation "P '/MM/' s ->> t" := (sss_compute (@mm_sss _) P s t) (at level 70, no associativity).
 Local Notation "P '/MM/' s ~~> t" := (sss_output (@mm_sss _) P s t) (at level 70, no associativity).
 

--- a/theories/ILL/Reductions/iBPCP_MM.v
+++ b/theories/ILL/Reductions/iBPCP_MM.v
@@ -13,6 +13,7 @@ Import ListNotations.
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
+Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW
   Require Import utils.

--- a/theories/ILL/Reductions/iBPCP_MM.v
+++ b/theories/ILL/Reductions/iBPCP_MM.v
@@ -13,7 +13,6 @@ Import ListNotations.
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW
   Require Import utils.

--- a/theories/ILL/Reductions/ndMM2_IMSELL.v
+++ b/theories/ILL/Reductions/ndMM2_IMSELL.v
@@ -21,8 +21,6 @@ From Undecidability.Shared.Libs.DLW
 From Undecidability.Synthetic
   Require Import Definitions ReducibilityFacts.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Infix "~p" := (@Permutation _) (at level 70).

--- a/theories/L/AbstractMachines/FlatPro/UnfoldClos.v
+++ b/theories/L/AbstractMachines/FlatPro/UnfoldClos.v
@@ -1,7 +1,6 @@
 From Undecidability.L.AbstractMachines.FlatPro Require Import LM_heap_correct LM_heap_def.
 From Undecidability.L.Prelim Require Import LoopSum.
 
-Set Default Proof Using "Type".
 Section fixH.
   Variable H : Heap.
 

--- a/theories/L/Complexity/UpToCNary.v
+++ b/theories/L/Complexity/UpToCNary.v
@@ -14,8 +14,6 @@ Proof. reflexivity. Qed.
 
 Smpl Add 2 rewrite leToC_eta in *: nary_prepare.
 
-Set Default Proof Using "Type".
-
 Section workaround.
   (*This makes the apply_nary tactic and the rewrites with leToC_eta and "=" work *)
   Local Generalizable Variables A R eqA B S eqB.

--- a/theories/L/Computability/MuRec.v
+++ b/theories/L/Computability/MuRec.v
@@ -1,6 +1,5 @@
 From Undecidability.L Require Export Datatypes.LNat Datatypes.LBool Tactics.LTactics Computability.Computability Tactics.Lbeta.
 
-Set Default Proof Using "Type".
 Section MuRecursor.
 
 Variable P : term.

--- a/theories/L/Datatypes/List/List_basics.v
+++ b/theories/L/Datatypes/List/List_basics.v
@@ -3,8 +3,6 @@ From Undecidability.L Require Import UpToC.
 From Undecidability.L.Datatypes Require Export List.List_enc LBool LNat.
 From Undecidability.Shared.Libs.PSL.Lists Require Export Filter.
 
-Set Default Proof Using "Type".
-
 Definition c__app := 16.
 #[global]
 Instance termT_append X {intX : registered X} : computableTime' (@List.app X) (fun A _ => (5,fun B _ => (length A * c__app + c__app,tt))).

--- a/theories/L/Datatypes/List/List_enc.v
+++ b/theories/L/Datatypes/List/List_enc.v
@@ -1,7 +1,6 @@
 From Undecidability.L.Tactics Require Import LTactics GenEncode.
 
 (* ** Encoding of lists *)
-Set Default Proof Using "Type".
 
 Section Fix_X.
   Variable (X:Type).

--- a/theories/L/Datatypes/List/List_eqb.v
+++ b/theories/L/Datatypes/List/List_eqb.v
@@ -4,8 +4,6 @@ From Undecidability.L Require Import Functions.EqBool.
 
 From Undecidability.L.Datatypes Require Export List.List_enc LBool LOptions LNat.
 
-Set Default Proof Using "Type".
-
 Section Fix_X.
   Variable (X:Type).
   Context {intX : registered X}.

--- a/theories/L/Datatypes/List/List_extra.v
+++ b/theories/L/Datatypes/List/List_extra.v
@@ -2,8 +2,6 @@ From Undecidability.L.Tactics Require Import LTactics.
 From Undecidability.L Require Import UpToC.
 From Undecidability.L.Datatypes Require Export List_enc List_in List_basics LBool LNat.
 
-Set Default Proof Using "Type".
-
 Definition lengthEq A :=
   fix f (t:list A) n :=
     match n,t with

--- a/theories/L/Datatypes/List/List_fold.v
+++ b/theories/L/Datatypes/List/List_fold.v
@@ -2,8 +2,6 @@ From Undecidability.L.Tactics Require Import LTactics.
 From Undecidability.L Require Import UpToC.
 From Undecidability.L.Datatypes Require Export List_enc LBool.
 
-Set Default Proof Using "Type".
-
 Section forallb. 
   Variable (X : Type).
   Context (H : registered X).

--- a/theories/L/Datatypes/List/List_in.v
+++ b/theories/L/Datatypes/List/List_in.v
@@ -3,7 +3,6 @@ From Undecidability.L Require Import UpToC.
 From Undecidability.L Require Import Functions.EqBool.
 
 From Undecidability.L.Datatypes Require Export List.List_enc.
-Set Default Proof Using "Type".
 
 Section list_in.
   Variable (X : Type). 

--- a/theories/L/Datatypes/List/List_nat.v
+++ b/theories/L/Datatypes/List/List_nat.v
@@ -2,8 +2,6 @@ From Undecidability.L.Tactics Require Import LTactics.
 From Undecidability.L Require Import UpToC.
 From Undecidability.L.Datatypes Require Export List.List_enc LNat LOptions LBool.
 
-Set Default Proof Using "Type".
-
 Definition c__ntherror := 15.
 Definition nth_error_time (X : Type) (A : list X) (n : nat) := (min (length A) n + 1) * c__ntherror. 
 #[global]

--- a/theories/L/Functions/EnumInt.v
+++ b/theories/L/Functions/EnumInt.v
@@ -4,7 +4,6 @@ From Undecidability.L.Functions Require Import Encoding Equality.
 From Undecidability.L.Datatypes Require Import LNat Lists LProd.
 Require Import Undecidability.Shared.Libs.PSL.Base Nat List Datatypes.
 
-Set Default Proof Using "Type".
 Import Nat.
 (* ** Enumeratibility of L-terms *)
 #[global]

--- a/theories/L/Functions/FinTypeLookup.v
+++ b/theories/L/Functions/FinTypeLookup.v
@@ -2,8 +2,6 @@ From Undecidability.L.Tactics Require Import LTactics.
 From Undecidability.L.Datatypes Require Import LFinType LBool LProd Lists.
 From Undecidability.L.Functions Require Import EqBool.
 
-Set Default Proof Using "Type".
-
 Section Lookup.
   Variable X Y : Type.
   Context {eqbX : X -> X -> bool}.

--- a/theories/L/TM/TMinL.v
+++ b/theories/L/TM/TMinL.v
@@ -5,8 +5,6 @@ From Undecidability.TM Require Import TM_facts.
 
 Require Import Undecidability.L.TM.TMinL.TMinL_extract.
 
-Set Default Proof Using "Type".
-
 Definition Halt' (Sigma : finType) n (M: TM Sigma n) (start: mconfig Sigma (state M) n) :=
   exists (f: mconfig _ (state M) _), halt (cstate f)=true /\ exists k, loopM start k = Some f.
 

--- a/theories/L/TM/TMinL/TMinL_extract.v
+++ b/theories/L/TM/TMinL/TMinL_extract.v
@@ -5,7 +5,6 @@ From Undecidability.L Require Import TM.TapeFuns.
 
 From Undecidability.TM Require Import TM_facts.
 
-Set Default Proof Using "Type".
 Local Notation L := TM.Lmove.
 Local Notation R := TM.Rmove.
 Local Notation N := TM.Nmove.

--- a/theories/L/TM/TapeFuns.v
+++ b/theories/L/TM/TapeFuns.v
@@ -4,7 +4,6 @@ From Undecidability.L Require Import TM.TMEncoding.
 From Undecidability.TM Require Import Util.TM_facts.
 
 
-Set Default Proof Using "Type".
 Section fix_sig.
   Variable sig : Type.
   Context `{reg_sig : registered sig}.

--- a/theories/L/Tactics/ComputableDemo.v
+++ b/theories/L/Tactics/ComputableDemo.v
@@ -2,7 +2,6 @@ From Undecidability.L.Datatypes Require Import LOptions LBool LNat Lists.
 From Undecidability.L.Tactics Require Import LTactics ComputableTactics.
 Require Import Nat.
 
-Set Default Proof Using "Type".
 Section demo.
 
 (* for examples of usage see LBool/LNat/Lists/Option/Encoding etc*)

--- a/theories/L/Tactics/LTactics.v
+++ b/theories/L/Tactics/LTactics.v
@@ -3,5 +3,3 @@ From MetaCoq.Template Require Export TemplateMonad.Core.
 (* * Certifying extraction from Coq to L with time bounds *)
 From Undecidability.L.Tactics Require Export Lsimpl mixedTactics ComputableTime Lbeta Computable ComputableTactics Lproc Lrewrite.
 From Undecidability.L.Complexity Require Export UpToCNary.
-
-Export Set Default Proof Using "Type".

--- a/theories/MinskyMachines/Deciders/MM_2_HALTING_dec.v
+++ b/theories/MinskyMachines/Deciders/MM_2_HALTING_dec.v
@@ -25,7 +25,6 @@ Require Import Undecidability.CounterMachines.Util.Facts.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 #[local] Notation "P // s ↓" := (sss_terminates (@mm_sss _) P s).
 #[local] Notation "P // r ->> s" := (sss_compute (@mm_sss _) P r s).

--- a/theories/MinskyMachines/Deciders/MPM2_HALT_dec.v
+++ b/theories/MinskyMachines/Deciders/MPM2_HALT_dec.v
@@ -93,7 +93,6 @@ Require Import ssreflect ssrbool ssrfun.
 Require Import Undecidability.CounterMachines.Util.Facts.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section Construction.
 Variable M : Mpm2.

--- a/theories/MinskyMachines/MM/mm_comp.v
+++ b/theories/MinskyMachines/MM/mm_comp.v
@@ -21,8 +21,6 @@ From Undecidability.MinskyMachines.MM
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 (* ** BSM recues to MM *)
 
 Tactic Notation "rew" "length" := autorewrite with length_db.

--- a/theories/MinskyMachines/MM/mm_defs.v
+++ b/theories/MinskyMachines/MM/mm_defs.v
@@ -17,8 +17,6 @@ From Undecidability.MinskyMachines
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/MM/mm_no_self.v
+++ b/theories/MinskyMachines/MM/mm_no_self.v
@@ -20,8 +20,6 @@ From Undecidability.MinskyMachines.MM
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/MM/mm_utils.v
+++ b/theories/MinskyMachines/MM/mm_utils.v
@@ -15,8 +15,6 @@ From Undecidability.Shared.Libs.DLW
 From Undecidability.MinskyMachines.MM
   Require Import mm_defs. 
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Tactic Notation "rew" "length" := autorewrite with length_db.

--- a/theories/MinskyMachines/MM2.v
+++ b/theories/MinskyMachines/MM2.v
@@ -11,7 +11,8 @@
 
 (** * Halting problem for two counter Minsky machines MM2_HALTING  *)
 
-Require Import List Arith Relations.
+Require Import Relations.Relation_Operators.
+#[local] Open Scope list_scope.
 
 Set Implicit Arguments.
 

--- a/theories/MinskyMachines/MMA/fractran_mma.v
+++ b/theories/MinskyMachines/MMA/fractran_mma.v
@@ -20,8 +20,6 @@ From Undecidability.FRACTRAN
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/MMA/mma_defs.v
+++ b/theories/MinskyMachines/MMA/mma_defs.v
@@ -14,8 +14,6 @@ From Undecidability.Shared.Libs.DLW
 
 From Undecidability.MinskyMachines Require Export MM.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Tactic Notation "rew" "length" := autorewrite with length_db.

--- a/theories/MinskyMachines/MMA/mma_simul.v
+++ b/theories/MinskyMachines/MMA/mma_simul.v
@@ -17,8 +17,6 @@ From Undecidability.MinskyMachines.MMA
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/MMA/mma_utils.v
+++ b/theories/MinskyMachines/MMA/mma_utils.v
@@ -17,8 +17,6 @@ From Undecidability.MinskyMachines.MMA
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/MMenv/env.v
+++ b/theories/MinskyMachines/MMenv/env.v
@@ -12,8 +12,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Reserved Notation " e '⇢' x " (at level 58).
 Reserved Notation " e [ v / x ] " (at level 57, v at level 0, x at level 0, 
                                    left associativity, format "e [ v / x ]").

--- a/theories/MinskyMachines/MMenv/mme_defs.v
+++ b/theories/MinskyMachines/MMenv/mme_defs.v
@@ -17,8 +17,6 @@ From Undecidability.MinskyMachines.MMenv Require Import env.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 (* * Minsky Machines
 
     A Minsky machine has n registers and there are just two instructions

--- a/theories/MinskyMachines/MMenv/mme_utils.v
+++ b/theories/MinskyMachines/MMenv/mme_utils.v
@@ -17,8 +17,6 @@ From Undecidability.MinskyMachines.MMenv
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "P // s ->> t" := (sss_compute (mm_sss_env eq_nat_dec) P s t).

--- a/theories/MinskyMachines/Reductions/BSM_MM.v
+++ b/theories/MinskyMachines/Reductions/BSM_MM.v
@@ -18,8 +18,6 @@ From Undecidability.StackMachines
 From Undecidability.MinskyMachines.MM
   Require Import mm_defs mm_utils mm_comp. 
 
-Set Default Proof Using "Type".
-
 Local Notation "P '/BSM/' s ↓" := (sss_terminates (@bsm_sss _) P s) (at level 70, no associativity).
 Local Notation "P '/MM/' s ~~> t" := (sss_output (@mm_sss _) P s t) (at level 70, no associativity).
 

--- a/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
@@ -27,8 +27,6 @@ From Undecidability.MinskyMachines Require Import mma_defs fractran_mma.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "P //ₐ s ↓" := (sss_terminates (@mma_sss 2) P s) (at level 70, no associativity).
 
 Section FRACTRAN_REG_MMA2_and_ON_ZERO.

--- a/theories/MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
@@ -20,8 +20,6 @@ From Undecidability.Synthetic
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section MM2_ndMM2.
 
   Notation STOP := (@ndmm2_stop _).

--- a/theories/MinskyMachines/Reductions/MMA2_to_MM2.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_MM2.v
@@ -16,8 +16,6 @@ From Undecidability.MinskyMachines Require Import MM2 mma_defs.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
@@ -20,8 +20,6 @@ From Undecidability.Synthetic
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Tactic Notation "vec2" hyp(v) "into" ident(x) ident(y) :=
     vec split v with x; vec split v with y; vec nil v; clear v.
 

--- a/theories/MinskyMachines/Reductions/MUREC_MM.v
+++ b/theories/MinskyMachines/Reductions/MUREC_MM.v
@@ -18,8 +18,6 @@ From Undecidability.MinskyMachines
 From Undecidability.MuRec 
   Require Import recalg ra_simul.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'"  := (@ra_rel _ f) (at level 0).
 Local Notation "P /MM/ s ↓" := (sss_terminates (@mm_sss _) P s) (at level 70, no associativity).
 

--- a/theories/MinskyMachines/ndMM2/ndmm2_utils.v
+++ b/theories/MinskyMachines/ndMM2/ndmm2_utils.v
@@ -12,8 +12,6 @@ Require Import List.
 From Undecidability.MinskyMachines 
   Require Import ndMM2.
 
-Set Default Proof Using "Type".
-
 Section ndMM2_monotonicity.
 
   Variables loc : Set.

--- a/theories/MuRec/Reductions/H10_to_MUREC_HALTING.v
+++ b/theories/MuRec/Reductions/H10_to_MUREC_HALTING.v
@@ -23,8 +23,6 @@ From Undecidability.H10
 From Undecidability.MuRec 
   Require Import recalg ra_dio_poly.
 
-Set Default Proof Using "Type".
-
 Section H10_MUREC_HALTING.
 
   Let f : H10_PROBLEM -> MUREC_PROBLEM.

--- a/theories/MuRec/minimizer.v
+++ b/theories/MuRec/minimizer.v
@@ -11,8 +11,6 @@ Require Import Arith Lia.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section nat_rev_ind.
 
   (* A reverse recursion principle *)

--- a/theories/MuRec/prim_min.v
+++ b/theories/MuRec/prim_min.v
@@ -14,8 +14,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section iter.
 
   Variable (X : Type) (f : X -> X). 

--- a/theories/MuRec/ra_ca.v
+++ b/theories/MuRec/ra_ca.v
@@ -14,8 +14,6 @@ From Undecidability.MuRec Require Import recalg.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Reserved Notation "  '[' f ';' v ']' '-[' n '>>' x " (at level 70).
 
 (* The intuitive meaning of [f;v] -[n>> x is

--- a/theories/MuRec/ra_dio_poly.v
+++ b/theories/MuRec/ra_dio_poly.v
@@ -20,8 +20,6 @@ From Undecidability.H10.Dio
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Section dio_poly.

--- a/theories/MuRec/ra_enum.v
+++ b/theories/MuRec/ra_enum.v
@@ -17,8 +17,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Section ra_min_extra.

--- a/theories/MuRec/ra_godel_beta.v
+++ b/theories/MuRec/ra_godel_beta.v
@@ -20,8 +20,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Opaque ra_cst_n ra_iter_n ra_iter ra_prim_min ra_prim_max.

--- a/theories/MuRec/ra_mm.v
+++ b/theories/MuRec/ra_mm.v
@@ -20,8 +20,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "i /e/ s '-1>' t" := (mm_sss_env eq_nat_dec i s t)  (at level 70, no associativity).

--- a/theories/MuRec/ra_mm_env.v
+++ b/theories/MuRec/ra_mm_env.v
@@ -20,8 +20,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "P // s ->> t" := (sss_compute (mm_sss_env eq_nat_dec) P s t).

--- a/theories/MuRec/ra_recomp.v
+++ b/theories/MuRec/ra_recomp.v
@@ -18,8 +18,6 @@ From Undecidability.MuRec Require Import recalg recomp prim_min ra_utils.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 Local Notation power := (mscal mult 1).
 

--- a/theories/MuRec/ra_sem_eq.v
+++ b/theories/MuRec/ra_sem_eq.v
@@ -15,8 +15,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Notation "[| f |]" := (@ra_rel _ f) (at level 0).
 
 Section soundness_and_completeness.

--- a/theories/MuRec/ra_univ.v
+++ b/theories/MuRec/ra_univ.v
@@ -23,8 +23,6 @@ From Undecidability.DiophantineConstraints
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Definition h10c_nat (c : h10c) :=

--- a/theories/MuRec/ra_univ_andrej.v
+++ b/theories/MuRec/ra_univ_andrej.v
@@ -20,8 +20,6 @@ From Undecidability.DiophantineConstraints
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Definition h10uc_eq a' b' (c : nat*nat*nat) :=

--- a/theories/MuRec/ra_utils.v
+++ b/theories/MuRec/ra_utils.v
@@ -17,8 +17,6 @@ From Undecidability.MuRec
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation "'⟦' f '⟧'" := (@ra_rel _ f) (at level 0).
 
 Local Notation power := (mscal mult 1).

--- a/theories/MuRec/recalg.v
+++ b/theories/MuRec/recalg.v
@@ -14,8 +14,6 @@ From Undecidability.Shared.Libs.DLW
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Reserved Notation " '[|' f '|]' " (at level 0).
 Local Reserved Notation "'⟦' f '⟧'".
 

--- a/theories/MuRec/recomp.v
+++ b/theories/MuRec/recomp.v
@@ -14,8 +14,6 @@ From Undecidability.Shared.Libs.DLW
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Local Notation power := (mscal mult 1).
 
 Section div_mult.

--- a/theories/MuRec/recursor.v
+++ b/theories/MuRec/recursor.v
@@ -12,8 +12,6 @@ From Undecidability.Shared.Libs.DLW
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Section recursor.
 
   Variables (F : nat -> Prop) 

--- a/theories/PCP/Reductions/HaltTM_1_to_PCPb.v
+++ b/theories/PCP/Reductions/HaltTM_1_to_PCPb.v
@@ -18,6 +18,7 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
+Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 Require Import Undecidability.TM.TM.
 

--- a/theories/PCP/Reductions/HaltTM_1_to_PCPb.v
+++ b/theories/PCP/Reductions/HaltTM_1_to_PCPb.v
@@ -18,7 +18,6 @@ From Undecidability.Shared.Libs.DLW
 
 Require Import Undecidability.Synthetic.Undecidability.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
-Require Import Undecidability.Synthetic.MoreReducibilityFacts.
 
 Require Import Undecidability.TM.TM.
 

--- a/theories/PCP/Reductions/MPCP_to_PCP.v
+++ b/theories/PCP/Reductions/MPCP_to_PCP.v
@@ -10,7 +10,6 @@ Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Shared.ListAutomation.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 (* * MPCP to PCP *)
 Section MPCP_PCP.

--- a/theories/PCP/Reductions/PCPX_iff_dPCP.v
+++ b/theories/PCP/Reductions/PCPX_iff_dPCP.v
@@ -9,7 +9,6 @@ Require Import Undecidability.Shared.ListAutomation.
 Require Import Undecidability.Synthetic.Definitions.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 Section derivable_iff_PCPX.
 

--- a/theories/PCP/Reductions/SR_to_MPCP.v
+++ b/theories/PCP/Reductions/SR_to_MPCP.v
@@ -13,7 +13,6 @@ Require Import Undecidability.Synthetic.Definitions.
 Import RuleNotation.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 (* * SR to MPCP *)
 Section SR_to_MPCP.

--- a/theories/PCP/Util/Facts.v
+++ b/theories/PCP/Util/Facts.v
@@ -6,8 +6,6 @@ Require Import Undecidability.PCP.PCP.
 Set Implicit Arguments. 
 Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 Module PCPListNotation.
 Notation "x 'el' A" := (In x A) (at level 70).
 Notation "A <<= B" := (incl A B) (at level 70).

--- a/theories/SOL/Reductions/H10p_to_SOL.v
+++ b/theories/SOL/Reductions/H10p_to_SOL.v
@@ -8,8 +8,6 @@ Require Import Undecidability.Shared.Dec.
 
 Import ListNotations SOLNotations PA2Notations.
 
-Set Default Proof Using "Type".
-
 Fixpoint encode_number n := match n with 
   | 0 => zero 
   | S n => σ (encode_number n) 

--- a/theories/SOL/Util/PA2_categoricity.v
+++ b/theories/SOL/Util/PA2_categoricity.v
@@ -7,8 +7,6 @@ From Undecidability.SOL.Util Require Import Syntax Subst Tarski PA2_facts.
 
 Import VectorNotations SubstNotations.
 
-Set Default Proof Using "Type".
-
 Unset Implicit Arguments.
 
 

--- a/theories/SOL/Util/PA2_facts.v
+++ b/theories/SOL/Util/PA2_facts.v
@@ -9,8 +9,6 @@ Require Import Undecidability.Shared.Dec.
 
 Import VectorNotations SubstNotations SOLNotations PA2Notations.
 
-Set Default Proof Using "Type".
-
 Arguments Vector.cons {_} _ {_} _, _ _ _ _.
 
 Unset Implicit Arguments.

--- a/theories/SOL/Util/Subst.v
+++ b/theories/SOL/Util/Subst.v
@@ -5,8 +5,6 @@ From Undecidability.Shared.Libs.PSL Require Import Vectors VectorForall.
 From Undecidability.SOL.Util Require Import Syntax.
 Require Import Undecidability.SOL.SOL.
 
-Set Default Proof Using "Type".
-
 (* We can reuse the Econs type class to extend the `.:` notation to substitutions. *)
 #[global] Instance econs_subst_indi `{funcs_signature} : Econs _ _ := econs_indi term.
 #[global] Instance econs_subst_func `{funcs_signature} ar : Econs _ _ := econs_ar ar function.

--- a/theories/SOL/Util/Syntax.v
+++ b/theories/SOL/Util/Syntax.v
@@ -4,8 +4,6 @@ From Undecidability.Shared.Libs.PSL Require Import Vectors VectorForall.
 From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts ReducibilityFacts.
 Require Import EqdepFacts Eqdep_dec.
 
-Set Default Proof Using "Type".
-
 Unset Implicit Arguments.
 
 #[global]

--- a/theories/SOL/Util/Tarski.v
+++ b/theories/SOL/Util/Tarski.v
@@ -6,8 +6,6 @@ Require Import Arith Lia Vector.
 Import SubstNotations.
 Unset Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Arguments eval_function {_ _ _ _ _}.
 Arguments eval_predicate {_ _ _ _ _}.
 Arguments eval {_ _ _ _}.

--- a/theories/SemiUnification/Reductions/CSSM_UB_to_SSemiU.v
+++ b/theories/SemiUnification/Reductions/CSSM_UB_to_SSemiU.v
@@ -26,7 +26,6 @@ From Undecidability.SemiUnification.Util Require Import Enumerable.
 
 Require Import ssreflect ssrfun ssrbool.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/SemiUnification/Reductions/RU2SemiU_to_LU2SemiU.v
+++ b/theories/SemiUnification/Reductions/RU2SemiU_to_LU2SemiU.v
@@ -19,7 +19,6 @@ From Undecidability.SemiUnification.Util Require Import Enumerable.
 
 Require Import ssreflect ssrfun ssrbool.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/SemiUnification/Reductions/SSemiU_to_RU2SemiU.v
+++ b/theories/SemiUnification/Reductions/SSemiU_to_RU2SemiU.v
@@ -19,7 +19,6 @@ From Undecidability.SemiUnification.Util Require Import Enumerable.
 
 Require Import ssreflect ssrfun ssrbool.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/SeparationLogic/Reductions/FSATdc_to_MSLSAT.v
+++ b/theories/SeparationLogic/Reductions/FSATdc_to_MSLSAT.v
@@ -10,7 +10,6 @@ From Undecidability.Shared Require Import Dec.
 Require Import Undecidability.Synthetic.DecidabilityFacts.
 
 Set Default Goal Selector "!".
-Set Default Proof Using "Type".
 
 
 

--- a/theories/Shared/Libs/DLW/Code/compiler.v
+++ b/theories/Shared/Libs/DLW/Code/compiler.v
@@ -81,7 +81,7 @@ Section linker.
     Qed.
     
     Fact comp_length i ll j : length (comp i ll j) = lsum ll.
-    Proof.
+    Proof using Hc.
       revert i j; induction ll as [ | x ll IH ]; simpl; intros i j; auto.
       rew length; rewrite IH, Hc; trivial.
     Qed.
@@ -133,14 +133,14 @@ Section linker.
   Definition compiler := comp linker (fst P) (snd P) i.
   
   Fact compiler_length : length compiler = length_compiler (snd P).
-  Proof. apply comp_length. Qed.
+  Proof using Hc. apply comp_length. Qed.
 
   Section linker_in_code.
 
     Hypothesis (Hlc : forall x, 1 <= lc x).
 
     Fact linker_in_code j : in_code j P -> in_code (linker j) (i,compiler).
-    Proof.
+    Proof using Hc Hlc.
       intros H; red in H; simpl in H.
       destruct (@list_split_length _ (snd P) (j - fst P)) as (ll & mm & H1 & H2);
         try lia.
@@ -160,7 +160,7 @@ Section linker.
           (j,x::nil) <sc P 
        -> (linker j, c linker j x) <sc (i,compiler)
        /\  linker (1+j) = lc x + linker j.
-  Proof.
+  Proof using Hc.
     case_eq P; intros iP lP HP (l & r & H1 & H2); simpl in H1.
     assert (linker j = lsum l + i) as Hj.
     { generalize (linker_app l (x::r)).
@@ -195,7 +195,7 @@ Section linker.
   
    Fact linker_out_code j : err < i \/ length_compiler (snd P) + i <= err 
                         -> out_code j P -> out_code (linker j) (i,compiler).
-  Proof.
+  Proof using Hc.
     intros H1 H2.
     red in H2.
     destruct (eq_nat_dec j (code_end P)) as [ H | H ].

--- a/theories/Shared/Libs/DLW/Code/compiler_correction.v
+++ b/theories/Shared/Libs/DLW/Code/compiler_correction.v
@@ -129,7 +129,7 @@ Section comp.
     Theorem compiler_sound i1 v1 i2 v2 w1 :
                       v1 ⋈ w1 /\ P /X/ (i1,v1) ->> (i2,v2)
         -> exists w2, v2 ⋈ w2 /\ Q /Y/ (linker i1,w1) ->> (linker i2,w2).
-    Proof.
+    Proof using HPQ Hilen Hicomp.
       change i1 with (fst (i1,v1)) at 2; change v1 with (snd (i1,v1)) at 1.
       change i2 with (fst (i2,v2)) at 2; change v2 with (snd (i2,v2)) at 2.
       generalize (i1,v1) (i2,v2); clear i1 v1 i2 v2.
@@ -163,7 +163,7 @@ Section comp.
                         /\ P /X/ st1 ->> st2
                         /\ Q /Y/ w2 -[q]-> w3
                         /\ q < p.
-    Proof.
+    Proof using HPQ Hicomp Hilen step_Y_fun step_X_tot.
       revert st1 w1 w3; intros (i1,v1) (j1,w1) (j3,w3); simpl fst; simpl snd.
       intros H1 H2 H3 H4 H5.
       destruct (in_code_subcode H3) as (I & HI).
@@ -198,7 +198,7 @@ Section comp.
 
     Theorem compiler_complete i1 v1 w1 : 
           v1 ⋈ w1 -> Q /Y/ (linker i1,w1) ↓ -> P /X/ (i1,v1) ↓.
-    Proof.
+    Proof using HPQ Hicomp Hilen step_Y_fun step_X_tot.
       intros H1 (st & (q & H2) & H3). 
       revert i1 v1 w1 H1 H2 H3.
       induction q as [ q IHq ] using (well_founded_induction lt_wf).
@@ -218,7 +218,7 @@ Section comp.
                             v1 ⋈ w1 /\ Q /Y/ (linker i1,w1) ~~> st
         -> exists i2 v2 w2, v2 ⋈ w2 /\ P /X/ (i1,v1) ~~> (i2,v2)
                                     /\ Q /Y/ (linker i2,w2) ~~> st.
-    Proof.
+    Proof using HPQ Hicomp Hilen step_Y_fun step_X_tot.
       intros (H1 & H2).
       destruct compiler_complete with (1 := H1) (2 := ex_intro (fun x => Q /Y/ (linker i1, w1) ~~> x) _ H2)
         as ((i2,v2) & H3 & H4).
@@ -253,7 +253,7 @@ Section comp.
   Proof. unfold iP, cP; destruct P; auto. Qed.
 
   Fact gen_linker_out i : out_code i (iP,cP) -> lnk i = iQ+length cQ.
-  Proof.
+  Proof using Hilen.
     intros H.
     unfold lnk.
     rewrite linker_out_err; unfold err; simpl; auto.
@@ -264,7 +264,7 @@ Section comp.
   Theorem gen_compiler_sound i1 v1 i2 v2 w1 : 
                     v1 ⋈ w1 /\ (iP,cP) /X/ (i1,v1) ~~> (i2,v2)
       -> exists w2, v2 ⋈ w2 /\ (iQ,cQ) /Y/ (lnk i1,w1) ~~> (lnk i2,w2).
-  Proof.
+  Proof using Hilen Hicomp.
     intros (H1 & H2 & H3).
     destruct compiler_sound with (2 := conj H1 H2) (linker := gen_linker) (Q := (iQ,cQ))
       as (w2 & G1 & G2).
@@ -277,13 +277,13 @@ Section comp.
 
   Theorem gen_compiler_complete i1 v1 w1 :
             v1 ⋈ w1 -> (iQ,gen_compiler) /Y/ (gen_linker i1,w1) ↓ -> (iP,cP) /X/ (i1,v1) ↓.
-  Proof.
+  Proof using Hilen Hicomp step_Y_fun step_X_tot.
     apply compiler_complete, compiler_subcode; auto.
   Qed.
 
   Corollary gen_compiler_output v w i' v' : 
         v ⋈ w -> (iP,cP) /X/ (iP,v) ~~> (i',v') -> exists w', (iQ,gen_compiler) /Y/ (iQ,w) ~~> (code_end (iQ,cQ),w') /\ v' ⋈ w'.
-  Proof.
+  Proof using Hilen Hicomp.
     intros H H1.
     destruct gen_compiler_sound with (1 := conj H H1) as (w1 & H2 & H3).
     exists w1.
@@ -294,7 +294,7 @@ Section comp.
 
   Corollary gen_compiler_terminates v w : 
           v ⋈ w -> (iQ,gen_compiler) /Y/ (iQ,w) ↓ -> (iP,cP) /X/ (iP,v) ↓.
-  Proof.
+  Proof using Hilen Hicomp step_Y_fun step_X_tot.
     intros H (w' & H').
     apply gen_compiler_complete with (1 := H).
     unfold gen_linker; rewrite linker_code_start; auto; firstorder.
@@ -308,7 +308,7 @@ Section comp.
                 /\ (forall i1 v1 w1 i2 v2, v1 ⋈ w1 /\ P /X/ (i1,v1) ~~> (i2,v2)     -> exists w2,    v2 ⋈ w2 /\ Q /Y/ (lnk i1,w1) ~~> (lnk i2,w2)) 
                 /\ (forall i1 v1 w1 j2 w2, v1 ⋈ w1 /\ Q /Y/ (lnk i1,w1) ~~> (j2,w2) -> exists i2 v2, v2 ⋈ w2 /\ P /X/ (i1,v1) ~~> (i2,v2) /\ j2 = lnk i2) 
            } }.
-  Proof.
+  Proof using Hilen Hicomp step_Y_fun step_X_tot.
     exists lnk, (iQ,cQ); split; auto; split; [ | split ].
     + rewrite <- (linker_code_start ilen (iP,cP) iQ err); auto.
     + rewrite P_eq; apply gen_linker_out.

--- a/theories/Shared/Libs/DLW/Code/sss.v
+++ b/theories/Shared/Libs/DLW/Code/sss.v
@@ -88,7 +88,7 @@ Section Small_Step_Semantics.
   (* Functionality of one step computations *)
 
   Fact sss_step_fun P s t1 t2 : P // s :1> t1 -> P // s :1> t2 -> t1 = t2.
-  Proof.
+  Proof using sss_fun.
     intros (k1 & l1 & i1 & r1 & d1 & ? & ? & H1)
            (k2 & l2 & i2 & r2 & d2 & ? & ? & H2).
     subst.
@@ -144,7 +144,7 @@ Section Small_Step_Semantics.
   (* sss_step is decidable *)
   
   Fact sss_step_dec P st1 st2 : { P // st1 :1> st2 } + { ~ P // st1 :1> st2 }.
-  Proof.
+  Proof using sss_fun sss_dec.
     destruct st1 as (j,d).
     destruct P as (k,ll).
     destruct (le_lt_dec k j) as [ H1 | H1 ].
@@ -245,7 +245,7 @@ Section Small_Step_Semantics.
          P // s -[k]-> t1 
       -> P // s -[k]-> t2 
       -> t1 = t2.
-  Proof.
+  Proof using sss_fun.
     intros H; revert H t2; induction 1 as [ | ? ? st2 ? H1 H2 IH2 ]; simpl; intros t2 Ht2; auto.
     inversion Ht2; auto.
     inversion Ht2; subst.
@@ -430,7 +430,7 @@ Section Small_Step_Semantics.
       -> P // s1 -[p]-> s2 
       -> P // s1 -[q]-> s2
       -> p = q.
-  Proof.
+  Proof using sss_fun.
     intros H1 H2; revert H2 q.
     induction 1 as [ s1 | p s1 s2 s3 H2 H3 IH3 ];
       intros q H5.
@@ -596,7 +596,7 @@ Section Small_Step_Semantics.
         -> P // st1 -[p]-> st2
         -> Q // st1 -[k]-> st3
         -> exists q, k = p+q /\ Q // st2 -[q]-> st3.
-  Proof.
+  Proof using sss_fun.
     revert P Q st3; intros P (j,cj) (n,d) H1 H2 H3.
     simpl in H1.
     revert k.
@@ -618,7 +618,7 @@ Section Small_Step_Semantics.
         -> P <sc Q
         -> P // st ~~> st1
         -> Q // st1 ↓.
-  Proof.
+  Proof using sss_fun.
     intros (st3 & (k & H1) & H2) H3 ((p & H4) & H5).
     destruct subcode_sss_subcode_inv with (2 := H3) (3 := H4) (4 := H1)
       as (q & _ & H6).
@@ -632,7 +632,7 @@ Section Small_Step_Semantics.
         -> P // st1 -+> st2
         -> Q // st1 -[p]-> st3
         -> exists q, q < p /\ Q // st2 -[q]-> st3.
-  Proof.
+  Proof using sss_fun.
     intros H1 H2 (k & ? & H3) H4.
     apply subcode_sss_subcode_inv with (3 := H3) in H4; auto.
     destruct H4 as (q & ? & ?); exists q; split; auto; lia.
@@ -646,7 +646,7 @@ Section Small_Step_Semantics.
                (HQ1 : forall st1 st3, (forall Q st2, Q <sc P -> Q // st1 -+> st2 -> P // st2 -]] st3 -> R st2 st3) -> R st1 st3).
 
     Theorem sss_compute_max_ind st1 st3 : P // st1 -]] st3 -> R st1 st3.
-    Proof.
+    Proof using sss_fun HQ0 HQ1.
       intros ((k & H1) & H2); revert st1 H1.
       induction k as [ k IH ] using (well_founded_induction_type lt_wf).
       intros st1 H1.
@@ -671,7 +671,7 @@ Section Small_Step_Semantics.
           -> P // st1 ->> st2
           -> P // st1 ->> st3
           -> P // st2 ->> st3.
-  Proof.
+  Proof using sss_fun.
     intros H2 (p & H3) (k & H4).
     apply subcode_sss_subcode_inv with (3 := H3) in H4; auto.
     destruct H4 as (q & _ & ?); exists q; auto.
@@ -685,7 +685,7 @@ Section Small_Step_Semantics.
              (HR1 : forall st1, (forall Q st2, Q <sc P -> Q // st1 -+> st2 -> R st2) -> R st1).
 
   Theorem sss_terminates_ind st : P // st ↓ -> R st.
-  Proof.
+  Proof using sss_fun HR0 HR1.
     intros (st2 & (k & H1) & H2); revert st st2 H1 H2.
     induction k as [ k IH ] using (well_founded_induction_type lt_wf).
     intros st1 st2 H1 H2.
@@ -715,7 +715,7 @@ Section Small_Step_Semantics.
         -> P // st1 ->> st2
         -> P // st1 -[k]-> st3
         -> exists q, q < k /\ P // st2 -[q]-> st3.
-  Proof.
+  Proof using sss_fun.
     intros H1 H2 (p & H3) H4.
     apply subcode_sss_subcode_inv with (3 := H3) in H4; auto.
     destruct H4 as (q & H4 & H5).
@@ -733,7 +733,7 @@ Section Small_Step_Semantics.
         -> P // st1 ->> st2
         -> Q // st1 -[k]-> st3
         -> exists q, q < k /\ Q // st2 -[q]-> st3.
-  Proof.
+  Proof using sss_fun.
     intros H H0 H1 H2 (p & H3) H4.
     apply subcode_sss_subcode_inv with (2 := H2) (3 := H3) in H4; auto.
     destruct H4 as (q & Hq & H4).
@@ -749,7 +749,7 @@ Section Small_Step_Semantics.
      -> (fst st1,i::nil) <sc P
      -> P // st1 -[k]-> st3
      -> exists k', k = S k' /\ P // st2 -[k']-> st3.
-  Proof.
+  Proof using sss_fun.
     intros H1 H2 H3 H4.
     apply sss_steps_inv in H4.
     destruct H4 as [ (_ & H4) | (k' & st & ? & H4 & ?) ].
@@ -795,7 +795,7 @@ Section Small_Step_Semantics.
           -> P // st1 -[a]-> st2
           -> P // st1 -[b]-> st3 
           -> a = b /\ st2 = st3.
-  Proof.
+  Proof using sss_fun.
     intros H1 H2 H3 H4.
     assert (a = b) as Hab.
     { destruct subcode_sss_subcode_inv with (3 := H3) (4 := H4)
@@ -813,7 +813,7 @@ Section Small_Step_Semantics.
           -> P // st1 ->> st2
           -> P // st1 ->> st3 
           -> st2 = st3.
-  Proof.
+  Proof using sss_fun.
     intros ? ? (a & H1) (b & H2).
     revert H1 H2; apply sss_steps_stop_fun; auto.
   Qed.
@@ -822,13 +822,13 @@ Section Small_Step_Semantics.
              P // st1 ~[a]~> st2
           -> P // st1 ~[b]~> st3 
           -> a = b /\ st2 = st3.
-  Proof.
+  Proof using sss_fun.
     intros (H1 & H2) (H3 & H4).
     revert H1 H3; apply sss_steps_stop_fun; auto.
   Qed.
 
   Fact sss_output_fun P st st1 st2 : P // st ~~> st1 -> P // st ~~> st2 -> st1 = st2.
-  Proof.
+  Proof using sss_fun.
     intros (H1 & H2) (H3 & H4); revert H2 H4 H1 H3; apply sss_compute_fun.
   Qed.
 
@@ -842,7 +842,7 @@ Section Small_Step_Semantics.
   Qed.
 
   Fact sss_progress_non_termination P st : P // st -+> st -> ~ P // st ↓.
-  Proof.
+  Proof using sss_fun.
     intros (a & H1 & H2) (st' & (b & H3) & H4).
     assert (P // st -[a+b]-> st') as H5.
     { apply sss_steps_trans with (1 := H2); auto. }
@@ -867,7 +867,7 @@ Section Small_Step_Semantics.
     Theorem sss_loop_sound x : pre x 
                             -> (exists n, C2 (iter f x n)) 
                             -> exists n y, P // (i,x) ->> (p,y) /\ spec (iter f x n) y.
-    Proof.
+    Proof using HP1 HP2 HC.
       intros H (n & Hn); revert x H Hn.
       induction n as [ | n IHn ]; intros x Hx Hn.
       simpl; exists 0; apply HP2; auto.
@@ -886,7 +886,7 @@ Section Small_Step_Semantics.
                                    -> out_code q P 
                                    -> P // (i,x) ->> (q,y) 
                                    -> p = q /\ exists n, C2 (iter f x n) /\ spec (iter f x n) y.
-    Proof.
+    Proof using sss_fun HP1 HP2 HC Hp Hf.
       intros Hx Hq (k & Hk); revert x Hx y q Hq Hk.
       induction k as [ k IHk ] using (well_founded_induction lt_wf); intros x Hx y q Hq Hk.
       destruct (HC Hx) as [ H | H ].

--- a/theories/Shared/Libs/DLW/Utils/bool_list.v
+++ b/theories/Shared/Libs/DLW/Utils/bool_list.v
@@ -261,7 +261,7 @@ Set Implicit Arguments.
     Qed.
 
     Fact lb_pointwise_mono_left l m k : l ⪯  m -> lb_pointwise k l ⪯   lb_pointwise k m.
-    Proof.
+    Proof using Hf1 Hf2.
       intros H; revert m H k.
       induction l as [ | x l IHl ]; intros m H k; auto.
       destruct m as [ | y m ].

--- a/theories/Shared/Libs/DLW/Utils/bool_nat.v
+++ b/theories/Shared/Libs/DLW/Utils/bool_nat.v
@@ -1203,10 +1203,10 @@ Local Reserved Notation "'⟬' x '⟭'".
     Proof. rewrite Hr; apply (@power_mono_l 1 _ 2); lia. Qed.
 
     Fact nat_meet_powers_eq i a b : (a*power i r)⇣(b*power i r) = (a⇣b)*power i r.
-    Proof. rewrite Hr, <- power_mult, nat_meet_mult_power2; auto. Qed.
+    Proof using Hr. rewrite Hr, <- power_mult, nat_meet_mult_power2; auto. Qed.
 
     Fact binary_power_split i a : { u : nat & { v | a = u⇡(v*power i r) /\ forall k, u⇣(k*power i r) = 0 } }.
-    Proof.
+    Proof using Hq Hr.
       destruct (@euclid a (power i r)) as (u & v & H1 & H2).
       + generalize (@power_ge_1 i r); intros; lia.
       + exists v, u.
@@ -1222,7 +1222,7 @@ Local Reserved Notation "'⟬' x '⟭'".
         
 
     Fact binary_le_power_inv i a b : a ≲ b * power i r -> { a' | a = a' * power i r /\ a' ≲ b }.
-    Proof.
+    Proof using Hq Hr.
       intros H.
       destruct (binary_power_split i a) as (u & v & H1 & H2).
       exists (v⇣b).
@@ -1254,7 +1254,7 @@ Local Reserved Notation "'⟬' x '⟭'".
       Qed.
 
       Fact nat_meet_powers_neq i j a b : i <> j -> a < r -> b < r -> (a*power i r)⇣(b*power j r) = 0.
-      Proof.
+      Proof using Hq Hr.
         intros Hij Ha Hb.
         destruct (lt_eq_lt_dec i j) as [ [] | ]; try lia.
         + apply nat_meet_neq_powers; auto.
@@ -1268,7 +1268,7 @@ Local Reserved Notation "'⟬' x '⟭'".
                  (forall i, i < n -> f i < r) 
               -> (forall i j, i < n -> j < n -> e i = e j -> i = j)
               -> sum_powers r n f e = ⇧ r n f e.
-    Proof.
+    Proof using Hq Hr.
       revert f e; induction n as [ | n IHn ]; intros f e H1 H2.
       + do 2 rewrite msum_0; auto.
       + rewrite msum_S.
@@ -1299,7 +1299,7 @@ Local Reserved Notation "'⟬' x '⟭'".
       Qed.
 
       Fact double_sum_powers_ortho : ∑ n (fun i => sum_powers r i (f i) (e i)) = msum nat_join 0 n (fun i => ⇧ r i (f i) (e i)).
-      Proof.
+      Proof using Hq Hr Hf He.
         rewrite nat_ortho_sum_join.
         + apply msum_ext; intros; apply dsmpo_1; auto.
         + intros; do 2 (rewrite dsmpo_1; auto).
@@ -1311,7 +1311,7 @@ Local Reserved Notation "'⟬' x '⟭'".
     End double_sum_powers_ortho.
 
     Fact sinc_injective n f : (forall i j, i < j < n -> f i < f j) -> forall i j, i < n -> j < n -> f i = f j -> i = j.
-    Proof.
+    Proof using Hq Hr.
       intros Hf i j Hi Hj E.
       destruct (lt_eq_lt_dec i j) as [ [] | ]; auto.
       + generalize (Hf i j); intros; lia.
@@ -1329,7 +1329,7 @@ Local Reserved Notation "'⟬' x '⟭'".
 
       Fact meet_sum_powers : (sum_powers r n f e)⇣(sum_powers r n g e) 
                            = sum_powers r n (fun i => f i ⇣ g i) e.
-      Proof.
+      Proof using Hf Hg He Hq Hr.
         generalize (sinc_injective _ He); intros H0.
         simpl; do 3 (rewrite sum_powers_ortho; auto).
         rewrite nat_meet_joins.
@@ -1346,7 +1346,7 @@ Local Reserved Notation "'⟬' x '⟭'".
       Qed.
 
       Fact binary_le_sum_powers : sum_powers r n f e ≲ sum_powers r n g e <-> forall i, i < n -> f i ≲ g i.
-      Proof.
+      Proof using Hf Hg He Hq Hr.
         rewrite binary_le_nat_meet, meet_sum_powers.
         split. 
         + intros E i Hi.
@@ -1365,7 +1365,7 @@ Local Reserved Notation "'⟬' x '⟭'".
          -> (forall i j, i < j < n -> f i < f j)
          -> (forall i, i < n -> a i < power p 2)  -> ∑ n (fun i => a i * power (f i) r) 
                                                    ≲ (power p 2-1) * ∑ n (fun i => power (f i) r).
-    Proof.
+    Proof using Hq Hr.
       intros H1 H2 H3.
       generalize (sinc_injective _ H2); intros H4.
       rewrite <- sum_0n_scal_l.
@@ -1395,7 +1395,7 @@ Local Reserved Notation "'⟬' x '⟭'".
                      /\ (forall i, i < k -> g i <> 0 /\ g i ≲ f (h i))
                      /\ (forall i, i < k -> h i < n)
                      /\ (forall i j, i < j < k -> h i < h j) } } }.
-    Proof.
+    Proof using Hq Hr.
       intros H1 H2 H3.
       generalize (sinc_injective _ H2); intros H0.
       simpl in H3; rewrite sum_powers_ortho in H3; auto.
@@ -1432,7 +1432,7 @@ Local Reserved Notation "'⟬' x '⟭'".
               -> (forall i j, i < j < n -> e i < e j)
               -> m ≲ sum_powers r n f e
               -> { g | m = sum_powers r n g e /\ forall i, i < n -> g i ≲ f i }.
-    Proof.
+    Proof using Hq Hr.
       intros H1 H2 H3.
       generalize (sinc_injective _ H2); intros H0.
       simpl in H3; rewrite sum_powers_ortho in H3; auto.
@@ -1460,7 +1460,7 @@ Local Reserved Notation "'⟬' x '⟭'".
          -> m ≲ (power p 2-1) * ∑ n (fun i => power (f i) r)
          -> exists a, m = ∑ n (fun i => a i * power (f i) r) 
                    /\ forall i, i < n -> a i < power p 2.
-    Proof.
+    Proof using Hq Hr.
       intros H1 H2 H3 H4.
       rewrite <- sum_0n_scal_l in H4.
       apply binary_le_sum_powers_inv in H4; auto.

--- a/theories/Shared/Libs/DLW/Utils/crt.v
+++ b/theories/Shared/Libs/DLW/Utils/crt.v
@@ -29,7 +29,7 @@ Section Informative_Chinese_Remainder_theorems.
     Variable (u v a b : nat) (Hu : u <> 0) (Hv : v <> 0) (Huv : is_gcd u v 1).
 
     Theorem CRT_bin_informative : { w | rem w u = rem a u /\ rem w v = rem b v /\ 2 < w }.
-    Proof.
+    Proof using Hu Hv Huv.
       destruct bezout_rel_prime with (1 := Huv) as (x & y & H1).
       assert (rem (x*u) v = rem 1 v) as H2.
       { rewrite rem_plus_div with (a := 1) (b := u*v); auto.

--- a/theories/Shared/Libs/DLW/Utils/fin_base.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_base.v
@@ -253,7 +253,7 @@ Section finite.
     Variable (X : Type) (P : X -> Prop) (Pdec : forall x, { P x } + { ~ P x }).
     
     Theorem fin_t_dec Q : @fin_t X Q -> fin_t (fun x => P x /\ Q x).
-    Proof.
+    Proof using Pdec.
       intros (l & Hl).
       exists (filter (fun x => if Pdec x then true else false) l).
       intros x; rewrite filter_In, <- Hl.

--- a/theories/Shared/Libs/DLW/Utils/fin_bij.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_bij.v
@@ -72,7 +72,7 @@ Section list_discr_vec.
   Variable (X : Type) (D : forall x y : X, { x = y } + { x <> y }).
 
   Fact vec_search n (v : vec X n) x : { p | x = vec_pos v p } + { ~ in_vec x v }.
-  Proof.
+  Proof using D.
     induction v as [ | y n v [ (p & ->) | H ] ].
     + right; simpl; auto.
     + left; exists (pos_nxt p); auto.
@@ -104,7 +104,7 @@ Section list_discr_vec.
          /\ (forall x, In x ll <-> f x <> None) 
          /\ (forall p, f (vec_pos v p) = Some p)
          /\ (forall x p, f x = Some p -> vec_pos v p = x) } } }.
-  Proof.
+  Proof using D.
     exists (length l), v, f; msplit 3.
     + intro; rewrite in_vec_list, Hv; apply Hl2.
     + intros x; rewrite <- Hl2.

--- a/theories/Shared/Libs/DLW/Utils/fin_choice.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_choice.v
@@ -74,7 +74,7 @@ Section finite_discrete_choice.
   Theorem list_discrete_choice l :
             (forall x, In x l -> ex (R x))
          -> exists f, forall x (Hx : In x l), R x (f x Hx).
-  Proof.
+  Proof using X_discrete.
     induction l as [ | x l IHl ]; intros Hl.
     + exists (fun x (Hx : @In X x nil) => False_rect Y Hx).
       intros _ [].
@@ -95,7 +95,7 @@ Section finite_discrete_choice.
   Fact finite_discrete_choice :
          finite X 
       -> (forall x, ex (R x)) -> exists f, forall x, R x (f x).
-  Proof.
+  Proof using X_discrete.
     intros (l & Hl) H.
     destruct list_discrete_choice with (l := l) as (f & Hf); auto.
     exists (fun x => f x (Hl x)); auto.
@@ -133,7 +133,7 @@ Section finite_t_dec_choose_one.
            (Pdec : forall x, { P x } + { ~ P x }).
 
   Fact list_dec_choose_one l : (exists x, In x l /\ P x) -> { x | In x l /\ P x }.
-  Proof.
+  Proof using Pdec.
     clear HX Q HQ.
     induction l as [ | x l IHl ]; intros H.
     + exfalso; destruct H as (_ & [] & _).
@@ -146,7 +146,7 @@ Section finite_t_dec_choose_one.
  
   Fact fin_t_dec_choose_one : 
          (exists x, Q x /\ P x) -> { x | Q x /\ P x }.
-  Proof.
+  Proof using HQ Pdec.
     revert HQ; intros (l & Hl) H.
     destruct (list_dec_choose_one l) as (x & H1 & H2).
     + destruct H as (x & ? & ?); exists x; rewrite <- Hl; auto.
@@ -154,7 +154,7 @@ Section finite_t_dec_choose_one.
   Qed.
 
   Fact finite_t_dec_choose_one : ex P -> sig P. 
-  Proof.
+  Proof using HX Pdec.
     clear Q HQ.
     revert HX; intros (l & Hl) H.
     destruct (list_dec_choose_one l) as (x & H1 & H2); firstorder.

--- a/theories/Shared/Libs/DLW/Utils/fin_quotient.v
+++ b/theories/Shared/Libs/DLW/Utils/fin_quotient.v
@@ -252,7 +252,7 @@ Section restriction_by_list.
   Theorem DEC_PER_list_proj_finite_discrete :
        { D & { _ : dec (@eq D) & { _ : finite_t D & { f : X -> D 
              | forall x y, In x l -> In y l -> R x y <-> f x = f y } } } }.
-  Proof.
+  Proof using Rper Rdec Hl.
     destruct decidable_PER_fp_quotient with (R := T) (l := l)
       as [ n cls repr G1 G2 G3 ]; auto.
     exists (option (pos n)).

--- a/theories/Shared/Libs/DLW/Utils/gcd.v
+++ b/theories/Shared/Libs/DLW/Utils/gcd.v
@@ -831,10 +831,10 @@ Section rem.
   Qed.
 
   Fact rem_diag : rem p p = 0.
-  Proof. apply rem_prop with 1; lia. Qed.
+  Proof using Hp. apply rem_prop with 1; lia. Qed.
 
   Fact rem_lt a : a < p -> rem a p = a.
-  Proof. apply rem_prop with 0; lia. Qed.
+  Proof using Hp. apply rem_prop with 0; lia. Qed.
 
   Fact rem_plus a b : rem (a+b) p = rem (rem a p + rem b p) p.
   Proof.
@@ -853,7 +853,7 @@ Section rem.
   Qed.
 
   Fact rem_plus_div a b : divides p b -> rem a p = rem (a+b) p.
-  Proof. 
+  Proof using Hp. 
     intros (n & Hn); subst.
     rewrite <- rem_plus_rem.
     f_equal.  
@@ -861,13 +861,13 @@ Section rem.
   Qed.
 
   Fact div_eq_0 n : n < p -> div n p = 0.
-  Proof. intros; apply div_prop with n; lia. Qed.
+  Proof using Hp. intros; apply div_prop with n; lia. Qed.
 
   Fact div_of_0 : div 0 p = 0.
-  Proof. apply div_eq_0; lia. Qed.
+  Proof using Hp. apply div_eq_0; lia. Qed.
 
   Fact div_ge_1 n : p <= n -> 1 <= div n p.
-  Proof.
+  Proof using Hp.
     intros H2.
     rewrite (div_rem_spec1 n p) in H2.
     generalize (div_rem_spec2 n Hp); intros H3.

--- a/theories/Shared/Libs/DLW/Utils/list_bool.v
+++ b/theories/Shared/Libs/DLW/Utils/list_bool.v
@@ -222,7 +222,7 @@ Section list_bool_succ_rect.
   Qed.
 
   Theorem list_bool_succ_rect : forall l, P l.
-  Proof. intro; apply list_bool_succ_rec with (1 := eq_refl). Qed.
+  Proof using HP0 HPS. intro; apply list_bool_succ_rec with (1 := eq_refl). Qed.
 
 End list_bool_succ_rect.
 

--- a/theories/Shared/Libs/DLW/Utils/php.v
+++ b/theories/Shared/Libs/DLW/Utils/php.v
@@ -425,7 +425,7 @@ Section PHP_rel.
                           
   Theorem PHP_rel : exists a x b y c v, l = a++x::b++y::c
                                        /\ In v m /\ R x v /\ R y v.
-  Proof.
+  Proof using Hlm image_R_l.
     destruct image_R_l as (Rl & H1 & H2).
     destruct finite_pigeon_hole with (2 := H1) as (v & x & y & z & H).
     + apply Forall2_length in H2; lia.

--- a/theories/Shared/Libs/DLW/Utils/power_decomp.v
+++ b/theories/Shared/Libs/DLW/Utils/power_decomp.v
@@ -41,7 +41,7 @@ Section power_decomp.
         -> (forall i, i < n -> f i < q)
         -> (forall i, i < n -> a i < p)
         -> ∑ n (fun i => a i * power (f i) p) < power q p.
-  Proof.
+  Proof using Hp.
     revert q; induction n as [ | n IHn ]; intros q Hf1 Hf2 Ha.
     + rewrite msum_0; apply power_ge_1; lia.
     + rewrite msum_plus1; auto.
@@ -65,7 +65,7 @@ Section power_decomp.
            (forall i j, i < j < n -> f i < f j)
         -> (forall i, i < n -> a i < p)
         ->  forall i, i < n -> is_digit (∑ n (fun i => a i * power (f i) p)) p (f i) (a i).
-  Proof.
+  Proof using Hp.
     intros Hf Ha.
     induction n as [ | n IHn ]; intros i Hi.
     + lia.
@@ -95,7 +95,7 @@ Section power_decomp.
          -> ∑ n (fun i => a i * power (f i) p)
           = ∑ n (fun i => b i * power (f i) p)
          -> forall i, i < n -> a i = b i.
-  Proof.
+  Proof using Hp.
     intros Hf Ha Hb E i Hi.
     generalize (power_decomp_is_digit _ _ Hf Ha Hi)
                (power_decomp_is_digit _ _ Hf Hb Hi).
@@ -113,7 +113,7 @@ Section power_decomp_uniq.
         -> ∑ (S n) (fun i => a i * power (f i) p) 
          = ∑ n (fun i => a (S i) * power (f (S i) - f 0 - 1) p) * power (S (f 0)) p
          + a 0 * power (f 0) p.
-  Proof.
+  Proof using Hp.
     intros Hf.
     rewrite msum_S, plus_comm; f_equal.
     rewrite <- sum_0n_scal_r.
@@ -141,7 +141,7 @@ Section power_decomp_uniq.
          -> ∑ n (fun i => a i * power (f i) p)
           = ∑ n (fun i => b i * power (f i) p)
          -> forall i, i < n -> a i = b i.
-  Proof.
+  Proof using Hp.
     revert f a b.
     induction n as [ | n IHn ]; intros f a b Hf Ha Hb.
     + intros; lia.

--- a/theories/Shared/Libs/DLW/Utils/prime.v
+++ b/theories/Shared/Libs/DLW/Utils/prime.v
@@ -215,7 +215,7 @@ Section prime.
               (HPm : forall x y, P x -> P y -> P (x*y)).
 
     Theorem prime_rect n : P n.
-    Proof.
+    Proof using HP0 HP1 HPp HPm.
       induction on n as IHn with measure n.
       destruct n as [ | [ | n ] ]; auto.
       destruct (@prime_factor (S (S n))) as (p & H1 & H2); try lia.
@@ -407,7 +407,7 @@ Section base_decomp.
     Proof. apply (proj2_sig (base_p_full n)). Qed.
 
     Fact base_p_uniq l1 l2 : Forall2 (fun x y => x < p /\ y < p) l1 l2 -> expand p l1 = expand p l2 -> l1 = l2.
-    Proof.
+    Proof using Hp.
       induction 1 as [ | x1 x2 l1 l2 H1 H2 IH2 ]; auto; simpl; intros H3.
       rewrite (plus_comm x1), (plus_comm x2), (mult_comm p), (mult_comm p) in H3.
       apply div_rem_uniq in H3; try lia.

--- a/theories/Shared/Libs/DLW/Utils/quotient.v
+++ b/theories/Shared/Libs/DLW/Utils/quotient.v
@@ -251,7 +251,7 @@ Section ep_quotient.
 
   Local Fact enum_quotient_rec : 
         { Y : Type & { _ : dec (@eq Y) & quotient R Y } }.
-  Proof.
+  Proof using HR1 HR2 Hf.
     exists Y, Y_discrete, cls, rpr; split; auto.
   Qed.
 

--- a/theories/Shared/Libs/DLW/Utils/rel_iter.v
+++ b/theories/Shared/Libs/DLW/Utils/rel_iter.v
@@ -141,7 +141,7 @@ Section rel_iter_bound.
   Notation "∑" := (msum plus 0).
 
   Lemma rel_iter_iter_bound n x y : rel_iter R n x y -> rel_iter_bound n x y.
-  Proof.
+  Proof using Hk1.
     intros H.
     apply rel_iter_sequence in H.
     destruct H as (f & H1 & H2 & H3).
@@ -195,7 +195,7 @@ Section rel_iter_bound.
      (to be proved in dio_expo.v) when the relation R does not grow more that linearly *)
 
   Theorem rel_iter_bound_equiv n x y : rel_iter R n x y <-> rel_iter_bound n x y.
-  Proof. split; auto. Qed.
+  Proof using Hk1. split; auto. Qed.
 
 End rel_iter_bound.
 

--- a/theories/Shared/Libs/DLW/Utils/seteq.v
+++ b/theories/Shared/Libs/DLW/Utils/seteq.v
@@ -306,7 +306,7 @@ Section seteq.
               (HP5 : forall l m k, l ≃ₛ m -> P l m -> m ≃ₛ k -> P m k -> P l k).
 
     Theorem lequiv_ind l m : l ≃ₛ m -> P l m.
-    Proof. rewrite <- lseq_lequiv_iff; induction 1; eauto. Qed.
+    Proof using All. rewrite <- lseq_lequiv_iff; induction 1; eauto. Qed.
 
   End lequiv_ind.
 

--- a/theories/Shared/Libs/DLW/Utils/sorting.v
+++ b/theories/Shared/Libs/DLW/Utils/sorting.v
@@ -64,7 +64,7 @@ Section php_fun.
   Variable (n : nat) (f : nat -> nat) (Hf : forall i, i <= n -> f i < n).
 
   Theorem php_fun : exists i j, i < j <= n /\ f i = f j.
-  Proof.
+  Proof using Hf.
     destruct PHP_rel with (R := fun x y => y = f x) (l := list_an 0 (S n)) (m := list_an 0 n)
       as (a & i & b & j & c & v & H1 & H2 & H3 & H4).
     + intros x; rewrite list_an_spec; simpl; intros [ _ H ].
@@ -139,7 +139,7 @@ Section split_interval.
                                                  /\ (forall j, g (h j) = j)
                                                  /\ (forall j, h (g j) = j) 
                                                  /\ g i = n } }.
-  Proof.
+  Proof using Hi.
     exists g, h.
     split; [ | split; [ | split; [ | split ] ] ]; auto.
     + intros j; unfold h. 

--- a/theories/Shared/Libs/DLW/Utils/sums.v
+++ b/theories/Shared/Libs/DLW/Utils/sums.v
@@ -68,20 +68,20 @@ Section msum.
   Hypothesis Hmonoid : monoid_theory m u.
 
   Fact msum_1 f : ∑ 1 f = f 0.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 H2 ].
     rewrite msum_S, msum_0, H2; auto.
   Qed.
 
   Fact msum_plus a b f : ∑ (a+b) f = ∑ a f ⊕ ∑ b (fun i => f (a+i)).
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 _ H3 ].
     revert f; induction a as [ | a IHa ]; intros f; simpl; auto.
     rewrite <- H3; f_equal; apply IHa.
   Qed.
 
   Fact msum_plus1 n f : ∑ (S n) f = ∑ n f ⊕ f n.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ _ H2 _ ].
     replace (S n) with (n+1) by lia.
     rewrite msum_plus; simpl; f_equal.
@@ -96,14 +96,14 @@ Section msum.
   Qed.
 
   Fact msum_unit n : ∑ n (fun _ => u) = u.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 _ _ ].
     induction n as [ | n IHn ]; simpl; auto.
     rewrite IHn; auto.
   Qed.
 
   Fact msum_comm a n f : (forall i, i < n -> f i ⊕ a = a ⊕ f i) -> ∑ n f ⊕ a = a ⊕ ∑ n f.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 H2 H3 ].
     revert f; induction n as [ | n IHn ]; intros f H; simpl; auto.
     + rewrite H1, H2; auto.
@@ -114,7 +114,7 @@ Section msum.
   Qed.
 
   Fact msum_sum n f g : (forall i j, i < j < n -> f j ⊕ g i = g i ⊕ f j) -> ∑ n (fun i => f i ⊕ g i) = ∑ n f ⊕ ∑ n g.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 H2 H3 ].
     revert f g; induction n as [ | n IHn ]; intros f g H; simpl; auto.
     rewrite IHn.
@@ -126,7 +126,7 @@ Section msum.
   Qed.
 
   Fact msum_of_unit n f : (forall i, i < n -> f i = u) -> ∑ n f = u.
-  Proof.
+  Proof using Hmonoid.
     intros H.
     rewrite <- (msum_unit n).
     apply msum_ext; auto.
@@ -135,7 +135,7 @@ Section msum.
   Fact msum_only_one n f i : i < n
                           -> (forall j, j < n -> i <> j -> f j = u)
                           -> ∑ n f = f i.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ M1 M2 M3 ].
     intros H1 H2.
     replace n with (i + 1 + (n-i-1)) by lia.
@@ -149,7 +149,7 @@ Section msum.
   Fact msum_msum n k f :
           (forall i1 j1 i2 j2, i1 < n -> j1 < k -> i2 < n -> j2 < k -> f i1 j1 ⊕ f i2 j2 = f i2 j2 ⊕ f i1 j1)
        -> ∑ n (fun i => ∑ k (f i)) = ∑ k (fun j => ∑ n (fun i => f i j)).
-  Proof.
+  Proof using Hmonoid.
     revert k f; induction n as [ | n IHn ]; intros k f Hf.
     + rewrite msum_0, msum_of_unit; auto.
     + rewrite msum_S, IHn.
@@ -162,7 +162,7 @@ Section msum.
   Qed.
 
   Fact msum_ends n f : (forall i, 0 < i <= n -> f i = u) -> ∑ (n+2) f = f 0 ⊕ f (S n).
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ H1 H2 H3 ].
     intros H.
     replace (n+2) with (1 + n + 1) by lia.
@@ -173,7 +173,7 @@ Section msum.
   Qed.
 
   Fact msum_first_two n f : 2 <= n -> (forall i, 2 <= i -> f i = u) -> ∑ n f = f 0 ⊕ f 1.
-  Proof.
+  Proof using Hmonoid.
     destruct Hmonoid as [ _ M2 _ ].
     intros Hn H1.
     destruct n as [ | [ | n ] ]; try lia.
@@ -192,28 +192,28 @@ Section msum.
   Proof. apply msum_S. Qed.
 
   Fact mscal_1 x : mscal 1 x = x.
-  Proof. 
+  Proof using Hmonoid.
     destruct Hmonoid as [ _ H2 _ ].
     rewrite mscal_S, mscal_0, H2; trivial.
   Qed.
 
   Fact mscal_of_unit n : mscal n u = u.
-  Proof. apply msum_of_unit; auto. Qed.
+  Proof using Hmonoid. apply msum_of_unit; auto. Qed.
 
   Fact mscal_plus a b x : mscal (a+b) x = mscal a x ⊕ mscal b x.
-  Proof. apply msum_plus. Qed.
+  Proof using Hmonoid. apply msum_plus. Qed.
 
   Fact mscal_plus1 n x : mscal (S n) x = mscal n x ⊕ x.
-  Proof. apply msum_plus1. Qed.
+  Proof using Hmonoid. apply msum_plus1. Qed.
 
   Fact mscal_comm n x y : x ⊕ y = y ⊕ x -> mscal n x ⊕ y = y ⊕ mscal n x.
-  Proof. intros H; apply msum_comm; auto. Qed.
+  Proof using Hmonoid. intros H; apply msum_comm; auto. Qed.
 
   Fact mscal_sum n x y : x ⊕ y = y ⊕ x -> mscal n (x ⊕ y) = mscal n x ⊕ mscal n y.
-  Proof. intro; apply msum_sum; auto. Qed.
+  Proof using Hmonoid. intro; apply msum_sum; auto. Qed.
 
   Fact mscal_mult a b x : mscal (a*b) x = mscal a (mscal b x).
-  Proof.
+  Proof using Hmonoid.
     induction a as [ | a IHa ]; simpl.
     + do 2 rewrite mscal_0; auto.
     + rewrite mscal_plus, IHa, mscal_S; auto.
@@ -221,7 +221,7 @@ Section msum.
 
   Fact msum_mscal n k f : (forall i j, i < n -> j < n -> f i ⊕ f j = f j ⊕ f i) 
                        -> ∑ n (fun i => mscal k (f i)) = mscal k (∑ n f).
-  Proof. intros H; apply msum_msum; auto. Qed.
+  Proof using Hmonoid. intros H; apply msum_msum; auto. Qed.
 
 End msum.
 
@@ -236,13 +236,13 @@ Section msum_morphism.
            (Hphi2 : forall x y, phi (m1 x y) = m2 (phi x) (phi y)).
 
   Fact msum_morph n f : phi (msum m1 u1 n f) = msum m2 u2 n (fun x => phi (f x)).
-  Proof.
+  Proof using Hphi1 Hphi2.
     revert f; induction n as [ | n IHn ]; intros f; simpl; auto.
     rewrite Hphi2, IHn; trivial.
   Qed.
 
   Fact mscal_morph n x : phi (mscal m1 u1 n x) = mscal m2 u2 n (phi x).
-  Proof. apply msum_morph. Qed.
+  Proof using Hphi1 Hphi2. apply msum_morph. Qed.
 
 End msum_morphism.
 
@@ -267,7 +267,7 @@ Section binomial_Newton.
              (distr_r : forall x y z, (y⊕z) ⊗ x = y⊗x ⊕ z⊗x).
 
   Fact times_zero_l x : z ⊗ x = z.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_r.
     destruct M_sum as [ S1 S2 S3 ].
     destruct M_times as [ T1 T2 T3 ].
     apply sum_cancel with (z⊗x).
@@ -275,7 +275,7 @@ Section binomial_Newton.
   Qed.
 
   Fact times_zero_r x : x ⊗ z = z.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_l.
     destruct M_sum as [ S1 S2 S3 ].
     destruct M_times as [ T1 T2 T3 ].
     apply sum_cancel with (x⊗z).
@@ -285,10 +285,10 @@ Section binomial_Newton.
   Notation "∑" := (msum sum zero).
 
   Fact sum_0n_scal n k f : ∑ n (fun i => scal k (f i)) = scal k (∑ n f).
-  Proof. apply msum_mscal; auto. Qed.
+  Proof using M_sum sum_comm. apply msum_mscal; auto. Qed.
 
   Fact scal_times k x y : scal k (x⊗y) = x⊗scal k y.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_l.
     destruct M_sum as [ S1 S2 S3 ].
     destruct M_times as [ T1 T2 T3 ].
     induction k as [ | k IHk ].
@@ -297,7 +297,7 @@ Section binomial_Newton.
   Qed.
 
   Fact scal_one_comm k x : scal k o ⊗ x = x ⊗ scal k o.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_r distr_l.
     destruct M_times as [ T1 T2 T3 ].
     induction k as [ | k IHk ].
     + rewrite mscal_0, times_zero_l, times_zero_r; auto.
@@ -306,7 +306,7 @@ Section binomial_Newton.
   Qed.
 
   Corollary scal_one k x : scal k x = scal k o ⊗ x.
-  Proof. 
+  Proof using M_sum M_times sum_cancel distr_r distr_l.
     destruct M_times as [ T1 T2 T3 ].
     rewrite <- (T2 x) at 1.
     rewrite scal_times.
@@ -314,14 +314,14 @@ Section binomial_Newton.
   Qed.
 
   Fact sum_0n_distr_l b n f : ∑ n (fun i => b⊗f i) = b⊗∑ n f.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_l.
     revert f; induction n as [ | n IHn ]; intros f.
     + do 2 rewrite msum_0; rewrite times_zero_r; auto.
     + do 2 rewrite msum_S; rewrite IHn, distr_l; auto.
   Qed.
 
   Fact sum_0n_distr_r b n f : ∑ n (fun i => f i⊗b) = ∑ n f ⊗ b.
-  Proof.
+  Proof using M_sum M_times sum_cancel distr_r.
     revert f; induction n as [ | n IHn ]; intros f.
     + do 2 rewrite msum_0; rewrite times_zero_l; auto.
     + do 2 rewrite msum_S; rewrite IHn, distr_r; auto.
@@ -340,7 +340,7 @@ Section binomial_Newton.
   Theorem binomial_Newton n a b :
         a ⊗ b = b ⊗ a
      -> expo n (a ⊕ b) = ∑ (S n) (fun i => scal (binomial n i) (expo (n - i) a ⊗ expo i b)).
-  Proof.
+  Proof using All.
     destruct M_sum as [ S1 S2 S3 ].
     destruct M_times as [ T1 T2 T3 ].
     intros Hab; induction n as [ | n IHn ].

--- a/theories/Shared/Libs/DLW/Utils/utils_decidable.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_decidable.v
@@ -147,7 +147,7 @@ Section sinc_decidable.
 
   Theorem sinc_decidable : (forall n, exists k, n <= k /\ P k)
                          * (forall n, { P n } + { ~ P n }).
-  Proof. split; auto. Qed.
+  Proof using HP Hf. split; auto. Qed.
 
 End sinc_decidable.
 
@@ -217,7 +217,7 @@ Section decidable_sinc.
 
   Theorem decidable_sinc : { f | (forall n, f n < f (S n))
                               /\ (forall n, P n <-> exists k, n = f k) }.
-  Proof. exists f; auto. Qed.
+  Proof using Pdec Punb. exists f; auto. Qed.
 
 End decidable_sinc.
 

--- a/theories/Shared/Libs/DLW/Utils/utils_list.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_list.v
@@ -176,7 +176,7 @@ Section list_injective.
   Hypothesis (HP1 : forall x l, ~ In x l -> P l -> P (x::l)).
   
   Theorem list_injective_rect l : list_injective l -> P l.
-  Proof.
+  Proof using HP0 HP1.
     induction l as [ [ | x l ] IHl ] using (measure_rect (@length _)).
     intro; apply HP0.
     intros; apply HP1.
@@ -486,7 +486,7 @@ Section prefix. (* as an inductive predicate *)
               (HP1 : forall x l ll, l <p ll -> P l ll -> P (x::l) (x::ll)).
               
     Definition prefix_rect l ll : prefix l ll -> P l ll.
-    Proof.
+    Proof using HP0 HP1.
       revert l; induction ll as [ | x ll IHll ]; intros l H.
       
       replace l with (nil : list X).
@@ -606,7 +606,7 @@ Section list_first_dec.
   
   Theorem list_choose_dec ll : { l : _ & { x : _ & { r | ll = l++x::r /\ P x /\ forall y, In y l -> ~ P y } } }
                              + { forall x, In x ll -> ~ P x }.
-  Proof.
+  Proof using Pdec.
     induction ll as [ | a ll IH ];
       [ | destruct (Pdec a) as [ Ha | Ha ]; [ | destruct IH as [ (l & x & r & H1 & H2 & H3) | H ]] ].
     * right; intros _ [].
@@ -617,7 +617,7 @@ Section list_first_dec.
   Qed.
   
   Theorem list_first_dec a ll : P a -> In a ll -> { l : _ & { x : _ & { r | ll = l++x::r /\ P x /\ forall y, In y l -> ~ P y } } }.
-  Proof.
+  Proof using Pdec.
     intros H1 H2.
     destruct (list_choose_dec ll) as [ H | H ]; trivial.
     destruct (H _ H2 H1).
@@ -630,7 +630,7 @@ Section list_dec.
   Variable (X : Type) (P Q : X -> Prop) (H : forall x, { P x } + { Q x }).
   
   Theorem list_dec l : { x | In x l /\ P x } + { forall x, In x l -> Q x }.
-  Proof.
+  Proof using H.
     induction l as [ | x l IHl ].
     + right; intros _ [].
     + destruct (H x) as [ Hx | Hx ].
@@ -866,7 +866,7 @@ Section list_discrim.
   Variable (X : Type) (P Q : X -> Prop) (PQdec : forall x, { P x } + { Q x}).
 
   Definition list_discrim l : { lP : _ & { lQ | l ~p lP++lQ /\ Forall P lP /\ Forall Q lQ } }.
-  Proof.
+  Proof using PQdec.
     induction l as [ | x l (lP & lQ & H1 & H2 & H3) ].
     + exists nil, nil; simpl; auto.
     + destruct (PQdec x) as [ H | H ].

--- a/theories/Shared/Libs/DLW/Utils/utils_nat.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_nat.v
@@ -376,7 +376,7 @@ Section nat_sorted.
   Hypothesis (HP2 : forall x y l, x < y -> P (y::l) -> P (x::y::l)).
   
   Theorem nat_sorted_rect l : nat_sorted l -> P l.
-  Proof.
+  Proof using HP0 HP1 HP2.
     induction l as [ [ | x [ | y l ] ] IHl ] using (measure_rect (@length _)).
     intro; apply HP0.
     intro; apply HP1.
@@ -541,7 +541,7 @@ Section nat_rev_bounded_ind.
   Variables (k : nat) (P : nat -> Prop) (HP : forall n, S n <= k -> P (S n) -> P n).
   
   Fact nat_rev_bounded_ind x y : x <= y <= k -> P y -> P x.
-  Proof.
+  Proof using HP.
     intros H1 H2.
     refine (proj1 (@nat_rev_ind (fun n => P n /\ n <= k) _ x y _ _)).
     clear x y H1 H2; intros n (H1 & H2); split; auto; lia.
@@ -580,7 +580,7 @@ Section nat_minimize.
     Qed.
 
     Definition min_dec : (exists n, P n) -> { m | P m /\ forall x, P x -> m <= x }.
-    Proof.
+    Proof using HP.
       intros H.
       destruct (@min_rec 0) as (m & H1 & H2).
       * destruct H as (n & Hn).
@@ -595,7 +595,7 @@ Section nat_minimize.
   End nat_min.
 
   Fact first_which : (exists x, P x) -> { m | P m /\ forall x, x < m -> ~ P x }.
-  Proof.
+  Proof using HP.
     intros H.
     destruct (min_dec H) as (m & H1 & H2).
     exists m; split; auto.
@@ -626,7 +626,7 @@ Section first_which_ni.
   Hypothesis HP : forall n, P n \/ ~ P n.
 
   Fact first_which_ni : (exists x, P x) -> exists m, P m /\ forall x, x < m -> ~ P x.
-  Proof.
+  Proof using HP.
     intros (n & Hn).
     destruct (@bounded_search_ni (S n)) as [ H1 | (m & H1 & H2 & H3) ].
     + intros; auto.

--- a/theories/Shared/Libs/DLW/Utils/utils_tac.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_tac.v
@@ -9,7 +9,6 @@
 
 Require Import Arith List Wellfounded Extraction.
 
-
 Set Implicit Arguments.
 
 Definition eqdec X := forall x y : X, { x = y } + { x <> y }.
@@ -64,7 +63,7 @@ Section forall_equiv.
   Variable (X : Type) (A P Q : X -> Prop) (HPQ : forall n, A n -> P n <-> Q n).
 
   Theorem forall_bound_equiv : (forall n, A n -> P n) <-> (forall n, A n -> Q n).
-  Proof.
+  Proof using HPQ.
     split; intros H n Hn; generalize (H _ Hn); apply HPQ; auto.
   Qed.
 
@@ -75,7 +74,7 @@ Section exists_equiv.
   Variable (X : Type) (P Q : X -> Prop) (HPQ : forall n, P n <-> Q n).
 
   Theorem exists_equiv : (exists n, P n) <-> (exists n, Q n).
-  Proof.
+  Proof using HPQ.
     split; intros (n & Hn); exists n; revert Hn; apply HPQ; auto.
   Qed.
 
@@ -90,7 +89,7 @@ Section measure_rect_123.
     Hypothesis F : forall x, (forall y, m y < m x -> P y) -> P x.
 
     Definition measure_rect x : P x.
-    Proof.
+    Proof using F.
       cut (Acc (fun x y => m x < m y) x).
       + revert x.
         refine (fix loop x H := @F x (fun x' H' => loop x' _)).
@@ -110,7 +109,7 @@ Section measure_rect_123.
     Let R c d := m' c < m' d.
 
     Definition measure_rect2 x y : P x y.
-    Proof.
+    Proof using F R.
       cut (Acc R (x,y)).
       + revert x y.
         refine (fix loop x y H := @F x y (fun x' y' H' => loop x' y' _)).
@@ -130,7 +129,7 @@ Section measure_rect_123.
     Let R c d := m' c < m' d.
 
     Definition measure_rect3 x y z : P x y z.
-    Proof.
+    Proof using F R.
       cut (Acc R (x,y,z)).
       + revert x y z.
         refine (fix loop x y z H := @F x y z (fun x' y' z' H' => loop x' y' z' _)).

--- a/theories/Shared/Libs/DLW/Vec/pos.v
+++ b/theories/Shared/Libs/DLW/Vec/pos.v
@@ -235,7 +235,7 @@ Section pos_left_right_rect.
              (HP2 : forall p, P (pos_right _ p)).
 
   Theorem pos_left_right_rect : forall p, P p.
-  Proof.
+  Proof using HP1 HP2.
     intros p.
     rewrite <- pos_lr_both.
     generalize (pos_both n m p); clear p; intros [|]; simpl; auto.

--- a/theories/Shared/Libs/DLW/Vec/vec.v
+++ b/theories/Shared/Libs/DLW/Vec/vec.v
@@ -165,7 +165,7 @@ Section vector.
   Variable eq_X_dec : forall x y : X, { x = y } + { x <> y }.
 
   Fixpoint vec_eq_dec n (u v : vec n) : { u = v } + { u <> v }.
-  Proof.
+  Proof using eq_X_dec.
     destruct u as [ | x n u ].
     + left.
       rewrite vec_0_nil; trivial.
@@ -672,7 +672,7 @@ Section vec_nat_induction.
   Hypothesis HP2 : forall v w, P v -> P w -> P (vec_plus v w).
   
   Theorem vec_nat_induction v : P v.
-  Proof.
+  Proof using HP0 HP1 HP2.
     induction v as [ v IHv ] using (measure_rect (@vec_sum n)).
     case_eq (vec_sum v).
     + intros Hv; apply vec_sum_is_zero in Hv; subst; auto.
@@ -798,7 +798,7 @@ Section map_vec_pos_equiv.
   Theorem map_vec_pos_equiv n (f : vec X n -> Y) : 
            (forall p v x y, R x y -> T (f (v[x/p])) (f (v[y/p])))
         -> forall v w, (forall p, R (v#>p) (w#>p)) -> T (f v) (f w).
-  Proof.
+  Proof using T_refl T_trans.
     revert f; induction n as [ | n IHn ]; intros f Hf v w H.
     + vec nil v; vec nil w; auto.
     + apply T_trans with (y := f (v[(w#>pos0)/pos0])).

--- a/theories/Shared/Libs/DLW/Wf/acc_irr.v
+++ b/theories/Shared/Libs/DLW/Wf/acc_irr.v
@@ -40,7 +40,7 @@ Section Acc_irrelevance.
                                ->  f (Acc_intro x H1) = f (Acc_intro x H2)).
 
   Theorem Acc_irrelevance x H1 H2 : @f x H1 = f H2.
-  Proof.
+  Proof using Hf.
     generalize (Acc_eq_total H1 H2).
     induction 1 as [ x H1 H2 _ IH ].
     apply Hf, IH.

--- a/theories/Shared/Libs/DLW/Wf/measure_ind.v
+++ b/theories/Shared/Libs/DLW/Wf/measure_ind.v
@@ -64,14 +64,14 @@ Section measure_rect.
       of Acc irrelevant functionals *)
 
   Let Fix_F_Acc_irr : forall x f g, @Fix_F x f = Fix_F g.
-  Proof.
+  Proof using F_ext.
     apply Acc_irrelevance.
     intros; apply F_ext; auto.
   Qed.
 
   Theorem measure_rect_fix x : 
           measure_rect x = @F x (fun y _ => measure_rect y).
-  Proof.
+  Proof using F_ext.
     unfold measure_rect; rewrite Fix_F_fix.
     apply F_ext.
     intros; apply Fix_F_Acc_irr.
@@ -104,7 +104,7 @@ Section measure_double_rect.
     Let Q c := match c with (x,y) => P x y end.
 
     Theorem measure_double_rect_paired x y : P x y.
-    Proof.
+    Proof using F.
       change (Q (x,y)).
       generalize (x,y); clear x y; intros c.
 
@@ -154,7 +154,7 @@ Section measure_double_rect.
 
     Theorem measure_double_rect_fix x y : 
              measure_double_rect x y = @F x y (fun x' y' _ => measure_double_rect x' y').
-    Proof.
+    Proof using F_ext.
       unfold measure_double_rect; rewrite Fix_F_2_fix.
       apply F_ext.
       intros; apply Fix_F_2_Acc_irr.

--- a/theories/Shared/Libs/DLW/Wf/wf_chains.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_chains.v
@@ -150,7 +150,7 @@ Section wf_chains.
   Hypothesis (HR : forall x, exists k, forall n y, chain n y x -> n <= k). 
 
   Theorem wf_chains : well_founded R.
-  Proof.
+  Proof using HR.
     intros x.
     destruct (HR x) as (k & Hk).
     revert Hk; apply Acc_chains.

--- a/theories/Shared/Libs/DLW/Wf/wf_finite.v
+++ b/theories/Shared/Libs/DLW/Wf/wf_finite.v
@@ -29,10 +29,10 @@ Section wf_strict_order_list.
   Implicit Type l : list X.
 
   Fact chain_trans n x y : chain R n x y -> n = 0 /\ x = y \/ R x y.
-  Proof. induction 1 as [ | ? ? ? ? ? ? [ [] | ] ]; subst; eauto. Qed.
+  Proof using Rtrans. induction 1 as [ | ? ? ? ? ? ? [ [] | ] ]; subst; eauto. Qed.
 
   Corollary chain_irrefl n x :~ chain R (S n) x x.
-  Proof.
+  Proof using Rirrefl Rtrans.
     intros H.
     apply chain_trans in H as [ (? & _) | H ]; try easy.
     revert H; apply Rirrefl.
@@ -45,14 +45,14 @@ Section wf_strict_order_list.
   Hint Resolve incl_nil_l incl_cons : core.
 
   Fact chain_list_incl l x y : chain_list R l x y -> l ⊆ m.
-  Proof. induction 1; simpl; eauto. Qed.
+  Proof using Hm. induction 1; simpl; eauto. Qed.
 
   (* Any chain of length above length m contains a duplicated
       value (by the PHP) hence a non nil sub-chain with identical 
       endpoints, contradicting chain_irrefl *)
 
   Lemma chain_bounded n x y : chain R n x y -> n <= length m.
-  Proof.
+  Proof using Hm Rirrefl Rtrans.
     intros H.
     destruct (le_lt_dec n (length m)) as [ | C ]; auto.
     destruct chain_chain_list with (1 := H)
@@ -76,7 +76,7 @@ Section wf_strict_order_list.
   Hint Resolve chain_bounded : core.
 
   Theorem wf_strict_order_list : well_founded R.
-  Proof. apply wf_chains; eauto. Qed.
+  Proof using Hm Rirrefl Rtrans. apply wf_chains; eauto. Qed.
 
 End wf_strict_order_list.
 
@@ -88,7 +88,7 @@ Section wf_strict_order_finite.
            (Rtrans : forall x y z, R x y -> R y z -> R x z).
 
   Theorem wf_strict_order_finite : well_founded R.
-  Proof.
+  Proof using HX Rirrefl Rtrans.
     destruct HX as (m & Hm).
     apply wf_strict_order_list with (m := m); auto.
   Qed.

--- a/theories/Shared/Libs/PSL/FCI.v
+++ b/theories/Shared/Libs/PSL/FCI.v
@@ -81,7 +81,7 @@ Section FCI.
   Qed.
 
   Definition F (A : list X) : list X.
-  Proof.
+  Proof using sigma R.
     destruct (pick A) as [[x _]|_].
     - exact (x::A).
     - exact A.

--- a/theories/Shared/Libs/PSL/Retracts.v
+++ b/theories/Shared/Libs/PSL/Retracts.v
@@ -4,7 +4,6 @@
 
 From Undecidability.Shared.Libs.PSL Require Import Base.
 
-
 (*
  * A retraction between types [A] and [B] is a tuple of two functions,
  * [f : A -> B] (called the injection function) and [g : B -> option A] (called the retract function),
@@ -353,7 +352,7 @@ Section Join.
   Hypothesis disjoint : forall (a : A) (b : B), Retr_f _ a <> Retr_f _ b.
 
   Lemma retract_join : retract retract_join_f retract_join_g.
-  Proof.
+  Proof using disjoint.
     unfold retract_join_f, retract_join_g. hnf; intros s z; split.
     - destruct s as [a|b]; intros H.
       + destruct (Retr_g retr1 z) eqn:E.

--- a/theories/Shared/Libs/PSL/Vectors/Vectors.v
+++ b/theories/Shared/Libs/PSL/Vectors/Vectors.v
@@ -7,7 +7,6 @@ From Coq.Vectors Require Import Fin Vector.
 From Undecidability.Shared.Libs.PSL Require Import Vectors.FinNotation.
 From Undecidability.Shared.Libs.PSL Require Export Vectors.Fin.
 
-
 (* Vector.nth should not reduce with simpl, except the index is given with a constructor *)
 Arguments Vector.nth {A} {m} (v') !p. 
 Arguments Vector.map {A B} f {n} !v. 
@@ -166,7 +165,7 @@ Section In_Dec.
   Qed.
 
   Global Instance In_dec (n : nat) (x : X) (xs : Vector.t X n) : dec (In x xs).
-  Proof. eapply dec_transfer. eapply in_dec_correct. auto. Defined.
+  Proof using X_dec. eapply dec_transfer. eapply in_dec_correct. auto. Defined.
 
 End In_Dec.
 

--- a/theories/StackMachines/BSM/bsm_defs.v
+++ b/theories/StackMachines/BSM/bsm_defs.v
@@ -17,8 +17,6 @@ From Undecidability.StackMachines
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/StackMachines/BSM/bsm_pcp.v
+++ b/theories/StackMachines/BSM/bsm_pcp.v
@@ -17,8 +17,6 @@ From Undecidability.StackMachines.BSM
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 (* ** iBPCP reduces to BSM *)
 
 Tactic Notation "rew" "length" := autorewrite with length_db.

--- a/theories/StackMachines/BSM/bsm_utils.v
+++ b/theories/StackMachines/BSM/bsm_utils.v
@@ -17,8 +17,6 @@ From Undecidability.StackMachines.BSM
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 Tactic Notation "rew" "length" := autorewrite with length_db.
 
 Local Notation "e #> x" := (vec_pos e x).

--- a/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB.v
+++ b/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB.v
@@ -28,7 +28,6 @@ Require Import Undecidability.StackMachines.Reductions.CM1_HALT_to_SMNdl_UB.CM1_
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/CM1_to_SMX.v
+++ b/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/CM1_to_SMX.v
@@ -26,7 +26,6 @@ From Undecidability.StackMachines.Util Require Import Facts Nat_facts List_facts
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Arguments in_combine_l {A B l l' x y}.

--- a/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/SMX.v
+++ b/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/SMX.v
@@ -14,8 +14,6 @@ Require Import List.
 Import ListNotations.
 Require Import Relation_Operators.
 
-Set Default Proof Using "Type".
-
 Section SMX.
   Context {State Symbol : Set}.
 

--- a/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/SMX_facts.v
+++ b/theories/StackMachines/Reductions/CM1_HALT_to_SMNdl_UB/SMX_facts.v
@@ -6,7 +6,6 @@ Require Import Undecidability.StackMachines.Reductions.CM1_HALT_to_SMNdl_UB.SMX.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Section SMX_facts.

--- a/theories/StackMachines/Reductions/SBTM_HALT_to_HaltBSM.v
+++ b/theories/StackMachines/Reductions/SBTM_HALT_to_HaltBSM.v
@@ -9,7 +9,6 @@ Import Vector.VectorNotations ListNotations SBTMNotations.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 #[local] Notation "P // s -[ k ]-> t" := (sss_steps (@bsm_sss _) P k s t).

--- a/theories/StackMachines/Reductions/SMNdl_UB_to_CSSM_UB.v
+++ b/theories/StackMachines/Reductions/SMNdl_UB_to_CSSM_UB.v
@@ -26,7 +26,6 @@ Require Import Undecidability.StackMachines.Util.SMN_transform.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
+++ b/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
@@ -21,8 +21,6 @@ From Undecidability.StackMachines.BSM
 From Undecidability.PCP 
   Require Import PCP PCP_facts.
 
-Set Default Proof Using "Type".
-
 Fact tile_concat_itau ln lt : tile_concat ln lt = (itau1 lt (rev ln), itau2 lt (rev ln)).
 Proof.
   induction ln as [ | i ln IH ]; simpl; auto.

--- a/theories/StackMachines/Util/CSSM_facts.v
+++ b/theories/StackMachines/Util/CSSM_facts.v
@@ -20,7 +20,6 @@ Require Import Undecidability.StackMachines.SSM.
 
 From Undecidability.StackMachines.Util Require Import Facts.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 (* width of a configuration *)

--- a/theories/StackMachines/Util/SMN_transform.v
+++ b/theories/StackMachines/Util/SMN_transform.v
@@ -21,7 +21,6 @@ From Undecidability.StackMachines.Util Require Import Facts List_facts SMN_facts
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Definition rt_rt1n := @clos_rt_rt1n_iff Config.

--- a/theories/StringRewriting/Reductions/CM2_HALT_to_SSTS01/CM2_HALT_to_SR2ab.v
+++ b/theories/StringRewriting/Reductions/CM2_HALT_to_SSTS01/CM2_HALT_to_SR2ab.v
@@ -10,7 +10,6 @@ Require Import Undecidability.CounterMachines.Util.Facts Undecidability.CounterM
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Arguments rt_trans {A R x y z}.

--- a/theories/StringRewriting/Reductions/CM2_HALT_to_SSTS01/SR2ab_to_SSTS01.v
+++ b/theories/StringRewriting/Reductions/CM2_HALT_to_SSTS01/SR2ab_to_SSTS01.v
@@ -9,7 +9,6 @@ Require Import Undecidability.StringRewriting.Util.List_facts.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Arguments rt_trans {A R x y z}.

--- a/theories/StringRewriting/Reductions/SBTM_HALT_to_SR.v
+++ b/theories/StringRewriting/Reductions/SBTM_HALT_to_SR.v
@@ -6,7 +6,6 @@ Require Import PeanoNat Lia.
 Require Import List ssreflect ssrbool ssrfun.
 Import ListNotations SBTMNotations.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Section Construction.

--- a/theories/StringRewriting/Reductions/SBTM_HALT_to_TSR.v
+++ b/theories/StringRewriting/Reductions/SBTM_HALT_to_TSR.v
@@ -9,7 +9,6 @@ Require Import PeanoNat Lia.
 Require Import List ssreflect ssrbool ssrfun.
 Import ListNotations SBTMNotations.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Section Construction.

--- a/theories/StringRewriting/Reductions/SR_to_PCSnf.v
+++ b/theories/StringRewriting/Reductions/SR_to_PCSnf.v
@@ -6,8 +6,6 @@ Require Import Undecidability.StringRewriting.SR.
 Require Import Undecidability.StringRewriting.Util.Definitions.
 Require Import Undecidability.Shared.ListAutomation.
 
-Set Default Proof Using "Type".
-
 Lemma derv_trans X R x y z :
     @derv X R x y -> derv R y z -> derv R x z.
 Proof.

--- a/theories/Synthetic/Infinite.v
+++ b/theories/Synthetic/Infinite.v
@@ -8,8 +8,6 @@ Import ListAutomationNotations.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 
-Set Default Proof Using "Type".
-
 Definition mu (p : nat -> Prop) :
   (forall x, dec (p x)) -> ex p -> sig p.
 Proof.

--- a/theories/Synthetic/InformativeReducibilityFacts.v
+++ b/theories/Synthetic/InformativeReducibilityFacts.v
@@ -1,7 +1,5 @@
 From Undecidability.Synthetic Require Import InformativeDefinitions DecidabilityFacts.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* ** Pre-order properties *)

--- a/theories/Synthetic/ListEnumerabilityFacts.v
+++ b/theories/Synthetic/ListEnumerabilityFacts.v
@@ -4,8 +4,6 @@ Require Cantor.
 Require Import List.
 Import ListNotations.
 
-Set Default Proof Using "Type".
-
 #[global]
 Instance list_in_dec X (x : X) (A : list X) :
   eq_dec X -> dec (In x A).

--- a/theories/Synthetic/MoreReducibilityFacts.v
+++ b/theories/Synthetic/MoreReducibilityFacts.v
@@ -7,69 +7,6 @@ From Undecidability.Shared Require Import Dec.
 
 Set Implicit Arguments.
 
-Module ReductionChainNotations.
-
-(* DLW: Thx to M. Wuttke for the tip, see coq-club ML *)
-
-Ltac redchain2Prop_rec xs :=
-  lazymatch xs with
-  | pair ?x (pair ?y ?xs) =>
-    let z := redchain2Prop_rec (pair y xs) in
-    constr:(x ⪯ y /\ z)
-  | pair ?x ?y => constr:(x ⪯ y)
-  end.
-
-Ltac redchain2Prop xs :=
-  let z := redchain2Prop_rec xs 
-  in  exact z.
-
-Declare Scope reduction_chain.
-Delimit Scope reduction_chain with redchain_scope.
-Notation "x '⪯ₘ' y" := (pair x y) (at level 80, right associativity, only parsing) : reduction_chain.
-Notation "'⎩' xs '⎭'" := (ltac:(redchain2Prop (xs % redchain_scope))) (only parsing).
-
-(*
-Definition Undec_Problem := { X : Type & X -> Prop }.
-
-Definition undec_problem X (P : X -> Prop) : Undec_Problem := existT _ X P.
-
-Notation "⎩ p ⎭" := (@undec_problem _ p) (format "⎩ p ⎭").
-
-Infix "⪯ₚ" := (fun p q : Undec_Problem => projT2 p ⪯ projT2 q : Prop) (at level 70).
-
-Reserved Notation "p '⪯ₗ' q 'by' l" (at level 70).
-
-Section reduction_chain.
-
-  Inductive reduction_chain : Undec_Problem -> Undec_Problem -> list Undec_Problem -> Prop :=
-    | reduction_chain_nil  : forall p, p ⪯ₗ p by nil
-    | reduction_chain_cons : forall p q r l, p ⪯ₚ q -> q ⪯ₗ r by l -> p ⪯ₗ r by q::l
-  where "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
-
-  Fact reduction_chain_reduces p q l : p ⪯ₗ q by l -> p ⪯ₚ q.
-  Proof.
-    induction 1 as [ p | p q r l H1 _ ? ].
-    + apply reduces_reflexive.
-    + apply reduces_transitive with (1 := H1); trivial.
-  Qed.
-
-  Fact reduction_chain_app p q r l m : p ⪯ₗ q by l -> q ⪯ₗ r by m -> p ⪯ₗ r by l++m.
-  Proof.
-    induction 1; intros; auto.
-    constructor 2; auto.
-  Qed.
-
-End reduction_chain.
-
-Notation "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
-
-Tactic Notation "red" "chain" "stop" := constructor 1.
-Tactic Notation "red" "chain" "step" constr(H) := constructor 2; [ apply H | ].
-Tactic Notation "red" "chain" "app" constr(H) := apply reduction_chain_app with (1 := H).
-*)
-
-End ReductionChainNotations.
-
 Section enum_red.
 
   Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop).

--- a/theories/Synthetic/MoreReducibilityFacts.v
+++ b/theories/Synthetic/MoreReducibilityFacts.v
@@ -1,0 +1,137 @@
+From Undecidability.Synthetic Require Import 
+  ReducibilityFacts DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts MoreEnumerabilityFacts.
+
+Require Import List.
+Import ListNotations.
+From Undecidability.Shared Require Import Dec.
+
+Set Implicit Arguments.
+
+Module ReductionChainNotations.
+
+(* DLW: Thx to M. Wuttke for the tip, see coq-club ML *)
+
+Ltac redchain2Prop_rec xs :=
+  lazymatch xs with
+  | pair ?x (pair ?y ?xs) =>
+    let z := redchain2Prop_rec (pair y xs) in
+    constr:(x ⪯ y /\ z)
+  | pair ?x ?y => constr:(x ⪯ y)
+  end.
+
+Ltac redchain2Prop xs :=
+  let z := redchain2Prop_rec xs 
+  in  exact z.
+
+Declare Scope reduction_chain.
+Delimit Scope reduction_chain with redchain_scope.
+Notation "x '⪯ₘ' y" := (pair x y) (at level 80, right associativity, only parsing) : reduction_chain.
+Notation "'⎩' xs '⎭'" := (ltac:(redchain2Prop (xs % redchain_scope))) (only parsing).
+
+(*
+Definition Undec_Problem := { X : Type & X -> Prop }.
+
+Definition undec_problem X (P : X -> Prop) : Undec_Problem := existT _ X P.
+
+Notation "⎩ p ⎭" := (@undec_problem _ p) (format "⎩ p ⎭").
+
+Infix "⪯ₚ" := (fun p q : Undec_Problem => projT2 p ⪯ projT2 q : Prop) (at level 70).
+
+Reserved Notation "p '⪯ₗ' q 'by' l" (at level 70).
+
+Section reduction_chain.
+
+  Inductive reduction_chain : Undec_Problem -> Undec_Problem -> list Undec_Problem -> Prop :=
+    | reduction_chain_nil  : forall p, p ⪯ₗ p by nil
+    | reduction_chain_cons : forall p q r l, p ⪯ₚ q -> q ⪯ₗ r by l -> p ⪯ₗ r by q::l
+  where "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
+
+  Fact reduction_chain_reduces p q l : p ⪯ₗ q by l -> p ⪯ₚ q.
+  Proof.
+    induction 1 as [ p | p q r l H1 _ ? ].
+    + apply reduces_reflexive.
+    + apply reduces_transitive with (1 := H1); trivial.
+  Qed.
+
+  Fact reduction_chain_app p q r l m : p ⪯ₗ q by l -> q ⪯ₗ r by m -> p ⪯ₗ r by l++m.
+  Proof.
+    induction 1; intros; auto.
+    constructor 2; auto.
+  Qed.
+
+End reduction_chain.
+
+Notation "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
+
+Tactic Notation "red" "chain" "stop" := constructor 1.
+Tactic Notation "red" "chain" "step" constr(H) := constructor 2; [ apply H | ].
+Tactic Notation "red" "chain" "app" constr(H) := apply reduction_chain_app with (1 := H).
+*)
+
+End ReductionChainNotations.
+
+Section enum_red.
+
+  Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop).
+  Variables (f : X -> Y) (Hf : forall x, p x <-> q (f x)).
+
+  Variables (Lq : _) (qe : list_enumerator Lq q).
+
+  Variables (x0 : X).
+  
+  Variables (d : eq_dec Y).
+  
+  Local Fixpoint L L' n :=
+    match n with
+    | 0 => []
+    | S n => L L' n ++ (filter (fun x => Dec (In (f x) (cumul Lq n))) (cumul L' n))
+    end.
+
+  Local Lemma enum_red L' :
+    list_enumerator__T L' X ->
+    list_enumerator (L L') p.
+  Proof using qe Hf.
+    intros HL'.
+    split.
+    + intros H.
+      eapply Hf in H. eapply (cumul_spec qe) in H as [m1]. destruct (cumul_spec__T HL' x) as [m2 ?]. 
+      exists (1 + m1 + m2). cbn. apply in_app_iff. right.
+      apply filter_In. split.
+      * eapply cum_ge'; eauto; lia.
+      * eapply Dec_auto. eapply cum_ge'; eauto; lia.
+    + intros [m H]. induction m.
+      * inversion H.
+      * cbn in H. apply in_app_or in H. destruct H; [now auto|].
+        apply filter_In in H. destruct H as [_ H].
+        destruct (Dec _) in H; [|easy].
+        eapply Hf. eauto.
+  Qed.
+
+End enum_red.
+
+Lemma enumerable_red X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> discrete Y -> enumerable q -> enumerable p.
+Proof.
+  intros [f] [] % enum_enumT [] % discrete_iff [L] % enumerable_enum.
+  eapply list_enumerable_enumerable.
+  eexists. eapply enum_red; eauto.
+Qed.
+
+Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> ~ enumerable (complement p) ->
+  ~ decidable q /\ ~ decidable (complement q).
+Proof.
+  intros. split; intros ?.
+  - eapply H1. eapply dec_red in H2; eauto.
+    eapply dec_compl in H2. eapply dec_count_enum; eauto.
+  - eapply H1. eapply dec_red in H2; eauto.
+    eapply dec_count_enum; eauto. now eapply red_comp.
+Qed.
+
+Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) :
+  p ⪯ q -> enumerable__T X -> ~ enumerable (complement p) -> discrete Y ->
+  ~ enumerable (complement q).
+Proof.
+  intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto.
+  now eapply red_comp.
+Qed.

--- a/theories/Synthetic/ReducibilityFacts.v
+++ b/theories/Synthetic/ReducibilityFacts.v
@@ -1,12 +1,6 @@
-From Undecidability.Synthetic Require Import DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts MoreEnumerabilityFacts.
-
-Require Import List.
-Import ListNotations.
-From Undecidability.Shared Require Import Dec.
+Require Import Undecidability.Synthetic.Definitions.
 
 Set Implicit Arguments.
-
-Set Default Proof Using "Type".
 
 (* ** Pre-order properties *)
 
@@ -24,7 +18,7 @@ Section Properties.
     unfold reduces, reduction.
     intros (f & Hf) (g & Hg).
     exists (fun x => g (f x)).
-    intro; rewrite Hf, Hg; tauto.
+    firstorder easy.
   Qed.
 
   (* ** An equivalent dependent definition *)
@@ -47,144 +41,16 @@ Section Properties.
 
 End Properties.
 
-Module ReductionChainNotations.
-
-(* DLW: Thx to M. Wuttke for the tip, see coq-club ML *)
-
-Ltac redchain2Prop_rec xs :=
-  lazymatch xs with
-  | pair ?x (pair ?y ?xs) =>
-    let z := redchain2Prop_rec (pair y xs) in
-    constr:(x ⪯ y /\ z)
-  | pair ?x ?y => constr:(x ⪯ y)
-  end.
-
-Ltac redchain2Prop xs :=
-  let z := redchain2Prop_rec xs 
-  in  exact z.
-
-Declare Scope reduction_chain.
-Delimit Scope reduction_chain with redchain_scope.
-Notation "x '⪯ₘ' y" := (pair x y) (at level 80, right associativity, only parsing) : reduction_chain.
-Notation "'⎩' xs '⎭'" := (ltac:(redchain2Prop (xs % redchain_scope))) (only parsing).
-
-(*
-Definition Undec_Problem := { X : Type & X -> Prop }.
-
-Definition undec_problem X (P : X -> Prop) : Undec_Problem := existT _ X P.
-
-Notation "⎩ p ⎭" := (@undec_problem _ p) (format "⎩ p ⎭").
-
-Infix "⪯ₚ" := (fun p q : Undec_Problem => projT2 p ⪯ projT2 q : Prop) (at level 70).
-
-Reserved Notation "p '⪯ₗ' q 'by' l" (at level 70).
-
-Section reduction_chain.
-
-  Inductive reduction_chain : Undec_Problem -> Undec_Problem -> list Undec_Problem -> Prop :=
-    | reduction_chain_nil  : forall p, p ⪯ₗ p by nil
-    | reduction_chain_cons : forall p q r l, p ⪯ₚ q -> q ⪯ₗ r by l -> p ⪯ₗ r by q::l
-  where "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
-
-  Fact reduction_chain_reduces p q l : p ⪯ₗ q by l -> p ⪯ₚ q.
-  Proof.
-    induction 1 as [ p | p q r l H1 _ ? ].
-    + apply reduces_reflexive.
-    + apply reduces_transitive with (1 := H1); trivial.
-  Qed.
-
-  Fact reduction_chain_app p q r l m : p ⪯ₗ q by l -> q ⪯ₗ r by m -> p ⪯ₗ r by l++m.
-  Proof.
-    induction 1; intros; auto.
-    constructor 2; auto.
-  Qed.
-
-End reduction_chain.
-
-Notation "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
-
-Tactic Notation "red" "chain" "stop" := constructor 1.
-Tactic Notation "red" "chain" "step" constr(H) := constructor 2; [ apply H | ].
-Tactic Notation "red" "chain" "app" constr(H) := apply reduction_chain_app with (1 := H).
-*)
-
-End ReductionChainNotations.
-
 Lemma dec_red X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> decidable q -> decidable p.
 Proof.
   unfold decidable, decider, reduces, reduction, reflects.
-  intros [f] [d]. exists (fun x => d (f x)). intros x. rewrite H. eapply H0.
+  intros [f] [d]. exists (fun x => d (f x)).
+  firstorder easy.
 Qed.
 
 Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
   p ⪯ q -> (fun x => ~ p x) ⪯ (fun y => ~ q y).
 Proof.
-  intros [f]. exists f. intros x. red in H. now rewrite H.
-Qed.
-
-Section enum_red.
-
-  Variables (X Y : Type) (p : X -> Prop) (q : Y -> Prop).
-  Variables (f : X -> Y) (Hf : forall x, p x <-> q (f x)).
-
-  Variables (Lq : _) (qe : list_enumerator Lq q).
-
-  Variables (x0 : X).
-  
-  Variables (d : eq_dec Y).
-  
-  Local Fixpoint L L' n :=
-    match n with
-    | 0 => []
-    | S n => L L' n ++ (filter (fun x => Dec (In (f x) (cumul Lq n))) (cumul L' n))
-    end.
-
-  Local Lemma enum_red L' :
-    list_enumerator__T L' X ->
-    list_enumerator (L L') p.
-  Proof using qe Hf.
-    intros HL'.
-    split.
-    + intros H.
-      eapply Hf in H. eapply (cumul_spec qe) in H as [m1]. destruct (cumul_spec__T HL' x) as [m2 ?]. 
-      exists (1 + m1 + m2). cbn. apply in_app_iff. right.
-      apply filter_In. split.
-      * eapply cum_ge'; eauto; lia.
-      * eapply Dec_auto. eapply cum_ge'; eauto; lia.
-    + intros [m H]. induction m.
-      * inversion H.
-      * cbn in H. apply in_app_or in H. destruct H; [now auto|].
-        apply filter_In in H. destruct H as [_ H].
-        destruct (Dec _) in H; [|easy].
-        eapply Hf. eauto.
-  Qed.
-
-End enum_red.
-
-Lemma enumerable_red X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> discrete Y -> enumerable q -> enumerable p.
-Proof.
-  intros [f] [] % enum_enumT [] % discrete_iff [L] % enumerable_enum.
-  eapply list_enumerable_enumerable.
-  eexists. eapply enum_red; eauto.
-Qed.
-
-Theorem not_decidable X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> ~ enumerable (complement p) ->
-  ~ decidable q /\ ~ decidable (complement q).
-Proof.
-  intros. split; intros ?.
-  - eapply H1. eapply dec_red in H2; eauto.
-    eapply dec_compl in H2. eapply dec_count_enum; eauto.
-  - eapply H1. eapply dec_red in H2; eauto.
-    eapply dec_count_enum; eauto. now eapply red_comp.
-Qed.
-
-Theorem not_coenumerable X Y (p : X -> Prop) (q : Y -> Prop) :
-  p ⪯ q -> enumerable__T X -> ~ enumerable (complement p) -> discrete Y ->
-  ~ enumerable (complement q).
-Proof.
-  intros. intros ?. eapply H1. eapply enumerable_red in H3; eauto.
-  now eapply red_comp.
+  intros [f Hf]. exists f. firstorder easy.
 Qed.

--- a/theories/Synthetic/ReducibilityFacts.v
+++ b/theories/Synthetic/ReducibilityFacts.v
@@ -54,3 +54,66 @@ Lemma red_comp X (p : X -> Prop) Y (q : Y -> Prop) :
 Proof.
   intros [f Hf]. exists f. firstorder easy.
 Qed.
+
+Module ReductionChainNotations.
+
+(* DLW: Thx to M. Wuttke for the tip, see coq-club ML *)
+
+Ltac redchain2Prop_rec xs :=
+  lazymatch xs with
+  | pair ?x (pair ?y ?xs) =>
+    let z := redchain2Prop_rec (pair y xs) in
+    constr:(x ⪯ y /\ z)
+  | pair ?x ?y => constr:(x ⪯ y)
+  end.
+
+Ltac redchain2Prop xs :=
+  let z := redchain2Prop_rec xs 
+  in  exact z.
+
+Declare Scope reduction_chain.
+Delimit Scope reduction_chain with redchain_scope.
+Notation "x '⪯ₘ' y" := (pair x y) (at level 80, right associativity, only parsing) : reduction_chain.
+Notation "'⎩' xs '⎭'" := (ltac:(redchain2Prop (xs % redchain_scope))) (only parsing).
+
+(*
+Definition Undec_Problem := { X : Type & X -> Prop }.
+
+Definition undec_problem X (P : X -> Prop) : Undec_Problem := existT _ X P.
+
+Notation "⎩ p ⎭" := (@undec_problem _ p) (format "⎩ p ⎭").
+
+Infix "⪯ₚ" := (fun p q : Undec_Problem => projT2 p ⪯ projT2 q : Prop) (at level 70).
+
+Reserved Notation "p '⪯ₗ' q 'by' l" (at level 70).
+
+Section reduction_chain.
+
+  Inductive reduction_chain : Undec_Problem -> Undec_Problem -> list Undec_Problem -> Prop :=
+    | reduction_chain_nil  : forall p, p ⪯ₗ p by nil
+    | reduction_chain_cons : forall p q r l, p ⪯ₚ q -> q ⪯ₗ r by l -> p ⪯ₗ r by q::l
+  where "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
+
+  Fact reduction_chain_reduces p q l : p ⪯ₗ q by l -> p ⪯ₚ q.
+  Proof.
+    induction 1 as [ p | p q r l H1 _ ? ].
+    + apply reduces_reflexive.
+    + apply reduces_transitive with (1 := H1); trivial.
+  Qed.
+
+  Fact reduction_chain_app p q r l m : p ⪯ₗ q by l -> q ⪯ₗ r by m -> p ⪯ₗ r by l++m.
+  Proof.
+    induction 1; intros; auto.
+    constructor 2; auto.
+  Qed.
+
+End reduction_chain.
+
+Notation "p '⪯ₗ' q 'by' l" := (reduction_chain p q l).
+
+Tactic Notation "red" "chain" "stop" := constructor 1.
+Tactic Notation "red" "chain" "step" constr(H) := constructor 2; [ apply H | ].
+Tactic Notation "red" "chain" "app" constr(H) := apply reduction_chain_app with (1 := H).
+*)
+
+End ReductionChainNotations.

--- a/theories/Synthetic/Undecidability.v
+++ b/theories/Synthetic/Undecidability.v
@@ -1,6 +1,6 @@
 Require Export Undecidability.Synthetic.Definitions.
-Require Import Undecidability.Synthetic.ReducibilityFacts.
 Require Import Undecidability.Synthetic.DecidabilityFacts.
+Require Import Undecidability.Synthetic.ReducibilityFacts.
 Require Import Undecidability.TM.SBTM.
 
 (*

--- a/theories/SystemF/Autosubst/syntax.v
+++ b/theories/SystemF/Autosubst/syntax.v
@@ -3,7 +3,6 @@ Require Import Undecidability.SystemF.SysF.
 
 Require Import Morphisms.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Notation "f === g" := (fext_eq f g) (at level 80).

--- a/theories/SystemF/Reductions/H10C_SAT_to_SysF_INH.v
+++ b/theories/SystemF/Reductions/H10C_SAT_to_SysF_INH.v
@@ -27,7 +27,6 @@ Require Import Undecidability.DiophantineConstraints.H10C.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Local Arguments nth_error_In {A l n x}.

--- a/theories/SystemF/Reductions/LU2SemiU_to_SysF_TYP.v
+++ b/theories/SystemF/Reductions/LU2SemiU_to_SysF_TYP.v
@@ -26,7 +26,6 @@ Module SU := SemiU.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/SystemF/Reductions/SysF_TYP_to_SysF_TC.v
+++ b/theories/SystemF/Reductions/SysF_TYP_to_SysF_TC.v
@@ -19,7 +19,6 @@ From Undecidability.SystemF.Util Require Import Facts poly_type_facts pure_term_
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/SystemF/Util/Facts.v
+++ b/theories/SystemF/Util/Facts.v
@@ -3,7 +3,6 @@ Import ListNotations.
 
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 (* Generic facts *)

--- a/theories/SystemF/Util/sn_facts.v
+++ b/theories/SystemF/Util/sn_facts.v
@@ -4,8 +4,6 @@ From Undecidability.SystemF.Util Require Import typing_facts term_facts step.
 Require Import Setoid Morphisms.
 Require List.
 
-Set Default Proof Using "Type".
-
 Definition pw_iff {X} p q := (forall x : X, p x <-> q x).
 Notation "p == q" := (pw_iff p q) (at level 70).
 

--- a/theories/TM/Basic/Duo.v
+++ b/theories/TM/Basic/Duo.v
@@ -2,7 +2,6 @@
 
 From Undecidability.TM Require Import Util.TM_facts.
 
-Set Default Proof Using "Type".
 (* ** Read two symbols *)
 
 

--- a/theories/TM/Basic/Mono.v
+++ b/theories/TM/Basic/Mono.v
@@ -1,7 +1,5 @@
 From Undecidability.TM Require Import Util.TM_facts.
 
-Set Default Proof Using "Type".
-
 (* * Basic 1-Tape Machines *)
 
 

--- a/theories/TM/Basic/Null.v
+++ b/theories/TM/Basic/Null.v
@@ -1,7 +1,5 @@
 From Undecidability.TM Require Import Util.Prelim Util.TM_facts.
 
-Set Default Proof Using "Type".
-
 (* * 0-tape Turing machine that does nothing. *)
 
 Section Mono_Nop.

--- a/theories/TM/Code/CaseList.v
+++ b/theories/TM/Code/CaseList.v
@@ -5,8 +5,6 @@ From Undecidability.TM Require Import ProgrammingTools.
 
 Local Arguments plus : simpl never. Local Arguments mult : simpl never.
 
-Set Default Proof Using "Type".
-
 
 Lemma tl_length (X : Type) (xs : list X) :
   length (tl xs) = pred (length xs).
@@ -19,8 +17,6 @@ Section CaseList.
   Variable X : Type.
   Variable (sigX : finType).
   Hypothesis (cX : codable sigX X).
-
-  Set Default Proof Using "Type".
 
   Definition stop (s: (sigList sigX)^+) :=
     match s with

--- a/theories/TM/Code/CasePair.v
+++ b/theories/TM/Code/CasePair.v
@@ -2,7 +2,6 @@
 
 From Undecidability.TM Require Import ProgrammingTools.
 
-Set Default Proof Using "Type".
 (* TODO: ~> base *)
 Lemma pair_eq (A B : Type) (a1 a2 : A) (b1 b2 : B) :
   (a1, b1) = (a2, b2) ->

--- a/theories/TM/Code/CaseSum.v
+++ b/theories/TM/Code/CaseSum.v
@@ -6,7 +6,6 @@ Lemma tl_length (X : Type) (xs : list X) :
   length (tl xs) = pred (length xs).
 Proof. destruct xs; cbn; auto. Qed.
 
-Set Default Proof Using "Type".
 Section CaseSum.
 
   Variable X Y : Type.

--- a/theories/TM/Code/CompareValue.v
+++ b/theories/TM/Code/CompareValue.v
@@ -12,8 +12,6 @@ From Undecidability Require Import TM.Lifting.LiftTapes.
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.
 
-Set Default Proof Using "Type".
-
 Lemma pair_inv (X Y : Type) (x1 x2 : X) (y1 y2 : Y) :
   (x1, y1) = (x2, y2) -> x1 = x2 /\ y1 = y2.
 Proof. intros H. now inv H. Qed.

--- a/theories/TM/Code/Copy.v
+++ b/theories/TM/Code/Copy.v
@@ -12,7 +12,6 @@ From Undecidability Require Import TM.Lifting.LiftAlphabet.
 
 
 Local Generalizable All Variables.
-Set Default Proof Using "Type".
 
 
 (* Don't simplify [skipn (S n) xs]; only, if the number and the lists are constructors *)

--- a/theories/TM/Code/List/App.v
+++ b/theories/TM/Code/List/App.v
@@ -10,8 +10,6 @@ Local Arguments mult : simpl never.
 Local Arguments Encode_list : simpl never.
 Local Arguments Encode_nat : simpl never.
 
-Set Default Proof Using "Type".
-
 
 From Undecidability Require Import TM.Basic.Mono TM.Code.Copy.
 

--- a/theories/TM/Code/List/Length.v
+++ b/theories/TM/Code/List/Length.v
@@ -11,7 +11,6 @@ Local Arguments Encode_nat : simpl never.
 
 
 (* ** Length *)
-Set Default Proof Using "Type".
 
 Section Lenght.
 

--- a/theories/TM/Code/List/Nth.v
+++ b/theories/TM/Code/List/Nth.v
@@ -10,8 +10,6 @@ Local Arguments mult : simpl never.
 Local Arguments Encode_list : simpl never.
 Local Arguments Encode_nat : simpl never.
 
-Set Default Proof Using "Type".
-
 (* ** Other Implementation of [nth_error] *)
 
 Section Nth'.

--- a/theories/TM/Code/List/Rev.v
+++ b/theories/TM/Code/List/Rev.v
@@ -10,8 +10,6 @@ Local Arguments mult : simpl never.
 Local Arguments Encode_list : simpl never.
 Local Arguments Encode_nat : simpl never.
 
-Set Default Proof Using "Type".
-
 (* Reverse a list *)
 Section Rev.
   (* Reversing is just consing and deconsing. We don't save the original list. *)

--- a/theories/TM/Code/ProgrammingTools.v
+++ b/theories/TM/Code/ProgrammingTools.v
@@ -3,7 +3,6 @@ Require Export Undecidability.TM.Compound.TMTac.
 Require Export Undecidability.TM.Basic.Mono Undecidability.TM.Compound.Multi.
 Require Import Lia.
 
-Export Set Default Proof Using "Type".
 (* * All tools for programming Turing machines *)
 
 (* All Coq modules in that the user programms Turing machine should [From Undecidability Require Import TM.Code.ProgrammingTools]. The module should additionally require and import the modules containing the constructor and deconstructor machines, e.g. [Require Import TM.Code.CaseNat], etc. *)

--- a/theories/TM/Compound/Compare.v
+++ b/theories/TM/Compound/Compare.v
@@ -12,7 +12,6 @@ Require Recdef.
 
 (* This two-tape machines reads symbols from the tapes. It moves right, until the read symbols are not equal, or one of the read symbol is a stop symbol. It returns [true] if both last read symbols are stop symbols. It returns [false] If one (or both) tapes finally are off the tape, or the last read symbols differ. *)
 
-Set Default Proof Using "Type".
 Section Compare.
   Import Recdef.
 

--- a/theories/TM/Compound/CopySymbols.v
+++ b/theories/TM/Compound/CopySymbols.v
@@ -7,8 +7,6 @@ From Undecidability Require Import TM.Lifting.LiftTapes.
 From Coq Require Import FunInd.
 From Coq Require Import Recdef.
 
-Set Default Proof Using "Type".
-
 (* * Copy Symbols from t0 to t1 *)
 
 (* This two-tape Turing machine copies the symbols from tape 0 to tape 1, until it reads a symbol x on tape 0 such that f(x)=true. This machine is similar to MoveToSymbol, with the only difference, that it copies the read symbols to another tape (without translating it). *)

--- a/theories/TM/Compound/MoveToSymbol.v
+++ b/theories/TM/Compound/MoveToSymbol.v
@@ -9,8 +9,6 @@ From Undecidability Require Import ArithPrelim.
 From Coq Require Import FunInd.
 From Coq Require Import Recdef.
 
-Set Default Proof Using "Type".
-
 (* * Move to a symbol and translate read symbols *)
 
 

--- a/theories/TM/Compound/Multi.v
+++ b/theories/TM/Compound/Multi.v
@@ -6,8 +6,6 @@ From Undecidability Require Import TM.Lifting.Lifting.
 
 From Undecidability Require Import TM.Compound.TMTac.
 
-Set Default Proof Using "Type".
-
 (* * Simple compound multi-tape Machines *)
 
 

--- a/theories/TM/Compound/Shift.v
+++ b/theories/TM/Compound/Shift.v
@@ -7,8 +7,6 @@ From Undecidability Require Import TM.Compound.Multi.
 From Coq Require Import FunInd.
 From Coq Require Import Recdef.
 
-Set Default Proof Using "Type".
-
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.
 

--- a/theories/TM/Compound/WriteString.v
+++ b/theories/TM/Compound/WriteString.v
@@ -3,8 +3,6 @@ Require Import List.
 From Undecidability Require Import TMTac.
 From Coq Require Import List.
 
-Set Default Proof Using "Type".
-
 (* Useful for running time stuff *)
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.

--- a/theories/TM/Hoare/HoareExamples.v
+++ b/theories/TM/Hoare/HoareExamples.v
@@ -12,7 +12,6 @@ Arguments plus : simpl never.
 
 (* Disable the warnings regarding [Undo]. This is a demonstration file. *)
 Set Warnings "-undo-batch-mode,-non-interactive".
-Set Default Proof Using "Type".
 
 
 (* *** Copy.v *)

--- a/theories/TM/L/CompilerBoolFuns/Compiler.v
+++ b/theories/TM/L/CompilerBoolFuns/Compiler.v
@@ -9,8 +9,6 @@ From Undecidability.TM Require Import TM_facts ProgrammingTools WriteValue CaseL
 From Undecidability.TM.L Require Import Alphabets Eval.
 From Undecidability.TM.L.CompilerBoolFuns Require Import Compiler_spec Compiler_facts ClosedLAdmissible.
 
-Set Default Proof Using "Type".
-
 Section APP_right.
 
   Definition APP_right : pTM (sigPro)^+ unit 2 :=

--- a/theories/TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
+++ b/theories/TM/L/CompilerBoolFuns/EncBoolsTM_boolList.v
@@ -13,8 +13,6 @@ From Undecidability.TM Require Import TM_facts Hoare ProgrammingTools.
 From Undecidability.TM.Code Require Import CaseBool CaseList WriteValue Copy ListTM.
 
 
-Set Default Proof Using "Type".
-
 
 Module Boollist2encBoolsTM.
 Section Fix.

--- a/theories/TM/L/Eval.v
+++ b/theories/TM/L/Eval.v
@@ -19,8 +19,6 @@ From Undecidability.TM.L Require Import UnfoldClos.
 
 Import CasePair Code.CaseList.
 
-Set Default Proof Using "Type".
-
 
 Module EvalL.
 Section Fix.

--- a/theories/TM/L/HeapInterpreter/LookupTM.v
+++ b/theories/TM/L/HeapInterpreter/LookupTM.v
@@ -4,7 +4,6 @@ From Undecidability Require Import TM.Code.ProgrammingTools LM_heap_def.
 From Undecidability.TM.L Require Import Alphabets.
 From Undecidability Require Import TM.Code.ListTM TM.Code.CasePair TM.Code.CaseSum TM.Code.CaseNat Hoare.Hoare.
 
-Set Default Proof Using "Type".
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.
 

--- a/theories/TM/L/HeapInterpreter/StepTM.v
+++ b/theories/TM/L/HeapInterpreter/StepTM.v
@@ -26,8 +26,6 @@ Section StepMachine.
   Variable retr_closures_step : Retract (sigList sigHClos) sigStep.
   Variable retr_heap_step : Retract sigHeap sigStep.
 
-  Set Default Proof Using "Type".
-
   (* Retracts *)
   (* Closures *)
   Local Definition retr_clos_step : Retract sigHClos sigStep := ComposeRetract retr_closures_step _.

--- a/theories/TM/L/HeapInterpreter/UnfoldClos.v
+++ b/theories/TM/L/HeapInterpreter/UnfoldClos.v
@@ -21,8 +21,6 @@ Import Coq.Init.Datatypes List.
 Open Scope string_scope.
 Require Import String.
 
-Set Default Proof Using "Type".
-
 From Undecidability Require Cons_constant.
 
 Module Private_UnfoldClos.

--- a/theories/TM/L/Transcode/Boollist_to_Enc.v
+++ b/theories/TM/L/Transcode/Boollist_to_Enc.v
@@ -15,8 +15,6 @@ From Coq Require Import Lia Ring Arith.
 
 From Undecidability Require Import TM.Code.List.Concat_Repeat.
 
-Set Default Proof Using "Type".
-
 Module BoollistToEnc.
   Section M.
     Import ProgrammingTools Combinators App CaseList CaseBool.

--- a/theories/TM/L/Transcode/Enc_to_Boollist.v
+++ b/theories/TM/L/Transcode/Enc_to_Boollist.v
@@ -18,8 +18,6 @@ From Undecidability Require Import TM.Code.List.Concat_Repeat.
 From Undecidability Require Import Cons_constant CaseCom CaseNat CaseList.
 
 
-Set Default Proof Using "Type".
-
 Module EncToBoollist.
   Section M.
     Import ProgrammingTools Combinators App CaseList CaseBool.

--- a/theories/TM/Lifting/LiftAlphabet.v
+++ b/theories/TM/Lifting/LiftAlphabet.v
@@ -1,7 +1,5 @@
 From Undecidability Require Import TM.Util.Prelim TM.Util.Relations TM.Util.TM_facts.
 
-Set Default Proof Using "Type".
-
 (* * Alphabet-Lift *)
 
 Section SujectTape.

--- a/theories/TM/Lifting/LiftTapes.v
+++ b/theories/TM/Lifting/LiftTapes.v
@@ -1,7 +1,5 @@
 From Undecidability Require Import TM.Util.Prelim TM.Util.Relations TM.Util.TM_facts.
 
-Set Default Proof Using "Type".
-
 (* * Tapes-Lift *)
 
 

--- a/theories/TM/PrettyBounds/MaxList.v
+++ b/theories/TM/PrettyBounds/MaxList.v
@@ -2,8 +2,6 @@
 
 From Undecidability.TM.Util Require Export Prelim ArithPrelim.
 
-Set Default Proof Using "Type".
-
 (* ** Basic lemmas about upper bounds *)
 
 (* An upper bound of a list is either in the list, or it is not in the list and is a strict upper bound *)

--- a/theories/TM/Reductions/Arbitrary_to_Binary.v
+++ b/theories/TM/Reductions/Arbitrary_to_Binary.v
@@ -6,7 +6,6 @@ Require Export Undecidability.TM.Basic.Mono Undecidability.TM.Compound.Multi.
 From Undecidability Require Import ArithPrelim.
 Require Import Undecidability.Shared.FinTypeEquiv Undecidability.Shared.FinTypeForallExists.
 
-Set Default Proof Using "Type".
 Section fix_Sigma.
 
   Variable n : nat.

--- a/theories/TM/Reductions/HaltTM_1_to_SBTM_HALT.v
+++ b/theories/TM/Reductions/HaltTM_1_to_SBTM_HALT.v
@@ -10,7 +10,6 @@ Require Import PeanoNat Lia.
 Require Import List ssreflect ssrbool ssrfun.
 Import ListNotations SBTMNotations.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module SBTM_facts.

--- a/theories/TM/Reductions/MMA_HALTING_n_to_HaltTM_n.v
+++ b/theories/TM/Reductions/MMA_HALTING_n_to_HaltTM_n.v
@@ -32,7 +32,6 @@ Require Import List Vector Lia PeanoNat Compare_dec.
 Import ListNotations.
 Require Import ssreflect ssrbool ssrfun.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 Module Argument.

--- a/theories/TM/Reductions/SBTM_HALT_to_HaltTM_1.v
+++ b/theories/TM/Reductions/SBTM_HALT_to_HaltTM_1.v
@@ -10,7 +10,6 @@ Require Import PeanoNat Lia.
 Require Import List ssreflect ssrbool ssrfun.
 Import ListNotations SBTMNotations.
 
-Set Default Proof Using "Type".
 Set Default Goal Selector "!".
 
 #[local] Notation "| a |" := (Vector.cons _ a 0 (Vector.nil _)).

--- a/theories/TM/Single/StepTM.v
+++ b/theories/TM/Single/StepTM.v
@@ -11,8 +11,6 @@ From Undecidability Require Import TM.Util.VectorPrelim.
 From Undecidability Require Import EncodeTapes TM.Util.VectorPrelim.
 Require Import FunInd.
 
-Set Default Proof Using "Type".
-
 Local Set Printing Coercions.
 
 (* Avoid using [Vector.to_list], because it doesn't [cbn] good. Use [vector_to_list] instead. *)
@@ -340,8 +338,7 @@ Section BookKeepingForRead.
 
   Variable sig : Type.
 
-  Set Default Proof Using "Type".
-
+  
   Fixpoint knowsFirstSymbols {n' : nat} (readSymbols : Vector.t (option sig) n') (tps : list (tape sig)) {struct readSymbols} : Prop :=
     match readSymbols, tps with
     | Vector.nil _,  nil => True /\ True /\ True

--- a/theories/TM/Univ/LookupAssociativeListTM.v
+++ b/theories/TM/Univ/LookupAssociativeListTM.v
@@ -8,7 +8,6 @@ From Undecidability.TM.Hoare Require Import Hoare HoareLegacy.
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.
 
-Set Default Proof Using "Type".
 (* * Lookup an entry in an associative list *)
 
 Section LookupAssociativeList.

--- a/theories/TM/Univ/LowLevel.v
+++ b/theories/TM/Univ/LowLevel.v
@@ -21,8 +21,6 @@ Section Graph.
 
   Variable (A : finType) (B : Type) (f : A -> B).
 
-  Set Default Proof Using "Type".
-
   Definition graph_of_fun : list (A*B) := map (fun x => (x, f x)) enum.
 
   Lemma graph_of_fun_functional x y1 y2 :

--- a/theories/TM/Univ/Univ.v
+++ b/theories/TM/Univ/Univ.v
@@ -11,7 +11,6 @@ From Coq Require Import ArithRing Lia.
 
 Local Arguments plus : simpl never.
 Local Arguments mult : simpl never.
-Set Default Proof Using "Type".
 
 Section Univ.
 

--- a/theories/TM/Util/Prelim.v
+++ b/theories/TM/Util/Prelim.v
@@ -13,7 +13,6 @@ Require Export smpl.Smpl Lia.
 
 Global Open Scope vector_scope.
 
-
 Section Loop.
   Variable (A : Type) (f : A -> A) (p : A -> bool).
 
@@ -92,7 +91,7 @@ Section LoopLift.
   Lemma loop_lift (k : nat) (a a' : A) :
     loop (A := A) f  h  a        k = Some a' ->
     loop (A := B) f' h' (lift a) k = Some (lift a').
-  Proof.
+  Proof using halt_lift_comp step_lift_comp.
     revert a. induction k as [ | k']; intros; cbn in *.
     - rewrite halt_lift_comp. destruct (h a); now inv H.
     - rewrite halt_lift_comp. destruct (h a) eqn:E.
@@ -103,7 +102,7 @@ Section LoopLift.
   Lemma loop_unlift (k : nat) (a : A) (b' : B) :
     loop f' h' (lift a) k = Some b' ->
     exists a' : A, loop f h a k = Some a' /\ b' = lift a'.
-  Proof.
+  Proof using halt_lift_comp step_lift_comp.
     revert a b'. induction k as [ | k']; intros; cbn in *.
     - rewrite halt_lift_comp in H.
       exists a. destruct (h a) eqn:E; now inv H.
@@ -130,7 +129,7 @@ Section LoopMerge.
     loop f h  a1 k1      = Some a2 ->
     loop f h' a2 k2      = Some a3 ->
     loop f h' a1 (k1+k2) = Some a3.
-  Proof.
+  Proof using halt_comp.
     revert a1 a2 a3. induction k1 as [ | k1' IH]; intros a1 a2 a3 HLoop1 HLoop2; cbn in HLoop1.
     - now destruct (h a1); inv HLoop1.
     - destruct (h a1) eqn:E.
@@ -144,7 +143,7 @@ Section LoopMerge.
       loop f h  a1 k1 = Some a2 /\
       loop f h' a2 k2 = Some a3 /\
       k1 + k2 <= k.
-  Proof.
+  Proof using halt_comp.
     revert a1 a3. revert k; refine (size_recursion id _); intros k IH. intros a1 a3 HLoop. cbv [id] in *.
     destruct k as [ | k']; cbn in *.
     - destruct (h' a1) eqn:E; inv HLoop.

--- a/theories/TM/Util/TM_facts.v
+++ b/theories/TM/Util/TM_facts.v
@@ -5,7 +5,7 @@
 From Undecidability.TM.Util Require Export Prelim Relations.
 Require Import Undecidability.Shared.Libs.PSL.Vectors.Vectors.
 Require Export Undecidability.TM.TM.
-       
+
 Section Fix_Sigma.
 
   Variable sig : Type.
@@ -535,7 +535,7 @@ Section MapTape.
   Variable g : tau -> sig.
 
   Definition mapTape : tape tau -> tape sig.
-  Proof.
+  Proof using g.
     destruct 1 eqn:E1.
     - apply niltape.
     - apply leftof.  apply (g t). apply (List.map g l).

--- a/theories/TRAKHTENBROT/BPCP_SigBPCP.v
+++ b/theories/TRAKHTENBROT/BPCP_SigBPCP.v
@@ -32,8 +32,6 @@ Import fol_notations.
 
 Set Implicit Arguments.
 
-Set Default Proof Using "Type".
-
 (* * Reduction from BPCP to specialized FSAT *)
 
 Local Notation ø := vec_nil.

--- a/theories/TRAKHTENBROT/Sig0.v
+++ b/theories/TRAKHTENBROT/Sig0.v
@@ -31,7 +31,7 @@ Section Σ_Σ0.
            (HΣ : forall r, ar_rels Σ r = 0).
 
   Definition Σ0 : fo_signature.
-  Proof.
+  Proof using Σ.
     exists Empty_set (rels Σ); exact (fun _ => 0).
   Defined.
 
@@ -77,7 +77,7 @@ Section Σ_Σ0.
                (HA : fol_sem M phi A).
 
     Local Lemma Σ_Σ0_soundness : fo_form_fin_dec_SAT (Σ_Σ0 A).
-    Proof.
+    Proof using HΣ Mdec HA.
       exists unit, M', finite_t_unit.
       exists. { intros r v; simpl; apply Mdec. }
       exists (fun _ => tt).
@@ -117,7 +117,7 @@ Section Σ_Σ0.
                (HA : fol_sem M' psi (Σ_Σ0 A)).
 
     Local Lemma Σ_Σ0_completeness : fo_form_fin_dec_SAT A.
-    Proof.
+    Proof using M'dec HA.
       exists unit, M, finite_t_unit.
       exists. { intros r v; simpl; apply M'dec. }
       exists (fun _ => tt).
@@ -127,7 +127,7 @@ Section Σ_Σ0.
   End completeness.
 
   Theorem Σ_Σ0_correct A : fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT (Σ_Σ0 A).
-  Proof.
+  Proof using HΣ.
     split.
     + intros (X & M & _ & G2 & phi & G3).
       apply Σ_Σ0_soundness with X M phi; auto.
@@ -181,7 +181,7 @@ Section Σ0_Σ.
                (HA : fol_sem M φ A).
 
     Local Lemma Σ0_Σ_soundness : fo_form_fin_dec_SAT (Σ0_Σ A).
-    Proof.
+    Proof using Mdec HA.
       exists unit, M', finite_t_unit.
       exists. { intros r v; simpl; apply Mdec. }
       exists (fun _ => tt).
@@ -223,7 +223,7 @@ Section Σ0_Σ.
                (HA : fol_sem M phi (Σ0_Σ A)).
 
     Local Lemma Σ0_Σ_completeness : fo_form_fin_dec_SAT A.
-    Proof.
+    Proof using Mdec HA.
       exists unit, M', finite_t_unit.
       exists. { intros r v; simpl; apply Mdec. }
       exists (fun _ => tt).

--- a/theories/TRAKHTENBROT/Sig1.v
+++ b/theories/TRAKHTENBROT/Sig1.v
@@ -30,7 +30,7 @@ Section Σ1_model.
   Variable (V : Type) (n : nat) (HV : V -> False).
 
   Definition ΣP1 : fo_signature.
-  Proof.
+  Proof using V n.
     exists V (pos n); intros _.
     + exact 1.
     + exact 1.
@@ -111,7 +111,7 @@ Section Σ1_model.
                                  (M' : fo_model ΣP1 (sig (fun v => Q v = true)))
                                  (_ : fo_model_dec M') psi,
                                  fol_sem M' psi A.
-  Proof.
+  Proof using Mdec HX HA HV.
     exists K, M'.
     exists.
     { unfold M'; intros p v; simpl; apply bool_dec. }

--- a/theories/TRAKHTENBROT/Sig1_1.v
+++ b/theories/TRAKHTENBROT/Sig1_1.v
@@ -90,7 +90,7 @@ Section Σ11_words.
   (* Signatures with arity always 1 for both syms and rels *)
 
   Definition Σ11 : fo_signature.
-  Proof.
+  Proof using X Y.
     exists X Y; intros _.
     + exact 1.
     + exact 1.
@@ -260,7 +260,7 @@ Section Σfull_mon_rem.
 
     Fact Σfull_mon_rec_sound φ : 
          fol_sem M' φ (Σfull_mon_rec A) <-> fol_sem M φ A.
-    Proof.
+    Proof using M HwA.
       revert φ HwA; induction A as [ | r v | b B HB C HC | q B HB ]; intros φ HA.
       + simpl; tauto.
       + simpl in v; unfold Σfull_mon_rec.
@@ -285,7 +285,7 @@ Section Σfull_mon_rem.
              (HA : fol_sem M φ A).
 
     Theorem Σfull_mon_rem_sound : fo_form_fin_dec_SAT_in Σfull_mon_red K.
-    Proof.
+    Proof using HwA Kfin Mdec HA.
       exists M', Kfin.
       exists.
       { intros [ (w,r) | r ]; simpl in r |- *; intro; apply Mdec. } 
@@ -328,7 +328,7 @@ Section Σfull_mon_rem.
 
       Fact Σfull_mon_rec_complete φ : 
         fol_sem M' φ (Σfull_mon_rec A) <-> fol_sem M φ A.
-      Proof.
+      Proof using HwA HM1' HM2'.
         revert φ HwA; induction A as [ | r v | b B HB C HC | q B HB ]; intros φ HwA.
         + simpl; tauto.
         + simpl in v; unfold Σfull_mon_rec.
@@ -357,7 +357,7 @@ Section Σfull_mon_rem.
              (HA : fol_sem M' φ Σfull_mon_red).
 
     Theorem Σfull_mon_rem_complete : fo_form_fin_dec_SAT_in A K.
-    Proof.
+    Proof using HwA Kfin M'dec HA.
       exists M, Kfin.
       exists.
       { intros r'; simpl in r'; intros v; apply M'dec. }
@@ -382,7 +382,7 @@ Section Σfull_mon_rem.
 
   Theorem Σfull_mon_red_correct : fo_form_fin_dec_SAT_in A K 
                               <-> fo_form_fin_dec_SAT_in Σfull_mon_red K.
-  Proof.
+  Proof using HwA.
     split.
     + intros (M & H1 & H2 & phi & H3).
       apply Σfull_mon_rem_sound with M phi; auto.
@@ -448,7 +448,7 @@ Section Σfull_mon_rem.
     Defined.
 
     Local Lemma Σfull_mon_red'_complete : fo_form_fin_dec_SAT_in Σfull_mon_red K.
-    Proof.
+    Proof using All.
       exists M', Kfin, Mdec, φ.
       simpl; split.
       + simpl in HA; generalize (proj1 HA).
@@ -476,7 +476,7 @@ Section Σfull_mon_rem.
   Theorem Σfull_mon_red'_correct : 
           fo_form_fin_dec_SAT_in A K
       <-> fo_form_fin_dec_SAT_in Σfull_mon_red' K.
-  Proof.
+  Proof using HwA.
     rewrite Σfull_mon_red_correct. 
     split.
     + apply Σfull_mon_red'_sound.
@@ -539,7 +539,7 @@ Section Σ11_Σ1.
 
   Theorem Σ11_Σ1_reduction : { B : fol_form (Σ11 Empty_set (list (pos n)*P + P)) 
                                  | fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT B }.
-  Proof.
+  Proof using HY.
     destruct Σ_no_sym_correct with (A := Σ11_red HY A) as (B & HB).
     { rewrite Σ11_red_no_syms; apply incl_refl. }
     exists B; rewrite <- HB; split; intros (X & H); exists X; revert H; apply Σ11_red_correct.

--- a/theories/TRAKHTENBROT/Sig2_SigSSn1.v
+++ b/theories/TRAKHTENBROT/Sig2_SigSSn1.v
@@ -66,7 +66,7 @@ Section Sig2_SigSSn1_encoding.
   Theorem Σ2_ΣSSn1_correct A : 
            (forall x, In x (fol_vars A) -> R (φ x) (ψ x))
         -> fol_sem M2 φ A <-> fol_sem MSSn1 ψ (Σ2_ΣSSn1 d A).
-  Proof.
+  Proof using All.
     revert d φ ψ H2 H3.
     induction A as [ | [] v | b A HA B HB | [] A HA ];
       intros d φ ψ H2 H3 H.
@@ -218,7 +218,7 @@ Section Σ2_ΣSSn1_enc_sound.
   Hint Resolve finite_t_sum finite_t_bool finite_t_prod : core.
 
   Theorem Σ2_ΣSSn1_enc_sound : fo_form_fin_dec_SAT (Σ2_ΣSSn1_enc n A).
-  Proof.
+  Proof using HX M2_dec HA.
     exists Y, MSSn1.
     exists. { unfold Y; auto. }
     exists.
@@ -321,7 +321,7 @@ Section Σ2_ΣSSn1_enc_complete.
   Hypothesis HY : finite_t Y.
 
   Theorem Σ2_ΣSSn1_enc_complete : fo_form_fin_dec_SAT A.
-  Proof.
+  Proof using All.
     exists X, M2.
     exists. 
     { unfold X; apply fin_t_finite_t.

--- a/theories/TRAKHTENBROT/Sig2_Sign.v
+++ b/theories/TRAKHTENBROT/Sig2_Sign.v
@@ -60,7 +60,7 @@ Section Sig2_Sig_n_encoding.
     Hypothesis HP : forall x y, P2 x y <-> Pn x y.
 
     Lemma Σ2_Σn_correct (A : fol_form Σ2) φ : ⟪ A ⟫ φ <-> ⟪Σ2_Σn A⟫' φ.
-    Proof.
+    Proof using HP.
       revert φ.
       induction A as [ | [] v | b A HA B HB | q A HA ]; intros phi.
       + simpl; tauto.
@@ -94,7 +94,7 @@ Section Sig2_Sig_n_encoding.
     Defined.
  
     Local Lemma Σ2_Σn_sound_loc : fo_form_fin_dec_SAT (Σ2_Σn A).
-    Proof.
+    Proof using All.
       exists X, Mn, H1.
       exists. { intros [] ?; apply H2. }
       exists phi.
@@ -131,7 +131,7 @@ Section Sig2_Sig_n_encoding.
     Defined.
  
     Local Lemma Σ2_Σn_complete_loc : fo_form_fin_dec_SAT A.
-    Proof.
+    Proof using All.
       exists X, M2, H1.
       exists. { intros [] ?; apply H2. }
       exists phi.

--- a/theories/TRAKHTENBROT/Sig_Sig_fin.v
+++ b/theories/TRAKHTENBROT/Sig_Sig_fin.v
@@ -49,7 +49,7 @@ Section discrete_to_finite_fix.
   Qed.
 
   Definition Σ_fin : fo_signature.
-  Proof.
+  Proof using HΣ1 HΣ2 ls lr.
     exists (sig Fn) (sig Re).
     + exact (fun s => ar_syms _ (proj1_sig s)).
     + exact (fun r => ar_rels _ (proj1_sig r)).
@@ -120,7 +120,7 @@ Section discrete_to_finite_fix.
              (M2' : fo_model_dec M') (x0 : X).
 
     Local Definition Σ_finite_rev_model1 : fo_model Σ X.
-    Proof.
+    Proof using HΣ1 HΣ2 x0 ls lr M'.
       split.
       + intros s.
         destruct (in_dec HΣ1 s ls) as [ H | H ].
@@ -172,7 +172,7 @@ Section discrete_to_finite_fix.
              (M2 : fo_model_dec M).
 
     Local Definition Σ_finite_rev_model2 : fo_model Σ' X.
-    Proof.
+    Proof using M.
       split.
       + intros (s & ?); apply (fom_syms M s).
       + intros (r & ?); apply (fom_rels M r).
@@ -293,7 +293,7 @@ Section discrete_to_finite.
               { _  : forall r, In (ir r) (fol_rels A) & 
               { B  : fol_form Σ'            
               | fo_form_fin_dec_SAT A <-> fo_form_fin_dec_SAT B } } } } } } } } } } } } } }.
-  Proof.
+  Proof using HΣ1 HΣ2.
     exists (Σ_fin Σ HΣ1 HΣ2 (fol_syms A) (fol_rels A)).
     exists. { apply Σ_fin_finite_syms. }
     exists. { apply Σ_fin_finite_rels. }
@@ -417,7 +417,7 @@ Section discr_finite_to_pos.
                (HA : fol_sem M φ A).
 
     Local Fact convert_soundness : fo_form_fin_dec_SAT_in (convert A) X.
-    Proof.
+    Proof using Xfin Mdec HA.
       exists M', Xfin.
       exists. { intros ? ?; apply Mdec. }
       exists φ.
@@ -469,7 +469,7 @@ Section discr_finite_to_pos.
                (HA : fol_sem M' φ (convert A)).
 
     Local Fact convert_completeness : fo_form_fin_dec_SAT_in A X.
-    Proof.
+    Proof using Xfin M'dec HA.
       exists M, Xfin.
       exists. { intros ? ?; apply M'dec. }
       exists φ.
@@ -490,7 +490,7 @@ Section discr_finite_to_pos.
               { B  : fol_form (Σpos Σ is ir)            
               | forall X, fo_form_fin_dec_SAT_in A X 
                       <-> fo_form_fin_dec_SAT_in B X } } } } } } } } }.
-  Proof.
+  Proof using All.
     exists n, m, js, jr.
     exists. { intros s s' E; rewrite <- (Hijs s), E, Hijs; auto. }
     exists. { simpl; auto. }
@@ -525,7 +525,7 @@ Section combine_the_two.
               { B  : fol_form (Σpos Σ is ir)            
               | fo_form_fin_dec_SAT A 
             <-> fo_form_fin_dec_SAT B } } } } } } } } } } }.
-  Proof.
+  Proof using HΣ1 HΣ2.
     destruct (Σ_finite_full HΣ1 HΣ2 A (incl_refl _) (incl_refl _)) as (B & HB).
     destruct Σ_finite_to_pos with (A := B)
       as (n & m & i & j & F1 & F2 & F3 & F4 & C & HC).
@@ -560,7 +560,7 @@ Section combine_the_two.
               { B  : fol_form (Σpos Σ i j)
               | fo_form_fin_dec_SAT A 
             <-> fo_form_fin_dec_SAT B } } } } }.
-  Proof.
+  Proof using HΣ1 HΣ2.
     destruct (Σ_discrete_to_pos' A) as (n & m & i & j & _ & _ & _ & _ & _ & _ & B & HB).
     exists n, m, i, j, B; auto.
   Qed.

--- a/theories/TRAKHTENBROT/Sig_discernable.v
+++ b/theories/TRAKHTENBROT/Sig_discernable.v
@@ -24,8 +24,6 @@ From Undecidability.TRAKHTENBROT
                  fol_ops fo_sig fo_terms fo_logic fo_sat 
                  Sig1_1 red_utils.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/TRAKHTENBROT/Sig_no_syms.v
+++ b/theories/TRAKHTENBROT/Sig_no_syms.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
 
 Import fol_notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Signature reduction for symbol free formulas *) 

--- a/theories/TRAKHTENBROT/Sig_noeq.v
+++ b/theories/TRAKHTENBROT/Sig_noeq.v
@@ -109,7 +109,7 @@ Section remove_interpreted_symbol.
     Theorem Σ_noeq_complete : 
                fo_form_fin_dec_SAT (Σ_noeq A)
             -> fo_form_fin_dec_eq_SAT e H_ae A.
-    Proof.
+    Proof using HA1 HA2.
       intros (X & M & H1 & H2 & phi & H5 & H3).
       apply fol_sem_congruence in H5
         as ((H4 & H5) & (H6 & H8 & H7)).

--- a/theories/TRAKHTENBROT/Sig_one_rel.v
+++ b/theories/TRAKHTENBROT/Sig_one_rel.v
@@ -41,7 +41,7 @@ Section Uniform_arities_to_one.
            (a : nat) (Ha : forall r, ar_rels Σ r = a).
 
   Definition Σone_rel : fo_signature.
-  Proof.
+  Proof using Σ a.
     exists (rels Σ) unit.
     + exact (fun _ => 0).
     + exact (fun _ => S a).
@@ -95,7 +95,7 @@ Section Uniform_arities_to_one.
         constants *)
 
     Definition Σunif_one_rel_model : fo_model Σ' X'.
-    Proof.
+    Proof using Ha M x0.
       split.
       + exact (fun r _ => inr r).
       + exact (fun r v => 
@@ -179,7 +179,7 @@ Section Uniform_arities_to_one.
     (* The model is recovered using constants as indices for each relation *)
 
     Definition Σone_unif_rel_model : fo_model Σ X.
-    Proof.
+    Proof using M' Ha HΣ.
       split.
       + intros ? _; exfalso; auto.
       + exact (fun r v => fom_rels M' tt (fom_syms M' r ø##cast v (Ha _))).

--- a/theories/TRAKHTENBROT/Sig_rem_constants.v
+++ b/theories/TRAKHTENBROT/Sig_rem_constants.v
@@ -31,7 +31,7 @@ Section remove_constants.
   Variable (Σ : fo_signature) (HΣ : forall s, ar_syms Σ s <= 1).
 
   Definition Σno_constants : fo_signature.
-  Proof.
+  Proof using Σ.
     exists (syms Σ) (rels Σ).
     + exact (fun _ => 1).
     + apply ar_rels.
@@ -122,7 +122,7 @@ Section remove_constants.
                (HA : fol_sem M φ A).
 
     Local Lemma Σrem_constants_soundness : fo_form_fin_dec_SAT_in (Σrem_constants 0 A) X.
-    Proof.
+    Proof using Xfin Mdec HA.
       exists M', Xfin, Mdec, φ.
       apply Σrem_constants_sound; auto.
     Qed.
@@ -180,7 +180,7 @@ Section remove_constants.
                (HA : fol_sem M' φ (Σrem_constants 0 A)).
 
     Local Lemma Σrem_constants_completeness : fo_form_fin_dec_SAT_in A X.
-    Proof.
+    Proof using Xfin M'dec HA.
       exists M, Xfin, M'dec, φ.
       revert HA; apply Σrem_constants_complete; auto.
     Qed.

--- a/theories/TRAKHTENBROT/Sig_rem_cst.v
+++ b/theories/TRAKHTENBROT/Sig_rem_cst.v
@@ -34,7 +34,7 @@ Section remove_constants.
            (ls : list (syms Σ)).
 
   Definition Σrem_cst : fo_signature.
-  Proof.
+  Proof using Σ.
     exists Empty_set (rels Σ).
     + intros [].
     + apply ar_rels.
@@ -69,7 +69,7 @@ Section remove_constants.
     Variable (X : Type) (M : fo_model Σ X).
 
     Definition Σrem_cst_model : fo_model Σ' X.
-    Proof.
+    Proof using M.
       split.
       + intros [].
       + apply (fom_rels M).
@@ -133,7 +133,7 @@ Section remove_constants.
     Variable (X : Type) (M' : fo_model Σ' X).
 
     Definition Σadd_cst_model σ (ψ : nat -> X) : fo_model Σ X.
-    Proof.
+    Proof using M'.
       split.
       + intros s _; exact (ψ (σ s)).
       + apply (fom_rels M').
@@ -248,14 +248,14 @@ Section reduction.
     Local Fact syms_map : { σ  : syms Σ -> nat           & 
                           { f  : nat -> option (syms Σ)  |
                             forall s, In s ls -> f (σ s) = Some s } }.
-    Proof. exists σ, f; auto. Qed.
+    Proof using Σd. exists σ, f; auto. Qed.
  
   End syms_map.
 
   Hint Resolve incl_refl : core.
 
   Theorem Sig_rem_cst_dep_red A : { B | @fo_form_fin_dec_SAT Σ A <-> @fo_form_fin_dec_SAT (Σrem_cst Σ) B }.
-  Proof.
+  Proof using Σ0 Σd.
     generalize (fol_vars_max_spec A).
     set (m := fol_vars_max A); intros Hm.
     destruct (syms_map A) as (g & f & Hfg).

--- a/theories/TRAKHTENBROT/Sig_rem_props.v
+++ b/theories/TRAKHTENBROT/Sig_rem_props.v
@@ -33,7 +33,7 @@ Section remove_constants.
   Variable (Σ : fo_signature) (HΣ : forall r, ar_rels Σ r <= 1).
 
   Definition Σno_props : fo_signature.
-  Proof.
+  Proof using Σ.
     exists (syms Σ) (rels Σ).
     + apply ar_syms.
     + exact (fun _ => 1).
@@ -47,7 +47,7 @@ Section remove_constants.
   Proof. intros [ | [ | a ] ]; auto; right; lia. Qed.
 
   Fixpoint Σrem_props (n : nat) A { struct A } : fol_form Σ'.
-  Proof.
+  Proof using HΣ.
     refine (match A with
       | ⊥              => ⊥
       | fol_atom r v   => 
@@ -106,7 +106,7 @@ Section remove_constants.
                (HA : fol_sem M φ A).
 
     Local Lemma Σrem_props_soundness : fo_form_fin_dec_SAT_in (Σrem_props 0 A) X.
-    Proof.
+    Proof using Xfin Mdec HA.
       exists M', Xfin.
       exists.
       { intros r; simpl; intros v; simpl in *.
@@ -157,7 +157,7 @@ Section remove_constants.
                (HA : fol_sem M' φ (Σrem_props 0 A)).
 
     Local Lemma Σrem_props_completeness : fo_form_fin_dec_SAT_in A X.
-    Proof.
+    Proof using Xfin M'dec HA.
       exists M, Xfin.
       exists.
       { intros r v; simpl in *.

--- a/theories/TRAKHTENBROT/Sig_rem_syms.v
+++ b/theories/TRAKHTENBROT/Sig_rem_syms.v
@@ -36,7 +36,7 @@ Section Sig_remove_symbols.
       and add an (interpreted) equality *)
 
   Definition Σnosyms : fo_signature.
-  Proof.
+  Proof using Σ.
     exists Empty_set (unit + (syms Σ + rels Σ))%type.
     + intros [].
     + intros [ | [ s | r ] ].
@@ -273,7 +273,7 @@ Section Sig_remove_symbols.
   Local Fact fol_rel_fun_spec s φ : 
              fol_sem M φ (fol_rel_fun s) 
          <-> graph_fun (fun v x => fom_rels M (inr (inl s)) (x##v)).
-  Proof.
+  Proof using HM.
     unfold fol_rel_fun; simpl; split.
     + intros H v x y H1 H2.
       specialize (H x y).
@@ -328,7 +328,7 @@ Section Sig_remove_symbols.
   Local Fact fol_rels_are_functions_spec ls φ : 
              fol_sem M φ (fol_rels_are_functions ls) 
          <-> forall s, In s ls -> is_graph_function (fun v x => fom_rels M (inr (inl s)) (x##v)).
-  Proof.
+  Proof using HM.
     unfold fol_rels_are_functions.
     rewrite fol_sem_lconj; split.
     + intros H s Hs; red.
@@ -402,14 +402,11 @@ Section completeness.
       rewrite fol_rels_are_functions_spec in HM; auto.
     Qed.
 
-    Let HA : fol_sem M φ (fol_rem_syms A).
-    Proof. simpl in HM; apply proj2 in HM; auto. Qed.
-
     Let F (s : syms Σ) : In s ls -> { f | forall v x, fom_rels M (inr (inl s)) (x##v) <-> x = f v }.
     Proof. intro; apply graph_tot_reif; auto. Qed.
 
     Local Definition Σsyms_Σnosyms_rev_model : fo_model Σ X.
-    Proof.
+    Proof using Xfin Mdec He HM Hls.
       split.
       + intros s.
         destruct (Hls s) as [ H | H ].
@@ -419,8 +416,11 @@ Section completeness.
         exact (fom_rels M (inr (inr r))).
     Defined.
 
+    Let HA : fol_sem M φ (fol_rem_syms A).
+    Proof. simpl in HM; apply proj2 in HM; auto. Qed.
+
     Local Fact Σsyms_Σnosyms_complete_nested : fol_sem Σsyms_Σnosyms_rev_model φ A.
-    Proof.
+    Proof using Xfin Mdec He HM Hls HAls.
       apply fol_rem_syms_spec.
       revert HA.
       apply fo_model_projection' with (i := fun x => x) (j := fun x => x) (ls := nil) 
@@ -448,7 +448,7 @@ Section completeness.
   Theorem Σsyms_Σnosyms_complete : 
           @fo_form_fin_dec_eq_SAT_in (Σnosyms Σ) e eq_refl (Σsyms_Σnosyms ls A) X
        -> fo_form_fin_discr_dec_SAT_in A X.
-  Proof.
+  Proof using Hls HAls.
     intros (M & H1 & H2 & H3 & phi & H5).
     cbn in H3.
     exists.

--- a/theories/TRAKHTENBROT/Sig_uniform.v
+++ b/theories/TRAKHTENBROT/Sig_uniform.v
@@ -31,7 +31,7 @@ Section vec_fill_tail.
   Variable (X : Type) (n : nat) (k : nat) (v : vec X k) (e : X).
 
   Definition vec_fill_tail : vec X n.
-  Proof.
+  Proof using v e.
     apply vec_set_pos; intros p.
     destruct (le_lt_dec k (pos2nat p)) as [ | H ].
     + exact e.
@@ -70,7 +70,7 @@ Section vec_first_half.
   Variable (X : Type) (n : nat) (k : nat) (Hk : k <= n).
 
   Definition vec_first_half (v : vec X n) : vec X k.
-  Proof.
+  Proof using Hk.
     apply vec_set_pos; intros p.
     refine (vec_pos v (@nat2pos _ (pos2nat p) _)).
     apply lt_le_trans with (2 := Hk), pos2nat_prop.
@@ -97,7 +97,7 @@ Section Sig_uniformize_rels.
   Variable (Σ : fo_signature) (n : nat) (Hn : forall r, ar_rels Σ r <= n).
 
   Definition Σunif : fo_signature.
-  Proof.
+  Proof using Σ n.
     exists (syms Σ) (rels Σ).
     + exact (ar_syms Σ).
     + exact (fun _ => n).
@@ -120,7 +120,7 @@ Section Sig_uniformize_rels.
     Variables (M : fo_model Σ X).
 
     Local Definition fom_uniformize : fo_model Σ' X.
-    Proof.
+    Proof using M Hn.
       split.
       + intros s; apply (fom_syms M s).
       + intros r v; exact (fom_rels M r (vec_first_half (Hn r) v)).
@@ -147,7 +147,7 @@ Section Sig_uniformize_rels.
     Variable (M' : fo_model Σ' X).
 
     Local Definition fom_specialize : fo_model Σ X.
-    Proof.
+    Proof using M' e.
       split.
       + intros s; apply (fom_syms M' s).
       + intros r v; exact (fom_rels M' r (vec_fill_tail n v e)).
@@ -219,7 +219,7 @@ Section Sig_uniformize_rels.
     Theorem fol_uniformize_complete A φ : 
           incl (fol_rels A) lr
        -> fol_sem M φ A <-> fol_sem M' φ (fol_uniformize A).
-    Proof.
+    Proof using Hlr.
       revert φ; induction A as [ | r v | b A HA B HB | q A HA ]; simpl; try tauto; intros phi Hr.
       + rewrite vec_map_fill_tail; rew fot.
         apply Hlr, Hr; simpl; auto.
@@ -237,7 +237,7 @@ Section Sig_uniformize_rels.
 
   Theorem Σuniformize_sound : fo_form_fin_dec_SAT_in A X
                            -> fo_form_fin_dec_SAT_in Σuniformize X.
-  Proof.
+  Proof using Hn.
     intros (M & H1 & H2 & phi & H).
     exists (fom_uniformize M), H1.
     exists.
@@ -251,7 +251,7 @@ Section Sig_uniformize_rels.
 
   Theorem Σuniformize_complete : fo_form_fin_dec_SAT_in Σuniformize X
                               -> fo_form_fin_dec_SAT_in A X.
-  Proof.
+  Proof using e HA.
     intros (M' & H1 & H2 & phi & H3 & H4).
     rewrite fol_all_uniform_after_spec in H3.
     exists (fom_specialize M'), H1.

--- a/theories/TRAKHTENBROT/Sign1_Sig.v
+++ b/theories/TRAKHTENBROT/Sign1_Sig.v
@@ -46,7 +46,7 @@ Section Sig_n1_Sig.
   Defined.
 
   Fixpoint Σn1_Σ (A : fol_form Σ) : fol_form Σ'.
-  Proof.
+  Proof using Hf Hp.
     refine (match A with
       | ⊥              => ⊥
       | fol_atom   _ v => fol_atom p (vec_map convert_t (cast v _))
@@ -108,7 +108,7 @@ Section Sig_n1_Sig.
                (HA : fol_sem M phi A).
 
     Local Fact convert_soundness : fo_form_fin_dec_SAT (convert A).
-    Proof.
+    Proof using Xfin Mdec HA.
       exists X, M', Xfin.
       exists.
       { intros r v; simpl in *.
@@ -160,7 +160,7 @@ Section Sig_n1_Sig.
                (HA : fol_sem M' phi (convert A)).
 
     Local Fact convert_completeness : fo_form_fin_dec_SAT A.
-    Proof.
+    Proof using Xfin M'dec HA.
       exists X, M, Xfin.
       exists.
       { intros [] v; apply M'dec. }

--- a/theories/TRAKHTENBROT/Sign_Sig.v
+++ b/theories/TRAKHTENBROT/Sign_Sig.v
@@ -47,7 +47,7 @@ Section Sig_n_Sig.
     Variables (X : Type) (M : fo_model Σ X).
 
     Local Definition M_enc_n : fo_model Σn X.
-    Proof.
+    Proof using M.
       exists; intros [] v.
       exact (fom_rels M r v).
     Defined.
@@ -86,7 +86,7 @@ Section Sig_n_Sig.
     Variables (X : Type) (Mn : fo_model Σn X) (x0 : X).
 
     Local Definition Mn_enc : fo_model Σ X.
-    Proof.
+    Proof using Mn x0.
       exists.
       + intros s v; apply x0.
       + intros r' v.

--- a/theories/TRAKHTENBROT/Sign_Sig2.v
+++ b/theories/TRAKHTENBROT/Sign_Sig2.v
@@ -218,7 +218,7 @@ Section SAT2_SATn.
     Let R (x : sig P) (y : X) := π1 x = y.
 
     Local Lemma SAT2_to_SATn : exists Y, fo_form_fin_dec_SAT_in A Y.
-    Proof.
+    Proof using All.
       exists (sig P).
       simpl in HA. destruct HA as (H2 & H3 & H4).
       change (fol_sem M2 ψ (Σ2_non_empty 0)) in H2.
@@ -285,7 +285,7 @@ Section SATn_SAT2.
     Notation P := (fom_rels Mn tt).
 
     Local Lemma SATn_to_SAT2 : exists Y, fo_form_fin_dec_SAT_in (@Σn_Σ2_enc n A) Y.
-    Proof.
+    Proof using All.
       destruct reln_hfs with (R := P)
         as (Y & H1 & mem & H3 & d & r & i & s & H6 & H7 & H9); auto.
       exists Y, (bin_rel_Σ2 mem), H1, (bin_rel_Σ2_dec _ H3), d·r·(fun n => i (φ n)).

--- a/theories/TRAKHTENBROT/bpcp.v
+++ b/theories/TRAKHTENBROT/bpcp.v
@@ -14,8 +14,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 From Undecidability.PCP Require Import PCP.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Section dec.

--- a/theories/TRAKHTENBROT/btree.v
+++ b/theories/TRAKHTENBROT/btree.v
@@ -32,8 +32,6 @@ From Undecidability.Shared.Libs.DLW.Wf
 From Undecidability.TRAKHTENBROT
   Require Import notations fol_ops.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Binary trees as concrete Hereditary Finite Sets *)

--- a/theories/TRAKHTENBROT/decidable.v
+++ b/theories/TRAKHTENBROT/decidable.v
@@ -21,8 +21,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Decidability and discreteness and closure properties *)

--- a/theories/TRAKHTENBROT/discernable.v
+++ b/theories/TRAKHTENBROT/discernable.v
@@ -15,8 +15,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Infix "∊" := In (at level 70, no associativity).

--- a/theories/TRAKHTENBROT/discrete.v
+++ b/theories/TRAKHTENBROT/discrete.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
 
 Import fol_notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Notation " e '#>' x " := (vec_pos e x).

--- a/theories/TRAKHTENBROT/enumerable.v
+++ b/theories/TRAKHTENBROT/enumerable.v
@@ -23,8 +23,6 @@ From Undecidability.TRAKHTENBROT
 
 (* * Enumerability and closure properties *)
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* We develop a basic theory of enumeration, ie empty types or

--- a/theories/TRAKHTENBROT/fo_congruence.v
+++ b/theories/TRAKHTENBROT/fo_congruence.v
@@ -22,8 +22,6 @@ Import fol_notations.
 
 Require Import Undecidability.Shared.ListAutomation.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Infix "∊" := In (at level 70, no associativity).

--- a/theories/TRAKHTENBROT/fo_definable.v
+++ b/theories/TRAKHTENBROT/fo_definable.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
 
 Import fol_notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * First order definability and closure properties *)

--- a/theories/TRAKHTENBROT/fo_enum.v
+++ b/theories/TRAKHTENBROT/fo_enum.v
@@ -21,8 +21,6 @@ From Undecidability.TRAKHTENBROT
 
 Import fol_notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Enumerability of the type of FO formulas *)

--- a/theories/TRAKHTENBROT/fo_logic.v
+++ b/theories/TRAKHTENBROT/fo_logic.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
 
 Require Import Undecidability.Shared.ListAutomation.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * The syntax and semantics of FO logic *)

--- a/theories/TRAKHTENBROT/fo_sat.v
+++ b/theories/TRAKHTENBROT/fo_sat.v
@@ -18,8 +18,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable fol_ops fo_sig fo_terms fo_logic.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Notation ø := vec_nil.

--- a/theories/TRAKHTENBROT/fo_sat_dec.v
+++ b/theories/TRAKHTENBROT/fo_sat_dec.v
@@ -18,8 +18,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils fol_ops fo_sig fo_terms fo_logic fo_sat decidable.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Decidability results for FSAT *)

--- a/theories/TRAKHTENBROT/fo_sig.v
+++ b/theories/TRAKHTENBROT/fo_sig.v
@@ -15,8 +15,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * First order signatures and models *)

--- a/theories/TRAKHTENBROT/fo_terms.v
+++ b/theories/TRAKHTENBROT/fo_terms.v
@@ -18,8 +18,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations utils decidable fol_ops fo_sig.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * First order terms, syntax and semantics *)

--- a/theories/TRAKHTENBROT/gfp.v
+++ b/theories/TRAKHTENBROT/gfp.v
@@ -15,8 +15,6 @@ From Undecidability.Shared.Libs.DLW.Utils
 From Undecidability.TRAKHTENBROT
   Require Import notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Kleene's greatest fixpoint of lia-continous operators *)

--- a/theories/TRAKHTENBROT/hfs.v
+++ b/theories/TRAKHTENBROT/hfs.v
@@ -21,8 +21,6 @@ From Undecidability.Shared.Libs.DLW.Wf
 From Undecidability.TRAKHTENBROT
   Require Import notations fol_ops membership btree.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * The Type Hereditary finite sets *)

--- a/theories/TRAKHTENBROT/membership.v
+++ b/theories/TRAKHTENBROT/membership.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
 
 Import fol_notations.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 Local Notation ø := vec_nil.

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -36,8 +36,6 @@ From Undecidability.TRAKHTENBROT
                  Sig1_1
                  Sig_discernable.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 Unset Strict Implicit.
 

--- a/theories/TRAKHTENBROT/red_enum.v
+++ b/theories/TRAKHTENBROT/red_enum.v
@@ -20,8 +20,6 @@ From Undecidability.TRAKHTENBROT
                  fol_ops fo_sig fo_terms fo_logic fo_enum decidable
                  fo_sat fo_sat_dec red_utils.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Collection of high-level enumerability results *)

--- a/theories/TRAKHTENBROT/red_undec.v
+++ b/theories/TRAKHTENBROT/red_undec.v
@@ -43,8 +43,6 @@ From Undecidability.TRAKHTENBROT
                                                f_n and R_1 occur into Σ *)
                  .
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Collection of high-level synthetic undecidability results *)

--- a/theories/TRAKHTENBROT/red_utils.v
+++ b/theories/TRAKHTENBROT/red_utils.v
@@ -31,8 +31,6 @@ From Undecidability.TRAKHTENBROT
                  Sig_noeq                  (* UTILITY: from interpreted to uninterpreted *)
                  .
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Common Tools for reductions *)

--- a/theories/TRAKHTENBROT/reln_hfs.v
+++ b/theories/TRAKHTENBROT/reln_hfs.v
@@ -18,8 +18,6 @@ From Undecidability.Shared.Libs.DLW.Vec
 From Undecidability.TRAKHTENBROT
   Require Import notations decidable fol_ops membership hfs.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Construction of the Hereditary Finite Sets model *)

--- a/theories/TRAKHTENBROT/utils.v
+++ b/theories/TRAKHTENBROT/utils.v
@@ -12,8 +12,6 @@ Require Import List Arith Lia Bool Eqdep_dec.
 From Undecidability.Shared.Libs.DLW.Utils
   Require Import utils_list finite.
 
-Set Default Proof Using "Type".
-
 Set Implicit Arguments.
 
 (* * Utilities for the Full Trakhtenbrot project *)

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,6 +1,7 @@
 -Q . Undecidability
 
 -arg -w -arg -notation-overridden
+-arg "-set 'Default Proof Using=Type'"
 COQDOCFLAGS = "--charset utf-8 -s --with-header ../website/resources/header.html --with-footer ../website/resources/footer.html --index indexpage"
 
 # coqdoc files
@@ -61,6 +62,7 @@ Synthetic/EnumerabilityFacts.v
 Synthetic/ListEnumerabilityFacts.v
 Synthetic/MoreEnumerabilityFacts.v
 Synthetic/ReducibilityFacts.v
+Synthetic/MoreReducibilityFacts.v
 Synthetic/InformativeReducibilityFacts.v
 Synthetic/Infinite.v
 

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,7 +1,7 @@
 -Q . Undecidability
 
 -arg -w -arg -notation-overridden
--arg "-set 'Default Proof Using=Type'"
+-arg "-set" -arg "'Default Proof Using = Type'"
 COQDOCFLAGS = "--charset utf-8 -s --with-header ../website/resources/header.html --with-footer ../website/resources/footer.html --index indexpage"
 
 # coqdoc files


### PR DESCRIPTION
This PR makes `Set Default Proof Using "Type"` uniform for the library (and future PRs). In particular:
- `Default Proof Using "Type"` is set globally via `_CoqProject`
- all individual `Set Default Proof Using "Type"` are removed
- additional, necessary `Proof using` are added
- `vos` compilation time slightly decreases from `user 9m37.746s` to `user 8m59.793s`
- `ReducibilityFacts` is refactored for minimal dependencies and more graceful failure

