### PR TITLE
Prepare to use MetaCoq 1.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   OCAML_VERSION: 4.07.1+flambda
-  CACHE_KEY: opam-flambda-8.15-metacoqrepo-${{github.base_ref}}-${{github.ref}} 
+  CACHE_KEY: opam-flambda-8.15-metacoqpre-${{github.base_ref}}-${{github.ref}} 
 jobs:
   build-deps:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         path: "~/.opam"
         key: ${{env.CACHE_KEY}}
         restore-keys: |
-          opam-flambda-8.15-metacoqrepo--refs/heads/${{github.base_ref}}
+          opam-flambda-8.15-metacoqpre--refs/heads/${{github.base_ref}}
 
     - name: Install OCaml
       if: steps.cache.outputs.cache-hit != 'true'
@@ -37,7 +37,7 @@ jobs:
         opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
         opam update
         opam upgrade
-        opam pin add -n -y -k git coq-metacoq-template.dev+8.15 "https://github.com/MetaCoq/metacoq.git#9493bb6"
+        opam pin add -n -y -k git coq-metacoq-template.dev+8.15 "https://github.com/MetaCoq/metacoq.git#f170ec6"
         opam install . --deps-only --with-doc --with-test 
         opam list --installed
   

--- a/theories/L/Tactics/GenEncode.v
+++ b/theories/L/Tactics/GenEncode.v
@@ -1,10 +1,10 @@
 From Undecidability.L Require Import L Tactics.Computable Tactics.ComputableTactics Tactics.Extract.
 From MetaCoq Require Import Template.All TemplateMonad.Core Template.Ast.
-Require Import String List.
-Export String.StringSyntax.
+Require Import List.
+From MetaCoq Require Export bytestring.
 
 Import MCMonadNotation.
-Local Open Scope string_scope.
+Local Open Scope bs.
 
 (* *** Generation of encoding functions *)
 
@@ -77,7 +77,7 @@ Definition tmGenEncode (n : ident) (A : Type) : TemplateMonad (encodable A) :=
   n4 <- tmEval cbv (n ++ "_correct") ;;
   Core.tmBind (tmMatchCorrect A) (fun m' => tmLemma n4 m';;ret d).
 
-Arguments tmGenEncode _%string _%type.
+Arguments tmGenEncode _%bs _%type.
 
 Definition tmGenEncodeInj (n : ident) (A : Type) : TemplateMonad unit :=
   d <- tmGenEncode n A;;
@@ -87,7 +87,7 @@ Definition tmGenEncodeInj (n : ident) (A : Type) : TemplateMonad unit :=
   d <- tmInstanceRed n3 None i;;
   ret tt.
 
-Arguments tmGenEncodeInj _%string _%type.
+Arguments tmGenEncodeInj _%bs _%type.
 
 
 (*

--- a/theories/L/Util/L_facts.v
+++ b/theories/L/Util/L_facts.v
@@ -386,7 +386,7 @@ Qed.
 
 (* Equivalence *)
 
-Reserved Notation "s '==' t" (at level 50).
+Reserved Notation "s '==' t" (at level 70).
 
 Inductive equiv : term -> term -> Prop :=
   | eqStep s t : step s t -> s == t


### PR DESCRIPTION
MetaCoq has a 1.0 release, which is currently integrated into the `opam` archive. This PR ports our library to be compatible with the code changes in the release.