### PR TITLE
No warnings for Coq 8.18

### DIFF
--- a/theories/FOL/Deduction/FragmentNDFacts.v
+++ b/theories/FOL/Deduction/FragmentNDFacts.v
@@ -126,7 +126,7 @@ Section ND_def.
 
   Lemma big_imps_nil A phi : A ⊢ phi <-> [] ⊢ (impl A phi).
   Proof.
-    specialize (big_imps A nil phi). rewrite <- (app_nil_end). easy.
+    specialize (big_imps A nil phi). rewrite app_nil_r. easy.
   Qed.
 
   Lemma subst_forall_prv phi {N Gamma} :

--- a/theories/FOL/TRAKHTENBROT/BPCP_SigBPCP.v
+++ b/theories/FOL/TRAKHTENBROT/BPCP_SigBPCP.v
@@ -63,7 +63,7 @@ Section BPCP_FIN_DEC_EQ_SAT.
   Local Fact fot_vars_lb_app l t : fo_term_vars (l⤜t) = fo_term_vars t.
   Proof.
     induction l as [ | x l IHl ]; simpl; rew fot; auto.
-    simpl; rewrite <- app_nil_end; auto.
+    simpl; rewrite app_nil_r; auto.
   Qed.
 
   Notation lb2term := (fun l => l⤜e).
@@ -221,8 +221,8 @@ Section BPCP_FIN_DEC_EQ_SAT.
     Let fot_sem_lb_app_e lb φ (H : length lb < S n) : ⟦lb⤜e⟧ φ = Some (exist _ lb H).
     Proof.
       revert H.
-      rewrite (app_nil_end lb); intros H.
-      rewrite <- app_nil_end at 1. 
+      rewrite <- (app_nil_r lb); intros H.
+      rewrite app_nil_r at 1. 
       apply fot_sem_lb_app_Some with (Ht := Nat.lt_0_succ _).
       rew fot; simpl; auto.
     Qed.
@@ -258,7 +258,7 @@ Section BPCP_FIN_DEC_EQ_SAT.
             simpl in H4; do 2 rewrite app_length in H4; lia.
         * clear H1 H3; revert H2 H4.
           intros (a & <-) (b & <-).
-          exists (b++a); rewrite app_ass; auto.
+          exists (b++a); rewrite <- app_assoc; auto.
     Qed.
 
     Let sem_phi_eq : ⟪ phi_eq ⟫ φ0.

--- a/theories/FOL/TRAKHTENBROT/Sig1_1.v
+++ b/theories/FOL/TRAKHTENBROT/Sig1_1.v
@@ -494,7 +494,7 @@ Section Σfull_mon_rem.
       destruct (H x); simpl; auto.
     + simpl.
       rewrite Σfull_mon_rec_syms, fol_syms_mquant.
-      rewrite fol_syms_bigop, <- app_nil_end; simpl.
+      rewrite fol_syms_bigop, app_nil_r; simpl.
       intros x; rewrite in_flat_map.
       intros (u & H & Hu); revert H.
       rewrite in_map_iff.

--- a/theories/FOL/TRAKHTENBROT/Sig_discernable.v
+++ b/theories/FOL/TRAKHTENBROT/Sig_discernable.v
@@ -269,7 +269,7 @@ Section discriminable_implies_FSAT_DEC.
       2: destruct (C s); auto.
       revert IH Ht; vec split v with a; vec nil v; intros IH Ht.
       simpl in Ht |- *.
-      rewrite <- app_nil_end in Ht.
+      rewrite app_nil_r in Ht.
       specialize (IH pos0); simpl in IH.
       assert (undiscernable x s) as Hxs by (apply Hδ; auto).
       rewrite IH.
@@ -293,7 +293,7 @@ Section discriminable_implies_FSAT_DEC.
         fol equiv.
         rewrite vec_map_map.
         clear Hy2.
-        revert G1; vec split v with a; vec nil v; simpl; rewrite <- app_nil_end; intros G1.
+        revert G1; vec split v with a; vec nil v; simpl; rewrite app_nil_r; intros G1.
         f_equal; apply term_equal; auto.
       + apply incl_app_inv in G1 as [].
         apply incl_app_inv in G2 as [].

--- a/theories/FOL/TRAKHTENBROT/fo_congruence.v
+++ b/theories/FOL/TRAKHTENBROT/fo_congruence.v
@@ -68,7 +68,7 @@ Section fol_congruence.
     Proof. simpl; f_equal; rewrite H_ae; simpl; auto. Qed.
 
     Let fol_syms_e x y : fol_syms (x ≡ y) = fo_term_syms x ++ fo_term_syms y.
-    Proof. simpl; rewrite H_ae; simpl; auto; rewrite <- app_nil_end; auto. Qed.
+    Proof. simpl; rewrite H_ae; simpl; auto; rewrite app_nil_r; auto. Qed.
 
     Let fol_rels_e x y : fol_rels (x ≡ y) = e::nil.
     Proof. auto. Qed.
