### PR TITLE
Intermediate files not require _undec files

### DIFF
--- a/theories/CounterMachines/Reductions/HaltTM_1_to_CM1_HALT.v
+++ b/theories/CounterMachines/Reductions/HaltTM_1_to_CM1_HALT.v
@@ -7,8 +7,7 @@
 
 (** ** HaltTM 1 reduces to CM1_HALT  *)
 
-Require Import Undecidability.Synthetic.Undecidability.
-Require Import Undecidability.Synthetic.ReducibilityFacts.
+From Undecidability.Synthetic Require Import Definitions ReducibilityFacts.
 
 Require Import Undecidability.TM.TM.
 

--- a/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/FRACTRAN_to_H10C_SAT.v
@@ -9,7 +9,7 @@
 
 Require Import List Arith Lia Max.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability Require Import Shared.Libs.DLW.Utils.utils H10.Dio.dio_logic H10.Dio.dio_elem.
 From Undecidability Require Import H10.FRACTRAN_DIO FRACTRAN.FRACTRAN.

--- a/theories/DiophantineConstraints/Reductions/H10SQC_SAT_to_H10UC_SAT.v
+++ b/theories/DiophantineConstraints/Reductions/H10SQC_SAT_to_H10UC_SAT.v
@@ -130,7 +130,7 @@ Lemma v_spec : φ' (v 0) = 0 /\ φ' (v 1) = 1.
 Proof using Hφ'.
   move: (Hφ'). rewrite -Forall_forall /ucs Forall_app /v012.
   move=> [/Forall_cons_iff [+]] /Forall_cons_iff [+] /Forall_cons_iff [+] _ _ => /=.
-  by lia.
+  by nia.
 Qed.
 
 Lemma h10sqc_of_h10ucs_spec {c} : Forall (h10uc_sem φ') (h10sqc_to_h10ucs c) -> h10sqc_sem φ c.

--- a/theories/FOL/FSAT_undec.v
+++ b/theories/FOL/FSAT_undec.v
@@ -1,11 +1,13 @@
 From Undecidability.TRAKHTENBROT Require Import bpcp red_undec fo_sig.
 From Undecidability.Synthetic Require Import Undecidability ReducibilityFacts.
 From Undecidability.FOL Require Import FSAT Reductions.FSATd_to_FSATdc Reductions.TRAKHTENBROT_to_FSAT.
+From Undecidability.PCP Require Import PCP_undec.
 
 Theorem FSAT_undec :
   undecidable FSAT.
 Proof.
-  apply (undecidability_from_reducibility BPCP_problem_undec).
+  apply (undecidability_from_reducibility dPCPb_undec).
+  apply (reduces_transitive dPCPb_to_BPCP).
   eapply reduces_transitive; try apply reduction. 
   apply (@FULL_TRAKHTENBROT_non_informative (Σrel 2)). left. exists tt. auto.
 Qed.
@@ -13,7 +15,8 @@ Qed.
 Theorem FSATd_undec :
   undecidable FSATd.
 Proof.
-  apply (undecidability_from_reducibility BPCP_problem_undec).
+  apply (undecidability_from_reducibility dPCPb_undec).
+  apply (reduces_transitive dPCPb_to_BPCP).
   eapply reduces_transitive; try apply reduction_disc.
   eapply reduces_transitive; try apply (@FULL_TRAKHTENBROT_non_informative (Σrel 2)).
   - left. exists tt. auto.

--- a/theories/FOL/Reductions/H10UPC_to_FOL_full_fragment.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL_full_fragment.v
@@ -6,7 +6,7 @@ From Undecidability.FOL Require Import Util.Syntax Util.FullTarski Util.FullTars
 From Undecidability.Shared Require Import Dec.
 From Undecidability.Shared.Libs.PSL Require Import Numbers.
 From Coq Require Import Arith Lia List.
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 
 (* ** Validity *)

--- a/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
@@ -964,7 +964,7 @@ Section ksatisfiability.
   Qed.
 End ksatisfiability.
 
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 (** Final collection of undecidability reductions *)
 Section undecResults.

--- a/theories/FOL/Reductions/H10UPC_to_FSAT.v
+++ b/theories/FOL/Reductions/H10UPC_to_FSAT.v
@@ -9,7 +9,7 @@ From Coq Require Import Arith Lia List.
 
 From Undecidability.FOL Require Import FSAT DoubleNegation.
 From Undecidability.Synthetic Require Import Definitions.
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Datatypes.
 Require Import Relation_Definitions.
 Require Import Setoid.

--- a/theories/FOL/Reductions/H10p_to_FA.v
+++ b/theories/FOL/Reductions/H10p_to_FA.v
@@ -1,4 +1,4 @@
-Require Import Undecidability.Synthetic.Definitions Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 From Undecidability.FOL.Util Require Import Syntax Syntax_facts FullTarski FullTarski_facts FullDeduction_facts FullDeduction FA_facts.
 Require Import Undecidability.FOL.PA.
 From Undecidability.H10 Require Import H10p.

--- a/theories/FRACTRAN/Reductions/HaltTM_1_to_FRACTRAN_HALTING.v
+++ b/theories/FRACTRAN/Reductions/HaltTM_1_to_FRACTRAN_HALTING.v
@@ -1,4 +1,4 @@
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 Require Import Undecidability.TM.TM.

--- a/theories/FRACTRAN/Reductions/MM_FRACTRAN.v
+++ b/theories/FRACTRAN/Reductions/MM_FRACTRAN.v
@@ -18,7 +18,7 @@ From Undecidability.MinskyMachines
 From Undecidability.FRACTRAN
   Require Import FRACTRAN fractran_utils mm_fractran prime_seq.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 Set Default Proof Using "Type".

--- a/theories/H10/FRACTRAN_DIO.v
+++ b/theories/H10/FRACTRAN_DIO.v
@@ -11,7 +11,7 @@
 
 Require Import List.
 
-From Undecidability.Synthetic Require Import Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW

--- a/theories/H10/Reductions/H10_to_H10p.v
+++ b/theories/H10/Reductions/H10_to_H10p.v
@@ -1,5 +1,5 @@
-From Undecidability.H10 Require Import H10 H10_undec Dio.dio_single H10p.
-From Undecidability.Synthetic Require Import Undecidability.
+From Undecidability.H10 Require Import H10 Dio.dio_single H10p.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Fin.
 Local Set Implicit Arguments.
 

--- a/theories/ILL/Reductions/EILL_CLL.v
+++ b/theories/ILL/Reductions/EILL_CLL.v
@@ -9,7 +9,7 @@
 
 Require Import List.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.ILL

--- a/theories/ILL/Reductions/EILL_ILL.v
+++ b/theories/ILL/Reductions/EILL_ILL.v
@@ -9,7 +9,7 @@
 
 Require Import List.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.ILL

--- a/theories/ILL/Reductions/ILL_CLL.v
+++ b/theories/ILL/Reductions/ILL_CLL.v
@@ -9,7 +9,7 @@
 
 Require Import List.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.ILL

--- a/theories/ILL/Reductions/MM_EILL.v
+++ b/theories/ILL/Reductions/MM_EILL.v
@@ -9,7 +9,7 @@
 
 Require Import List.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW 
   Require Import pos vec sss.

--- a/theories/MinskyMachines/Reductions/BSM_MM.v
+++ b/theories/MinskyMachines/Reductions/BSM_MM.v
@@ -7,7 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW 
   Require Import utils list_bool pos vec subcode sss.

--- a/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/FRACTRAN_to_MMA2.v
@@ -18,7 +18,7 @@
 
     The reduction goes via regular FRACTRAN termination *)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW Require Import pos vec sss.
 

--- a/theories/MinskyMachines/Reductions/HaltTM_1_to_MM.v
+++ b/theories/MinskyMachines/Reductions/HaltTM_1_to_MM.v
@@ -7,7 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 Require Import Undecidability.TM.TM.

--- a/theories/MinskyMachines/Reductions/MMA2_to_MM2.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_MM2.v
@@ -9,7 +9,7 @@
 
 Require Import List Arith Relations Lia.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW Require Import utils pos vec sss subcode.
 From Undecidability.MinskyMachines Require Import MM2 mma_defs.

--- a/theories/MinskyMachines/Reductions/MMA2_to_MMA2_zero.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_MMA2_zero.v
@@ -9,7 +9,7 @@
 
 Require Import List Arith Relations Lia.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW Require Import utils pos vec sss subcode.

--- a/theories/MinskyMachines/Reductions/MM_to_MMA2.v
+++ b/theories/MinskyMachines/Reductions/MM_to_MMA2.v
@@ -18,7 +18,7 @@
 
     The reduction goes via regular FRACTRAN termination *)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.Shared.Libs.DLW Require Import Utils.utils Vec.pos Vec.vec.

