### PR TITLE
move notations into module

### DIFF
--- a/theories/FOL/TRAKHTENBROT/discrete.v
+++ b/theories/FOL/TRAKHTENBROT/discrete.v
@@ -14,6 +14,7 @@ From Undecidability.Shared.Libs.DLW.Utils
 
 From Undecidability.Shared.Libs.DLW.Vec 
   Require Import pos vec.
+Import VectorNotations.
 
 From Undecidability.FOL.TRAKHTENBROT
   Require Import notations decidable gfp fol_ops fo_sig fo_terms fo_logic fo_definable fo_sat.

--- a/theories/FRACTRAN/Util/prime_seq.v
+++ b/theories/FRACTRAN/Util/prime_seq.v
@@ -18,6 +18,7 @@ From Undecidability.Shared.Libs.DLW
 
 Set Implicit Arguments.
 
+Import VectorNotations.
 Local Notation "e #> x" := (vec_pos e x).
 Local Notation "e [ v / x ]" := (vec_change e x v).
 

--- a/theories/MinskyMachines/MM.v
+++ b/theories/MinskyMachines/MM.v
@@ -14,6 +14,8 @@ Require Import List.
 From Undecidability.Shared.Libs.DLW
   Require Import Vec.pos Vec.vec Code.sss.
 
+Export VectorNotations.
+
 Set Implicit Arguments.
 
 (** * Halting problem for Minsky machines  *)

--- a/theories/Shared/Libs/DLW/Utils/godel_coding.v
+++ b/theories/Shared/Libs/DLW/Utils/godel_coding.v
@@ -15,6 +15,7 @@ From Undecidability.Shared.Libs.DLW
 Set Implicit Arguments.
 Set Default Goal Selector "!".
 
+Import VectorNotations.
 #[local] Notation "e #> x" := (vec_pos e x).
 #[local] Notation "e [ v / x ]" := (vec_change e x v).
 

--- a/theories/Shared/Libs/DLW/Vec/vec.v
+++ b/theories/Shared/Libs/DLW/Vec/vec.v
@@ -538,9 +538,15 @@ Arguments vec_plus {n}.
 Arguments vec_zero {n}.
 Arguments vec_one {n}.
 
+Module VectorNotations.
+
 Reserved Notation " e '#>' x " (at level 58, format "e #> x").
 Reserved Notation " e [ v / x ] " (at level 57, v at level 0, x at level 0, 
                                    left associativity, format "e [ v / x ]").
+
+End VectorNotations.
+
+Import VectorNotations.
 
 Local Notation " e '#>' x " := (vec_pos e x).
 Local Notation " e [ v / x ] " := (vec_change e x v).

--- a/theories/StackMachines/BSM.v
+++ b/theories/StackMachines/BSM.v
@@ -41,6 +41,7 @@ Section Binary_Stack_Machine.
   Notation POP  := (bsm_pop n).
   Notation PUSH := (bsm_push n).
 
+  Import VectorNotations.
   Local Notation "e #> x" := (vec_pos e x).
   Local Notation "e [ x := v ]" := (vec_change e x v) (no associativity, at level 50).
 

--- a/theories/StackMachines/Util/BSM_sss.v
+++ b/theories/StackMachines/Util/BSM_sss.v
@@ -16,6 +16,8 @@ Require Import List Bool Lia Nat.
 From Undecidability.Shared.Libs.DLW 
   Require Import list_bool pos vec sss.
 
+Export VectorNotations.
+
 Set Implicit Arguments.
 
 (** * Halting problem for binary stack machines BSM_HALTING  *)


### PR DESCRIPTION
This notation is reserved and only used in some parts of the development. But since it is still globally reserved, importing `vec.v` still produces warnings about clashing notations. A proper fix is to move these notations into a module. 

This is a first draft, presumably the definition should also be moved into such a module so that one does not have to re-define the notation elsewhere.

Making the notation no longer globally enabled would be great because it otherwise clashes with the ones defined in [FOL/Syntax/SyntacticOps.v](https://github.com/uds-psl/coq-library-undecidability/blob/coq-8.20/theories/FOL/Syntax/SyntacticOps.v).