@@ -367,7 +367,7 @@ Section fol_congruence.
     Fact fol_congruence_syms : fol_syms fol_congruence ⊑ ls.
     Proof.
       unfold fol_congruence.
-      rewrite fol_syms_bin, fol_equivalence_syms, <- app_nil_end.
+      rewrite fol_syms_bin, fol_equivalence_syms, app_nil_r.
       apply fol_congruent_syms.
     Qed.
 

--- a/theories/FOL/TRAKHTENBROT/fo_definable.v
+++ b/theories/FOL/TRAKHTENBROT/fo_definable.v
@@ -180,14 +180,14 @@ Section fo_definability.
     set (f := fun k Hk => proj1_sig (H k Hk)).
     exists (fol_lconj (list_in_map l f)); msplit 2. 
     + rewrite fol_syms_bigop.
-      intros s; simpl; rewrite <- app_nil_end.
+      intros s; simpl; rewrite app_nil_r.
       rewrite in_flat_map.
       intros (A & H1 & H2).
       apply In_list_in_map_inv in H1.
       destruct H1 as (k & Hk & ->).
       revert H2; apply (proj2_sig (H k Hk)); auto.
     + rewrite fol_rels_bigop.
-      intros s; simpl; rewrite <- app_nil_end.
+      intros s; simpl; rewrite app_nil_r.
       rewrite in_flat_map.
       intros (A & H1 & H2).
       apply In_list_in_map_inv in H1.
@@ -224,14 +224,14 @@ Section fo_definability.
     set (f := fun k Hk => proj1_sig (H k Hk)).
     exists (fol_ldisj (list_in_map l f)); msplit 2. 
     + rewrite fol_syms_bigop.
-      intros s; simpl; rewrite <- app_nil_end.
+      intros s; simpl; rewrite app_nil_r.
       rewrite in_flat_map.
       intros (A & H1 & H2).
       apply In_list_in_map_inv in H1.
       destruct H1 as (k & Hk & ->).
       revert H2; apply (proj2_sig (H k Hk)); auto.
     + rewrite fol_rels_bigop.
-      intros s; simpl; rewrite <- app_nil_end.
+      intros s; simpl; rewrite app_nil_r.
       rewrite in_flat_map.
       intros (A & H1 & H2).
       apply In_list_in_map_inv in H1.

--- a/theories/FOL/TRAKHTENBROT/fo_logic.v
+++ b/theories/FOL/TRAKHTENBROT/fo_logic.v
@@ -171,7 +171,7 @@ Section fol_subst.
       rewrite fo_term_vars_map; rew fot.
       rewrite flat_map_concat_map, map_map.
       rewrite <- flat_map_concat_map.
-      rewrite <- app_nil_end.
+      rewrite app_nil_r.
       rewrite flat_map_single, map_id; auto.
   Qed.
 
@@ -221,19 +221,19 @@ Section fol_subst.
   Fact fol_vars_bigop c l A : fol_vars (fol_bigop c A l) = flat_map fol_vars l++fol_vars A.
   Proof.
     induction l; simpl; auto.
-    rewrite app_ass; f_equal; auto.
+    rewrite <- app_assoc; f_equal; auto.
   Qed.
 
   Fact fol_syms_bigop c l A : fol_syms (fol_bigop c A l) = flat_map fol_syms l++fol_syms A.
   Proof. 
     induction l; simpl; auto.
-    rewrite app_ass; f_equal; auto.
+    rewrite <- app_assoc; f_equal; auto.
   Qed.
 
   Fact fol_rels_bigop c l A : fol_rels (fol_bigop c A l) = flat_map fol_rels l++fol_rels A.
   Proof. 
     induction l; simpl; auto.
-    rewrite app_ass; f_equal; auto.
+    rewrite <- app_assoc; f_equal; auto.
   Qed.
 
   Fact fol_subst_bigop c l A σ : (fol_bigop c A l)⦃σ⦄ = fol_bigop c (A⦃σ⦄) (map (fol_subst σ) l).
@@ -270,7 +270,7 @@ Section fol_subst.
       rewrite IHn; simpl fol_vars; rewrite flat_map_flat_map.
       do 2 rewrite flat_map_concat_map; f_equal; apply map_ext.
       intros [ | a ]; auto; simpl flat_map.
-      rewrite <- app_nil_end.
+      rewrite app_nil_r.
       destruct (le_lt_dec n a); destruct (le_lt_dec (S n) (S a)); auto; lia.
   Qed.
  
@@ -454,19 +454,19 @@ Section fol_semantics.
   Fact fol_vars_vec_fa n A : fol_vars (@fol_vec_fa n A) = flat_map (@fol_vars _) (vec_list A).
   Proof.
     unfold fol_vec_fa; rewrite fol_vars_bigop; simpl.