--- a/theories/MinskyMachines/Reductions/MUREC_MM.v
+++ b/theories/MinskyMachines/Reductions/MUREC_MM.v
@@ -7,7 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW 
   Require Import pos vec sss.

--- a/theories/MinskyMachines/Reductions/PCPb_to_MM.v
+++ b/theories/MinskyMachines/Reductions/PCPb_to_MM.v
@@ -7,7 +7,7 @@
 (*         CeCILL v2 FREE SOFTWARE LICENSE AGREEMENT          *)
 (**************************************************************)
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 Require Import Undecidability.Synthetic.ReducibilityFacts.
 
 From Undecidability.PCP              Require Import PCP PCPb_iff_iPCPb.

--- a/theories/MuRec/Reductions/H10C_SAT_to_RA_UNIV_HALT.v
+++ b/theories/MuRec/Reductions/H10C_SAT_to_RA_UNIV_HALT.v
@@ -16,7 +16,7 @@ Require Import Undecidability.MuRec.RA_UNIV_HALT.
 
 Require Import Undecidability.DiophantineConstraints.H10C.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 Set Implicit Arguments.
 

--- a/theories/MuRec/Reductions/H10_to_MUREC_HALTING.v
+++ b/theories/MuRec/Reductions/H10_to_MUREC_HALTING.v
@@ -9,7 +9,7 @@
 
 Require Import List.
 
