### PR TITLE
add computableTime instance for Nat.sqrt

### DIFF
--- a/theories/L/Datatypes/LNat.v
+++ b/theories/L/Datatypes/LNat.v
@@ -148,6 +148,25 @@ Proof.
   - unfold sub_time. rewrite Nat.le_min_l. unfold modulo_time, c__modulo. solverec. 
 Qed. 
 
+Definition c__sqrt_iter := 5.
+Definition sqrt_iter_time (k p q r: nat) := 4 + 20 * k.
+#[global] Instance termT_sqrt_iter:
+  computableTime' Init.Nat.sqrt_iter
+  (fun k _ => (c__sqrt_iter, (fun p _ => (1, (fun q _ => (1, (fun r _ => (sqrt_iter_time k p q r, tt)))))))).
+Proof.
+  extract; solverec; try solve [reflexivity].
+  all: unfold sqrt_iter_time, c__sqrt_iter.
+  - now ring_simplify.
+  - lia.
+Qed.
+
+Definition sqrt_time n := c__sqrt_iter + sqrt_iter_time n 0 0 0 + 3.
+#[global] Instance termT_sqrt:
+  computableTime' Init.Nat.sqrt (fun n _ => (sqrt_time n, tt)).
+Proof.
+  extract. solverec. reflexivity.
+Qed.
+
 (* now some more encoding-related properties:*)
 
 Fixpoint nat_unenc (s : term) :=


### PR DESCRIPTION
Are `computableTime` instances for common functions useful in context of this library?