### PR TITLE
Faster HOU

### DIFF
--- a/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
+++ b/theories/FOL/Reductions/H10UPC_to_FOL_minimal.v
@@ -6,7 +6,7 @@ From Undecidability.FOL Require Import Util.Syntax Util.Kripke Util.Deduction Ut
 From Undecidability.Shared Require Import Dec.
 From Undecidability.Shared.Libs.PSL Require Import Numbers.
 From Coq Require Import Arith Lia List.
-
+Import Undecidability.Shared.ListAutomation.ListInstances.
 
 (* ** Validity *)
 

--- a/theories/FOL/Reductions/PCPb_to_binZF.v
+++ b/theories/FOL/Reductions/PCPb_to_binZF.v
@@ -3,7 +3,7 @@
 From Undecidability.FOL Require Import Util.FullTarski_facts Util.Syntax_facts Util.FullDeduction_facts.
 From Undecidability.FOL Require Import ZF Reductions.PCPb_to_ZF binZF Util.sig_bin.
 From Undecidability Require Import Shared.ListAutomation.
-Import ListAutomationNotations.
+Import ListAutomationNotations. Import ListInstances.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/FOL/Reductions/PCPb_to_minZF.v
+++ b/theories/FOL/Reductions/PCPb_to_minZF.v
@@ -3,7 +3,7 @@
 From Undecidability.FOL Require Import Util.FullTarski_facts Util.Syntax_facts Util.FullDeduction_facts.
 From Undecidability.FOL Require Import ZF Reductions.PCPb_to_ZF minZF.
 From Undecidability Require Import Shared.ListAutomation.
-Import ListAutomationNotations.
+Import ListAutomationNotations. Import ListInstances.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/HOU/calculus/confluence.v
+++ b/theories/HOU/calculus/confluence.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 Require Import Morphisms Setoid.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import prelim terms semantics. 
-
+Import ArsInstances.
 (* * Confluence *)
 Section Confluence.
 

--- a/theories/HOU/calculus/equivalence.v
+++ b/theories/HOU/calculus/equivalence.v
@@ -3,7 +3,7 @@ Require Import Morphisms Lia FinFun.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics confluence. 
-
+Import ArsInstances.
 
 (* * Equational Theory *)
 Section Equivalence.
@@ -17,7 +17,7 @@ Section Equivalence.
     Global Instance equiv_lam_proper:
       Proper (equiv step ++> equiv step) (@lam X).
     Proof.
-      intros ? ? (v & H1 & H2) % church_rosser; eauto. 
+      intros ? ? (v & H1 & H2) % church_rosser; trivial. 
       rewrite H1, H2. reflexivity. 
     Qed.
 
@@ -25,15 +25,14 @@ Section Equivalence.
     Global Instance equiv_app_proper:
       Proper (equiv step ++> equiv step ++> equiv step) (@app X).
     Proof.
