### PR TITLE
Remove ill-placed notation definitions from FOL Friedman translation

### DIFF
--- a/theories/FOL/Utils/FriedmanTranslation.v
+++ b/theories/FOL/Utils/FriedmanTranslation.v
@@ -8,10 +8,6 @@ From Undecidability.FOL Require Import FullSyntax.
 From Undecidability.FOL.Arithmetics Require Import Robinson NatModel.
 Import Vector.VectorNotations.
 
-Notation "I ⊨= phi" := (forall rho, sat I rho phi) (at level 20).
-Notation "I ⊨=T T" := (forall psi, T psi -> I ⊨= psi) (at level 20).
-Notation "I ⊫= Gamma" := (forall rho psi, In psi Gamma -> sat I rho psi) (at level 20).
-
 Section Signature.
 
   
@@ -245,6 +241,7 @@ Section Arithmetic.
 
   Existing Instance PA_preds_signature.
   Existing Instance PA_funcs_signature.
+  Notation "I ⊫= Gamma" := (forall rho psi, In psi Gamma -> sat I rho psi) (at level 20).
 
   Lemma nat_sat_Fr_Q P :
     (extend_interp interp_nat P) ⊫= Fr_ Qeq.

--- a/theories/FOL/Utils/FriedmanTranslationFragment.v
+++ b/theories/FOL/Utils/FriedmanTranslationFragment.v
@@ -7,10 +7,6 @@ Import ListAutomationFacts ListAutomationInstances.
 From Undecidability.FOL Require Import FragmentSyntax.
 Import Vector.VectorNotations.
 
-Notation "I ⊨= phi" := (forall rho, sat I rho phi) (at level 20).
-Notation "I ⊨=T T" := (forall psi, T psi -> I ⊨= psi) (at level 20).
-Notation "I ⊫= Gamma" := (forall rho psi, In psi Gamma -> sat I rho psi) (at level 20).
-
 Section Signature.
   Import FragmentSyntax.
   Existing Instance frag_operators | 0.


### PR DESCRIPTION
Turns out that putting these notations here is a bad idea for coq-library-fol. In particular, `-fol` likes to tweak these notations in various places which leads to overridden notation warnings. Fixing them is mostly downstream but requires that these notations are removed here.