-    rewrite app_nil_end; auto. 
+    rewrite app_nil_r; auto. 
   Qed.
 
   Fact fol_syms_vec_fa n A : fol_syms (@fol_vec_fa n A) = flat_map (@fol_syms _) (vec_list A).
   Proof.
     unfold fol_vec_fa; rewrite fol_syms_bigop; simpl.
-    rewrite app_nil_end; auto. 
+    rewrite app_nil_r; auto.
   Qed.
 
   Fact fol_rels_vec_fa n A : fol_rels (@fol_vec_fa n A) = flat_map (@fol_rels _) (vec_list A).
   Proof.
     unfold fol_vec_fa; rewrite fol_rels_bigop; simpl.
-    rewrite app_nil_end; auto. 
+    rewrite app_nil_r; auto.
   Qed.
  
   Fact fol_sem_vec_fa n A φ : ⟪@fol_vec_fa n A⟫ φ <-> forall p, ⟪vec_pos A p⟫ φ.

--- a/theories/FOL/TRAKHTENBROT/fo_terms.v
+++ b/theories/FOL/TRAKHTENBROT/fo_terms.v
@@ -256,7 +256,7 @@ Section fo_term_extra.
          fo_term_vars (t⟬f⟭) = flat_map (fun n => fo_term_vars (f n)) (fo_term_vars t).
   Proof.
     induction t as [ n | s v IHv ]; rew fot; auto.
-    + simpl; rewrite <- app_nil_end; auto.
+    + simpl; rewrite app_nil_r; auto.
     + rewrite vec_list_vec_map.
       rewrite flat_map_flat_map.
       rewrite flat_map_concat_map, map_map, <- flat_map_concat_map.

--- a/theories/FRACTRAN/FRACTRAN/mm_fractran.v
+++ b/theories/FRACTRAN/FRACTRAN/mm_fractran.v
@@ -73,7 +73,7 @@ Fixpoint encode_mm_instr m i (l : list (mm_instr (pos m))) : list (nat * nat) :=
 
 Fact encode_mm_instr_app m i l r : @encode_mm_instr m i (l++r) = encode_mm_instr i l++encode_mm_instr (length l+i) r.
 Proof.
-  revert i; induction l as [ | rho l IHl ]; intros i; simpl; auto; rewrite IHl, app_ass.
+  revert i; induction l as [ | rho l IHl ]; intros i; simpl; auto; rewrite IHl, <- app_assoc.
   do 3 f_equal; lia.
 Qed.
 

--- a/theories/ILL/Ll/eill.v
+++ b/theories/ILL/Ll/eill.v
@@ -66,7 +66,7 @@ Proof.
     rewrite map_map.
     apply in_ill1_bang_l.
     apply in_ill1_perm with (((£ a ⊸ £ p) ⊸ £ q) :: ((map (fun c => !⦑c⦒) Si ++ map £ Ga) ++ nil)).
-    * rewrite <- app_nil_end; auto.
+    * rewrite app_nil_r; auto.
     * apply in_ill1_limp_l.
       2: apply in_ill1_ax.
       apply in_ill1_limp_r.
@@ -81,19 +81,19 @@ Proof.
     apply in_ill1_perm with (£ p ⊸ £ q ⊸ £ r :: (map (fun c => !⦑c⦒) Si ++ map £ Ga) 
                                              ++ (map (fun c => !⦑c⦒) Si ++ map £ De)).
     * apply Permutation_cons; auto.
-      rewrite app_ass; apply Permutation_app; auto.
-      do 2 rewrite <- app_ass; apply Permutation_app; auto.
+      rewrite <- app_assoc; apply Permutation_app; auto.
+      do 2 rewrite app_assoc; apply Permutation_app; auto.
       apply Permutation_app_comm.
     * apply in_ill1_limp_l; auto.
       apply in_ill1_perm with (£ q ⊸ £ r :: ((map (fun c => !⦑c⦒) Si ++ map £ De) ++ nil)).
-      - rewrite <- app_nil_end; auto.
+      - rewrite app_nil_r; auto.
       - apply in_ill1_limp_l; auto.
         apply in_ill1_ax.
   + rewrite <- map_map; apply S_ill_restr_weak_cntr with (1 := in_map _ _ _ H1); simpl.
     rewrite map_map.
     apply in_ill1_bang_l.
     apply in_ill1_perm with (£ p & £ q ⊸ £ r :: ((map (fun c => !⦑c⦒) Si ++ map £ Ga) ++ nil)).
-    * rewrite <- app_nil_end; auto.
+    * rewrite app_nil_r; auto.
     * apply in_ill1_limp_l.
       - apply in_ill1_with_r; auto.
       - apply in_ill1_ax.

--- a/theories/ILL/Ll/eill_mm.v
+++ b/theories/ILL/Ll/eill_mm.v
@@ -347,7 +347,7 @@ Section Minsky.
     + intros H1 H2.
       rewrite vec_pos_plus in H1.
       apply in_geill_perm with (vec_map_list v rx ++ vec_map_list w rx ++ Ga).