-      intros ? ? (v & H1 & H2) % church_rosser ? ? (v' & H3 & H4) % church_rosser;
-        eauto.
+      intros ? ? (v & H1 & H2) % church_rosser ? ? (v' & H3 & H4) % church_rosser; trivial.
       rewrite H1, H2, H3, H4. reflexivity.
     Qed.
 
     Lemma ren_equiv s t delta:
       s ≡ t -> ren delta s ≡ ren delta t.
     Proof.
-      intros (v & ? & ?) % church_rosser; eauto.
+      intros (v & ? & ?) % church_rosser; trivial.
       transitivity (ren delta v); [| symmetry].
       all: eapply equiv_star, ren_steps; eauto.
     Qed.
@@ -47,7 +46,7 @@ Section Equivalence.
     Lemma subst_equiv s t sigma:
       s ≡ t -> sigma • s ≡ sigma • t.
     Proof.
-      intros (v & ? & ?) % church_rosser; eauto.
+      intros (v & ? & ?) % church_rosser; trivial.
       transitivity (sigma • v); [| symmetry].
       all: eapply equiv_star, subst_steps; eauto.
     Qed.
@@ -61,7 +60,7 @@ Section Equivalence.
     Lemma subst_pointwise_equiv (s: exp X) sigma tau:
       (forall x, x ∈ vars s -> sigma x ≡ tau x) -> sigma • s ≡ tau • s.
     Proof.
-      induction s in sigma, tau |-*; cbn -[vars]; eauto.
+      induction s in sigma, tau |-*; cbn -[vars]; [eauto|eauto|..].
       - intros H; eapply equiv_lam_proper, IHs.
         intros []; cbn -[vars]. reflexivity.
         intros ? % vars_varof % varofLambda % varof_vars % H.
@@ -78,46 +77,47 @@ Section Equivalence.
     Lemma equiv_var_eq (x y: fin):
       var x ≡ var y -> x = y.
     Proof.
-      intros; eapply equiv_unique_normal_forms in H; eauto.
+      intros; eapply equiv_unique_normal_forms in H; trivial.
       congruence.
     Qed.
       
     Lemma equiv_const_eq (x y: X):
       const x ≡ const y -> x = y.
     Proof.
-      intros; eapply equiv_unique_normal_forms in H; eauto.
+      intros; eapply equiv_unique_normal_forms in H; trivial.
       congruence.
     Qed.
 
     Lemma equiv_lam_elim (s t: exp X):
       lambda s ≡ lambda t -> s ≡ t.
     Proof.
-      intros (v & [] %steps_lam & [] %steps_lam) % church_rosser; intuition; subst.
+      intros (v & [] %steps_lam & [] %steps_lam) % church_rosser; [|eauto].
+      intuition idtac; subst.
       injection H as ->; eauto. 
     Qed.
 
     Lemma equiv_app_elim (s s' t t': exp X):
       s t ≡ s' t' ->  isAtom (head s) -> isAtom (head s') -> s ≡ s' /\ t ≡ t'.
     Proof.
-      intros (v & [] % steps_app & [] % steps_app) % church_rosser H3; eauto.
-      * do 2 destruct H, H0; intuition; subst;
+      intros (v & [] % steps_app & [] % steps_app) % church_rosser H3; trivial.
+      * do 2 destruct H, H0; intuition idtac; subst;
           injection H as -> ->; eauto.
-      * do 2 destruct H; destruct H0; intuition; subst.
+      * do 2 destruct H; destruct H0; intuition idtac; subst.
         all: destruct (head s'); cbn in *; intuition.
-      * do 2 destruct H0; destruct H; intuition; subst.
+      * do 2 destruct H0; destruct H; intuition idtac; subst.
         all: destruct (head s); cbn in *; intuition.
-      * destruct H, H0; intuition.
+      * destruct H, H0; intuition idtac.
         all: destruct (head s); cbn in *; intuition.
     Qed.
 
     Lemma equiv_anti_ren delta (s t: exp X):
       Injective delta -> ren delta s ≡ ren delta t -> s ≡ t.
     Proof.
-      intros ? (v & H1 & H2) % church_rosser; eauto.
+      intros ? (v & H1 & H2) % church_rosser; trivial.
       eapply steps_anti_ren in H1 as [].
       eapply steps_anti_ren in H2 as [].
-      intuition; subst.
-      eapply anti_ren in H4; eauto.
+      intuition idtac; subst.
+      eapply anti_ren in H4; trivial.
       subst; eauto. 
     Qed.
   
@@ -130,46 +130,46 @@ Section Equivalence.
       var x ≡ s t -> isAtom (head s) -> False.
     Proof.
       intros EQ.
-      destruct (head s) as [y | | | ] eqn: H'; intuition.                   
-      all: eapply church_rosser in EQ as (v & L & R); eauto.
-      all: inv L; firstorder using normal_var.  
+      destruct (head s) as [y | | | ] eqn: H'; intuition idtac.
+      all: eapply church_rosser in EQ as (v & L & R); trivial.
+      all: inv L; firstorder idtac using normal_var.  
       all: eapply steps_app in R as [R|R].
       1, 3: destruct R as (? & ? & ? & ?); discriminate.
-      all:  destruct R; intuition; rewrite H' in *; syn.
+      all:  destruct R; intuition idtac; rewrite H' in *; syn.
     Qed.
 
     Lemma equiv_neq_lambda_app (s' s t: exp X):
       lambda s' ≡ s t -> isAtom (head s) -> False.
     Proof.
       intros EQ. 
-      destruct (head s) as [y | | | ] eqn: H'; intuition. 
-      all: eapply church_rosser in EQ as (v & L & R); eauto.
+      destruct (head s) as [y | | | ] eqn: H'; intuition idtac. 
+      all: eapply church_rosser in EQ as (v & L & R); trivial.
       all: eapply steps_lam in L as (v' & ? & ?); subst. 
       all: eapply steps_app in R as [R|R].
       1, 3: destruct R as (? & ? & ? & ?); discriminate.
-      all: destruct R; intuition; rewrite H' in *; syn.
+      all: destruct R; intuition idtac; rewrite H' in *; syn.
     Qed.
 
     Lemma equiv_neq_var_lambda (x: nat) s: ~ var x ≡ lambda s.
     Proof.
-      intros (v & ? & ?) % church_rosser; eauto.
-      inv H; firstorder using normal_var.
-      eapply steps_lam in H0 as []; intuition; discriminate.
+      intros (v & ? & ?) % church_rosser; trivial.
+      inv H; firstorder idtac using normal_var.
+      eapply steps_lam in H0 as []; intuition idtac; discriminate.
     Qed.
 
     Lemma equiv_neq_var_const (x: nat) c: ~ var x ≡ const c.
     Proof.
-      intros (v & ? & ?) % church_rosser; eauto.
-      inv H; firstorder using normal_var.
+      intros (v & ? & ?) % church_rosser; trivial.
+      inv H; firstorder idtac using normal_var.
       inv H0. inv H.
     Qed.
 
 
     Lemma equiv_neq_const_lam  s c: ~ const c ≡ lambda s.
     Proof.
-      intros (v & ? & ?) % church_rosser; eauto.
-      inv H; firstorder using normal_var.
-      eapply steps_lam in H0 as []; intuition; discriminate.
+      intros (v & ? & ?) % church_rosser; trivial.
+      inv H; firstorder idtac using normal_var.
+      eapply steps_lam in H0 as []; intuition idtac; discriminate.
       inv H1. 
     Qed.
 
@@ -177,12 +177,12 @@ Section Equivalence.
       const c ≡ s t -> isAtom (head s) -> False.
     Proof.
       intros EQ.
-      destruct (head s) as [y | | | ] eqn: H'; intuition.                   
-      all: eapply church_rosser in EQ as (v & L & R); eauto.
-      all: inv L; firstorder using normal_const.  
+      destruct (head s) as [y | | | ] eqn: H'; intuition idtac.                   
+      all: eapply church_rosser in EQ as (v & L & R); trivial.
+      all: inv L; firstorder idtac using normal_const.  
       all: eapply steps_app in R as [R|R].
       1, 3: destruct R as (? & ? & ? & ?); discriminate.
-      all:  destruct R; intuition; rewrite H' in *; syn.
+      all:  destruct R; intuition idtac; rewrite H' in *; syn.
     Qed.
 
   End DisjointnessProperties.
@@ -198,8 +198,8 @@ Section Equivalence.
       s ≡ t ->  v1 = v2.
     Proof using E1 E2.
       destruct E1 as [H1 N1], E2 as [H2 N2].
-      intros H; eapply equiv_unique_normal_forms; eauto.
-      now rewrite <-H1, <-H2.  
+      intros H; eapply equiv_unique_normal_forms; trivial.
+      now rewrite <-H1, <-H2.
     Qed.
 
     Lemma equiv_huet_backward:
@@ -261,7 +261,7 @@ Ltac Discriminate :=
 Lemma equiv_head_equal X (s t: exp X):
   s ≡ t -> isAtom (head s) -> isAtom (head t) -> head s = head t.
 Proof.
-  induction s in t |-*; destruct t; intros; try Discriminate; Injection H; subst; eauto.
-  - cbn in *; intuition.
+  induction s in t |-*; destruct t; intros; try Discriminate; Injection H; subst; trivial.
+  - cbn in *; intuition idtac.
   - cbn; eapply IHs1; eauto. 
 Qed. 

--- a/theories/HOU/calculus/evaluator.v
+++ b/theories/HOU/calculus/evaluator.v
@@ -3,7 +3,7 @@ Require Import Morphisms Setoid.
 From Undecidability.HOU Require Import std.std. 
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics confluence typing order normalisation. 
-
+Import ArsInstances.
 
 (* * Evaluator *)
 Section Evaluator.

--- a/theories/HOU/calculus/normalisation.v
+++ b/theories/HOU/calculus/normalisation.v
@@ -3,7 +3,7 @@ Require Import Morphisms Lia.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics confluence typing order. 
-
+Import ArsInstances.
 (* * Weak Normalisation *)
 
 

--- a/theories/HOU/calculus/terms_extension.v
+++ b/theories/HOU/calculus/terms_extension.v
@@ -4,7 +4,7 @@ Import ListNotations.
 From Undecidability.HOU Require Import std.std.
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics equivalence typing order confluence. 
-
+Import ListInstances ArsInstances.
 (* * Terms Extension *)
 
 Notation "sigma •₊ A" := (map (subst_exp sigma) A) (at level 69).

--- a/theories/HOU/concon/concon.v
+++ b/theories/HOU/concon/concon.v
@@ -1,1 +1,0 @@
-From Undecidability.HOU Require Export concon.conservativity concon.constants concon.enumerability.

--- a/theories/HOU/concon/conservativity.v
+++ b/theories/HOU/concon/conservativity.v
@@ -3,7 +3,7 @@ Require Import Lia List.
 From Undecidability.HOU Require Import calculus.calculus concon.conservativity_constants
   unification.higher_order_unification unification.systemunification
   unification.nth_order_unification.
-Import ListNotations.
+Import ListNotations ListInstances ArsInstances.
 
 Global Hint Rewrite @consts_Lam @consts_AppL @consts_AppR : simplify.
 
@@ -29,9 +29,9 @@ Section InhabitingTypes.
     intros H2. unfold inhab.
     destruct (type_decompose A) as (L & beta & ->); simplify in H2; cbn in H2.
     specialize (arity_decomposed L beta) as H3.
-    rewrite H3. eapply Lambda_ordertyping; eauto.
-    econstructor; cbn; eauto.
-    rewrite nth_error_app2; simplify; eauto; lia.
+    rewrite H3. eapply Lambda_ordertyping; trivial.
+    econstructor; cbn; trivial.
+    rewrite nth_error_app2; simplify; trivial; lia.
   Qed.
 
 
@@ -42,7 +42,7 @@ Section InhabitingTypes.
     intros H; unfold inhab in H.
     eapply Lambda_ordertyping_inv in H as (L & B & ? & ? & ?); subst.
     inv H. rewrite <-H1 in H3.
-    rewrite nth_error_app2 in H3; simplify in *; eauto.
+    rewrite nth_error_app2 in H3; simplify in *; trivial.
     destruct B; cbn in H1; try lia. now rewrite H3.
   Qed.
 
@@ -99,11 +99,11 @@ Section Conservativity.
                   | None => var x
                   end).
       exists (target' Delta). exists (sigma >> subst_exp tau). split; [|split].
-      - intros ???; eapply preservation_under_substitution; eauto.
+      - intros ???; eapply preservation_under_substitution; [eauto|].
         unfold tau; intros ?? EQ; rewrite EQ.
         eauto using ordertyping_soundness.
-      - erewrite <-compSubstSubst_exp; eauto. symmetry.
-        erewrite <-compSubstSubst_exp; eauto. symmetry.
+      - erewrite <-compSubstSubst_exp; trivial. symmetry.
+        erewrite <-compSubstSubst_exp; trivial. symmetry.
         now rewrite H0.
       - eauto.
     Qed.
@@ -126,17 +126,17 @@ Section Conservativity.
                     | None => var 0
                     end
                   end).
-      exists (target' (map (ctype X) C)). exists (sigma >> subst_consts zeta). intuition.
+      exists (target' (map (ctype X) C)). exists (sigma >> subst_consts zeta). intuition trivial.
       - intros ???. eapply ordertyping_preservation_consts.
         now eapply weakening_ordertyping_app, T.
         intros c H1. unfold zeta.
-        destruct (find c C0); eauto.
+        destruct (find c C0); trivial.
         + econstructor; eapply typing_constants; eauto.
         + eapply Consts_consts
             with (S := (map sigma (nats (length Gamma)))) in H1 as H2.
           unfold C; eapply find_in in H2 as [y H2]. rewrite H2.
-          eapply ordertyping_monotone, inhab_app, inhab_typing'; eauto.
-          erewrite map_nth_error; eauto. now eapply find_Some.
+          eapply ordertyping_monotone, inhab_app, inhab_typing'; trivial.
+          erewrite map_nth_error; trivial. now eapply find_Some.
           eapply in_map, lt_nats, nth_error_Some_lt; eauto.
       - rewrite !subst_const_comm_id. now rewrite EQ.
         all: eapply subst_consts_ident; intros x;
@@ -147,7 +147,7 @@ Section Conservativity.
         + cbn in H0; intuition; subst.
           eapply find_Some, nth_error_In in H1; exact H1.
         + destruct (find d C) eqn: H2.
-          all: rewrite ?consts_inhab in H0; cbn in H0; intuition.
+          all: rewrite ?consts_inhab in H0; cbn in H0; intuition trivial.
     Qed.
 
     Lemma downcast_constants Gamma s t Delta sigma:
@@ -156,9 +156,9 @@ Section Conservativity.
       ord' Sigma <= 1 /\ (forall x c, c ∈ consts (tau x) -> c ∈ Consts [s; t]).
     Proof using n Leq.
       intros [m H] % ordertypingSubst_complete EQ.
-      eapply ordertypingSubst_monotone with (m := S m) in H; eauto.
+      eapply ordertypingSubst_monotone with (m := S m) in H; trivial.
       eapply downcast_constants_ordered in H as (Sigma & tau & ?); [|lia|eauto].
-      exists Sigma; exists tau; intuition. eapply ordertypingSubst_soundness; eauto.
+      exists Sigma; exists tau; intuition trivial. eapply ordertypingSubst_soundness; eauto.
     Qed.
 
     Lemma ordertyping_from_basetyping Sigma u B:
@@ -167,7 +167,7 @@ Section Conservativity.
       Sigma ⊢(n) u : B.
     Proof.
       induction 2; [eauto|eauto| |].
-      - simplify; intros; econstructor; eapply IHtyping; intuition.
+      - simplify; intros; econstructor; eapply IHtyping; intuition trivial.
         eauto using normal_lam_elim. cbn; simplify; intuition.
       - intros; enough (ord A <= n).
         + econstructor; [eapply IHtyping1 | eapply IHtyping2].
@@ -175,7 +175,7 @@ Section Conservativity.
           1, 4: eauto using normal_app_r, normal_app_l.
           2, 4: eauto.
           1, 2: simplify; eauto; intuition.
-        + eapply head_atom in H0; eauto; cbn in H0.
+        + eapply head_atom in H0; [|easy]. cbn in H0.
           destruct (head_decompose s) as [T].
           rewrite H3 in H0_.
           eapply AppR_typing_inv in H0_ as (? & ? & ?).
@@ -184,7 +184,7 @@ Section Conservativity.
           destruct (head s); cbn in H0; eauto.
           all: inv H5.
           eapply ord'_elements in H2; eauto.
-          eapply H; cbn; simplify; cbn; intuition.
+          eapply H; cbn; simplify; cbn; intuition trivial.
     Qed.
 
 
@@ -201,10 +201,10 @@ Section Conservativity.
                       end).
     exists (Delta ++ target' Gamma). exists tau. split.
     - intros x B H'. unfold tau. rewrite H'; destruct dec_in.
-      eapply weakening_ordertyping_app, T; eauto.
+      eapply weakening_ordertyping_app, T; trivial.
       eapply ordertyping_monotone; eauto.
-    - rewrite !(subst_extensional) with (sigma := tau) (tau := sigma); eauto.
-      all: intros; unfold tau; destruct dec_in; eauto; simplify in *.
+    - rewrite !(subst_extensional) with (sigma := tau) (tau := sigma); trivial.
+      all: intros; unfold tau; destruct dec_in; trivial; simplify in *.
       all: exfalso; eauto.
   Qed.
 
@@ -216,13 +216,13 @@ Section Conservativity.
     intros T T1 T2 H.
     pose (P x := x ∈ vars s ++ vars t).
     edestruct (downcast_variables) as (Sigma' & tau' & T' & H' & O');
-      eauto; clear T H sigma Delta.
+      [eassumption..|]; clear T H sigma Delta.
     edestruct (downcast_constants) as (Sigma'' & tau'' & T'' & H'' & O'' & C'');
-      eauto; clear T' H' tau'.
-    edestruct (normalise_subst) as (tau''' & R & H & T); eauto.
+      [eassumption..|]; clear T' H' tau'.
+    edestruct (normalise_subst) as (tau''' & R & H & T); [eassumption|].
     eapply ordertyping_weak_ordertyping with (sigma := tau''').
     - intros. eapply ordertyping_from_basetyping.
-      + intros ?; erewrite consts_subset_steps; eauto.
+      + intros ?; erewrite consts_subset_steps; trivial.
         intros H2 % C''; cbn in H2; simplify in H2.
         destruct H2; eapply typing_constants; [|eauto| |eauto]; eauto.
       + eauto.
@@ -238,7 +238,7 @@ Section Conservativity.
   Proof.
     unfold linearize_terms. cbn; simplify.
     split; unfold Consts; intros ? [x] % in_flat_map; eapply in_flat_map.
-    all: intuition; try mapinj. eexists; intuition; eauto.
+    all: intuition; try mapinj. eexists; split; [eassumption|].
     now rewrite consts_ren in H1.
     exists (ren shift x); intuition. now rewrite consts_ren.
   Qed.
@@ -252,7 +252,7 @@ Section Conservativity.
     intros T1 T2 H.
     pose (P x := x ∈ Vars' E). pose (s := linearize_terms (left_side E)).
     pose (t := linearize_terms (right_side E)).
-    edestruct (downcast_variables) with (s := s) (t := t) as (Sigma' & tau' & T' & H' & O'); eauto.
+    edestruct (downcast_variables) with (s := s) (t := t) as (Sigma' & tau' & T' & H' & O'); [eassumption|..].
     1: unfold s, t; now rewrite !linearize_terms_subst, linearize_terms_equiv.
     clear T2 H sigma Delta.
     edestruct (downcast_constants) with (s := s) (t := t)
@@ -260,12 +260,12 @@ Section Conservativity.
     edestruct (normalise_subst) as (tau''' & R & H & T); eauto.
     edestruct ordertyping_weak_ordertyping with (s := s) (t := t) (sigma := tau''').
     - intros. eapply ordertyping_from_basetyping.
-      + intros ?; erewrite consts_subset_steps; eauto.
+      + intros ?; erewrite consts_subset_steps; trivial.
         intros H2 % C''. cbn [Consts flat_map] in H2.
         simplify in H2. unfold s, t in H2.
         rewrite !linearize_consts in H2.
         destruct H2; eapply typing_Consts.
-        eapply left_ordertyping; eauto. eauto.
+        eapply left_ordertyping; [eassumption|..]. eauto.
         eapply right_ordertyping; eauto. eauto.
       + eauto.
       + domin H0; eauto.
@@ -276,7 +276,7 @@ Section Conservativity.
           injection H1 as ->; eauto.
       + simplify; rewrite O', O''; cbn; eauto.
     - rewrite !subst_pointwise_equiv with (sigma := tau''') (tau := tau''); eauto.
-    - destruct H0 as [tau]. exists x. exists tau. destruct H0; split; eauto.
+    - destruct H0 as [tau]. exists x. exists tau. destruct H0; split; trivial.
       unfold s, t in H1; now rewrite <-linearize_terms_equiv, <-!linearize_terms_subst.
   Qed.
 
@@ -354,7 +354,7 @@ Section Conservativity.
     unfold OU.
     edestruct unification_downcast_eqs as (Sigma & tau & H1); eauto using equiv_pointwise_eqs, @H₀'.
     intros ???; eapply ordertyping_soundness; eauto.
-    exists Sigma, tau; intuition; eauto using equiv_eqs_pointwise.
+    exists Sigma, tau; intuition idtac. eauto using equiv_eqs_pointwise.
   Qed.
 
 
@@ -368,7 +368,7 @@ Section Conservativity.
   Lemma SU_conservative_forward n (I: ordsysuni X n):
     SOU X n I -> SU X (SU_conservative I).
   Proof.
-    intros (Delta & sigma & T & H). exists Delta; exists sigma. intuition.
+    intros (Delta & sigma & T & H). exists Delta; exists sigma. intuition trivial.
     eapply ordertypingSubst_soundness; eauto.
   Qed.
 
@@ -377,7 +377,7 @@ Section Conservativity.
   Proof.
     intros Leq (Delta & sigma & T & H).
     edestruct unification_downcast_eqs as (Sigma & tau & H1); eauto using equiv_pointwise_eqs, @H₀'.
-    exists Sigma, tau; intuition; eauto using equiv_eqs_pointwise.
+    exists Sigma, tau; intuition idtac. eauto using equiv_eqs_pointwise.
   Qed.
 
   Theorem unification_step n: 1 <= n -> OU n X ⪯ OU (S n) X.
@@ -413,7 +413,5 @@ Section Conservativity.
     intros H; exists SU_conservative; split;
       eauto using SU_conservative_forward, SU_conservative_backward.
   Qed.
-
-
 
 End Conservativity.

--- a/theories/HOU/concon/conservativity_constants.v
+++ b/theories/HOU/concon/conservativity_constants.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 Require Import Morphisms Lia List.
 From Undecidability.HOU Require Import calculus.calculus.
-Import ListNotations.
+Import ListNotations ListInstances ArsInstances.
 
 (* * Conservativity *)
 
@@ -36,13 +36,13 @@ Section Constants.
     Lemma consts_ren delta s:
       consts (ren delta s) = consts s.
     Proof.
-      induction s in delta |-*; cbn; intuition; congruence.
+      induction s in delta |-*; cbn; intuition idtac; congruence.
     Qed.
 
     Lemma vars_subst_consts x s sigma:
       x ∈ vars s -> consts (sigma x) ⊆ consts (sigma • s).
     Proof.
-      intros H % vars_varof; induction H in sigma |-*; cbn; intuition.
+      intros H % vars_varof; induction H in sigma |-*; cbn; [auto with listdb..|].
       rewrite <-IHvarof; cbn; unfold funcomp; now rewrite consts_ren.
     Qed.
 
@@ -53,14 +53,14 @@ Section Constants.
       induction s in sigma |-*.
       - right; exists f; intuition.
       - cbn; intuition.
-      - intros H % IHs; cbn -[vars]; intuition.
-        destruct H0 as [[]]; cbn -[vars] in *; intuition.
-        right. exists n. intuition.
+      - intros H % IHs; cbn -[vars]; intuition idtac.
+        destruct H0 as [[]]; cbn -[vars] in *; intuition idtac.
+        right. exists n. intuition eauto with listdb.
         unfold funcomp in H1; now rewrite consts_ren in H1.
-      - cbn; simplify; intuition.
-        + specialize (IHs1 _ H0); intuition.
+      - cbn; simplify; intuition idtac.
+        + specialize (IHs1 _ H0); intuition idtac.
           destruct H as [y]; right; exists y; intuition.
-        + specialize (IHs2 _ H0); intuition.
+        + specialize (IHs2 _ H0); intuition idtac.
           destruct H as [y]; right; exists y; intuition.
     Qed.
 
@@ -68,7 +68,7 @@ Section Constants.
     Lemma consts_subset_step s t:
       s > t -> consts t ⊆ consts s.
     Proof.
-      induction 1; cbn; intuition.
+      induction 1; cbn; [|auto with listdb..].
       subst. unfold beta.
       intros x ? % consts_subst_in; simplify.
       destruct H; [tauto|].
@@ -86,7 +86,7 @@ Section Constants.
     Lemma consts_subst_vars sigma s:
       consts (sigma • s) ⊆ consts s ++ Consts (map sigma (vars s)).
     Proof.
-      intros x [|[y]] % consts_subst_in; simplify; intuition.
+      intros x [|[y]] % consts_subst_in; simplify; intuition idtac.
       right; eapply Consts_consts; eauto using in_map.
     Qed.
 
@@ -99,15 +99,15 @@ Section Constants.
     Lemma consts_AppL S t:
       consts (AppL S t) === Consts S ++ consts t.
     Proof.
-      induction S; cbn; intuition.
+      induction S; cbn; [trivial with listdb|].
       rewrite IHS; now rewrite app_assoc.
     Qed.
 
     Lemma consts_AppR s T:
       consts (AppR s T) === consts s ++ Consts T.
     Proof.
-      induction T; cbn; intuition.
-      rewrite IHT. intuition.
+      induction T; cbn; [auto with listdb|].
+      rewrite IHT.
       split; intros c; simplify; intuition.
     Qed.
 
@@ -132,7 +132,7 @@ Section Constants.
     Lemma ren_subst_consts_commute X Y (zeta: X -> exp Y) delta s:
       subst_consts (zeta >> ren delta) (ren delta s) = ren delta (subst_consts zeta s).
     Proof.
-      induction s in delta, zeta |-*; cbn; eauto.
+      induction s in delta, zeta |-*; cbn; trivial.
       - f_equal. rewrite <-IHs. f_equal.
         asimpl. reflexivity.
       - now rewrite IHs1, IHs2.
@@ -143,7 +143,7 @@ Section Constants.
       subst_consts kappa (subst_consts zeta s) =
       subst_consts (zeta >> subst_consts kappa) s.
     Proof.
-      induction s in zeta, kappa |-*; cbn; eauto.
+      induction s in zeta, kappa |-*; cbn; trivial.
       - f_equal. rewrite IHs. f_equal. fext.
         unfold funcomp at 4; unfold funcomp at 4.
         intros; rewrite <-ren_subst_consts_commute.
@@ -155,11 +155,11 @@ Section Constants.
     Lemma subst_consts_ident Y zeta s:
       (forall x: Y, x ∈ consts s -> zeta x = const x) -> subst_consts zeta s = s.
     Proof.
-      intros; induction s in zeta, H |-*; cbn; eauto.
-      eapply H; cbn; eauto.
-      rewrite IHs; eauto.
+      intros; induction s in zeta, H |-*; cbn; trivial.
+      eapply H; cbn; tauto.
+      rewrite IHs; trivial.
       unfold funcomp; now intros x -> % H.
-      rewrite IHs1, IHs2; eauto.
+      rewrite IHs1, IHs2; trivial.
       all: intros; apply H; cbn; simplify; intuition.
     Qed.
 
@@ -171,13 +171,13 @@ Section Constants.
       induction s in zeta, sigma, delta |-*; intros H; cbn.
       - reflexivity.
       - unfold funcomp; asimpl.
-        rewrite idSubst_exp; eauto.
+        rewrite idSubst_exp; trivial.
         intros y; unfold funcomp; cbn.
         rewrite H; reflexivity.
       - f_equal. erewrite IHs with (delta := 0 .: delta >> shift).
-        2: intros []; cbn; unfold funcomp; eauto; rewrite H; reflexivity.
+        2: intros []; cbn; unfold funcomp; trivial; rewrite H; reflexivity.
         f_equal; [| now asimpl].
-        fext; intros []; cbn; eauto.
+        fext; intros []; cbn; trivial.
         unfold funcomp at 2.
         now rewrite ren_subst_consts_commute.
       - erewrite IHs1, IHs2; eauto.
@@ -187,7 +187,7 @@ Section Constants.
     Global Instance step_subst_consts X Y:
       Proper (Logic.eq ++> step ++> step) (@subst_consts X Y).
     Proof.
-      intros ? zeta -> s t H; induction H in zeta |-*; cbn; eauto.
+      intros ? zeta -> s t H; induction H in zeta |-*; cbn; [|eauto..].
       econstructor; subst; unfold beta.
       erewrite subst_const_comm with (delta := shift).
       f_equal. fext.
@@ -198,14 +198,14 @@ Section Constants.
     Global Instance steps_subst_consts X Y:
       Proper (Logic.eq ++> star step ++> star step) (@subst_consts X Y).
     Proof.
-      intros ? zeta -> s t H; induction H in zeta |-*; cbn; eauto; rewrite H; eauto.
+      intros ? zeta -> s t H; induction H in zeta |-*; cbn; trivial; rewrite H; eauto.
     Qed.
 
 
     Global Instance equiv_subst_consts X Y:
       Proper (Logic.eq ++> equiv step ++> equiv step) (@subst_consts X Y).
     Proof.
-      intros ? zeta -> s t [v [H1 H2]] % church_rosser; eauto;
+      intros ? zeta -> s t [v [H1 H2]] % church_rosser; trivial;
         now rewrite H1, H2.
     Qed.
 
@@ -213,10 +213,10 @@ Section Constants.
     Lemma subst_consts_consts X Y (zeta: X -> exp Y) (s: exp X):
       consts (subst_consts zeta s) === Consts (map zeta (consts s)).
     Proof.
-      unfold Consts; induction s in zeta |-*; cbn; simplify; intuition.
+      unfold Consts; induction s in zeta |-*; cbn; simplify; [eauto with listdb|eauto with listdb|..].
       - rewrite IHs.
         unfold funcomp; rewrite <-map_map, !flat_map_concat_map, map_map.
-        erewrite map_ext with (g := consts); intuition.
+        erewrite map_ext with (g := consts); intuition eauto with listdb.
         now rewrite consts_ren.
       - rewrite IHs1, IHs2, !flat_map_concat_map; simplify.
         now rewrite concat_app.
@@ -234,7 +234,7 @@ Section Constants.
     Lemma subst_consts_up Y Z (zeta: Y -> exp Z) (sigma: fin -> exp Y):
       up (sigma >> subst_consts zeta) = up sigma >> subst_consts (zeta >> ren shift).
     Proof.
-      fext; intros []; cbn; eauto.
+      fext; intros []; cbn; trivial.
       unfold funcomp at 1 2.
       now rewrite <-ren_subst_consts_commute.
     Qed.
@@ -243,9 +243,9 @@ Section Constants.
       subst_consts zeta s = s ->
       (sigma >> subst_consts zeta) • s = subst_consts zeta (sigma • s).
     Proof.
-      induction s in zeta, sigma |-*; cbn; eauto.
+      induction s in zeta, sigma |-*; cbn; [trivial|congruence|..].
       - injection 1 as H. f_equal.
-        rewrite <-IHs; eauto.
+        rewrite <-IHs; trivial.
         now rewrite subst_consts_up.
       - injection 1 as H. f_equal; eauto.
     Qed.
@@ -255,7 +255,7 @@ Section Constants.
     Lemma typing_constants X n Gamma s A :
       Gamma ⊢(n) s : A -> forall c, c ∈ consts s -> ord (ctype X c) <= S n.
     Proof.
-      induction 1; cbn;  intuition; subst; eauto.
+      induction 1; cbn;  intuition idtac; subst; trivial.
       simplify in H1; intuition.
     Qed.
 
@@ -273,13 +273,13 @@ Section Constants.
       Gamma ⊢ s : A -> (forall x, x ∈ consts s -> Gamma ⊢ zeta x : ctype X x) ->
       Gamma ⊢ subst_consts zeta s : A.
     Proof.
-      induction 1 in zeta |-*; cbn; eauto.
+      induction 1 in zeta |-*; cbn; [eauto|eauto|..].
       - intros H'. econstructor. eapply IHtyping.
-        intros; eapply preservation_under_renaming; eauto.
+        intros; eapply preservation_under_renaming; [eauto|].
         intros ?; cbn; eauto.
       - intros H'. econstructor.
-        eapply IHtyping1; intros ??; eapply H'; simplify; intuition.
-        eapply IHtyping2; intros ??; eapply H'; simplify; intuition.
+        eapply IHtyping1; intros ??; eapply H'; simplify; intuition idtac.
+        eapply IHtyping2; intros ??; eapply H'; simplify; intuition idtac.
     Qed.
 
 
@@ -287,19 +287,19 @@ Section Constants.
       Gamma ⊢(n) s : A -> (forall x, x ∈ consts s -> Gamma ⊢(n) zeta x : ctype X x) ->
       Gamma ⊢(n) subst_consts zeta s : A.
     Proof.
-      induction 1 in zeta |-*; cbn; eauto.
+      induction 1 in zeta |-*; cbn; [eauto|eauto|..].
       - intros H'. econstructor. eapply IHordertyping.
-        intros; eapply ordertyping_preservation_under_renaming; eauto.
+        intros; eapply ordertyping_preservation_under_renaming; [eauto|].
         intros ?; cbn; eauto.
       - intros H'. econstructor.
-        eapply IHordertyping1; intros ??; eapply H'; simplify; intuition.
-        eapply IHordertyping2; intros ??; eapply H'; simplify; intuition.
+        eapply IHordertyping1; intros ??; eapply H'; simplify; intuition idtac.
+        eapply IHordertyping2; intros ??; eapply H'; simplify; intuition idtac.
     Qed.
 
     Lemma subst_consts_Lambda Y Z (zeta: Y -> exp Z) k s:
         subst_consts zeta (Lambda k s) = Lambda k (subst_consts (zeta >> ren (plus k)) s).
     Proof.
-        induction k in zeta |-*; cbn; asimpl; eauto.
+        induction k in zeta |-*; cbn; asimpl; trivial.
         f_equal. rewrite IHk. f_equal. f_equal.
         asimpl. fext; intros x; unfold funcomp; f_equal; fext; intros ?.
         unfold shift; simplify; f_equal; lia.

--- a/theories/HOU/concon/constants.v
+++ b/theories/HOU/concon/constants.v
@@ -296,10 +296,6 @@ Section RemoveConstants.
     intros ?? H; unfold inv_term; now rewrite H.
   Qed.
 
-  
-
-  
-  
   Lemma subst_consts_subst Z (s: exp X) sigma tau theta zeta (kappa: X -> exp Z):
     (forall x, x ∈ vars s -> sigma • subst_consts zeta (tau x) >* subst_consts kappa (theta x)) ->
     (forall x, x ∈ consts s -> sigma • zeta x >* kappa x) ->

--- a/theories/HOU/firstorder.v
+++ b/theories/HOU/firstorder.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 
 Require Import List Lia Arith Init.Wf Morphisms Program.Program.
 From Undecidability.HOU Require Import concon.conservativity calculus.calculus.
-Import ListNotations.
+Import ListNotations ListInstances.
 From Undecidability.HOU.unification Require Import systemunification nth_order_unification.
 
 Tactic Notation "simplify" := Undecidability.HOU.std.tactics.simplify.  
@@ -91,7 +91,7 @@ Section LambdaFreeness.
     Gamma ⊢ s : A -> nf s -> ord A <= 1 -> isAtom (head s).
   Proof.
     destruct 2; subst; intros.
-    destruct k; cbn; simplify; eauto.
+    destruct k; cbn; simplify; [eauto|].
     inv H. now eapply ord_arr_one in H0.
   Qed.
 
@@ -111,8 +111,8 @@ Section LambdaFreeness.
         * inv H3. rewrite H6 in H7.
           simplify in H7. lia.
       + eapply orderlisttyping_element in H2 as [B []]. 2:now eauto.
-        eapply H; eauto.
-        eapply ordertyping_one_atom; eauto.
+        eapply H; [eauto..|].
+        eapply ordertyping_one_atom; [eauto..|].
         eapply ord'_elements; eauto.
   Qed.
 
@@ -121,9 +121,9 @@ Section LambdaFreeness.
     (Delta ⊢(1) sigma x : A) -> ord A <= 1 ->
     normal (sigma x) -> lambda_free (sigma x).
   Proof.
-    intros H1  H3 H4; eapply order_one_lambda_free; eauto.
+    intros H1  H3 H4; eapply order_one_lambda_free; [eauto..|].
     eapply head_atom; eauto.
-    destruct sigma; cbn; intuition.
+    destruct sigma; cbn; intuition idtac.
     inv H1. eapply ord_arr_one; eauto.
   Qed.
 
@@ -647,7 +647,7 @@ Section Unification.
       decomp s t = None -> lambda_free s -> lambda_free t -> ~ unifies sigma s t.
     Proof.
       decomp_ind.
-      1 - 2: intros; destruct t; unfold unifies; eauto; cbn; congruence.
+      1 - 2: intros; destruct t; unfold unifies; cbn; solve [congruence | eauto].
       1 - 2: intros ?? _ H1 H2; inv H1; inv H2.
       1 - 2: intros ???? _ H H1 H2 U; inv H1; inv H2;
         eapply H; eauto; unfold unifies in *; cbn in *; congruence.
@@ -700,7 +700,7 @@ Section Unification.
     Lemma size_subst tau s:
       size (tau • s) = size s + Sum (map (tau >> size) (vars s)).
     Proof.
-      induction s in tau |-*; cbn; simplify; eauto.  
+      induction s in tau |-*; cbn; simplify; trivial.  
       - rewrite IHs. f_equal. f_equal. clear IHs.  generalize (vars s) as A.
         induction A as [|[] ?]; cbn; eauto.
         + destruct eq_dec; rewrite IHA; intuition.
@@ -757,7 +757,8 @@ Section Unification.
       decomp' E = Some E' -> forall u v, (u,v) ∈ E' -> u <> v.
     Proof.
       decomp_ind. all: intuition idtac; simplify in *.
-      subst; destruct H2; eauto; eapply decomp_irrefl; eauto.
+      subst; destruct H2; [|eauto].
+      eapply decomp_irrefl; eauto.
     Qed.
 
     Lemma eqs_size_induction P:
@@ -786,7 +787,7 @@ Section Unification.
         eapply Vars_decomp' in DE as H9; simplify in H9; cbn in H9.
         assert (Vars' (update x s var •₊₊ E') ⊆ Vars' E) by
             (rewrite singlepoint_subst_Vars'; eapply incl_cons_project_r; eauto).
-        destruct (IH (update x s var •₊₊ E') x) as [tau]; eauto.
+        destruct (IH (update x s var •₊₊ E') x) as [tau]; trivial.
         + eapply H9; firstorder.
         + intros ? % singlepoint_subst_Vars'_variable; intuition. 
         + rewrite equi_unifiable_cons in U'.

--- a/theories/HOU/firstorder.v
+++ b/theories/HOU/firstorder.v
@@ -1,8 +1,9 @@
 Set Implicit Arguments.
 
 Require Import List Lia Arith Init.Wf Morphisms Program.Program.
-From Undecidability.HOU Require Import unification.unification concon.conservativity calculus.calculus.
+From Undecidability.HOU Require Import concon.conservativity calculus.calculus.
 Import ListNotations.
+From Undecidability.HOU.unification Require Import systemunification nth_order_unification.
 
 Tactic Notation "simplify" := Undecidability.HOU.std.tactics.simplify.  
 

--- a/theories/HOU/second_order/dowek/encoding.v
+++ b/theories/HOU/second_order/dowek/encoding.v
@@ -4,7 +4,7 @@ Import ListNotations.
 From Undecidability.HOU Require Import std.std calculus.calculus second_order.diophantine_equations.
 From Undecidability.HOU.unification Require Import 
   systemunification nth_order_unification.
-
+Import ArsInstances.
 (* * Higher-Order Motivation *)
 
 (* ** Church Numerals *)
@@ -75,8 +75,8 @@ Section ChurchEncoding.
   Lemma typing_enc Gamma n: Gamma ⊢(3) enc n : alpha → (alpha → alpha) → alpha.
   Proof.
     unfold enc. econstructor. econstructor.
-    eapply AppL_ordertyping_repeated; eauto.
-    eapply repeated_ordertyping; simplify; eauto.
+    eapply AppL_ordertyping_repeated; [|eauto].
+    eapply repeated_ordertyping; simplify; trivial.
     intros ? <- % repeated_in; eauto. 
   Qed.
 
@@ -84,7 +84,7 @@ Section ChurchEncoding.
   Lemma enc_app n s t:
     enc n s t ≡ AppL (repeat t n) s.
   Proof.
-    unfold enc. do 2 (rewrite stepBeta; asimpl; cbn; eauto).
+    unfold enc. do 2 (rewrite stepBeta; asimpl; cbn; trivial).
     now rewrite !repeated_map; cbn. 
   Qed.
 
@@ -114,7 +114,7 @@ Section ChurchEncoding.
   Lemma enc_add' n m s f:
     enc (n + m) s f ≡ (enc n) (enc m s f) f.
   Proof.
-    induction n; cbn; simplify; eauto.
+    induction n; cbn; simplify; [eauto|].
     now rewrite IHn.
   Qed.
 
@@ -147,8 +147,8 @@ Section ChurchEncoding.
     enc n = enc m -> n = m.
   Proof.
     injection 1 as H.
-    induction n in m, H |-*; destruct m; try discriminate; eauto.
-    erewrite IHn; eauto.
+    induction n in m, H |-*; destruct m; try discriminate; trivial.
+    erewrite IHn; trivial.
     injection H; eauto.
   Qed.
 
@@ -165,7 +165,7 @@ Section ChurchEncoding.
   Lemma enc_equiv_injective n m:
     enc n ≡ enc m -> n = m.
   Proof.
-    intros ? % equiv_unique_normal_forms; eauto.
+    intros ? % equiv_unique_normal_forms; trivial.
     eapply enc_injective; eauto.
   Qed.
   
@@ -178,7 +178,7 @@ Section ChurchEncoding.
     destruct s...  
     enough ({ n | s = AppL (repeat (var 0) n) (var 1)} +
             forall n, s <> AppL (repeat (var 0) n) (var 1)).
-    - destruct H; [left|right]; intuition.
+    - destruct H; [left|right]; intuition idtac.
       destruct s0 as [n]; exists n; now subst.
       injection H; eapply n; eauto. 
     - induction s...  
@@ -208,32 +208,32 @@ Proof.
   intros H'; Injection H'. clear H'. Injection H. clear H. rename H0 into H.
   asimpl in H. 
   destruct k as [|[|[]]]; cbn in H.
-  - eapply equiv_app_elim in H; intuition.
+  - eapply equiv_app_elim in H; (intuition idtac); [|eauto|].
     symmetry in H1; eapply equiv_neq_var_app in H1 as [].
     all: cbn; simplify; destruct a; cbn in isA; eauto.
-  - do 2 (rewrite stepBeta in H; asimpl; eauto).
-    eapply equiv_app_elim in H; intuition.
+  - do 2 (rewrite stepBeta in H; asimpl; trivial).
+    eapply equiv_app_elim in H; (intuition idtac); [|eauto|].
     symmetry in H1; eapply equiv_neq_var_app in H1 as [].
     all: cbn; simplify; destruct a as [[] | | |]; cbn in isA; eauto.  
   - rewrite <-AppR_subst in H. remember (AppR a T) as t. clear isA a T Heqt.
-    do 4 (rewrite stepBeta in H; asimpl; cbn; asimpl; eauto).
+    do 4 (rewrite stepBeta in H; asimpl; cbn; asimpl; trivial).
     rewrite idSubst_exp in H; [|intros [|[]]; cbn; eauto].  eapply normal_Lambda in N.
     pose (sigma := @var X 0 .: var 0 (var 1) .: shift >> (shift >> var)). fold sigma in H.
     enough (exists n, t = AppL (repeat (var 0) n) (var 1)) as [n ->] by now (exists n).
     induction t as [[| [|]] | | |]; cbn in H; try solve [unfold funcomp in H; Discriminate].
     + exists 0; reflexivity.
-    + eapply head_atom in N as isA; eauto. 
-      eapply equiv_app_elim in H as [EQ1 EQ2]; eauto.
-      2: eapply atom_head_lifting; eauto.
+    + eapply head_atom in N as isA; [|eauto]. 
+      eapply equiv_app_elim in H as [EQ1 EQ2]; [|eauto|].
+      2: eapply atom_head_lifting; trivial.
       2: intros [| [| []]]; cbn; eauto.
       destruct t1 as [[| [|]] | | |]; cbn in EQ1; try Discriminate.
       * mp IHt2; [eauto using normal_app_r|]. specialize (IHt2 EQ2). 
         destruct IHt2 as [n IHt2]; exists (S n); cbn; now rewrite IHt2.
       * unfold funcomp in EQ1; Injection EQ1. discriminate.
       * eapply equiv_neq_var_app in EQ1 as [].
-        eapply atom_head_lifting; eauto.
+        eapply atom_head_lifting; trivial.
         intros [| [| []]]; cbn; eauto.
-  - repeat (rewrite stepBeta in H; cbn; asimpl; eauto).
+  - repeat (rewrite stepBeta in H; cbn; asimpl; trivial).
     Discriminate. 
 Qed.
 
@@ -316,7 +316,7 @@ Section Encoding.
     Proof.
       intros; unfold constEQ.
       split; cbn [fst snd].
-      + econstructor; eauto. 
+      + econstructor; trivial. 
         eapply Gamma__dwk_nth, Vars__de_in; eauto; cbn; intuition.
       + eapply typing_enc. 
     Qed.
@@ -345,7 +345,7 @@ Section Encoding.
     Lemma typing_equations d e:
       e ∈ E -> d ∈ eqs e -> Gamma__dwk ⊢₂(3) d : alpha → (alpha → alpha) → alpha. 
     Proof.
-      intros H H1; destruct e; cbn in H1; intuition; subst.
+      intros H H1; destruct e; cbn in H1; intuition idtac; subst.
       all: eauto using typing_constEQ, typing_addEQ, typing_mulEQ. 
       all: eapply typing_varEQ, Vars__de_in; eauto; cbn; intuition.
     Qed. 
@@ -373,5 +373,3 @@ Next Obligation.
   all: intros ? ?; mapinj;
     eapply in_Equations in H1 as [? []];eapply typing_equations; eauto.
 Qed.
-
-

--- a/theories/HOU/second_order/dowek/reduction.v
+++ b/theories/HOU/second_order/dowek/reduction.v
@@ -4,7 +4,7 @@ From Undecidability.HOU Require Import std.std calculus.calculus.
 Import ListNotations.
 From Undecidability.HOU.second_order Require Import diophantine_equations dowek.encoding.
 Require Import Undecidability.HOU.unification.nth_order_unification.
-
+Import ArsInstances.
 (* ** Equivalences *)
 Section EquationEquivalences.
 
@@ -27,7 +27,7 @@ Section EquationEquivalences.
     Lemma backward_vars x:
       sigma • fst (varEQ x) ≡ sigma • snd (varEQ x) ->  exists n, sigma x = enc n.
     Proof using N.
-      intros ?. eapply enc_characteristic; eauto.
+      intros ?. eapply enc_characteristic; trivial.
       cbn in H. asimpl. asimpl in H.
       unfold shift in *. unfold funcomp at 5 in H.
       asimpl in H. rewrite <-H.
@@ -131,7 +131,7 @@ Section Forward.
     remember (s,t) as q. clear Heqq.
     cbn in *. eapply in_Equations in H' as (e & ? & ?).
     eapply H in H0.
-    destruct e; cbn in *; intuition; subst.
+    destruct e; cbn in *; intuition idtac; subst.
     all: try eapply forward_add. all: try eapply forward_consts.
     all: try eapply forward_mult. all: try eapply forward_vars.
     all: unfold encs, funcomp; eauto. try eapply enc_sol_encodes.
@@ -157,7 +157,7 @@ Section Backward.
     sigma x = enc n -> sub_sol sigma x = n.
   Proof.
     intros H; unfold sub_sol; destruct dec_enc as [[m H']|H'].
-    rewrite H' in H; eapply enc_injective in H; eauto.
+    rewrite H' in H; eapply enc_injective in H; trivial.
     eapply H' in H; intuition.
   Qed.
 
@@ -177,13 +177,13 @@ Section Backward.
     2 - 3: eapply backward_vars in EQy as [m]; eauto.
     2 - 3: eapply backward_vars in EQz as [p]; eauto.
     all: repeat (erewrite sub_sol_enc; [|eauto]).
-    - eapply backward_consts; eauto.
+    - eapply backward_consts; [eauto|].
       eapply H, in_Equations; eexists; intuition eauto.
       cbn; intuition.
-    - eapply backward_add; eauto.
+    - eapply backward_add; [eauto..|].
       eapply H, in_Equations; eexists; intuition eauto.
       cbn; intuition.
-    - eapply backward_mult; eauto.
+    - eapply backward_mult; [eauto..|].
       eapply H, in_Equations; eexists; intuition eauto.
       cbn; intuition.
   Qed.

--- a/theories/HOU/second_order/goldfarb/encoding.v
+++ b/theories/HOU/second_order/goldfarb/encoding.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 Require Import RelationClasses Morphisms List Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import calculus.calculus second_order.diophantine_equations
   systemunification nth_order_unification.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 (* * Second-Order Realisation *)
 

--- a/theories/HOU/second_order/goldfarb/multiplication.v
+++ b/theories/HOU/second_order/goldfarb/multiplication.v
@@ -4,7 +4,7 @@ From Undecidability.HOU Require Import std.std axioms.
 Require Import RelationClasses Morphisms Init.Wf Init.Nat Setoid.
 From Undecidability.HOU Require Import calculus.calculus second_order.goldfarb.encoding.
 Require Import FinFun Coq.Arith.Wf_nat.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 
 Section Multiplication.

--- a/theories/HOU/second_order/goldfarb/reduction.v
+++ b/theories/HOU/second_order/goldfarb/reduction.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 Require Import RelationClasses Morphisms Init.Wf List Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import calculus.calculus unification.unification.
 From Undecidability.HOU.second_order Require Export diophantine_equations goldfarb.encoding goldfarb.multiplication.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 
 (* ** Equivalences *)
@@ -222,7 +222,7 @@ Section Backward.
       all: repeat (erewrite decode_subst_encodes;[|eauto]).
       + eapply backward_consts; (eauto 4).
       + eapply backward_add; (eauto 1); eapply EQs; (eauto 5).
-      + eapply backward_mult; (eauto 1); eapply EQs; intuition.
+      + eapply backward_mult; (eauto 1); eapply EQs; intuition idtac.
   Qed.
 End Backward.
 
@@ -311,16 +311,16 @@ Proof.
     all: eapply H10_to_SOU.
   - intros E. split.
     + intros H % H10_SU. destruct H as (Delta & sigma & H1 & H2).
-      exists Delta. exists sigma. intuition. eapply foldeqs_correct, equiv_pointwise_eqs; (eauto 2).
+      exists Delta. exists sigma. intuition idtac. eapply foldeqs_correct, equiv_pointwise_eqs; (eauto 2).
       cbn. intros s1 s2 (d&H3&H4) % in_flat_map.
-      destruct d; cbn in H4; intuition.
+      destruct d; cbn in H4; intuition idtac.
       all: change s1 with (fst (s1, s2)); rewrite <-?H, <-?H0.
       all: change s2 with (snd (s1, s2)); rewrite <-?H, <-?H0.
       all: cbn; (eauto 2).
     + intros (Delta & sigma & T & EQ). eapply SU_H10. exists Delta, sigma.
-      intuition.  eapply equiv_eqs_pointwise; (eauto 1); eapply foldeqs_correct; (eauto 2).
+      intuition idtac.  eapply equiv_eqs_pointwise; (eauto 1); eapply foldeqs_correct; (eauto 2).
       cbn. intros s1 s2 (d&H3&H4) % in_flat_map.
-      destruct d; cbn in H4; intuition.
+      destruct d; cbn in H4; intuition idtac.
       all: change s1 with (fst (s1, s2)); rewrite <-?H1, <-?H0.
       all: change s2 with (snd (s1, s2)); rewrite <-?H1, <-?H0.
       all: cbn; (eauto 2).

--- a/theories/HOU/std/ars/basic.v
+++ b/theories/HOU/std/ars/basic.v
@@ -67,24 +67,24 @@ Section ClosureRelations.
     induction 1; cbn; eauto.
   Qed.
 
-  Global Instance multiple_transitive R:
+  #[local] Instance multiple_transitive R:
     Transitive (multiple R).
   Proof.
     intros ?; eapply multiple_trans.
   Qed.
 
-  Global Instance star_preorder R: PreOrder (star R).
+  #[local] Instance star_preorder R: PreOrder (star R).
   Proof.
     constructor; hnf; eauto using star_trans.
   Qed.
 
-  Global Instance star_exp R:
+  #[local] Instance star_exp R:
     R <<= star R.
   Proof.
     unfold subrelation; eauto.
   Qed.
 
-  Global Instance multiple_exp R:
+  #[local] Instance multiple_exp R:
     R <<= multiple R.
   Proof.
     unfold subrelation; eauto.
@@ -98,7 +98,7 @@ Section ClosureRelations.
   Qed.
 
 
-  Global Instance multiple_star R : multiple R <<= star R.
+  #[local] Instance multiple_star R : multiple R <<= star R.
   Proof.
     induction 1; eauto.
   Qed.
@@ -132,21 +132,21 @@ Section ClosureRelations.
        multiple_exp counted_exp : core.
 
 
-  Global Instance star_mono R S :
+  #[local] Instance star_mono R S :
     R <<= S -> star R <<= star S.
   Proof.
     intros H x y.
     induction 1; eauto.
   Qed.
 
-  Global Instance multiple_mono R S :
+  #[local] Instance multiple_mono R S :
     R <<= S -> multiple R <<= multiple S.
   Proof.
     intros H x y.
     induction 1; eauto.
   Qed.
 
-  Global Instance eval_subrel R:
+  #[local] Instance eval_subrel R:
     (evaluates R) <<= (star R).
   Proof. intros x y []. assumption. Qed. 
 
@@ -198,7 +198,7 @@ Section ClosureRelations.
     intros []; eauto using sym.
   Qed.
 
-  Global Instance sym_Symmetric R:
+  #[local] Instance sym_Symmetric R:
     Symmetric (sym R).
   Proof.
     firstorder using sym_symmetric.
@@ -230,13 +230,13 @@ Section ClosureRelations.
   Qed.
 
 
-  Global Instance equiv_star R:
+  #[local] Instance equiv_star R:
     star R <<= equiv R.
   Proof.
     induction 1; unfold equiv in *; eauto using sym, star.
   Qed.
 
-  Global Instance equiv_rel R:
+  #[local] Instance equiv_rel R:
     R <<= equiv R.
   Proof.
     transitivity (star R); typeclasses eauto. 
@@ -266,7 +266,7 @@ Section ClosureRelations.
   Proof. intros ->;eapply refl_equiv. Qed.
 
 
-  Global Instance equiv_equivalence R:
+  #[local] Instance equiv_equivalence R:
     Equivalence (equiv R).
   Proof.
     constructor; firstorder using refl_equiv, equiv_trans, equiv_symm.
@@ -312,3 +312,18 @@ End ClosureRelations.
 #[export] Hint Constructors star multiple counted : core.
 #[export] Hint Resolve star_trans multiple_trans counted_trans star_exp
      multiple_exp counted_exp equiv_join : core.
+
+Module ArsInstances.
+#[export] Existing Instance multiple_transitive.
+#[export] Existing Instance star_preorder.
+#[export] Existing Instance star_exp.
+#[export] Existing Instance multiple_exp.
+#[export] Existing Instance multiple_star.
+#[export] Existing Instance star_mono.
+#[export] Existing Instance multiple_mono.
+#[export] Existing Instance eval_subrel.
+#[export] Existing Instance sym_Symmetric.
+#[export] Existing Instance equiv_star.
+#[export] Existing Instance equiv_rel.
+#[export] Existing Instance equiv_equivalence.
+End ArsInstances.

--- a/theories/HOU/std/ars/confluence.v
+++ b/theories/HOU/std/ars/confluence.v
@@ -6,7 +6,7 @@ http://www.ps.uni-saarland.de/courses/sem-ws17/confluence.v
 Set Implicit Arguments.
 Require Import Morphisms FinFun.
 From Undecidability.HOU Require Import std.tactics std.misc std.ars.basic.
-
+Import ArsInstances.
 #[export] Hint Constructors star multiple counted : core.
 
 Section Confluence.

--- a/theories/HOU/std/ars/evaluator.v
+++ b/theories/HOU/std/ars/evaluator.v
@@ -6,7 +6,7 @@ http://www.ps.uni-saarland.de/courses/sem-ws17/confluence.v
 Set Implicit Arguments.
 Require Import Morphisms FinFun ConstructiveEpsilon.
 From Undecidability.HOU Require Import std.tactics std.decidable std.misc std.ars.basic std.ars.confluence.
-
+Import ArsInstances.
 Section Evaluator.
 
   Variables (X: Type) (R: X -> X -> Prop) (rho: X -> X). 

--- a/theories/HOU/std/ars/list_reduction.v
+++ b/theories/HOU/std/ars/list_reduction.v
@@ -1,8 +1,7 @@
 Set Implicit Arguments.
 Require Import List Morphisms FinFun.
 From Undecidability.HOU Require Import std.tactics std.ars.basic std.ars.confluence.
-Import ListNotations.
-
+Import ListNotations ArsInstances.
 Section ListRelations.
 
   Variable (X : Type) (R: X -> X -> Prop).
@@ -52,7 +51,7 @@ Section ListRelations.
       + destruct (IHstar s t A' T); eauto.
   Qed.
   
-  Global Instance lsteps_cons :
+  #[export] Instance lsteps_cons :
     Proper (star R ++> star lstep ++> star lstep) cons. 
   Proof.
     intros ??; induction 1; intros ??; induction 1; eauto. 
@@ -63,9 +62,9 @@ Section ListRelations.
   Proof.
     intros conf ?. induction x; intros.
     - inv H. inv H0. exists nil; eauto. inv H. inv H1.
-    - destruct y, z; try solve [exfalso; eapply lsteps_cons_nil; eauto].
+    - destruct y, z; try solve [exfalso; eapply lsteps_cons_nil; eassumption].
       eapply lsteps_cons_inv in H; eapply lsteps_cons_inv in H0.
-      intuition; destruct (IHx _ _ H2 H3) as [V].
+      intuition idtac; destruct (IHx _ _ H2 H3) as [V].
       destruct (conf _ _ _ H1 H) as [v].
       exists (v :: V).
       now rewrite H5, H0. now rewrite H6, H4.
@@ -76,9 +75,9 @@ Section ListRelations.
   Lemma normal_lstep_in A:
     Normal lstep A -> forall x, In x A  -> Normal R x.
   Proof.
-    induction A; cbn; intuition; subst; eauto.
+    induction A; cbn; intuition idtac; subst; trivial.
     intros ? H1. eapply H. constructor. eassumption.
-    eapply IHA; eauto. intros ? H2. eapply H.
+    eapply IHA; trivial. intros ? H2. eapply H.
     econstructor 2; eauto. 
   Qed.
 
@@ -87,7 +86,7 @@ Section ListRelations.
   Lemma normal_in_lstep A:
     (forall x, In x A  -> Normal R x) -> Normal lstep A.
   Proof.
-    induction A; cbn; intuition. 
+    induction A; cbn; intuition idtac. 
     - intros ? H1. inv H1.
     - intros ? H1. inv H1.
       eapply H; eauto.
@@ -128,21 +127,21 @@ Section ListRelations.
     - subst. injection HeqT' as ??; subst; intuition.
     - subst. inv H.
       + destruct x'. eapply lstep_cons_nil in H1 as [].
-        edestruct IHstar; eauto. inv H1.
-        * intuition.
+        edestruct IHstar; trivial. inv H1.
+        * intuition idtac.
           transitivity x; eauto. 
-        * intuition. transitivity x'; eauto.
+        * intuition idtac. transitivity x'; eauto.
       + destruct x'. eapply lstep_nil_cons in H1 as [].
-        edestruct IHstar; eauto. inv H1; intuition. 
+        edestruct IHstar; trivial. inv H1; intuition idtac. 
         * transitivity x; eauto. 
         * transitivity x'; eauto. 
   Qed.
 
 
-  Global Instance equiv_lstep_cons_proper:
+  #[export] Instance equiv_lstep_cons_proper:
     Proper (equiv R ++> equiv lstep ++> equiv lstep) cons.
   Proof.
-    intros ??; induction 1; intros ??; induction 1; eauto.
+    intros ??; induction 1; intros ??; induction 1; [eauto|..].
     - rewrite <-IHstar. destruct H.
       eauto. symmetry. eauto.
     - rewrite <-(IHstar x0 x0); try reflexivity.
@@ -162,7 +161,7 @@ Section ListRelations.
     (forall s t S T, equiv R s t -> equiv lstep S T -> P S T -> P (s :: S) (t :: T)) ->
     forall S T, equiv lstep S T -> P S T.
   Proof.
-    intros B IH S T H; induction S in T, H |-*; destruct T; eauto.
+    intros B IH S T H; induction S in T, H |-*; destruct T; trivial.
     - exfalso; eapply not_equiv_lstep_nil_cons; eauto. 
     - exfalso; eapply not_equiv_lstep_nil_cons; symmetry; eauto. 
     - eapply equiv_lstep_cons_inv in H as (? & ?).

--- a/theories/HOU/std/lists/basics.v
+++ b/theories/HOU/std/lists/basics.v
@@ -50,16 +50,16 @@ Section BasicLemmas.
   Proof. firstorder. Qed.
 
   
-  Global Instance incl_preorder: PreOrder (@incl X). 
+  #[local] Instance incl_preorder: PreOrder (@incl X). 
   Proof. firstorder. Qed.
 
-  Global Instance strict_incl_transitive: Transitive (@strict_incl X).
+  #[local] Instance strict_incl_transitive: Transitive (@strict_incl X).
   Proof. firstorder. Qed.
 
-  Global Instance seteq_preorder: PreOrder (@seteq X).
+  #[local] Instance seteq_preorder: PreOrder (@seteq X).
   Proof. firstorder. Qed.
 
-  Global Instance seteq_equivalence: Equivalence (@seteq X).
+  #[local] Instance seteq_equivalence: Equivalence (@seteq X).
   Proof. firstorder. Qed.
 
   Hint Resolve incl_refl seteq_refl : listdb.
@@ -79,22 +79,22 @@ Section BasicLemmas.
       intuition; subst; intuition.
   Qed.
 
-  Global Instance proper_in_incl: Proper (eq ++> incl ==> Basics.impl) (@In X).
+  #[local] Instance proper_in_incl: Proper (eq ++> incl ==> Basics.impl) (@In X).
   Proof.
     intros ?? -> ???. firstorder.   
   Qed.
 
-  Global Instance in_seteq_proper: Proper (eq ++> seteq ++> iff) (@In X).
+  #[local] Instance in_seteq_proper: Proper (eq ++> seteq ++> iff) (@In X).
   Proof.
     intros ?? -> ???. firstorder.
   Qed.
 
 
   (* ⊆ *)
-  Global Instance subrel_incl_seteq: subrelation seteq (@incl X).
+  #[local] Instance subrel_incl_seteq: subrelation seteq (@incl X).
   Proof. intros ??; firstorder. Qed.
 
-  Global Instance incl_seteq_proper: Proper (seteq ++> seteq ++> iff) (@incl X).
+  #[local] Instance incl_seteq_proper: Proper (seteq ++> seteq ++> iff) (@incl X).
   Proof. firstorder. Qed.
 
   
@@ -150,10 +150,10 @@ Section BasicLemmas.
   Proof. intros; eapply incl_app; intuition. Qed.
 
 
-  Global Instance incl_cons_proper: Proper (eq ++> incl ++> incl) (@cons X).
+  #[local] Instance incl_cons_proper: Proper (eq ++> incl ++> incl) (@cons X).
   Proof. intros ??-> ???; firstorder. Qed.
 
-  Global Instance seteq_cons_proper: Proper (eq ++> seteq ++> seteq) (@cons X).
+  #[local] Instance seteq_cons_proper: Proper (eq ++> seteq ++> seteq) (@cons X).
   Proof. intros ??-> ???; firstorder. Qed.
 
  
@@ -178,7 +178,7 @@ Section BasicLemmas.
   Lemma strict_incl_project A B: A ⊊ B -> exists x, x ∈ B /\ ~ x ∈ A.
   Proof. firstorder. Qed.
 
-  Global Instance strict_incl_incl_subrel:
+  #[local] Instance strict_incl_incl_subrel:
     subrelation (@strict_incl X) (@incl X).
   Proof. firstorder. Qed.
 
@@ -207,12 +207,12 @@ Section BasicLemmas.
   End WellFoundedStrictInclusion.
     
   (* app *)
-  Global Instance proper_app_incl: Proper (incl ++> incl ++> incl) (@app X).
+  #[local] Instance proper_app_incl: Proper (incl ++> incl ++> incl) (@app X).
   Proof.
     intros A A' H1 B B' H2; induction A; firstorder auto with *.
   Qed.
   
-  Global Instance proper_app_seteq: Proper (seteq ++> seteq ++> seteq) (@app X).
+  #[local] Instance proper_app_seteq: Proper (seteq ++> seteq ++> seteq) (@app X).
   Proof.
     intros A A' [H1 H2] B B' [H3 H4].
     split; eapply proper_app_incl; firstorder. 
@@ -237,18 +237,18 @@ Section BasicLemmas.
     induction A; cbn; autorewrite with listdb; intuition.
   Qed.
 
-  Global Instance proper_incl_seteq: Proper (@seteq X ++> @seteq X ++> iff) incl.
+  #[local] Instance proper_incl_seteq: Proper (@seteq X ++> @seteq X ++> iff) incl.
   Proof.
     intros ??????; firstorder.
   Qed.
 
-  Global Instance proper_rev_incl: Proper (incl ++> incl) (@rev X).
+  #[local] Instance proper_rev_incl: Proper (incl ++> incl) (@rev X).
   Proof.
     intros A B H. now rewrite rev_seteq, H, rev_seteq. 
   Qed.
   
   
-  Global Instance proper_rev_seteq: Proper (seteq ++> seteq) (@rev X).
+  #[local] Instance proper_rev_seteq: Proper (seteq ++> seteq) (@rev X).
   Proof.
     intros A B [H1 H2]; split; eapply proper_rev_incl; eauto.  
   Qed.
@@ -276,7 +276,7 @@ Section BasicLemmas.
     reflexivity.
   Qed.
 
-  Global Instance map_incl_proper : Proper (eq ++> incl ++> incl) (@map Y X).
+  #[local] Instance map_incl_proper : Proper (eq ++> incl ++> incl) (@map Y X).
   Proof.
     intros ?? -> A B H.
     induction A; cbn; eauto with listdb.
@@ -284,7 +284,7 @@ Section BasicLemmas.
     eapply in_map; firstorder.
   Qed.      
 
-  Global Instance map_seteq_proper : Proper (eq ++> seteq ++> seteq) (@map Y X).
+  #[local] Instance map_seteq_proper : Proper (eq ++> seteq ++> seteq) (@map Y X).
   Proof.
     intros ?? -> A B [H1 H2]; split; apply map_incl_proper; firstorder. 
   Qed.      
@@ -308,7 +308,7 @@ Section BasicLemmas.
   Proof. induction A; cbn; [ constructor | ]; destruct (p a); cbn; lia. Qed.
 
 
-  Global Instance filter_incl_proper: Proper (eq ++> incl ++> incl) (@filter X).
+  #[local] Instance filter_incl_proper: Proper (eq ++> incl ++> incl) (@filter X).
   Proof.
     intros ?? ->  A B H2; induction A; cbn; eauto with listdb.
     destruct y eqn: H1; eauto with listdb. 
@@ -316,7 +316,7 @@ Section BasicLemmas.
     eapply filter_In; intuition. 
   Qed.
 
-  Global Instance filter_seqteq_proper: Proper (eq ++> seteq ++> seteq) (@filter X).
+  #[local] Instance filter_seqteq_proper: Proper (eq ++> seteq ++> seteq) (@filter X).
   Proof.
     intros f g -> A B [H2 H3]; split; apply filter_incl_proper; firstorder. 
   Qed.
@@ -349,3 +349,26 @@ Tactic Notation "lsimpl" "in" hyp_list(H) := autorewrite with listdb in H.
 Tactic Notation "lsimpl" "in" "*" := autorewrite with listdb in *. 
 
 Ltac lauto  := eauto with listdb. 
+
+Module ListInstances.
+#[export] Existing Instance incl_preorder.
+#[export] Existing Instance strict_incl_transitive.
+#[export] Existing Instance seteq_preorder.
+#[export] Existing Instance seteq_equivalence.
+#[export] Existing Instance proper_in_incl.
+#[export] Existing Instance in_seteq_proper.
+#[export] Existing Instance subrel_incl_seteq.
+#[export] Existing Instance incl_seteq_proper.
+#[export] Existing Instance incl_cons_proper.
+#[export] Existing Instance seteq_cons_proper.
+#[export] Existing Instance strict_incl_incl_subrel.
+#[export] Existing Instance proper_app_incl.
+#[export] Existing Instance proper_app_seteq.
+#[export] Existing Instance proper_incl_seteq.
+#[export] Existing Instance proper_rev_incl.
+#[export] Existing Instance proper_rev_seteq.
+#[export] Existing Instance map_incl_proper.
+#[export] Existing Instance map_seteq_proper.
+#[export] Existing Instance filter_incl_proper.
+#[export] Existing Instance filter_seqteq_proper.
+End ListInstances.

--- a/theories/HOU/third_order/encoding.v
+++ b/theories/HOU/third_order/encoding.v
@@ -2,8 +2,7 @@ Set Implicit Arguments.
 Require Import RelationClasses Morphisms List Lia
       Arith Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import std.std calculus.calculus third_order.pcp.
-Import ListNotations.
-
+Import ListNotations ArsInstances.
 (* * Third-Order Encoding *)
 Section Encoding.
 

--- a/theories/HOU/third_order/huet.v
+++ b/theories/HOU/third_order/huet.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 Require Import RelationClasses Morphisms List Arith Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.unification.
 From Undecidability.HOU Require Import third_order.pcp third_order.encoding.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 (* * Huet Reduction *)
 Section HuetReduction.
@@ -20,30 +20,30 @@ Section HuetReduction.
     (lambda lambda lambda h (AppR f (Enc 1 2 (heads S))) (AppR f (repeat (var (u 1)) (length S)))) :
     ((alpha → alpha) → (alpha → alpha) → (alpha → alpha → alpha) →  alpha).
   Proof.
-    do 4 econstructor. econstructor. econstructor; cbn; (eauto 1); cbn; (eauto 2).
+    do 4 econstructor. econstructor. econstructor; cbn; trivial; cbn; trivial.
     - eapply AppR_ordertyping with (L := repeat (alpha → alpha)  (length S) ); simplify.
       erewrite <-map_length; eapply Enc_typing.
-      all: econstructor; (eauto 2).
-      simplify; cbn; (eauto 3). 
+      all: econstructor; trivial.
+      simplify; cbn; eauto. 
     - eapply AppR_ordertyping. 
       + eapply repeated_ordertyping; simplify; [|eauto]. 
         intros s H'. eapply repeated_in in H'. subst.
         econstructor; cbn. 2: eauto. eauto.
-      + econstructor; simplify; (eauto 3).
+      + econstructor; simplify; eauto.
   Qed.
 
   Lemma HGamma₀t₀A₀ (S: list card) : 
     [Arr (repeat (alpha → alpha) (length S)) alpha; (alpha → alpha) → alpha] ⊢( 3) 
     (lambda lambda lambda h (AppR f (Enc 1 2 (tails S))) (var (u 1) (g (var (u 1))))) :
     ((alpha → alpha) → (alpha → alpha) → (alpha → alpha → alpha) →  alpha).
-  Proof with cbn [ord' ord alpha]; simplify; cbn; (eauto 3).
+  Proof with cbn [ord' ord alpha]; simplify; cbn; (eauto 2).
     do 4 econstructor. econstructor. econstructor; (eauto 2)...
     cbn; (eauto 4). 
     2: do 2 econstructor...
     2 - 3: econstructor...
     eapply AppR_ordertyping with (L := repeat (alpha → alpha) (length S)); simplify.
     erewrite <-map_length; eapply Enc_typing.
-    all: econstructor...
+    all: econstructor; trivial; simplify; cbn; lia.
   Qed.
 
   (* ** Reduction Function *)
@@ -191,9 +191,9 @@ Section HuetReduction.
     simplify in EQ1 EQ2; rewrite !AppR_app in EQ1; rewrite !AppR_app in EQ2.
     simplify in H1; assert (length S1 = l) as H2 by lia; clear H1; subst.
     rewrite !AppR_Lambda' in EQ1, EQ2; simplify; (eauto 2).
-    rewrite AppR_Lambda' in EQ2; simplify; (eauto 2).
-    rewrite it_up_var_sapp in EQ1; simplify; intros; try lia.
-    rewrite !it_up_var_sapp in EQ2; simplify; intros; try lia. 
+    rewrite AppR_Lambda' in EQ2; simplify; trivial.
+    rewrite it_up_var_sapp in EQ1; simplify; intros; [|lia..].
+    rewrite !it_up_var_sapp in EQ2; simplify; intros; [|lia..].
 
     destruct (AppL_decomposition (AppR x T') (|S2|)) as [[I t] (H1&H2&H3)]. 
     rewrite H2 in EQ1, EQ2.
@@ -218,11 +218,10 @@ Section HuetReduction.
       3, 5, 9: eauto. 3, 4, 6:eauto.
       (* close var goals *)
       2 - 3: intros; cbn; unfold funcomp, u, v; intuition discriminate.
-      exists I; intuition; eauto using nats_lt; (eauto 2).
+      exists I; intuition idtac.
       2: rewrite <-!select_map; (eauto 2). 
       subst; cbn [map select concat AppL] in H6, EQ1.
-      eapply end_is_var in EQ1 as (? & ? & ? & ?);
-        eauto; simplify.
+      eapply end_is_var in EQ1 as (? & ? & ? & ?); trivial.
       eapply H3; cbn; (eauto 1); cbn; now simplify in *.
       intros; cbn; intuition; discriminate.
       intros ? ? % repeated_in; subst; (eauto 2).
@@ -233,8 +232,8 @@ Section HuetReduction.
         assert (i < length S2 \/ i >= length S2) as [H42|H42] by lia.
         ** rewrite nth_error_app1, nth_error_repeated in H6; simplify; (eauto 2).
            injection H6 as H6. eapply (f_equal ord) in H6. simplify in H6.
-           symmetry in H6; eapply Nat.eq_le_incl in H6; simplify in H6.
-           intuition. cbn in H6. lia. 
+           symmetry in H6; eapply Nat.eq_le_incl in H6. simplify in H6.
+           cbn in H6. lia. 
         ** rewrite <-H2 in EQ1. asimpl in EQ1. rewrite sapp_ge_in in EQ1; simplify; (eauto 2).
            eapply equiv_head_equal in EQ1; simplify; cbn; (eauto 2).
            simplify in EQ1; cbn in EQ1. discriminate EQ1.

--- a/theories/HOU/third_order/simplified.v
+++ b/theories/HOU/third_order/simplified.v
@@ -2,7 +2,7 @@ Set Implicit Arguments.
 Require Import RelationClasses Morphisms List Lia Init.Nat Setoid.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.unification.
 From Undecidability.HOU Require Import third_order.pcp third_order.encoding.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 Definition MPCP' '(c, C) :=
   exists I, I ⊆ nats (length C) /\
@@ -51,13 +51,13 @@ Section SimplifiedReduction.
     - intros x A. destruct x as [| [|]]; try discriminate; cbn.
       injection 1 as ?; subst. 
       eapply finst_typing; eauto.
-    - cbn -[enc]. rewrite !enc_subst_id; eauto. 
-      rewrite !AppR_subst, !Enc_subst_id; eauto.
+    - cbn -[enc]. rewrite !enc_subst_id; trivial. 
+      rewrite !AppR_subst, !Enc_subst_id; trivial.
       cbn; rewrite !ren_plus_base, !ren_plus_combine;
         change (1 + 1) with 2.
       erewrite <-map_length at 1. symmetry.
       erewrite <-map_length at 1. erewrite !finst_equivalence.
-      all: simplify; eauto.
+      all: simplify; trivial.
       now rewrite <-!enc_app, EQ. 
   Qed.  
 
@@ -67,22 +67,22 @@ Section SimplifiedReduction.
   Proof.
     destruct P as [c C].
     intros (Delta & sigma & T1 & EQ).
-    specialize (T1 0 (Arr (repeat (alpha → alpha) (length C)) alpha)); mp T1; eauto.
+    specialize (T1 0 (Arr (repeat (alpha → alpha) (length C)) alpha)); mp T1; trivial.
     eapply ordertyping_preservation_under_renaming with (delta := add 2) (Delta := alpha :: alpha :: Delta) in T1.
     2: intros ??; cbn; eauto. 
-    eapply main_lemma with (u := 0) (v := 1) in T1 as (I & S & H); eauto.
+    eapply main_lemma with (u := 0) (v := 1) in T1 as (I & S & H); trivial.
     2, 3: intros (?&?&?) % vars_ren; discriminate. 
-    exists I. intuition.
-    revert EQ. cbn -[enc]. rewrite !enc_subst_id; eauto. 
-    rewrite !AppR_subst; rewrite ?Enc_subst_id; eauto; cbn -[add].
+    exists I. intuition idtac.
+    revert EQ. cbn -[enc]. rewrite !enc_subst_id; trivial. 
+    rewrite !AppR_subst; rewrite ?Enc_subst_id; trivial; cbn -[add].
     all: unfold funcomp; cbn -[add]; rewrite !ren_plus_base, !ren_plus_combine;
       change (1 + 1) with 2.
-    specialize (H (heads C)) as H1; mp H1; simplify; eauto.
-    specialize (H (tails C)) as H2; mp H2; simplify; eauto.
+    specialize (H (heads C)) as H1; mp H1; simplify; trivial.
+    specialize (H (tails C)) as H2; mp H2; simplify; trivial.
     destruct H1 as [t' [-> H1]], H2 as [t'' [-> H2]].
     rewrite <-!select_map, !enc_concat, <-!enc_app.
     intros EQ % equiv_lam_elim % equiv_lam_elim.
-    eapply enc_eq in EQ. 1 - 2: intuition. lia.
+    eapply enc_eq in EQ. 1 - 2: intuition idtac. lia.
     all: intros s; try eapply H1; try eapply H2.
   Qed.
 

--- a/theories/HOU/unification/higher_order_unification.v
+++ b/theories/HOU/unification/higher_order_unification.v
@@ -3,6 +3,7 @@ Import ListNotations.
 
 From Undecidability.HOU.calculus Require Import 
   prelim terms syntax semantics equivalence typing order evaluator. 
+Import ArsInstances.
 
 (* * Higher-Order Unification *)
 Section UnificationDefinitions.
@@ -59,9 +60,9 @@ Section Normalisation.
               | right _ => sigma x
               end).
       split; [| split].
-      1-2: intros x; destruct dec_in; intuition.
+      1-2: intros x; destruct dec_in; intuition trivial.
       eapply eta_correct. eapply eta_normal. 
-      intros x B H. destruct dec_in; intuition.
+      intros x B H. destruct dec_in; [|eauto].
       destruct I; cbn. generalize (T x x0 e).
       rewrite H in e; injection e as ->.
       eapply eta_typing.
@@ -80,11 +81,11 @@ Section Normalisation.
     split; intros (Delta & sigma & H1 & H2); [| exists Delta; exists sigma; intuition].
     eapply normalise_subst in H1 as (tau & H5 & H6 & H7).
     pose (theta x := if nth (Gammaᵤ I) x then tau x else var x).
-    exists Delta. exists theta. intuition.
+    exists Delta. exists theta. intuition idtac.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
     + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
-      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
-      all: intros ? H; eapply typing_variables in H; eauto; domin H.
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); trivial.
+      all: intros ? H; eapply typing_variables in H; trivial; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto].
       domin Heqo; eauto.  
@@ -96,7 +97,7 @@ Section Normalisation.
     U X I -> U X I'.
   Proof.
     intros H1 H2 H3 H4; intros (Delta & sigma & T & N); exists Delta; exists sigma; split.
-    rewrite <-H3; eauto. now rewrite <-H1, <-H2, N. 
+    rewrite <-H3; trivial. now rewrite <-H1, <-H2, N. 
   Qed.
 
   
@@ -114,7 +115,7 @@ Section Normalisation.
     U X I <-> U X (uni_normalise I).
   Proof.
     split; intros H; [eapply @U_reduction|eapply @U_reduction with (I := uni_normalise I)].
-    all: eauto; cbn; eapply equiv_join.
+    all: trivial; cbn; eapply equiv_join.
     1, 3, 6, 8: rewrite eta_correct. all: reflexivity. 
   Qed.
 

--- a/theories/HOU/unification/nth_order_unification.v
+++ b/theories/HOU/unification/nth_order_unification.v
@@ -1,6 +1,6 @@
 Require Import List Lia Morphisms.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.higher_order_unification unification.systemunification.
-Import ListNotations.
+Import ListNotations ArsInstances.
 
 (* * Nth-Order Unification *)
 Section NthOrderUnificationDefinition.
@@ -69,7 +69,7 @@ Section NthOrderSystemUnification.
   Lemma ordertyping_combine Gamma n E L:
     Gamma ⊢₊(n) left_side E : L -> Gamma ⊢₊(n) right_side E : L -> Gamma ⊢₊₊(n) E : L.
   Proof.
-    intros H1 H2; induction E in L, H1, H2 |-*; inv H1; inv H2; eauto.
+    intros H1 H2; induction E in L, H1, H2 |-*; inv H1; inv H2; trivial.
     destruct a; eauto.
   Qed.
 
@@ -107,7 +107,7 @@ Section NthOrderSystemUnification.
     intros H; econstructor; eapply AppR_ordertyping with (L := L).
     eapply orderlisttyping_preservation_under_renaming; eauto.
     intros x ?; cbn; eauto.
-    econstructor; eauto; simplify; cbn; intuition.
+    econstructor; trivial; simplify; cbn; intuition.
   Qed.
 
 
@@ -136,18 +136,18 @@ Section NthOrderSystemUnification.
    Lemma OU_SOU n: OU n X ⪯ SOU n.
    Proof.
      exists (orduni_ordsysuni n); intros I.
-     split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition.
-     firstorder; injection H; intros; subst; eauto.
+     split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition idtac.
+     firstorder idtac; injection H; intros; subst; trivial.
      firstorder.
    Qed.
 
   Lemma SOU_OU n (I: ordsysuni n) (H: ord' L₀' < n):
     SOU n I <-> OU n X (ordsysuni_orduni I H).
   Proof.
-    split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition;
+    split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition idtac;
       cbn [s₀ t₀ ordsysuni_orduni] in *.
     rewrite !linearize_terms_subst, linearize_terms_equiv. now apply equiv_pointwise_eqs.
-     eapply equiv_eqs_pointwise; eauto.
+     eapply equiv_eqs_pointwise; [|eassumption].
      now rewrite <-linearize_terms_equiv, <-!linearize_terms_subst.
   Qed.
 
@@ -193,7 +193,7 @@ Section SubstitutionTransformations.
   Proof.
     intros H; eapply ordertypingSubst_soundness in H as H';
       eapply normalise_subst in H' as [tau].
-    exists tau; intuition. intros ???.
+    exists tau; intuition idtac. intros ???.
     eapply ordertyping_preservation_under_steps; [eapply H0 |].
     eapply H; eauto.
   Qed.
@@ -219,11 +219,11 @@ Section Normalisation.
     split; intros (Delta & sigma & H1 & H2); [| exists Delta; exists sigma; intuition].
     eapply normalise_subst in H1 as (tau & H5 & H6 & H7).
     pose (theta x := if nth (Gammaᵤ I) x then tau x else var x).
-    exists Delta. exists theta. intuition.
+    exists Delta. exists theta. intuition idtac.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
     + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
-      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
-      all: intros ? H; eapply typing_variables in H; eauto; domin H.
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); trivial.
+      all: intros ? H; eapply typing_variables in H; trivial; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto].
       domin Heqo; eauto.
@@ -236,11 +236,11 @@ Section Normalisation.
     intros Leq; split; intros (Delta & sigma & H1 & H2); [| exists Delta; exists sigma; intuition].
     eapply ordertyping_normalise_subst in H1 as (tau & H5 & H6 & H7).
     pose (theta x := if nth (Gamma₀ I) x then tau x else var x).
-    exists Delta. exists theta. intuition.
+    exists Delta. exists theta. intuition idtac.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
     + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
-      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
-      all: intros ? H; eapply typing_variables in H; eauto; domin H.
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); trivial.
+      all: intros ? H; eapply typing_variables in H; [|eauto]; domin H.
       all: unfold theta; now rewrite H, H5.
     + unfold theta; destruct nth eqn: ?; [|eauto]; domin Heqo; eauto.
   Qed.
@@ -251,11 +251,11 @@ Section Normalisation.
     intros Leq; split; intros (Delta & sigma & H1 & H2); [| exists Delta; exists sigma; intuition].
     eapply ordertyping_normalise_subst in H1 as (tau & H5 & H6 & H7).
     pose (theta x := if nth (@Gamma₀' _ _ I) x then tau x else var x).
-    exists Delta. exists theta. intuition.
+    exists Delta. exists theta. intuition idtac.
     + intros ???; unfold theta; rewrite H; eapply H7; eauto.
-    + intros; eauto.
+    + intros; trivial.
       rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
-      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
+      rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); [eauto|..].
       all: intros ? ?; enough (x ∈ dom Gamma₀') as D;
         [domin D; unfold theta; rewrite D; eauto|].
       all: eapply Vars_listtyping.
@@ -275,7 +275,7 @@ Section Normalisation.
     OU n X I -> OU n X I'.
   Proof.
     intros H1 H2 H3 H4; intros (Delta & sigma & T & N); exists Delta; exists sigma; split.
-    rewrite <-H3; eauto. now rewrite <-H1, <-H2, N.
+    rewrite <-H3; trivial. now rewrite <-H1, <-H2, N.
   Qed.
 
 
@@ -293,7 +293,7 @@ Section Normalisation.
     OU n X I <-> OU n X (orduni_normalise n I).
   Proof.
     split; intros H; [eapply @OU_reduction|eapply @OU_reduction with (I := orduni_normalise n I)].
-    all: eauto; cbn; eapply equiv_join.
+    all: trivial; cbn; eapply equiv_join.
     1, 3, 6, 8: rewrite eta₀_correct. all: reflexivity.
   Qed.
 

--- a/theories/HOU/unification/systemunification.v
+++ b/theories/HOU/unification/systemunification.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 Require Import List Lia.
 From Undecidability.HOU Require Import std.std calculus.calculus unification.higher_order_unification.
-Import ListNotations.
+Import ListNotations ListInstances ArsInstances.
 
 (* * System Unification *)
 Section SystemUnification.
@@ -40,7 +40,7 @@ Section SystemUnification.
   Lemma typing_combine Gamma E L:
     Gamma ⊢₊ left_side E : L -> Gamma ⊢₊ right_side E : L -> Gamma ⊢₊₊ E : L.
   Proof.
-    intros H1 H2; induction E in L, H1, H2 |-*; inv H1; inv H2; eauto.
+    intros H1 H2; induction E in L, H1, H2 |-*; inv H1; inv H2; trivial.
     destruct a; eauto.
   Qed.
 
@@ -86,7 +86,7 @@ Section SystemUnification.
   Lemma equiv_eqs_pointwise sigma E:
     (sigma •₊ left_side E) ≡₊ (sigma •₊ right_side E) -> (forall s t, (s, t) ∈ E -> sigma • s ≡ sigma • t).
   Proof.
-    induction E; cbn; intuition; subst.
+    induction E; cbn; intuition idtac; subst.
     all: eapply equiv_lstep_cons_inv in H; intuition.
   Qed.
 
@@ -95,8 +95,8 @@ Section SystemUnification.
     (forall s t, (s, t) ∈ E -> sigma • s ≡ sigma • t) ->
     (sigma •₊ left_side E) ≡₊ (sigma •₊ right_side E).
   Proof.
-    induction E as [| [s t]]; cbn; intros; eauto; intuition.
-    rewrite H; intuition.
+    induction E as [| [s t]]; cbn; intros; [eauto|].
+    rewrite H; intuition idtac.
     rewrite IHE; intuition.
   Qed.
 
@@ -116,7 +116,7 @@ Section SystemUnification.
     all_terms P (e :: E) -> P (fst e) /\ P (snd e) /\ all_terms P E.
   Proof.
     destruct e as [s t]; intros H; cbn.
-    specialize (H s t) as H'; cbn in H'; intuition.
+    specialize (H s t) as H'; cbn in H'; intuition idtac.
     intros ???; eapply H; cbn; intuition.
   Qed.
 
@@ -126,7 +126,7 @@ Section SystemUnification.
   Proof.
     unfold all_eqs; cbn; split.
     - eauto using all_terms_cons.
-    - intros (? & ? & ?) ? ? [->|H']; firstorder.
+    - intros (? & ? & ?) ? ? [->|H']; firstorder idtac.
   Qed.
 
   Hint Rewrite all_terms_cons_iff : simplify.
@@ -186,9 +186,9 @@ Section SystemUnification.
     Gamma ⊢₊ S : L -> Gamma ⊢ linearize_terms S : (Arr (rev L) A) → A.
   Proof.
     intros H; econstructor; eapply AppR_typing with (L := L).
-    eapply listtyping_preservation_under_renaming; eauto.
-    intros x ?; cbn; eauto.
-    econstructor; eauto; simplify; cbn; intuition.
+    eapply listtyping_preservation_under_renaming; [eassumption|..].
+    intros x ?; cbn; trivial.
+    econstructor; trivial; simplify; cbn; intuition.
   Qed.
 
 
@@ -197,9 +197,9 @@ Section SystemUnification.
   Proof.
     split.
     - intros ? H % vars_varof. inv H. eapply varof_vars in H1.
-      rewrite AppR_vars in H1. simplify in H1. cbn in H1; intuition.
+      rewrite AppR_vars in H1. simplify in H1. cbn in H1; intuition idtac.
       discriminate. eapply in_flat_map in H as [? []].
-      mapinj. eapply vars_ren in H0 as []. intuition.
+      mapinj. eapply vars_ren in H0 as []. intuition idtac.
       injection H1 as ->. eapply in_flat_map. eexists; eauto.
     - intros x H. eapply varof_vars; econstructor; eapply vars_varof.
       rewrite AppR_vars; simplify; right.
@@ -229,18 +229,18 @@ Section SystemUnification.
    Lemma U_SU: U X ⪯ SU.
    Proof.
      exists (uni_sysuni); intros I.
-     split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition.
-     firstorder; injection H; intros; subst; eauto.
+     split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; intuition idtac.
+     firstorder idtac; injection H; intros; subst; trivial.
      eapply H2; firstorder.
    Qed.
 
    Lemma SU_U: SU ⪯ U X.
    Proof.
      exists (sysuni_uni).
-     intros I; split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; destruct I; intuition;
+     intros I; split; intros (Delta & sigma & H1 & H2); exists Delta; exists sigma; destruct I; intuition idtac;
        cbn [sᵤ tᵤ sysuni_uni] in *.
      rewrite !linearize_terms_subst, linearize_terms_equiv. now apply equiv_pointwise_eqs.
-     eapply equiv_eqs_pointwise; eauto.
+     eapply equiv_eqs_pointwise; [|eassumption].
      now rewrite <-linearize_terms_equiv, <-!linearize_terms_subst.
    Qed.
 
@@ -272,12 +272,12 @@ Proof.
   split; intros (Delta & sigma & H1 & H2); [| exists Delta; exists sigma; intuition].
   eapply normalise_subst in H1 as (tau & H5 & H6 & H7).
   pose (theta x := if nth (@Gammaᵤ' _ I) x then tau x else var x).
-  exists Delta. exists theta. intuition.
+  exists Delta. exists theta. intuition idtac.
   + intros ???; unfold theta; rewrite H; eapply H7; eauto.
   + rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma).
-    rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); eauto.
+    rewrite subst_pointwise_equiv with (sigma := theta) (tau := sigma); [eauto|..].
     all: intros ? ?; enough (x ∈ dom Gammaᵤ') as D;
-      [domin D; unfold theta; rewrite D|]; eauto.
+      [domin D; unfold theta; rewrite D|]; [eauto|].
     all: eapply Vars_listtyping.
     2, 4: eapply in_flat_map; eexists; (intuition eauto).
     2: change t with (snd (s, t)); eapply in_map; eauto.

--- a/theories/LambdaCalculus/Reductions/wCBNclosed_to_KrivineMclosed_HALT.v
+++ b/theories/LambdaCalculus/Reductions/wCBNclosed_to_KrivineMclosed_HALT.v
@@ -7,11 +7,11 @@
 
 From Undecidability.LambdaCalculus Require Import
   wCBN Krivine Util.term_facts Util.wCBN_facts Util.Krivine_facts.
+Require Import List Relations.
 Import Undecidability.L.L (term, var, app, lam).
 Import Undecidability.L.Util.L_facts.
 Import wCBN (subst, step).
 
-Require Import Relations.
 Require Import ssreflect.
 
 Set Default Goal Selector "!".

--- a/theories/LambdaCalculus/Util/wCBN_facts.v
+++ b/theories/LambdaCalculus/Util/wCBN_facts.v
@@ -2,7 +2,7 @@ From Undecidability.LambdaCalculus Require Import wCBN Util.term_facts.
 Import L.L (term, var, app, lam).
 Require Import Undecidability.L.Util.L_facts.
 Import wCBN (subst, step, stepApp, stepLam).
-Require Import Relations.
+Require Import Relations Lia.
 Require Import ssreflect ssrbool ssrfun.
 
 Set Default Goal Selector "!".

--- a/theories/PCP/Util/PCP_facts.v
+++ b/theories/PCP/Util/PCP_facts.v
@@ -60,7 +60,7 @@ Proof. induction A; simpl; auto; rewrite app_ass; simpl; f_equal; auto. Qed.
 Definition card_eq : forall x y : card bool, {x = y} + {x <> y}.
 Proof.
   intros. repeat decide equality.
-Defined.
+Qed.
 
 Global Hint Rewrite (@tau1_app nat) (@tau2_app nat) (@tau1_cards nat) (@tau2_cards nat) : list.
 

--- a/theories/SeparationLogic/Reductions/FSATdc_to_MSLSAT.v
+++ b/theories/SeparationLogic/Reductions/FSATdc_to_MSLSAT.v
@@ -8,6 +8,7 @@ Import ListAutomationNotations.
 
 From Undecidability.Shared Require Import Dec.
 Require Import Undecidability.Synthetic.DecidabilityFacts.
+Import ListInstances.
 
 Set Default Goal Selector "!".
 

--- a/theories/Shared/ListAutomation.v
+++ b/theories/Shared/ListAutomation.v
@@ -16,8 +16,7 @@ Module ListAutomationNotations.
 End ListAutomationNotations.
 Import ListAutomationNotations.
 
-#[global]
-Instance list_in_dec X (x : X) (A : list X) :
+#[local] Instance list_in_dec X (x : X) (A : list X) :
   eq_dec X -> dec (x el A).
 Proof.
   intros D. apply in_dec. exact D.
@@ -88,8 +87,8 @@ Lemma incl_nil X (A : list X) :
   nil <<= A.
 Proof. intros x []. Qed.
 
-Global Hint Rewrite <- app_assoc : list.
-Global Hint Rewrite rev_app_distr map_app prod_length : list.
+#[export] Hint Rewrite <- app_assoc : list.
+#[export] Hint Rewrite rev_app_distr map_app prod_length : list.
 #[export] Hint Resolve in_eq in_nil in_cons in_or_app : core.
 #[export] Hint Resolve incl_refl incl_tl incl_cons incl_appl incl_appr incl_app incl_nil : core.
 
@@ -170,8 +169,7 @@ End Inclusion.
 
 Require Import Setoid Morphisms.
 
-#[global]
-Instance incl_preorder X : 
+#[local] Instance incl_preorder X : 
   PreOrder (@incl X).
 Proof.
   constructor; hnf; unfold incl; auto. 
@@ -181,59 +179,64 @@ Definition equi X (A B : list X) : Prop := incl A B /\ incl B A.
 Local Notation "A === B" := (equi A B) (at level 70).
 #[export] Hint Unfold equi : core.
 
-#[global]
-Instance equi_Equivalence X : 
+#[local] Instance equi_Equivalence X : 
   Equivalence (@equi X).
 Proof. 
   constructor; hnf; firstorder. 
 Qed.
 
-#[global]
-Instance incl_equi_proper X : 
+#[local] Instance incl_equi_proper X : 
   Proper (@equi X ==> @equi X ==> iff) (@incl X).
 Proof. 
   hnf. intros A B D. hnf. firstorder. 
 Qed.
 
-#[global]
-Instance cons_incl_proper X x : 
+#[local] Instance cons_incl_proper X x : 
   Proper (@incl X ==> @incl X) (@cons X x).
 Proof.
   hnf. apply incl_shift.
 Qed.
 
-#[global]
-Instance cons_equi_proper X x : 
+#[local] Instance cons_equi_proper X x : 
   Proper (@equi X ==> @equi X) (@cons X x).
 Proof. 
   hnf. firstorder.
 Qed.
 
-#[global]
-Instance in_incl_proper X x : 
+#[local] Instance in_incl_proper X x : 
   Proper (@incl X ==> Basics.impl) (@In X x).
 Proof.
   intros A B D. hnf. auto.
 Qed.
 
-#[global]
-Instance in_equi_proper X x : 
+#[local] Instance in_equi_proper X x : 
   Proper (@equi X ==> iff) (@In X x).
 Proof. 
   intros A B D. firstorder. 
 Qed.
 
-#[global]
-Instance app_incl_proper X : 
+#[local] Instance app_incl_proper X : 
   Proper (@incl X ==> @incl X ==> @incl X) (@app X).
 Proof. 
   intros A B D A' B' E. auto.
 Qed.
 
-#[global]
-Instance app_equi_proper X : 
+#[local] Instance app_equi_proper X : 
   Proper (@equi X ==> @equi X ==> @equi X) (@app X).
 Proof. 
   hnf. intros A B D. hnf. intros A' B' E.
   destruct D, E; auto.
 Qed.
+
+Module ListInstances.
+#[export] Existing Instance list_in_dec.
+#[export] Existing Instance incl_preorder.
+#[export] Existing Instance equi_Equivalence.
+#[export] Existing Instance incl_equi_proper.
+#[export] Existing Instance cons_incl_proper.
+#[export] Existing Instance cons_equi_proper.
+#[export] Existing Instance in_incl_proper.
+#[export] Existing Instance in_equi_proper.
+#[export] Existing Instance app_incl_proper.
+#[export] Existing Instance app_equi_proper.
+End ListInstances.

--- a/theories/StringRewriting/Reductions/SR_to_PCSnf.v
+++ b/theories/StringRewriting/Reductions/SR_to_PCSnf.v
@@ -5,6 +5,7 @@ Require Import Undecidability.StringRewriting.PCSnf.
 Require Import Undecidability.StringRewriting.SR.
 Require Import Undecidability.StringRewriting.Util.Definitions.
 Require Import Undecidability.Shared.ListAutomation.
+Import ListInstances.
 
 Lemma derv_trans X R x y z :
     @derv X R x y -> derv R y z -> derv R x z.

--- a/theories/StringRewriting/Util/Definitions.v
+++ b/theories/StringRewriting/Util/Definitions.v
@@ -1,7 +1,7 @@
 Require Import Undecidability.StringRewriting.SR.
 Require Import Undecidability.Shared.ListAutomation.
 Require Import Setoid Morphisms Lia.
-Import ListAutomationNotations.
+Import ListAutomationNotations ListInstances.
 Local Set Implicit Arguments.
 Local Unset Strict Implicit.
 

--- a/theories/Synthetic/Infinite.v
+++ b/theories/Synthetic/Infinite.v
@@ -152,7 +152,7 @@ Section Inf.
     exists (f (mu' H1 H2)). split; try apply proj2_sig.
     intros y Hy. exists (mu' H1 H2). split; trivial.
     intros n <-. apply mu_least, Hy.
-  Defined.
+  Qed.
 
   Definition gen' A :=
     proj1_sig (gen A).

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -683,7 +683,6 @@ HOU/concon/conservativity_consequences.v
 HOU/concon/constants.v
 HOU/concon/constants_consequences.v
 HOU/concon/enumerability.v
-HOU/concon/concon.v
 
 FOLP/Util/axioms.v
 FOLP/Util/unscoped.v


### PR DESCRIPTION
This PR conservatively improves `HOU` compilation speed by better goal and side effect management.
It removes a lot of superfluous implicit `auto with *`.
Only imports and proofs are adjusted, no statement is changed.