### PR TITLE
improve performance of TM/Single/StepTM.v

### DIFF
--- a/theories/TM/Single/StepTM.v
+++ b/theories/TM/Single/StepTM.v
@@ -384,7 +384,7 @@ Section ToSingleTape.
   Notation nMax := (finMax' n).
   Local Arguments finMax' : simpl never.
 
-  Notation sigSim := (FinType(EqType(boundary + sigList (sigTape sig)))).
+  Definition sigSim := (FinType(EqType(boundary + sigList (sigTape sig)))).
 
   Implicit Types (T : tapes sig n).
 


### PR DESCRIPTION
Improve compilation of `TM/Single/StepTM.v` from
`TM/Single/StepTM.vo (real: 12.93, user: 12.80, sys: 0.11, mem: 573864 ko)`
to
`TM/Single/StepTM.vo (real: 7.41, user: 7.31, sys: 0.08, mem: 535524 ko)`
by changing one `Notation` to `Definition` for smaller proof terms.