-      rewrite vec_map_list_plus, app_ass; auto.
+      rewrite vec_map_list_plus, <- app_assoc; auto.
       apply Hv.
       lia.
       apply Hw; auto; lia.
@@ -357,7 +357,7 @@ Section Minsky.
            vec_pos v p = 0 
         -> Σ; vec_map_list v rx ⊦ ry p.
   Proof.
-    rewrite (app_nil_end (_ _ rx)).
+    rewrite <- (app_nil_r (_ _ rx)).
     intros H.
     apply g_eill_mono_Si with Σ0.
     unfold Σ; intros ? ?; apply in_or_app; left; auto.

--- a/theories/ILL/Reductions/ndMM2_IMSELL.v
+++ b/theories/ILL/Reductions/ndMM2_IMSELL.v
@@ -118,16 +118,16 @@ Section ndmm2_imsell.
   Proof.
     unfold ndmm2_imsell_ctx.
     apply Permutation_sym, perm_trans with (1 := Permutation_cons_append _ _).
-    rewrite !app_ass; apply Permutation_app; auto.
+    rewrite <- !app_assoc; apply Permutation_app; auto.
     simpl; apply Permutation_sym, perm_trans with (1 := Permutation_cons_append _ _).
-    now rewrite app_ass.
+    now rewrite <- app_assoc.
   Qed.
 
   Fact ndmm2_imsell_perm2 Σ x y : ⟬Σ,x,1+y⟭ ~p β::⟬Σ,x,y⟭ .
   Proof.
     unfold ndmm2_imsell_ctx.
     apply Permutation_sym, perm_trans with (1 := Permutation_cons_append _ _).
-    rewrite !app_ass; repeat apply Permutation_app; auto.
+    rewrite <- !app_assoc; repeat apply Permutation_app; auto.
     simpl; apply Permutation_sym, perm_trans with (1 := Permutation_cons_append _ _); auto.
   Qed.
 
@@ -138,7 +138,7 @@ Section ndmm2_imsell.
         ->  ⟬Σ,x,y⟭  ⊢ A 
        <-> ![∞]⟬c⟭ :: ⟬Σ,x,y⟭  ++ nil ⊢ A.
   Proof using Hi.
-    intros H; rewrite <- app_nil_end.
+    intros H; rewrite app_nil_r.
     apply S_imsell_extract; auto.
     apply in_app_iff; left.
     apply in_map_iff.
@@ -161,7 +161,7 @@ Section ndmm2_imsell.
       apply in_imsell_bang_l, in_imsell_limp_l; auto.
       apply in_imsell_limp_r.
       apply in_imsell_perm with (1 := Permutation_sym (Permutation_cons_append _ _)).
-      unfold ndmm2_imsell_ctx; simpl; rewrite <- app_nil_end.
+      unfold ndmm2_imsell_ctx; simpl; rewrite app_nil_r.
       apply S_imsell_gen_weak; auto.
 
     + apply ndmm2_imsell_weak with (1 := H1); simpl.
@@ -177,17 +177,17 @@ Section ndmm2_imsell.
     + apply ndmm2_imsell_weak with (1 := H1); simpl.
       apply in_imsell_bang_l.
       apply in_imsell_perm with (Γ := α⊸⌊q⌋⊸⌊p⌋ :: (α::nil) ++ ⟬Σ,x,y⟭).
-      * apply Permutation_sym, perm_skip; rewrite <- app_nil_end; simpl; auto.
+      * apply Permutation_sym, perm_skip; rewrite app_nil_r; simpl; auto.
       * apply in_imsell_limp_l; auto.
-        rewrite app_nil_end with (l := ⟬_,_,_⟭).
+        rewrite <- app_nil_r with (l := ⟬_,_,_⟭).
         apply in_imsell_limp_l; auto.
 
     + apply ndmm2_imsell_weak with (1 := H1); simpl.
       apply in_imsell_bang_l.
       apply in_imsell_perm with (Γ := β⊸⌊q⌋⊸⌊p⌋ :: (β::nil) ++ ⟬Σ,x,y⟭).
-      * apply Permutation_sym, perm_skip; rewrite <- app_nil_end; simpl; auto.
+      * apply Permutation_sym, perm_skip; rewrite app_nil_r; simpl; auto.
       * apply in_imsell_limp_l; auto.
-        rewrite app_nil_end with (l := ⟬_,_,_⟭).
+        rewrite <- app_nil_r with (l := ⟬_,_,_⟭).
         apply in_imsell_limp_l; auto.
 
     + apply ndmm2_imsell_weak with (1 := H1); simpl.
@@ -205,7 +205,7 @@ Section ndmm2_imsell.
       rewrite ndmm2_imsell_eq2 in IH2 |- *.
       apply in_imsell_bang_r; auto.
       intros (v,A); simpl. 
