### PR TITLE
Adapt to Coq PR #18591: better refolding of List.app inducing "simpl never" now better respected

### DIFF
--- a/theories/StringRewriting/Reductions/MM2_ZERO_HALTING_to_SSTS01.v
+++ b/theories/StringRewriting/Reductions/MM2_ZERO_HALTING_to_SSTS01.v
@@ -603,7 +603,7 @@ Proof.
   elim: u s.
   - move=> [|y1 [|y2 s]].
     + rewrite ?app_nil_l. move=> <-. right. right. by exists [].
-    + move=> [] <- <- /=. right. by left.
+    + move=> []. rewrite [in [] ++ _]/List.app => <- <- /=. right. by left.
     + move=> [] <- <- ->. left. by exists s.
   - move=> x1 u IH [|y1 s].
     + rewrite ?app_nil_l. move=> <-. right. right. by exists (x1 :: u).
@@ -707,7 +707,7 @@ Proof.
         ** rewrite app_nil_r /= ?map_app. move: (a) => [|?]; first done.
            move=> Hi [] H1 [<-] H2.
            move=> y [?] [/(mm2_instr_at_unique Hi) <-] Hxy.
-           inversion Hxy. subst.
+           inversion Hxy. subst. try rewrite [in LHS]/List.app in H1.
            eexists (u' ++ [sz]), v', (_ :: _).
            rewrite -?app_assoc. constructor; [done | by rewrite /= ?map_app H1 H2].
         ** rewrite ?map_app filter_app /= app_nil_r /step.


### PR DESCRIPTION
Tactic `injection` (called here via the introduction pattern `[]`) routinely calls `simpl` to simplify the application of the underlying injectors to the terms to invert. We modify two cases in `MM2_ZERO_HALTING_to_SSTS01.v` where, after coq/coq#18591, these calls to `simpl` stop reducing `[] ++ l` into `l` due to `List.app` (i.e. `++`) being declared `simpl never`.

The reason `simpl` formerly reduced `[] ++ l` is that `simpl` called on a subterm of the form `injector ([a] ++ l])` wrongly failed to refold the underlying occurrences of `List.app`, producing instead `(fix f := ... code of List.app ...) [] l`, leading to miss the `simpl never` request.

We fix the script by explicitly unfolding `++` in the two cases where `[] ++ l` was produced.

I tried at some time to understand if the use of `simpl never` in the file was actually motivated by `List.app` being not enough refolded, but apparently no. So, I kept the `simpl never` and locally modified instead the two failing places.

If I'm correct, the change is backwards compatible. So, if the change looks ok to you, it can be merged as soon as now.