-From Undecidability.Synthetic Require Import Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW.Utils
   Require Import utils_tac utils_nat.

--- a/theories/PCP/Reductions/PCPb_iff_dPCPb.v
+++ b/theories/PCP/Reductions/PCPb_iff_dPCPb.v
@@ -1,4 +1,4 @@
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.PCP
   Require Import PCP Util.Facts PCPX_iff_dPCP.

--- a/theories/SOL/Reductions/H10p_to_SOL.v
+++ b/theories/SOL/Reductions/H10p_to_SOL.v
@@ -2,7 +2,7 @@ Require Import PeanoNat Lia Vector List.
 From Undecidability.SOL Require Import SOL PA2.
 From Undecidability.Shared.Libs.PSL Require Import Vectors VectorForall.
 From Undecidability.SOL.Util Require Import Syntax Subst Tarski PA2_facts PA2_categoricity.
-From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts ReducibilityFacts Undecidability.
+From Undecidability.Synthetic Require Import Definitions DecidabilityFacts EnumerabilityFacts ListEnumerabilityFacts ReducibilityFacts.
 From Undecidability.H10 Require Import H10p.
 Require Import Undecidability.Shared.Dec.
 

--- a/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
+++ b/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
@@ -10,7 +10,7 @@
 Require Import List Arith Lia.
 Import ListNotations.
 
-Require Import Undecidability.Synthetic.Undecidability.
+Require Import Undecidability.Synthetic.Definitions.
 
 From Undecidability.Shared.Libs.DLW 
   Require Import utils list_bool pos vec subcode sss.

--- a/theories/TRAKHTENBROT/Sig_discernable.v
+++ b/theories/TRAKHTENBROT/Sig_discernable.v
@@ -27,6 +27,7 @@ From Undecidability.TRAKHTENBROT
 Set Default Proof Using "Type".
 
 Set Implicit Arguments.
+Unset Strict Implicit.
 
 Import fol_notations.
 

--- a/theories/TRAKHTENBROT/bpcp.v
+++ b/theories/TRAKHTENBROT/bpcp.v
@@ -183,12 +183,9 @@ Proof. apply pcp_hand_dec, bool_dec. Qed.
 Definition BPCP_input := list (list bool * list bool).
 Definition BPCP_problem (R : BPCP_input) := exists l, R ⊳ l∕l.
 
-From Undecidability.Synthetic Require Import Undecidability.
-From Undecidability.PCP Require Import PCP_undec.
+Require Import Undecidability.Synthetic.Definitions.
 
-Theorem BPCP_problem_undec :
-  undecidable BPCP_problem.
+Theorem dPCPb_to_BPCP : dPCPb ⪯ BPCP_problem.
 Proof.
-  apply (undecidability_from_reducibility dPCPb_undec).
   exists (fun R => R). intros R. tauto.
 Qed.

--- a/theories/TRAKHTENBROT/red_dec.v
+++ b/theories/TRAKHTENBROT/red_dec.v
@@ -39,6 +39,7 @@ From Undecidability.TRAKHTENBROT
 Set Default Proof Using "Type".
 
 Set Implicit Arguments.
+Unset Strict Implicit.
 
 Local Infix "≢" := discernable (at level 70, no associativity).
 


### PR DESCRIPTION
The conservative PR cleans up `Require` chains such that we have
- intermediate (reduction) files do not require `_undec` files
- better modularity, maintainability, parallel compilation
- less side effects due to imported long `_undec` chains

As a result the set of `_undec` files is a compilation leaf. Removing all `_undec` files does not break compilation. This is beneficial for partial compilation (e.g. during Coq version upgrade debugging).