-      rewrite <- app_nil_end, in_app_iff, in_map_iff.
+      rewrite app_nil_r, in_app_iff, in_map_iff.
       intros [ (? & HvA & ?) | HvA ].
       * now inversion HvA; subst.
       * now apply repeat_spec in HvA; inversion HvA.

--- a/theories/L/Tactics/Extract.v
+++ b/theories/L/Tactics/Extract.v
@@ -179,7 +179,7 @@ Definition tmArgsOfConstructor ind i :=
 
 (*  Classes for computable terms and (Scott-) encodable types *)
 
-Class extracted {A : Type} (a : A) := int_ext : L.term.
+Class extracted {A : Type} (a : A) : Set := int_ext : L.term.
 Arguments int_ext {_} _ {_}.
 #[export] Typeclasses Transparent extracted. (* This is crucial to use this inside monads  *)
 #[export] Hint Extern 0 (extracted _) => progress (cbn [Common.my_projT1]): typeclass_instances. 

--- a/theories/MinskyMachines/MMenv/mme_utils.v
+++ b/theories/MinskyMachines/MMenv/mme_utils.v
@@ -386,7 +386,7 @@ Section mm_env_utils.
             revert G2; apply subcode_sss_progress; auto.
           - replace (9*S k+i) with (9*k+(9+i)) by lia.
             revert G5; apply subcode_sss_compute.
-            subcode_tac; rewrite <- app_nil_end; auto.
+            subcode_tac; rewrite app_nil_r; auto.
     Qed.
 
   End mm_multi_copy.
@@ -420,7 +420,7 @@ Section mm_env_utils.
         * mm env INC with dst.
           replace (S (n+i)) with (n+(1+i)) by lia.
           revert H2; apply subcode_sss_compute.
-          subcode_tac; simpl; rewrite <- app_nil_end; auto.
+          subcode_tac; simpl; rewrite app_nil_r; auto.
     Qed.
 
     Definition mm_set n i := mm_erase dst zero i ++ mm_incs n.

--- a/theories/MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MM2_to_ndMM2_ACCEPT.v
@@ -47,7 +47,7 @@ Section MM2_ndMM2.
   Fact mm2_linstr_enc_app i l m : mm2_linstr_enc i (l++m) = mm2_linstr_enc i l ++ mm2_linstr_enc (length l+i) m.
   Proof.
     revert i; induction l as [ | ? l IHl ]; intros ?; simpl; auto.
-    rewrite app_ass, IHl; do 3 f_equal; auto.
+    rewrite <- app_assoc, IHl; do 3 f_equal; auto.
   Qed.
 
   Fact mm2_linstr_enc_In i P c : 

--- a/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
+++ b/theories/MinskyMachines/Reductions/MMA2_to_ndMM2_ACCEPT.v
@@ -63,7 +63,7 @@ Section MMA2_ndMM2.
   Fact mma2_linstr_enc_app i l m : ⟪i,l++m⟫ₗ = ⟪i,l⟫ₗ ++ ⟪length l+i,m⟫ₗ.
   Proof.
     revert i; induction l as [ | ? l IHl ]; intros ?; simpl; auto.
-    rewrite app_ass, IHl; do 3 f_equal; auto.
+    rewrite <- app_assoc, IHl; do 3 f_equal; auto.
   Qed.
 
   Fact mma2_linstr_enc_In i P c : 

--- a/theories/MuRec/Util/ra_mm_env.v
+++ b/theories/MuRec/Util/ra_mm_env.v
@@ -203,7 +203,7 @@ Section ra_compiler.
             ++ rew length.
                revert G5; rewrite Nat.add_assoc, (Nat.add_comm _ (length _)).
                apply subcode_sss_compute.
-               subcode_tac; rewrite <- app_nil_end; auto.
+               subcode_tac; rewrite app_nil_r; auto.
         * intros v e H3 H4 H5.
           assert ((i,P) // (i,e) ↓) as H6.
           { apply subcode_sss_terminates with (2 := H3); auto. }
@@ -220,7 +220,7 @@ Section ra_compiler.
              * split; simpl; auto; lia. }
             destruct H7 as (st & H7 & H8).
             assert ( (length P+i,Q) <sc (i,P++Q) ) as H9.
-            { subcode_tac; rewrite <- app_nil_end; auto. }
+            { subcode_tac; rewrite app_nil_r; auto. }
             destruct subcode_sss_compute_inv 
               with (P := (length P+i,Q)) (3 := H7)
               as (st2 & F1 & _ & F2); auto.
@@ -701,7 +701,7 @@ Section ra_compiler.
           replace (length Q1+(length F+(length Q2+length Q3))+i)
              with (2*(2+n)+(23+length F+length G+9*n+i)).
           revert F22; apply subcode_sss_compute; auto.
