### PR TITLE
Remove `Proof with` from HOU and SOL

### DIFF
--- a/theories/HOU/second_order/dowek/encoding.v
+++ b/theories/HOU/second_order/dowek/encoding.v
@@ -172,19 +172,19 @@ Section ChurchEncoding.
 
   Lemma dec_enc s:
     { n | s = enc n} + forall n, s <> enc n.
-  Proof with try (right; intros [] ?; discriminate).
+  Proof.
     unfold enc. 
-    destruct s...  
-    destruct s...  
+    destruct s; try (right; intros [] ?; discriminate).
+    destruct s; try (right; intros [] ?; discriminate).
     enough ({ n | s = AppL (repeat (var 0) n) (var 1)} +
             forall n, s <> AppL (repeat (var 0) n) (var 1)).
     - destruct H; [left|right]; intuition idtac.
       destruct s0 as [n]; exists n; now subst.
       injection H; eapply n; eauto. 
-    - induction s...  
-      + destruct f as [| []]...  
+    - induction s; try (right; intros [] ?; discriminate).
+      + destruct f as [| []]; try (right; intros [] ?; discriminate).
         left; now (exists 0).
-      + destruct s1 as [[] | | |]...
+      + destruct s1 as [[] | | |]; try (right; intros [] ?; discriminate).
         destruct IHs2 as [[n IHs2]|IHs2].
         * left. exists (S n). now subst.
         * right. intros []; try discriminate.

--- a/theories/HOU/third_order/huet.v
+++ b/theories/HOU/third_order/huet.v
@@ -36,11 +36,11 @@ Section HuetReduction.
     [Arr (repeat (alpha → alpha) (length S)) alpha; (alpha → alpha) → alpha] ⊢( 3) 
     (lambda lambda lambda h (AppR f (Enc 1 2 (tails S))) (var (u 1) (g (var (u 1))))) :
     ((alpha → alpha) → (alpha → alpha) → (alpha → alpha → alpha) →  alpha).
-  Proof with cbn [ord' ord alpha]; simplify; cbn; (auto 2).
-    do 4 econstructor. econstructor. econstructor; (auto 2)...
+  Proof.
+    do 4 econstructor. econstructor. econstructor; (auto 2); cbn [ord' ord alpha]; simplify; cbn; (auto 2).
     cbn. lia. 
-    2: do 2 econstructor...
-    2 - 3: econstructor...
+    2: do 2 econstructor; cbn [ord' ord alpha]; simplify; cbn; (auto 2).
+    2 - 3: econstructor; cbn [ord' ord alpha]; simplify; cbn; (auto 2).
     eapply AppR_ordertyping with (L := repeat (alpha → alpha) (length S)); simplify.
     erewrite <-length_map; eapply Enc_typing.
     all: econstructor; trivial; simplify; cbn; lia.

--- a/theories/SOL/Util/Syntax.v
+++ b/theories/SOL/Util/Syntax.v
@@ -607,24 +607,24 @@ Section Enumerability.
 
   Lemma enum_term :
     list_enumerator__T L_term term.
-  Proof with eapply cum_ge'; eauto; lia.
+  Proof.
     intros t. induction t.
     - exists (S n); cbn. apply in_or_app. right. now left.
     - apply vec_forall_cml in IH as [m H]. 2: exact L_term_cml.
       exists (S (m + n + ar)); cbn. in_app 3. eapply in_concat. eexists. split.
       1: in_collect (n, ar). 1,2: apply L_nat_correct; lia.
       in_collect v. rewrite <- vecs_from_correct in H |-*. eapply Forall_ext.
-      2: apply H. cbn. intros...
+      2: apply H. cbn. intros. eapply cum_ge'; eauto; lia.
     - apply vec_forall_cml in IH as [m H]. 2: exact L_term_cml.
       destruct (el_T f) as [m' H']. exists (S (m + m')); cbn.
-      in_app 4. eapply in_concat. eexists. split. 1: in_collect f...
+      in_app 4. eapply in_concat. eexists. split. 1: in_collect f; eapply cum_ge'; eauto; lia.
       in_collect v. rewrite <- vecs_from_correct in H |-*. eapply Forall_ext.
-      2: apply H. cbn. intros...
+      2: apply H. cbn. intros. eapply cum_ge'; eauto; lia.
   Qed.
 
   Lemma enum_form :
     list_enumerator__T L_form form.
-  Proof with eapply cum_ge'; eauto; lia.
+  Proof. 
     intros phi. induction phi.
     - exists 0. now left.
     - rename t into v. destruct (@vec_forall_cml term L_term _ v) as [m H]; eauto.
@@ -633,22 +633,27 @@ Section Enumerability.
         * exists (S (m + n + ar)); cbn. in_app 2. eapply in_concat.
           eexists. split. 1: in_collect (n, ar). 1,2: apply L_nat_correct; lia.
           in_collect v. rewrite <- vecs_from_correct in H |-*. eapply Forall_ext.
-          2: apply H. cbn. intros...
+          2: apply H. cbn. intros. eapply cum_ge'; eauto; lia.
         * destruct (el_T P) as [m']. exists (S (m + m')); cbn. in_app 3.
-          eapply in_concat. eexists. split. 1: in_collect P...
+          eapply in_concat. eexists. split. 1: in_collect P; eapply cum_ge'; eauto; lia.
           in_collect v. rewrite <- vecs_from_correct in H |-*. eapply Forall_ext.
-          2: apply H. cbn. intros...
+          2: apply H. cbn. intros. eapply cum_ge'; eauto; lia.
     - destruct (el_T b) as [m], IHphi1 as [m1], IHphi2 as [m2]. 
       exists (1 + m + m1 + m2); cbn. in_app 4. apply in_concat. eexists. split.
-      in_collect b... in_collect (phi1, phi2)...
+      + in_collect b; eapply cum_ge'; eauto; lia.
+      + in_collect (phi1, phi2); eapply cum_ge'; eauto; lia.
     - destruct (el_T q) as [m], IHphi as [m']. exists (S (m + m')); cbn. in_app 5.
-      apply in_concat. eexists. split. in_collect q... in_collect phi...
+      apply in_concat. eexists. split. in_collect q; eapply cum_ge'; eauto; lia.
+      in_collect phi. eapply cum_ge'; eauto; lia.
     - destruct (el_T q) as [m], IHphi as [m']. exists (S (m + m' + n)); cbn.
       in_app 6. apply in_concat. eexists. split. in_collect (q, n). 
-      eapply cum_ge'; eauto; lia. apply L_nat_correct; lia. in_collect phi...
+      eapply cum_ge'; eauto; lia. apply L_nat_correct; lia. in_collect phi.
+      eapply cum_ge'; eauto; lia.
     - destruct (el_T q) as [m], IHphi as [m']. exists (S (m + m' + n)); cbn.
-      in_app 7. apply in_concat. eexists. split. in_collect (q, n). 
-      eapply cum_ge'; eauto; lia. apply L_nat_correct; lia. in_collect phi...
+      in_app 7. apply in_concat. eexists. split.
+      + in_collect (q, n). eapply cum_ge'; eauto; lia.
+        apply L_nat_correct; lia.
+      + in_collect phi; eapply cum_ge'; eauto; lia.
   Qed.
 
 End Enumerability.


### PR DESCRIPTION
Only FOL has the deprecated `Proof with` notation.