-          unfold Q3; subcode_tac; rewrite <- app_nil_end; auto.
+          unfold Q3; subcode_tac; rewrite app_nil_r; auto.
           rewrite Q1_length, Q2_length, Q3_length; lia.
           rewrite Q2_length; unfold s2; lia. }
     Qed.
@@ -749,7 +749,7 @@ Section ra_compiler.
         1: unfold s2; auto.
         apply subcode_sss_terminates_inv with (P := (i,Q1++F)) (2 := G3); auto.
         1: apply mm_sss_env_fun.
-        1: rewrite <- app_ass; apply subcode_left; auto.
+        1: rewrite app_assoc; apply subcode_left; auto.
         split.
         + rewrite Q1_length.
           replace s2 with (length F+(11+9*n+i)).
@@ -1077,7 +1077,7 @@ Section ra_compiler.
           unfold s4, s1; lia. }
         { replace (length Q4+i) with (2*(1+n)+(9+s4)).
           unfold Q4; revert F5; apply subcode_sss_compute; auto.
-          unfold s4; subcode_tac; rewrite <- app_nil_end; auto.
+          unfold s4; subcode_tac; rewrite app_nil_r; auto.
           unfold s4, Q4; rew length; lia. }
     Qed.
 

--- a/theories/PCP/Util/PCP_facts.v
+++ b/theories/PCP/Util/PCP_facts.v
@@ -62,10 +62,10 @@ Qed.
 
 
 Lemma itau1_app {X : Type} {P : stack X} A B : itau1 P (A++B) = itau1 P A ++ itau1 P B.
-Proof. induction A; simpl; auto; rewrite app_ass; simpl; f_equal; auto. Qed.
+Proof. induction A; simpl; auto; rewrite <- app_assoc; simpl; f_equal; auto. Qed.
 
 Lemma itau2_app {X : Type} {P : stack X} A B : itau2 P (A++B) = itau2 P A ++ itau2 P B.
-Proof. induction A; simpl; auto; rewrite app_ass; simpl; f_equal; auto. Qed.
+Proof. induction A; simpl; auto; rewrite <- app_assoc; simpl; f_equal; auto. Qed.
 
 Definition card_eq : forall x y : card bool, {x = y} + {x <> y}.
 Proof.

--- a/theories/Shared/Libs/DLW/Code/compiler.v
+++ b/theories/Shared/Libs/DLW/Code/compiler.v
@@ -105,7 +105,7 @@ Section linker.
     destruct P as (iP,lP).
     rewrite H; simpl in H |- *.
     destruct mm as [ | x mm ].
-    * rewrite <- app_nil_end.
+    * rewrite app_nil_r.
       solve eq nat dec.
     * rew length.
       dest eq nat dec as [ H1 | H1 ]; [ lia | clear H1 ].
@@ -168,7 +168,7 @@ Section linker.
       rewrite <- E; auto; f_equal; lia. }
     assert (linker (1+j) = lc x + linker j) as HSj.
     {  generalize (linker_app (l++x::nil) r).
-      rewrite HP, app_ass; simpl; intros H3.
+      rewrite HP, <- app_assoc; simpl; intros H3.
       specialize (H3 H1).
       eq goal H3; f_equal.
       f_equal.
@@ -190,7 +190,7 @@ Section linker.
   Fact linker_code_end : linker (code_end P) = lsum (snd P)+i.
   Proof.
     unfold code_end; rewrite Nat.add_comm.
-    apply (linker_app _ nil), app_nil_end.
+    apply (linker_app _ nil), eq_sym, app_nil_r.
   Qed.
   
    Fact linker_out_code j : err < i \/ length_compiler (snd P) + i <= err 
@@ -212,7 +212,7 @@ Section linker.
     destruct (eq_nat_dec j (code_end P)) as [ H | H ].
     + rewrite H1, H; unfold code_end.
       rewrite Nat.add_comm, linker_app with (mm := nil); auto.
-      rewrite <- app_nil_end; auto.
+      rewrite app_nil_r; auto.
     + apply linker_err_code; red in H2; unfold code_end, code_start in *; lia.
   Qed.
 

--- a/theories/Shared/Libs/DLW/Code/subcode.v
+++ b/theories/Shared/Libs/DLW/Code/subcode.v
@@ -83,7 +83,7 @@ Section subcode.
   Fact subcode_refl P : P <sc P.
   Proof.
     destruct P; exists nil, nil; split; simpl.
-    rewrite <- app_nil_end; auto.
+    rewrite app_nil_r; auto.
     lia.
   Qed.
 
@@ -114,7 +114,7 @@ Section subcode.
   Fact subcode_right n m l r : n = m+length l -> (n,r) <sc (m,l++r).
   Proof.
     exists l, nil; split; auto.
-    rewrite <- app_nil_end; auto.
+    rewrite app_nil_r; auto.
   Qed.
 
   Fact subcode_app_end P n l r : P <sc (n,l) -> P <sc (n,l++r).
@@ -214,7 +214,7 @@ Ltac subcode_tac :=
          | |- subcode (_,?i)      (_,?l++?i)      => exists l, nil 
          | |- subcode (_,?i::nil) (_,?l++?i::?r)  => exists l, r 
          | |- subcode (_,?i)      (_,?l++?i++?r)  => exists l, r 
-       end; try rewrite <- !app_nil_end;
+       end; try rewrite !app_nil_r;
        split; auto; rew length; try lia.
 
 (* Add it to auto so that fam sss * will try it to solve the subcode goal it generates *)

--- a/theories/Shared/Libs/DLW/Utils/utils_list.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_list.v
@@ -293,7 +293,7 @@ Proof.
   destruct H as [ H | (m & H1 & H2) ]; auto.
   destruct m as [ | y m ].
   left; exists nil; simpl in *; split; auto.
-  revert H1; do 2 rewrite <- app_nil_end; auto.
+  revert H1; do 2 rewrite app_nil_r; auto.
   inversion H2; subst.
   right; exists m; auto.
 Qed.
@@ -345,9 +345,9 @@ Proof.
   intros H1 H2 H.
   apply list_app_eq_inv in H.
   destruct H as [ (m & H3 & H4) | (m & H3 & H4) ]; destruct m.
-  inversion H4; subst; rewrite <- app_nil_end; auto.
+  inversion H4; subst; rewrite app_nil_r; auto.
   inversion H4; subst; destruct H1; apply in_or_app; right; left; auto.
-  inversion H4; subst; rewrite <- app_nil_end; auto.
+  inversion H4; subst; rewrite app_nil_r; auto.
   inversion H4; subst; destruct H2; apply in_or_app; right; left; auto.
 Qed.
 
@@ -372,7 +372,7 @@ Section flat_map.
       - apply IHl in Hm2.
         destruct Hm2 as (l1 & m1 & x' & m2 & l2 & G1 & G2 & G3 & G4); subst.
         exists (x::l1), m1, x', m2, l2; simpl; repeat (split; auto).
-        rewrite app_ass; auto.
+        rewrite <- app_assoc; auto.
       - exists nil, r1, x, m, l; auto.
   Qed.
 
@@ -457,7 +457,7 @@ Section prefix. (* as an inductive predicate *)
   Fact prefix_app_lft l r1 r2 : r1 <p r2 -> l++r1 <p l++r2.
   Proof.
     intros (a & ?); subst.
-    exists a; rewrite app_ass; auto.
+    exists a; rewrite <- app_assoc; auto.
   Qed.
   
   Fact prefix_inv x y l ll : x::l <p y::ll -> x = y /\ l <p ll.
@@ -474,7 +474,7 @@ Section prefix. (* as an inductive predicate *)
   Qed.
 
   Fact prefix_refl l : l <p l.
-  Proof. exists nil; rewrite <- app_nil_end; auto. Qed.
+  Proof. exists nil; rewrite app_nil_r; auto. Qed.
 
   Fact prefix_trans l1 l2 l3 : l1 <p l2 -> l2 <p l3 -> l1 <p l3.
   Proof. intros (m1 & H1) (m2 & H2); subst; exists (m1++m2); solve list eq. Qed.

--- a/theories/Shared/Libs/DLW/Utils/utils_tac.v
+++ b/theories/Shared/Libs/DLW/Utils/utils_tac.v
@@ -30,7 +30,7 @@ Tactic Notation "spec" "in" hyp(H) :=
        end 
      end.
 
-Ltac solve_list_eq := simpl; repeat progress (try rewrite app_ass; try rewrite <- app_nil_end; simpl; auto); auto.
+Ltac solve_list_eq := simpl; repeat progress (try rewrite <- app_assoc; try rewrite app_nil_r; simpl; auto); auto.
 
 Tactic Notation "solve" "list" "eq" := solve_list_eq.
 

--- a/theories/Shared/Libs/DLW/Vec/vec.v
+++ b/theories/Shared/Libs/DLW/Vec/vec.v
@@ -753,7 +753,7 @@ Section vec_map_list.
                                  ++ vec_map_list v (fun p => f (pos_nxt p)) 
                                  ++ vec_map_list w (fun p => f (pos_nxt p))).
       * apply Permutation_app; auto.
-      * do 2 rewrite <- app_ass.
+      * do 2 rewrite app_assoc.
         apply Permutation_app; auto.
        apply Permutation_app_comm.
   Qed.

--- a/theories/StackMachines/BSM/bsm_utils.v
+++ b/theories/StackMachines/BSM/bsm_utils.v
@@ -1020,12 +1020,12 @@ Section Binary_Stack_Machines.
      in (i,full_decoder i lt) // (i,v) ->> (p,v[nil/c][hh/h][ll/l]).
     Proof using Hhl Hcl Hch.
       intros H1 H2 H3 H4.
-      rewrite app_nil_end in H1.
+      rewrite <- app_nil_r in H1.
       generalize (@full_dec_spec_rec i ln nil lt v H1 H4).
       destruct (tile_concat ln lt) as (hh,ll).
       intros E.
       apply sss_compute_trans with (1 := E); auto.
-      rewrite H2, H3; repeat rewrite <- app_nil_end.
+      rewrite H2, H3; repeat rewrite app_nil_r.
       apply full_dec_start_spec_0; rew vec.
     Qed.
  
@@ -1267,7 +1267,7 @@ Section Binary_Stack_Machines.
         apply sss_compute_trans with (st2 := (16+i,v[(list_nat_bool ln)/a])).
         apply subcode_sss_compute with (P := (i,copy_stack s a h i)); auto.
         apply copy_stack_spec with (list_nat_bool ln); auto.
-        rewrite H2, <- app_nil_end; auto.
+        rewrite H2, app_nil_r; auto.
 
         apply sss_compute_trans with (st2 := (lFD+16+i,v[nil/a][hh/h][ll/l])).
         apply subcode_sss_compute with (P := (16+i,full_decoder a h l (lFD+16+i) (lFD+26+i) (16+i) lt)); auto.
@@ -1303,7 +1303,7 @@ Section Binary_Stack_Machines.
         apply sss_compute_trans with (st2 := (16+i,v[(list_nat_bool ln++lc)/a])).
         apply subcode_sss_compute with (P := (i,copy_stack s a h i)); auto.
         apply copy_stack_spec with (list_nat_bool ln++lc); auto.
-        rewrite H2, <- app_nil_end; auto.
+        rewrite H2, app_nil_r; auto.
 
         apply subcode_sss_compute_trans with (2 := Hw1); auto. 
 
@@ -1316,7 +1316,7 @@ Section Binary_Stack_Machines.
         
         unfold main_loop.
         subst lc.
-        rewrite <- app_nil_end in H3.
+        rewrite app_nil_r in H3.
         case_eq (tile_concat ln lt).
         intros hh ll E; rewrite E in H5.
         destruct (compare_stack_neq_spec Hhl (lFD+16+i) p (lFD+26+i) (v[nil/a][hh/h][ll/l]))
@@ -1325,7 +1325,7 @@ Section Binary_Stack_Machines.
         apply sss_compute_trans with (st2 := (16+i,v[(list_nat_bool ln)/a])).
         apply subcode_sss_compute with (P := (i,copy_stack s a h i)); auto.
         apply copy_stack_spec with (list_nat_bool ln); auto.
-        rewrite H2, <- app_nil_end; auto.
+        rewrite H2, app_nil_r; auto.
 
         apply sss_compute_trans with (st2 := (lFD+16+i,v[nil/a][hh/h][ll/l])).
         apply subcode_sss_compute with (P := (16+i,full_decoder a h l (lFD+16+i) (lFD+26+i) (16+i) lt)); auto.
@@ -1389,7 +1389,7 @@ Section Binary_Stack_Machines.
         * left.
           destruct H1 as (H1 & H4).
           exists ln, nil.
-          rewrite <- app_nil_end.
+          rewrite app_nil_r.
           split; auto.
           right.
           rewrite H2; auto.

--- a/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
+++ b/theories/StackMachines/Reductions/iPCPb_to_BSM_HALTING.v
@@ -26,7 +26,7 @@ Proof.
   induction ln as [ | i ln IH ]; simpl; auto.
   rewrite itau1_app, itau2_app; simpl.
   generalize (nth i lt ([], [])); intros (a,b); rewrite IH.
-  repeat rewrite <- app_nil_end; auto.
+  repeat rewrite app_nil_r; auto.
 Qed.
 
 (* tiles_solvable & iBPCP is the same predicate except that the existentially

--- a/theories/TM/Compound/TMTac.v
+++ b/theories/TM/Compound/TMTac.v
@@ -49,7 +49,7 @@ Tactic Notation "vector_destruct" hyp(tin) :=
       | _ => simple apply all_vec_correct2;try clear tin;let tin' := fresh tin in intros tin'
       end 
   in
-  let tac n :=  revert dependent tin; refine (all_vec_correct _);
+  let tac n := generalize dependent tin; refine (all_vec_correct _);
     cbn [all_vec];introT n;cbn [Vector.nth Vector.caseS];intros
   in
     once lazymatch type of tin with

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -1,6 +1,6 @@
 -Q . Undecidability
 
--arg -w -arg -notation-overridden
+-arg -w -arg -notation-overridden,-opaque-let
 -arg "-set" -arg "'Default Proof Using = Type'"
 COQDOCFLAGS = "--charset utf-8 -s --with-header ../website/resources/header.html --with-footer ../website/resources/footer.html --index indexpage"
 


### PR DESCRIPTION
- Fixed deprecated stdlib lemma warnings
- Muted ~500 `Let` ... `Qed` warnings (new syntax is `#[clearbody] Let` ... `Defined`)